### PR TITLE
Set catalog field to optional in admin form

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ matrix:
   include:
     - python: 3.5
       env: TOXENV=quality
+    - python: 2.7
+      env: TOXENV=quality
     - python: 3.5
       env: TOXENV=docs
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+Fixed EnterpriseCustomer form to make Catalog field optional
+
 [0.5.0] - 2016-11-28
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/enterprise/admin/forms.py
+++ b/enterprise/admin/forms.py
@@ -75,7 +75,7 @@ class EnterpriseCustomerAdminForm(forms.ModelForm):
         normally be set up as a plain number entry field.
         """
         super(EnterpriseCustomerAdminForm, self).__init__(*args, **kwargs)
-        self.fields['catalog'] = forms.ChoiceField(choices=self.get_catalog_options())
+        self.fields['catalog'] = forms.ChoiceField(choices=self.get_catalog_options(), required=False)
 
     def get_catalog_options(self):
         """

--- a/enterprise/api.py
+++ b/enterprise/api.py
@@ -2,6 +2,7 @@
 """
 Helper functions for enterprise app.
 """
+from __future__ import absolute_import, unicode_literals
 
 from enterprise.models import EnterpriseCustomerBrandingConfiguration
 


### PR DESCRIPTION
Fixes an issue in 0.4.0 where the catalog field is required to be non-null for the EnterpriseCustomer form.

Related to #7.

**Dependencies**: None

**Merge deadline**: ASAP

**Testing instructions**:

1. With edx-enterprise 0.4.0, go to create a new EnterpriseCustomer.
2. Note that you cannot leave the default "None" value for the catalog field; an error prevents you from saving.
3. Update to this branch.
4. Note that you can now create a new EnterpriseCustomer with a blank catalog. 


**Notes**

1. This PR also adds a Python 2.7 quality check to Travis, per @bradenmacdonald's request.

**Reviewers**
- [x] @mtyaka
- [x] @asadiqbal08 and or @saleem-latif
- [ ] (Optional) @mattdrayer
