### PR TITLE
Manage Learners: fixed User.post_save handler causing migrations to fail

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[0.4.1] - 2016-11-24
+~~~~~~~~~~~~~~~~~~~~
+
+Fixed User.post_save handler causing initial migrations to fail
+
 [0.4.0] - 2016-11-21
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/course_catalog_api.py
+++ b/enterprise/course_catalog_api.py
@@ -2,6 +2,8 @@
 """
 Utilities to get details from the course catalog API.
 """
+from __future__ import absolute_import, unicode_literals
+
 from django.utils.translation import ugettext_lazy as _
 
 try:

--- a/enterprise/signals.py
+++ b/enterprise/signals.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+"""
+Django signal handlers.
+"""
+from __future__ import absolute_import, unicode_literals
+
+from logging import getLogger
+
+from enterprise.models import EnterpriseCustomerUser, PendingEnterpriseCustomerUser
+from enterprise.utils import disable_for_loaddata
+
+logger = getLogger(__name__)  # pylint: disable=invalid-name
+
+
+@disable_for_loaddata
+def handle_user_post_save(sender, **kwargs):  # pylint: disable=unused-argument
+    """
+    Handle User model changes - checks if pending enterprise customer user record exists and upgrades it to actual link.
+    """
+    created = kwargs.get("created", False)
+    user_instance = kwargs.get("instance", None)
+
+    if user_instance is None:
+        return  # should never happen, but better safe than 500 error
+
+    try:
+        pending_link_record = PendingEnterpriseCustomerUser.objects.get(user_email=user_instance.email)
+    except PendingEnterpriseCustomerUser.DoesNotExist:
+        return  # nothing to do in this case
+
+    if not created:
+        # existing user changed his email to match one of pending link records - try linking him to EC
+        try:
+            existing_record = EnterpriseCustomerUser.objects.get(user_id=user_instance.id)
+            message_template = "User {user} have changed email to match pending Enterprise Customer link, " \
+                               "but was already linked to Enterprise Customer {enterprise_customer} - " \
+                               "deleting pending link record"
+            logger.info(message_template.format(
+                user=user_instance, enterprise_customer=existing_record.enterprise_customer
+            ))
+            pending_link_record.delete()
+            return
+        except EnterpriseCustomerUser.DoesNotExist:
+            pass  # everything ok - current user is not linked to other ECs
+
+    EnterpriseCustomerUser.objects.create(
+        enterprise_customer=pending_link_record.enterprise_customer,
+        user_id=user_instance.id
+    )
+    pending_link_record.delete()

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -4,6 +4,11 @@ Utility functions for enterprise app.
 """
 from __future__ import absolute_import, unicode_literals
 
+from functools import wraps
+
+
+USER_POST_SAVE_DISPATCH_UID = "user_post_save_upgrade_pending_enterprise_customer_user"
+
 
 def get_available_idps():
     """
