### PR TITLE
ENT-95: Add ability to enroll existing users in course

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,15 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[0.20.0] - 2017-01-30
+~~~~~~~~~~~~~~~~~~~~~
+
+Added
+-----
+
+* Add ability to select existing learners to be enrolled in courses from admin
+
+
 [0.19.1] - 2017-01-30
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.19.1"
+__version__ = "0.20.0"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/admin/forms.py
+++ b/enterprise/admin/forms.py
@@ -16,7 +16,7 @@ from django.utils.translation import ugettext as _
 
 from enterprise import utils
 from enterprise.admin.utils import (ProgramStatuses, ValidationMessages, email_or_username__to__email,
-                                    get_course_runs_from_program, validate_email_to_link)
+                                    get_course_runs_from_program, split_usernames_and_emails, validate_email_to_link)
 from enterprise.course_catalog_api import CourseCatalogApiClient
 from enterprise.lms_api import EnrollmentApiClient
 from enterprise.models import EnterpriseCustomer, EnterpriseCustomerIdentityProvider
@@ -124,7 +124,22 @@ class ManageLearnersForm(forms.Form):
             return email_or_username
 
         email = email_or_username__to__email(email_or_username)
-        validate_email_to_link(email, email_or_username, ValidationMessages.INVALID_EMAIL_OR_USERNAME)
+        bulk_entry = len(split_usernames_and_emails(email)) > 1
+        if bulk_entry:
+            for email in split_usernames_and_emails(email):
+                validate_email_to_link(
+                    email,
+                    None,
+                    ValidationMessages.INVALID_EMAIL_OR_USERNAME,
+                    ignore_existing=True
+                )
+            email = email_or_username
+        else:
+            validate_email_to_link(
+                email,
+                email_or_username,
+                ValidationMessages.INVALID_EMAIL_OR_USERNAME,
+            )
 
         return email
 

