### PR TITLE
ENT-134/ENT-162: Add option to defer enrollments in the course-specific consent gate

### DIFF
--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.22.0"
+__version__ = "0.23.0"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/permissions.py
+++ b/enterprise/api/permissions.py
@@ -1,0 +1,26 @@
+"""
+Permission classes for the Enterprise API.
+"""
+from __future__ import absolute_import, unicode_literals
+
+from rest_framework import permissions
+
+from enterprise.api.utils import get_service_usernames
+
+
+class IsServiceUserOrReadOnly(permissions.IsAuthenticated):
+    """
+    This request is authenticated as a service user, or is a read-only request.
+    """
+
+    def has_permission(self, request, view):
+        """
+        Enforce that the user is authenticated. If the request isn't read-only (unsafe), then deny permission unless
+        the user is a service user.
+        """
+        service_users = get_service_usernames()
+
+        return (
+            request.method in permissions.SAFE_METHODS or
+            request.user.username in service_users
+        )

--- a/enterprise/api/throttles.py
+++ b/enterprise/api/throttles.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, unicode_literals
 
 from rest_framework.throttling import UserRateThrottle
 
-from django.conf import settings
+from enterprise.api.utils import get_service_usernames
 
 SERVICE_USER_SCOPE = 'service_user'
 
@@ -36,10 +36,7 @@ class ServiceUserThrottle(UserRateThrottle):
             }
             ```
         """
-        service_users = {
-            getattr(settings, 'ECOMMERCE_SERVICE_WORKER_USERNAME', None),
-            getattr(settings, 'ENTERPRISE_SERVICE_WORKER_USERNAME', None),
-        }
+        service_users = get_service_usernames()
 
         # User service user throttling rates for service user.
         if request.user.username in service_users:

--- a/enterprise/api/utils.py
+++ b/enterprise/api/utils.py
@@ -1,0 +1,19 @@
+"""
+Utility functions for the Enterprise API.
+"""
+from __future__ import absolute_import, unicode_literals
+
+from django.conf import settings
+
+
+SERVICE_USERNAMES = (
+    'ECOMMERCE_SERVICE_WORKER_USERNAME',
+    'ENTERPRISE_SERVICE_WORKER_USERNAME'
+)
+
+
+def get_service_usernames():
+    """
+    Return the set of service usernames that are given extended permissions in the API.
+    """
+    return {getattr(settings, username, None) for username in SERVICE_USERNAMES}

--- a/enterprise/api/v1/urls.py
+++ b/enterprise/api/v1/urls.py
@@ -12,6 +12,11 @@ from enterprise.api.v1 import views
 router = DefaultRouter()  # pylint: disable=invalid-name
 router.register("site", views.SiteViewSet, 'site')
 router.register("auth-user", views.UserViewSet, 'auth-user')
+router.register(
+    "enterprise-course-enrollment",
+    views.EnterpriseCourseEnrollmentViewSet,
+    'enterprise-course-enrollment'
+)
 router.register("enterprise-customer", views.EnterpriseCustomerViewSet, 'enterprise-customer')
 router.register("enterprise-learner", views.EnterpriseCustomerUserViewSet, 'enterprise-learner')
 router.register("user-data-sharing-consent", views.UserDataSharingConsentAuditViewSet, 'user-data-sharing-consent')

--- a/enterprise/templates/enterprise/grant_data_sharing_permissions.html
+++ b/enterprise/templates/enterprise/grant_data_sharing_permissions.html
@@ -61,6 +61,9 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json
                     % if redirect_url:
                         <input type="hidden" name="redirect_url" value="${redirect_url}" />
                     % endif
+                    % if enrollment_deferred:
+                        <input type="hidden" name="enrollment_deferred" value="true" />
+                    % endif
                     <button type="submit" class="action-primary action">Submit</button>
                     <p class="note">*${ messages['note'] }
                 </form>

--- a/test_utils/factories.py
+++ b/test_utils/factories.py
@@ -11,7 +11,7 @@ from faker import Factory as FakerFactory
 from django.contrib.auth.models import User
 from django.contrib.sites.models import Site
 
-from enterprise.models import (EnterpriseCustomer, EnterpriseCustomerBrandingConfiguration,
+from enterprise.models import (EnterpriseCourseEnrollment, EnterpriseCustomer, EnterpriseCustomerBrandingConfiguration,
                                EnterpriseCustomerEntitlement, EnterpriseCustomerIdentityProvider,
                                EnterpriseCustomerUser, PendingEnrollment, PendingEnterpriseCustomerUser,
                                UserDataSharingConsentAudit)
@@ -199,3 +199,23 @@ class EnterpriseCustomerEntitlementFactory(factory.django.DjangoModelFactory):
     id = factory.LazyAttribute(lambda x: FAKER.random_int(min=1))  # pylint: disable=invalid-name
     entitlement_id = factory.LazyAttribute(lambda x: FAKER.random_int(min=1))
     enterprise_customer = factory.SubFactory(EnterpriseCustomerFactory)
+
+
+class EnterpriseCourseEnrollmentFactory(factory.django.DjangoModelFactory):
+    """
+    EnterpriseCourseEnrollment factory.
+
+    Creates an instance of EnterpriseCourseEnrollment with minimal boilerplate.
+    """
+
+    class Meta(object):
+        """
+        Meta for EnterpriseCourseEnrollmentFactory.
+        """
+
+        model = EnterpriseCourseEnrollment
+
+    id = factory.LazyAttribute(lambda x: FAKER.random_int(min=1))  # pylint: disable=invalid-name
+    course_id = factory.LazyAttribute(lambda x: FAKER.slug())
+    consent_granted = True
+    enterprise_customer_user = factory.SubFactory(EnterpriseCustomerUserFactory)


### PR DESCRIPTION
This allows for ecommerce to collect consent by redirecting users
to the usual enterprise data consent page before the user has an
EnterpriseCourseEnrollment.

**JIRA tickets**: ENT-134.

**Discussions**: Architecture discussed extensively on the wiki and in meetings, then the revised proposal was presented to the Arch Council on Oct. 21 and given thumbs up.

**Dependencies**: None

**Testing instructions**:

Test this PR by following the testing instructions on https://github.com/edx/ecommerce/pull/1127.

**Reviewers**
- [x] @mtyaka 
- [ ] edX reviewer[s] TBD