@@ -49,3 +54,22 @@ def get_all_field_names(model):
     .. _Django documentation: https://docs.djangoproject.com/en/1.8/ref/models/meta/
     """
     return [f.name for f in model._meta.get_fields()]
+
+
+def disable_for_loaddata(signal_handler):
+    """
+    Decorator that turns off signal handlers when loading fixture data.
+
+    Django docs instruct to avoid further changes to the DB if raw=True as it might not be in a consistent state.
+    See https://docs.djangoproject.com/en/dev/ref/signals/#post-save
+    """
+    # http://stackoverflow.com/a/15625121/882918
+    @wraps(signal_handler)
+    def wrapper(*args, **kwargs):
+        """
+        Function wrapper.
+        """
+        if kwargs.get('raw', False):
+            return
+        signal_handler(*args, **kwargs)
+    return wrapper

--- a/test_utils/factories.py
+++ b/test_utils/factories.py
@@ -105,6 +105,7 @@ class UserFactory(factory.DjangoModelFactory):
 
         model = User
 
+    id = factory.LazyAttribute(lambda x: FAKER.random_int(min=1))  # pylint: disable=invalid-name
     email = factory.LazyAttribute(lambda x: FAKER.email())
     username = factory.LazyAttribute(lambda x: FAKER.user_name())
     first_name = factory.LazyAttribute(lambda x: FAKER.first_name())

--- a/tests/test_apps.py
+++ b/tests/test_apps.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for the `edx-enterprise` models module.
+"""
+
+from __future__ import absolute_import, unicode_literals, with_statement
+
+import unittest
+
+import mock
+from pytest import mark
+
+from django.contrib.auth.models import User
+from django.db.models.signals import pre_migrate
+
+import enterprise
+from test_utils.factories import EnterpriseCustomerFactory, UserFactory
+
+
+@mark.django_db
+class TestEnterpriseConfig(unittest.TestCase):
+    """
+    Test edx-enterprise app config.
+    """
+
+    def setUp(self):
+        """
+        Set up test environment.
+        """
+        super(TestEnterpriseConfig, self).setUp()
+        self.post_save_mock = mock.Mock()
+        patcher = mock.patch('enterprise.signals.handle_user_post_save', self.post_save_mock)
+        patcher.start()
+        self.app_config = enterprise.apps.EnterpriseConfig('enterprise', enterprise)
+        self.addCleanup(patcher.stop)
+
+    def test_ready_connects_user_post_save_handler(self):
+        self.app_config.ready()
+
+        user = UserFactory()
+
+        assert self.post_save_mock.call_count == 1
+        call_args, call_kwargs = self.post_save_mock.call_args_list[0]
+        assert call_args == ()
+        assert call_kwargs["sender"] == User
+        assert call_kwargs["instance"] == user
+        assert call_kwargs["created"]
+
+    def test_ready_does_not_fire_user_post_save_handler_for_other_models(self):
+        self.app_config.ready()
+        EnterpriseCustomerFactory()
+
+        assert not self.post_save_mock.called
+
+    def test_ready_disconnects_user_post_save_handler_for_migration(self):
+        self.app_config.ready()
+        pre_migrate.send(mock.Mock())
+
+        UserFactory()
+
+        assert not self.post_save_mock.called

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for the `edx-enterprise` models module.
+"""
+
+from __future__ import absolute_import, unicode_literals, with_statement
+
+import unittest
+
+import ddt
+import mock
+from pytest import mark
+
+from enterprise.models import EnterpriseCustomerUser, PendingEnterpriseCustomerUser
+from enterprise.signals import handle_user_post_save
+from test_utils.factories import (
+    EnterpriseCustomerFactory, EnterpriseCustomerUserFactory, PendingEnterpriseCustomerUserFactory, UserFactory
+)
+
+
+@mark.django_db
+@ddt.ddt
+class TestUserPostSaveSignalHandler(unittest.TestCase):
+    """
+    Test User post_save signal handler.
+    """
+
+    def test_handle_user_post_save_no_user_instance_nothing_happens(self):
+        # precondition checks
+        assert len(PendingEnterpriseCustomerUser.objects.all()) == 0
+        assert len(EnterpriseCustomerUser.objects.all()) == 0
+
+        parameters = {"instance": None, "created": False}
+        handle_user_post_save(mock.Mock(), **parameters)
+
+        assert len(PendingEnterpriseCustomerUser.objects.all()) == 0
+        assert len(EnterpriseCustomerUser.objects.all()) == 0
+
+    def test_handle_user_post_save_no_matching_pending_link(self):
+        user = UserFactory(email="jackie.chan@hollywood.com")
+
+        assert len(PendingEnterpriseCustomerUser.objects.all()) == 0, "Precondition check: no pending links available"
+        assert len(EnterpriseCustomerUser.objects.all()) == 0, "Precondition check: no links exists"
+
+        parameters = {"instance": user, "created": True}
+        handle_user_post_save(mock.Mock(), **parameters)
+
+        assert len(PendingEnterpriseCustomerUser.objects.all()) == 0
+        assert len(EnterpriseCustomerUser.objects.all()) == 0
+
+    def test_handle_user_post_save_created_user(self):
+        email = "jackie.chan@hollywood.com"
+        user = UserFactory(id=1, email=email)
+        pending_link = PendingEnterpriseCustomerUserFactory(user_email=email)
+
+        assert len(EnterpriseCustomerUser.objects.filter(user_id=user.id)) == 0, "Precondition check: no links exists"
+        assert len(PendingEnterpriseCustomerUser.objects.filter(user_email=email)) == 1, \
+            "Precondition check: pending link exists"
+
+        parameters = {"instance": user, "created": True}
+        handle_user_post_save(mock.Mock(), **parameters)
+
+        assert len(PendingEnterpriseCustomerUser.objects.all()) == 0
+        assert len(EnterpriseCustomerUser.objects.filter(
+            enterprise_customer=pending_link.enterprise_customer, user_id=user.id
+        )) == 1
+
+    def test_handle_user_post_save_modified_user_not_linked(self):
+        email = "jackie.chan@hollywood.com"
+        user = UserFactory(id=1, email=email)
+        pending_link = PendingEnterpriseCustomerUserFactory(user_email=email)
+
+        assert len(EnterpriseCustomerUser.objects.filter(user_id=user.id)) == 0, "Precondition check: no links exists"
+        assert len(PendingEnterpriseCustomerUser.objects.filter(user_email=email)) == 1, \
+            "Precondition check: pending link exists"
+
+        parameters = {"instance": user, "created": False}
+        handle_user_post_save(mock.Mock(), **parameters)
+
+        assert len(PendingEnterpriseCustomerUser.objects.all()) == 0
+        assert len(EnterpriseCustomerUser.objects.filter(
+            enterprise_customer=pending_link.enterprise_customer, user_id=user.id
+        )) == 1
+
+    def test_handle_user_post_save_modified_user_already_linked(self):
+        email = "jackie.chan@hollywood.com"
+        user = UserFactory(id=1, email=email)
+        enterprise_customer1, enterprise_customer2 = EnterpriseCustomerFactory(), EnterpriseCustomerFactory()
+        existing_link = EnterpriseCustomerUserFactory(enterprise_customer=enterprise_customer1, user_id=user.id)
+        PendingEnterpriseCustomerUserFactory(enterprise_customer=enterprise_customer2, user_email=email)
+
+        assert len(EnterpriseCustomerUser.objects.filter(user_id=user.id)) == 1, "Precondition check: links exists"
+        assert len(PendingEnterpriseCustomerUser.objects.filter(user_email=email)) == 1, \
+            "Precondition check: pending link exists"
+
+        parameters = {"instance": user, "created": False}
+        handle_user_post_save(mock.Mock(), **parameters)
+
+        link = EnterpriseCustomerUser.objects.get(user_id=user.id)
+        # TODO: remove suppression when https://github.com/landscapeio/pylint-django/issues/78 is fixed
+        assert link.id == existing_link.id, "Should keep existing link intact"  # pylint: disable=no-member
+        assert link.enterprise_customer == enterprise_customer1, "Should keep existing link intact"
+
+        assert len(PendingEnterpriseCustomerUser.objects.all()) == 0, "Should delete pending link"
+
+    def test_handle_user_post_save_raw(self):
+        email = "jackie.chan@hollywood.com"
+        user = UserFactory(id=1, email=email)
+        PendingEnterpriseCustomerUserFactory(user_email=email)
+
+        assert len(EnterpriseCustomerUser.objects.filter(user_id=user.id)) == 0, "Precondition check: no links exists"
+        assert len(PendingEnterpriseCustomerUser.objects.filter(user_email=email)) == 1, \
+            "Precondition check: pending link exists"
+
+        parameters = {"instance": user, "created": False, "raw": True}
+        handle_user_post_save(mock.Mock(), **parameters)
+
+        assert len(EnterpriseCustomerUser.objects.filter(user_id=user.id)) == 0, "Link have been created"
+        assert len(PendingEnterpriseCustomerUser.objects.filter(user_email=email)) == 1, \
+            "Pending link should be kept"


### PR DESCRIPTION
**Description:** Fixes migration/DB deployment error caused by User.post_save handler.

**Related:** #8

**JIRA:** [ENT-48](https://openedx.atlassian.net/browse/ENT-48)

**Testing instructions:**

* Run bokchoy test suite - should get past "Loading the fixture data from the filesystem into the default MySQL DB." and actually run the suite. ([failed bokchoy run](https://build.testeng.edx.org/job/edx-platform-accessibility-pr/27918/console) for reference).
* Migrate `commerce` and `enterprise` to zero (you might need to fake `commerce` 0001 and manually delete auth_user record)
* Apply commerce 0001 migration only. *Expected result:* migration works. *Failure condition:* migration fails complaining about missing enterprise_pendingenterprisecustomeruser table.
* Unapply commerce 0001 (might need faking again).
* Migrate everything at once (`./manage.py lms migrate --settings=devstack). **Expected result:* migrations succeed.

**Reviewers:**
- [x] @mtyaka
- [x] @asadiqbal08 and or @saleem-latif 
- [ ] (Optional) @mattdrayer 

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Commits are squashed
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)