--- a/enterprise/admin/utils.py
+++ b/enterprise/admin/utils.py
@@ -137,7 +137,7 @@ def validate_email_to_link(email, raw_email=None, message_template=None, ignore_
         raise ValidationError(ValidationMessages.USER_ALREADY_REGISTERED.format(
             email=email, ec_name=existing_record.enterprise_customer.name
         ))
-    return bool(existing_record)
+    return existing_record or False
 
 
 def get_course_runs_from_program(program):
@@ -178,3 +178,14 @@ def get_earliest_start_date_from_program(program):
     if not start_dates:
         return None
     return min(start_dates)
+
+
+def split_usernames_and_emails(email_field):
+    """
+    Split the contents of the email field into a list.
+
+    In some cases, a user could enter a comma-separated value inline in the
+    Manage Learners form. We should check to see if that's the case, and
+    provide a list of email addresses or usernames if it is.
+    """
+    return [name.strip() for name in email_field.split(',')]

--- a/enterprise/conf/locale/en/LC_MESSAGES/django.po
+++ b/enterprise/conf/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-01-26 19:12-0600\n"
+"POT-Creation-Date: 2017-01-30 09:14-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -110,13 +110,13 @@ msgstr ""
 msgid "Do not notify"
 msgstr ""
 
-#: enterprise/admin/forms.py:364
+#: enterprise/admin/forms.py:379
 msgid ""
 "Selected Identity Provider does not exist, please contact system "
 "administrator for more info."
 msgstr ""
 
-#: enterprise/admin/forms.py:374
+#: enterprise/admin/forms.py:389
 #, python-brace-format
 msgid ""
 "Site ({identity_provider_site}) of selected identity provider does not match "
@@ -219,48 +219,56 @@ msgid ""
 "{ec_name}"
 msgstr ""
 
-#: enterprise/admin/views.py:220
+#: enterprise/admin/views.py:226
 #, python-brace-format
 msgid "Error at line {line}: {message}\n"
 msgstr ""
 
-#: enterprise/admin/views.py:247
+#: enterprise/admin/views.py:253
 #, python-brace-format
 msgid "{count} new user was linked to {enterprise_customer_name}."
 msgid_plural "{count} new users were linked to {enterprise_customer_name}."
 msgstr[0] ""
 msgstr[1] ""
 
-#: enterprise/admin/views.py:254
+#: enterprise/admin/views.py:266
 #, python-brace-format
 msgid ""
 "Some users were already linked to this Enterprise Customer: {list_of_emails}"
 msgstr ""
 
-#: enterprise/admin/views.py:261
+#: enterprise/admin/views.py:274
+#, python-brace-format
+msgid ""
+"The following learners are already associated with another Enterprise "
+"Customer. These learners were not added to {enterprise_customer_name}: "
+"{list_of_emails}"
+msgstr ""
+
+#: enterprise/admin/views.py:284
 #, python-brace-format
 msgid "Some duplicate emails in the CSV were ignored: {list_of_emails}"
 msgstr ""
 
-#: enterprise/admin/views.py:340
+#: enterprise/admin/views.py:367
 #, python-brace-format
 msgid "{enrolled_count} user was enrolled to {course_id}."
 msgid_plural "{enrolled_count} users were enrolled to {course_id}."
 msgstr[0] ""
 msgstr[1] ""
 
-#: enterprise/admin/views.py:346
+#: enterprise/admin/views.py:373
 msgid ""
 "The following users do not have an account on {}. They have not been "
 "enrolled in the course. When these users create an account, they will be "
 "enrolled in the course automatically: {}"
 msgstr ""
 
-#: enterprise/admin/views.py:375
+#: enterprise/admin/views.py:402
 msgid "Enrollment of some users failed: {}"
 msgstr ""
 
-#: enterprise/admin/views.py:501
+#: enterprise/admin/views.py:539
 #, python-brace-format
 msgid "Email {email} is not linked to Enterprise Customer {ec_name}"
 msgstr ""
@@ -312,58 +320,58 @@ msgid ""
 "at login, or if it's required when registering for eligible courses."
 msgstr ""
 
-#: enterprise/models.py:245
+#: enterprise/models.py:247
 msgid "Enterprise Customer User"
 msgstr ""
 
-#: enterprise/models.py:246
+#: enterprise/models.py:248
 msgid "Enterprise Customer Users"
 msgstr ""
 
-#: enterprise/models.py:403
+#: enterprise/models.py:405
 msgid "Please add only .PNG files for logo images."
 msgstr ""
 
-#: enterprise/models.py:411
+#: enterprise/models.py:413
 msgid "Branding Configuration"
 msgstr ""
 
-#: enterprise/models.py:412
+#: enterprise/models.py:414
 msgid "Branding Configurations"
 msgstr ""
 
-#: enterprise/models.py:525
+#: enterprise/models.py:527
 msgid ""
 "Stores whether the user linked to this model has consented to have their "
 "information shared with the linked EnterpriseCustomer."
 msgstr ""
 
-#: enterprise/models.py:566
+#: enterprise/models.py:568
 msgid "Enterprise Customer Entitlement"
 msgstr ""
 
-#: enterprise/models.py:567
+#: enterprise/models.py:569
 msgid "Enterprise Customer Entitlements"
 msgstr ""
 
-#: enterprise/models.py:574
+#: enterprise/models.py:576
 msgid ""
 "Enterprise customer's entitlement id for relationship with e-commerce coupon."
 msgstr ""
 
-#: enterprise/models.py:615
+#: enterprise/models.py:617
 msgid "The enterprise learner to which this enrollment is attached."
 msgstr ""
 
-#: enterprise/models.py:620
+#: enterprise/models.py:622
 msgid "Whether the learner has granted consent for this particular course."
 msgstr ""
 
-#: enterprise/models.py:627
+#: enterprise/models.py:629
 msgid "The course ID in which the learner was enrolled."
 msgstr ""
 
-#: enterprise/models.py:698
+#: enterprise/models.py:700
 msgid ""
 "Fill in a standard Django template that, when rendered, produces the email "
 "you want sent to newly-enrolled Enterprise Customer users. The following "
@@ -385,7 +393,7 @@ msgid ""
 "course, a program, or something else.</li></ul></ul>"
 msgstr ""
 
-#: enterprise/models.py:716
+#: enterprise/models.py:718
 #, python-brace-format
 msgid ""
 "Fill in a string that can be used to generate a dynamic subject line for "
@@ -410,7 +418,7 @@ msgid "Search email address or username"
 msgstr ""
 
 #: enterprise/templates/enterprise/admin/manage_learners.html:97
-#: enterprise/templates/enterprise/admin/manage_learners.html:123
+#: enterprise/templates/enterprise/admin/manage_learners.html:125
 msgid "User Email"
 msgstr ""
 
@@ -419,11 +427,16 @@ msgid "Username"
 msgstr ""
 
 #: enterprise/templates/enterprise/admin/manage_learners.html:99
-#: enterprise/templates/enterprise/admin/manage_learners.html:124
+#: enterprise/templates/enterprise/admin/manage_learners.html:126
 msgid "Linked Date"
 msgstr ""
 
-#: enterprise/templates/enterprise/admin/manage_learners.html:144
+#: enterprise/templates/enterprise/admin/manage_learners.html:100
+#: enterprise/templates/enterprise/admin/manage_learners.html:127
+msgid "Enroll"
+msgstr ""
+
+#: enterprise/templates/enterprise/admin/manage_learners.html:148
 msgid "Link learners"
 msgstr ""
 
@@ -501,12 +514,12 @@ msgid ""
 "auth providers."
 msgstr ""
 
-#: enterprise/utils.py:320
+#: enterprise/utils.py:321
 #, python-brace-format
 msgid "You've been enrolled in {course_name}!"
 msgstr ""
 
-#: enterprise/utils.py:376
+#: enterprise/utils.py:377
 msgid "`user` must have one of either `email` or `user_email`."
 msgstr ""
 

--- a/enterprise/conf/locale/en/LC_MESSAGES/djangojs.po
+++ b/enterprise/conf/locale/en/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-01-26 19:12-0600\n"
+"POT-Creation-Date: 2017-01-30 09:14-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,34 +21,34 @@ msgstr ""
 msgid "Enter a valid course ID"
 msgstr ""
 
-#: enterprise/static/enterprise/admin/manage_learners.js:71
+#: enterprise/static/enterprise/admin/manage_learners.js:82
 msgid "Are you sure you want to unlink %(email)s?"
 msgstr ""
 
-#: enterprise/static/enterprise/admin/manage_learners.js:103
+#: enterprise/static/enterprise/admin/manage_learners.js:114
 msgid "---------"
 msgstr ""
 
-#: enterprise/static/enterprise/admin/manage_learners.js:104
+#: enterprise/static/enterprise/admin/manage_learners.js:115
 msgid "Audit"
 msgstr ""
 
-#: enterprise/static/enterprise/admin/manage_learners.js:105
+#: enterprise/static/enterprise/admin/manage_learners.js:116
 msgid "Verified"
 msgstr ""
 
-#: enterprise/static/enterprise/admin/manage_learners.js:106
+#: enterprise/static/enterprise/admin/manage_learners.js:117
 msgid "Professional Education"
 msgstr ""
 
-#: enterprise/static/enterprise/admin/manage_learners.js:107
+#: enterprise/static/enterprise/admin/manage_learners.js:118
 msgid "Professional Education (no ID)"
 msgstr ""
 
-#: enterprise/static/enterprise/admin/manage_learners.js:108
+#: enterprise/static/enterprise/admin/manage_learners.js:119
 msgid "Credit"
 msgstr ""
 
-#: enterprise/static/enterprise/admin/manage_learners.js:109
+#: enterprise/static/enterprise/admin/manage_learners.js:120
 msgid "Honor"
 msgstr ""

--- a/enterprise/static/enterprise/admin/manage_learners.js
+++ b/enterprise/static/enterprise/admin/manage_learners.js
@@ -64,6 +64,17 @@ function switchTo(newEnrollmentMode, otherEnrollmentMode) {
     newEnrollmentMode.timeout = setTimeout(newEnrollmentMode.apply, 300);
 }
 
+function addCheckedLearnersToEnrollBox() {
+    var checkedEmailContainers = $(".enroll-checkbox:checked").parent().siblings('.email-container');
+    var checked_emails = [];
+    $.each(checkedEmailContainers, function () {
+        checked_emails.push($.trim($(this).text()));
+    });
+    if ($("#id_email_or_username").val() === "") {
+        $("#id_email_or_username").val(checked_emails.join(", "));
+    }
+}
+
 function loadPage() {
     $("table.learners-table .delete-cell input[type='button']").click(function () {
         var $row = $(this).parents("tr");
@@ -118,7 +129,6 @@ function loadPage() {
         console.log("Handling "+evt.type+" on program ID input");
         switchTo(programEnrollment, courseEnrollment);
     });
-
     courseEnrollment.$control.parents("form").on("submit", function() {
        courseEnrollment.$control.oldValue = null;
        programEnrollment.$control.oldValue = null;
@@ -129,6 +139,7 @@ function loadPage() {
     } else if (programEnrollment.$control.val()) {
         programEnrollment.$control.trigger("input");
     }
+    $("#learner-management-form").submit(addCheckedLearnersToEnrollBox);
 }
 
 $(loadPage());

--- a/enterprise/templates/enterprise/admin/manage_learners.html
+++ b/enterprise/templates/enterprise/admin/manage_learners.html
@@ -97,19 +97,21 @@ global Javascript variables that can be used in any of the loaded packages.
         <th>{% trans "User Email" %}</th>
         <th>{% trans "Username" %}</th>
         <th>{% trans "Linked Date" %}</th>
+        <th>{% trans "Enroll" %}</th>
         <th></th>
       </tr>
       </thead>
       <tbody>
       {% for learner in learners %}
       <tr class="form-row {% cycle 'row1' 'row2' %}" data-email="{{ learner.user_email }}">
-        <td>
+        <td class="email-container">
           <a href="{% url 'admin:enterprise_enterprisecustomeruser_change' learner.id %}">
             {{ learner.user_email }}
           </a>
         </td>
         <td>{{ learner.user.username }}</td>
         <td>{{ learner.created }}</td>
+        <td><input type="checkbox" class="enroll-checkbox"></td>
         <td class="delete-cell"><input type="button" value="Unlink"></td>
       </tr>
       {% endfor %}
@@ -122,18 +124,20 @@ global Javascript variables that can be used in any of the loaded packages.
       <tr>
         <th>{% trans "User Email" %}</th>
         <th>{% trans "Linked Date" %}</th>
+        <th>{% trans "Enroll" %}</th>
         <th></th>
       </tr>
       </thead>
       <tbody>
       {% for learner in pending_learners %}
       <tr class="form-row {% cycle 'row1' 'row2' %}" data-email="{{ learner.user_email }}">
-        <td>
+        <td class="email-container">
           <a href = "{% url 'admin:enterprise_pendingenterprisecustomeruser_change' learner.id %}">
             {{ learner.user_email }}
           </a>
         </td>
         <td>{{ learner.created }}</td>
+        <td><input type="checkbox" class="enroll-checkbox"></td>
         <td class="delete-cell"><input type="button" value="Unlink"></td>
       </tr>
       {% endfor %}
@@ -142,7 +146,7 @@ global Javascript variables that can be used in any of the loaded packages.
   </div>
   <div class="forms-panel">
     <h1>{% trans "Link learners" %}</h1>
-    <form action="" method="post" enctype="multipart/form-data">
+    <form action="" method="post" enctype="multipart/form-data" id="learner-management-form">
       {% csrf_token %}
       {# as_p will render the form fields wrapped in <p> tags: #}
       {{ manage_learners_form.as_p }}

--- a/spec/javascripts/enterprise_admin_spec.js
+++ b/spec/javascripts/enterprise_admin_spec.js
@@ -197,3 +197,35 @@ describe("Manage Learners form", function () {
         });
     })
 });
+
+describe("Enroll checkboxes", function () {
+
+    beforeEach(function () {
+        jasmine.getFixtures().fixturesPath = '__spec__/fixtures';
+        loadFixtures('manage_learners_form.html');
+        loadPage();
+    });
+
+    describe("when submitting the form and there is no value in the email box", function () {
+        beforeEach(function (done) {
+            result = addCheckedLearnersToEnrollBox();
+            done();
+        }, 5000);
+
+        it("fills in the email box with the emails of checked users", function () {
+            expect($("#id_email_or_username").val()).toBe('peter@yarrow.com, mary@travers.com');
+        });
+    });
+
+    describe("when submitting the form and there is a value in the email box", function () {
+        beforeEach(function (done) {
+            $("#id_email_or_username").val('john@smith.com')
+            result = addCheckedLearnersToEnrollBox();
+            done();
+        }, 5000);
+
+        it("keeps the value that was already in the box", function () {
+            expect($("#id_email_or_username").val()).toBe("john@smith.com")
+        });
+    })
+});

--- a/spec/javascripts/fixtures/manage_learners_form.html
+++ b/spec/javascripts/fixtures/manage_learners_form.html
@@ -30,4 +30,30 @@
     </p>
     <input type="submit" value="Submit">
   </form>
+  <div>
+      <div class="email-container">
+          peter@yarrow.com
+      </div>
+      <div>
+          <input type="checkbox" class="enroll-checkbox" checked>
+      </div>
+  </div>
+
+  <div>
+      <div class="email-container">
+          paul@stookey.com
+      </div>
+      <div>
+          <input type="checkbox" class="enroll-checkbox">
+      </div>
+  </div>
+
+  <div>
+      <div class="email-container">
+          mary@travers.com
+      </div>
+      <div>
+          <input type="checkbox" class="enroll-checkbox" checked>
+      </div>
+  </div>
 </div>


### PR DESCRIPTION
**Description:**

This pull request adds two main capabilities; one which was the goal, and one which was a side effect of the goal:

1. Admin users can select multiple existing EnterpriseCustomerUsers and PendingEnterpriseCustomerUsers to be enrolled in a course that they choose using the standard enrollment form, which is also used to link new users.

2. Users may enter comma-separated values in the enrollment form, rather than just upload a CSV file, to process multiple linkings/enrollments at once.

**JIRA:** [ENT-95](https://openedx.atlassian.net/browse/ENT-95)

**Dependencies:** Pending pull request from @e-kolpakov to have the ability to enroll users in Programs as well as courses. Should also wait on #26 so that we can put the new Javascript stuff under Jasmine testing.

**Merge deadline:** 2017-01-30

**Screenshots:**

![screen shot 2017-01-12 at 11 12 13 pm](https://cloud.githubusercontent.com/assets/7773758/21918224/279d0c64-d91d-11e6-975b-81b60c98cc9b.png)

**Sandbox:** TBD (pending deployment)

**Testing instructions:**

1. Install this app in a devstack (you may need to remove `edx-enterprise` from `requirements/edx/base.txt` to stop paver from trying to reinstall the pip version every time you run the server)
1. In the LMS admin panel, go to the Enterprise section
2. Create an EnterpriseCustomer - the details aren't important, since we don't need SSO
3. In the EnterpriseCustomer page, open the Manage Learners page
4. Add some Learners and Pending Learners one at a time by entering email addresses and usernames in the box to the right of the screen - don't enroll them in courses.
2. Check the "enroll" boxes of a few Learners and PendingLearners
3. Enter a valid course ID and select a valid mode for that course
4. Click Submit
5. Check that the learners you selected have been enrolled in the relevant course (if EnterpriseCustomerUsers) or have been attached to a PendingEnrollment object (if PendingEnterpriseCustomerUsers).

**Reviewers:**
- [x] @bdero 
- [ ] edX reviewers TBD 

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Commits are (reasonably) squashed
- [x] Translations are updated
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:**

1. As in #27, we're waiting on the Programs PR to finalize the work and make sure that this works in that context as well.
2. ~~This will need Jasmine testing, which we can get to once #26 is merged.~~
3. UI may need some sprucing up.