### PR TITLE
ENT-20 Enterprise Customer Setup: Configure Cobranding

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,2 @@
 Eugeny Kolpakov <eugeny@opencraft.com>
+Asad Iqbal <aiqbal@edx.org>

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,15 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[0.1.1] - 2016-11-03
+~~~~~~~~~~~~~~~~~~~~
+
+Added
+_____
+
+* Enterprise Customer Branding Model and Django admin integration
+
+
 [0.1.0] - 2016-10-13
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 
 default_app_config = 'enterprise.apps.EnterpriseConfig'  # pylint: disable=invalid-name

--- a/enterprise/admin.py
+++ b/enterprise/admin.py
@@ -8,7 +8,7 @@ from simple_history.admin import SimpleHistoryAdmin  # likely a bug in import or
 from django.contrib import admin
 
 from enterprise.actions import export_as_csv_action
-from enterprise.models import EnterpriseCustomer, EnterpriseCustomerUser
+from enterprise.models import EnterpriseCustomer, EnterpriseCustomerBrandingConfiguration, EnterpriseCustomerUser
 
 
 def get_all_field_names(model):
@@ -24,15 +24,29 @@ def get_all_field_names(model):
     return [f.name for f in model._meta.get_fields()]
 
 
+class EnterpriseCustomerBrandingConfigurationInline(admin.StackedInline):
+    """
+    Django admin model for EnterpriseCustomerBrandingConfiguration.
+
+    The admin interface has the ability to edit models on the same page as a parent model. These are called inlines.
+    https://docs.djangoproject.com/en/1.8/ref/contrib/admin/#django.contrib.admin.StackedInline
+    """
+
+    model = EnterpriseCustomerBrandingConfiguration
+    can_delete = False
+
+
 @admin.register(EnterpriseCustomer)
 class EnterpriseCustomerAdmin(SimpleHistoryAdmin):
     """
     Django admin model for EnterpriseCustomer.
     """
 
-    list_display = ("name", "uuid", "active",)
+    list_display = ("name", "uuid", "active", "logo")
+
     list_filter = ("active",)
     search_fields = ("name", "uuid",)
+    inlines = [EnterpriseCustomerBrandingConfigurationInline, ]
 
     EXPORT_AS_CSV_FIELDS = ["name", "active", "uuid"]
 
@@ -42,6 +56,15 @@ class EnterpriseCustomerAdmin(SimpleHistoryAdmin):
 
     class Meta(object):
         model = EnterpriseCustomer
+
+    @staticmethod
+    def logo(instance):
+        """
+        Instance is EnterpriseCustomer.
+        """
+        if instance.branding_configuration:
+            return instance.branding_configuration.logo
+        return None
 
 
 @admin.register(EnterpriseCustomerUser)

--- a/enterprise/apps.py
+++ b/enterprise/apps.py
@@ -14,3 +14,5 @@ class EnterpriseConfig(AppConfig):
     """
 
     name = 'enterprise'
+    valid_extensions = ['.png', ]
+    image_size = 250 * 1024

--- a/enterprise/migrations/0002_enterprisecustomerbrandingconfiguration.py
+++ b/enterprise/migrations/0002_enterprisecustomerbrandingconfiguration.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import django.utils.timezone
+from django.db import migrations, models
+
+import model_utils.fields
+
+import enterprise.models
+import enterprise.validators
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('enterprise', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='EnterpriseCustomerBrandingConfiguration',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('created', model_utils.fields.AutoCreatedField(default=django.utils.timezone.now, verbose_name='created', editable=False)),
+                ('modified', model_utils.fields.AutoLastModifiedField(default=django.utils.timezone.now, verbose_name='modified', editable=False)),
+                ('logo', models.ImageField(validators=[enterprise.validators.validate_image_extension, enterprise.validators.validate_image_size], upload_to=enterprise.models.logo_path, max_length=255, blank=True, help_text='Please add only .PNG files for logo images.', null=True)),
+                ('enterprise_customer', models.OneToOneField(to='enterprise.EnterpriseCustomer')),
+            ],
+            options={
+                'verbose_name': 'Enterprise Customer Branding',
+                'verbose_name_plural': 'Enterprise Customer Brandings',
+            },
+        ),
+    ]

--- a/enterprise/validators.py
+++ b/enterprise/validators.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+"""
+Database models field validators.
+"""
+from __future__ import absolute_import, unicode_literals
+
+import os
+
+from django.apps import apps
+from django.core.exceptions import ValidationError
+from django.utils.translation import ugettext_lazy as _
+
+
+def get_app_config():
+    """
+    :return Application configuration.
+    """
+    return apps.get_app_config('enterprise')
+
+
+def validate_image_extension(value):
+    """
+    Validate that a particular image extension.
+    """
+    config = get_app_config()
+    ext = os.path.splitext(value.name)[1]
+    if config and not ext.lower() in getattr(config, 'valid_extensions', []):
+        raise ValidationError(_('Unsupported file extension.'))
+
+
+def validate_image_size(image):
+    """
+    Validate that a particular image size.
+    """
+    config = get_app_config()
+    if config and not image.size < getattr(config, 'image_size', 0):
+        raise ValidationError(_("The logo image file size must be less than 250KB."))


### PR DESCRIPTION
[ENT-20](https://openedx.atlassian.net/browse/ENT-20)

@mattdrayer @e-kolpakov your initial thoughts ? 

<img width="1273" alt="screen shot 2016-10-26 at 3 46 18 pm" src="https://cloud.githubusercontent.com/assets/7334669/19725822/3684c172-9ba1-11e6-8649-67319890a329.png">
##### NOTE: It is in WIP State. missing test coverage

**Reviewers:**
- [x] @e-kolpakov
- [ ] @mattdrayer  (???)

**Checklist:**
- [ ] Reviewed and approved
- [ ] Add yourself to AUTHORS
- [ ] Bump version number in `enterprise/__init__.py`: 0.1.1
- [ ] Document new in this version CHANGELOG.rst
- [ ] Add relevant information to README and/or docs
- [ ] Make sure CI build pass
- [ ] (optional) achieve 100% diff coverage