### PR TITLE
ENT-111: Added alphabetical ordering for catalog drop down and displayed catalog details link next to selected catalog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,16 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[0.9.0] - 2016-12-29
+~~~~~~~~~~~~~~~~~~~~
+
+Added
+-----
+
+* In django admin page for enterprise customer added alphabetical ordering for
+  catalog drop down and displayed catalog details link next to selected catalog.
+
+
 [0.8.0] - 2016-12-08
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/admin/forms.py
+++ b/enterprise/admin/forms.py
@@ -153,6 +153,9 @@ class EnterpriseCustomerAdminForm(forms.ModelForm):
         model = EnterpriseCustomer
         fields = "__all__"
 
+    class Media:
+        js = ('enterprise/admin/enterprise_customer.js', )
+
     def __init__(self, *args, **kwargs):
         """
         Initialize the form.
@@ -161,7 +164,15 @@ class EnterpriseCustomerAdminForm(forms.ModelForm):
         normally be set up as a plain number entry field.
         """
         super(EnterpriseCustomerAdminForm, self).__init__(*args, **kwargs)
-        self.fields['catalog'] = forms.ChoiceField(choices=self.get_catalog_options(), required=False)
+
+        self.fields['catalog'] = forms.ChoiceField(
+            choices=self.get_catalog_options(),
+            required=False,
+            help_text="<a id='catalog-details-link' href='#' target='_blank'"
+                      "data-url-template='{catalog_admin_url}'> View catalog details.</a>".format(
+                          catalog_admin_url=utils.get_catalog_admin_url_template(),
+                      )
+        )
 
     def get_catalog_options(self):
         """
@@ -170,9 +181,13 @@ class EnterpriseCustomerAdminForm(forms.ModelForm):
         Once retrieved, these name pairs can be used directly as a value
         for the `choices` argument to a ChoiceField.
         """
+        catalogs = get_all_catalogs(self.user)
+        # order catalogs by name.
+        catalogs = sorted(catalogs, key=lambda catalog: catalog.get('name', '').lower())
+
         return ((None, _('None'),),) + tuple(
             (catalog['id'], catalog['name'],)
-            for catalog in get_all_catalogs(self.user)
+            for catalog in catalogs
         )
 
 

--- a/enterprise/static/enterprise/admin/enterprise_customer.js
+++ b/enterprise/static/enterprise/admin/enterprise_customer.js
@@ -1,0 +1,20 @@
+(function($){
+    $(document).ready(function(){
+        var $catalog_anchor = $("#catalog-details-link"),
+            // URL template with a place holder '{catalog_id}'
+            // Sample url template: http://localhost:18381/admin/catalogs/catalog/{catalog_id}/change/
+            url_template = $catalog_anchor.data("urlTemplate"),
+            selected_catalog = 0;
+
+        $("[name='catalog']").on("change", function(event){
+            selected_catalog = $(event.target).val();
+            $catalog_anchor.attr(
+                "href", selected_catalog && url_template.replace("{catalog_id}", selected_catalog)
+            ).text(
+                selected_catalog && "View catalog '{catalog_name}' details.".replace(
+                    "{catalog_name}", $(event.target).find("option:selected").text()
+                )
+            );
+        }).change();
+    });
+})(django.jQuery);

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, unicode_literals
 
 import logging
 import os
+import re
 from functools import wraps
 
 from django.conf import settings
@@ -123,3 +124,45 @@ def patch_mako_lookup():
     # Both add an item to the setting AND insert the lookup for immediate use
     settings.MAKO_TEMPLATES['main'].insert(0, template_location)
     add_lookup('main', template_location)
+
+
+def get_catalog_admin_url(catalog_id):
+    """
+    Get url to catalog details admin page.
+
+    Arguments:
+        catalog_id (int): Catalog id for which to return catalog details url.
+
+    Returns:
+         URL pointing to catalog details admin page for the give catalog id.
+
+    Example:
+        >>> get_catalog_admin_url_template(2)
+        "http://localhost:18381/admin/catalogs/catalog/2/change/"
+    """
+    return get_catalog_admin_url_template().format(catalog_id=catalog_id)
+
+
+def get_catalog_admin_url_template():
+    """
+    Get template of catalog admin url.
+
+    URL template will contain a placeholder '{catalog_id}' for catalog id.
+
+    Returns:
+        A string containing template for catalog url.
+
+    Example:
+        >>> get_catalog_admin_url_template()
+        "http://localhost:18381/admin/catalogs/catalog/{catalog_id}/change/"
+    """
+    api_base_url = getattr(settings, "COURSE_CATALOG_API_URL", "")
+
+    # Extract FQDN (Fully Qualified Domain Name) from API URL.
+    match = re.match(r"^(?P<fqdn>(?:https?://)?[^/]+)", api_base_url)
+
+    if not match:
+        return ""
+
+    # Return matched FQDN from catalog api url appended with catalog admin path
+    return match.group("fqdn").rstrip("/") + "/admin/catalogs/catalog/{catalog_id}/change/"

--- a/test_settings.py
+++ b/test_settings.py
@@ -81,3 +81,4 @@ SITE_ID = 1
 EDX_API_KEY = "PUT_YOUR_API_KEY_HERE"
 
 ENTERPRISE_ENROLLMENT_API_URL = "http://localhost:8000/api/enrollment/v1/"
+COURSE_CATALOG_API_URL = "http://localhost:18381/api/v1/"


### PR DESCRIPTION
Hi @mattdrayer , @asadiqbal08 , @e-kolpakov 

Kindly take a look at this PR, This PR adds alphabetical ordering for course catalog dropdown in enterprise customer admin page. It also adds a link for viewing catalog details of the currently selected catalog.

__Description of [ENT-111](https://openedx.atlassian.net/browse/ENT-111):__
As an edX Admin, I need to select an existing catalog for an Enterprise.
__Acceptance Criteria__
1. Catalog dropdown ordered alphabetically by name
2. Display currently-selected catalog next to dropdown list/selector as a hyperlink (see #3)
3. Displayed catalog links to location discovery app. https://prod-edx-discovery.edx.org/admin/catalogs/catalog/47/change/

__Testing Instructions:__

1. Go to course discovery admin page at https://discovery-enterprise.sandbox.edx.org/admin/catalogs/ (login with staff account) and add different course catalogs.
2. Visit enterprise customer admin page at https://enterprise.sandbox.edx.org/admin/enterprise/enterprisecustomer/  (login with staff account) and add an enterprise customer.
    - Make sure that catalogs in catalog drop down are ordered alphabetically by name.
    - Make sure that there is a link below drop down that points to currently selected catalog item.
3. After saving enterprise customer, make sure "catalog" column in enterprise customer list view has a link pointing to catalog details view.
 <img width="1280" alt="screen shot 2016-12-22 at 2 35 50 pm" src="https://cloud.githubusercontent.com/assets/7114956/21421308/0753542e-c854-11e6-8be5-20259ae9cc61.png">



