### PR TITLE
ENT-97: Add txt templates

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,4 @@ include CHANGELOG.rst
 include CONTRIBUTING.rst
 include LICENSE.txt
 include README.rst
-recursive-include enterprise *.html *.png *.gif *js *.css *jpg *jpeg *svg *py
+recursive-include enterprise *.html *.png *.gif *js *.css *jpg *jpeg *svg *py *.txt

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.21.0"
+__version__ = "0.21.1"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name


### PR DESCRIPTION
Adds *.txt to the manifest so that templates like `user_notification.txt` are include in the distribution.

**JIRA tickets**: [ENT-97](https://openedx.atlassian.net/browse/ENT-97)

**Discussions**: See stacktrace reported in [this comment](https://openedx.atlassian.net/browse/ENT-97?focusedCommentId=240522&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-240522)

**Merge deadline**: ASAP - as this is holding up feature development

**Testing instructions**:

To verify the issue:
1. Clone this repo at master.
1. Create a virtualenv, and install the requirements with `make requirements`
1. Create a distribution tar file by running `python setup.py sdist`
1. Dump the list of files included in the tar file using `tar xfz dist/edx-enterprise-0.21.0.tar.gz`.
1. Note this file is missing from the list: `enterprise/templates/enterprise/emails/user_notification.txt`.

To verify the fix:
1. Checkout this PR's branch, `jill/add-text-templates`
1. Repeat steps 3-4 above.  This will generate `dist/edx-enterprise-0.21.1.tar.gz`
1. Note that this file is now present in the list: `enterprise/templates/enterprise/emails/user_notification.txt`

**Reviewers**
- [ ] @bdero 
- [ ] edX reviewer[s] TBD