### PR TITLE
ENT-112: Resolve conflicting urls for User API endpoint.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,14 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[0.19.1] - 2017-01-30
+~~~~~~~~~~~~~~~~~~~~~
+
+Added
+-----
+
+* Resolved conflicting urls for User API endpoint.
+
 [0.19.0] - 2017-01-30
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.19.0"
+__version__ = "0.19.1"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/v1/urls.py
+++ b/enterprise/api/v1/urls.py
@@ -11,7 +11,7 @@ from enterprise.api.v1 import views
 # that is why we have disabled 'invalid-name' check for variable definition below.
 router = DefaultRouter()  # pylint: disable=invalid-name
 router.register("site", views.SiteViewSet, 'site')
-router.register("user", views.UserViewSet, 'user')
+router.register("auth-user", views.UserViewSet, 'auth-user')
 router.register("enterprise-customer", views.EnterpriseCustomerViewSet, 'enterprise-customer')
 router.register("enterprise-learner", views.EnterpriseCustomerUserViewSet, 'enterprise-learner')
 router.register("user-data-sharing-consent", views.UserDataSharingConsentAuditViewSet, 'user-data-sharing-consent')

--- a/tests/api/test_views.py
+++ b/tests/api/test_views.py
@@ -33,7 +33,7 @@ class TestEnterpriseAPIViews(APITest):
     @ddt.data(
         (
             factories.UserFactory,
-            reverse('user-list'),
+            reverse('auth-user-list'),
             itemgetter('username'),
             [
                 {


### PR DESCRIPTION
Hi @mattdrayer , @asadiqbal08 , @zubair-arbi 

Kindly take a look at this PR, URL for `users` api endpoint was conflicting with a url of edx-platform's user api endpoint. 

__Description of Changes:__
edx-platform defines API endpoint for `User` model coming from `django.contrib.auth` app, these endpoints are defined [here](https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/user_api/serializers.py#L14) and [here](https://github.com/edx/edx-platform/blob/master/lms/djangoapps/mobile_api/users/serializers.py#L105). These urls were conflicting with the one added in https://github.com/edx/edx-enterprise/pull/30. So, I renamed urls to a unique pattern so that they do not conflict with existing ones.
