### PR TITLE
ENT-181: Add API endpoint to fetch enterprise learner entitlements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ----------
 
+[0.22.0] - 2017-02-14
+---------------------
+
+* Added API endpoint for fetching entitlements available to an enterprise learner
+
+
 [0.21.2] - 2017-02-07
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.21.2"
+__version__ = "0.22.0"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -97,3 +97,27 @@ class EnterpriseCustomerUserSerializer(serializers.ModelSerializer):
     user = UserSerializer()
     enterprise_customer = EnterpriseCustomerSerializer()
     data_sharing_consent = UserDataSharingConsentAuditSerializer(many=True)
+
+
+class EnterpriseCustomerUserEntitlementSerializer(serializers.Serializer):
+    """
+    Serializer for the entitlements of EnterpriseCustomerUser.
+
+    This Serializer is for read only endpoint of enterprise learner's entitlements
+    It will ignore any state changing requests like POST, PUT and PATCH.
+    """
+    entitlements = serializers.ListField(
+        child=serializers.DictField()
+    )
+
+    def create(self, validated_data):
+        """
+        Do not perform any operations for state changing requests.
+        """
+        pass
+
+    def update(self, instance, validated_data):
+        """
+        Do not perform any operations for state changing requests.
+        """
+        pass

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -6,6 +6,8 @@ from __future__ import absolute_import, unicode_literals
 from edx_rest_framework_extensions.authentication import BearerAuthentication, JwtAuthentication
 from rest_framework import filters, permissions, viewsets
 from rest_framework.authentication import SessionAuthentication
+from rest_framework.decorators import detail_route
+from rest_framework.response import Response
 from rest_framework_oauth.authentication import OAuth2Authentication
 
 from django.contrib.auth.models import User
@@ -81,6 +83,26 @@ class EnterpriseCustomerUserViewSet(EnterpriseReadOnlyModelViewSet):
     )
     filter_fields = FIELDS
     ordering_fields = FIELDS
+
+    @detail_route()
+    def entitlements(self, request, pk=None):  # pylint: disable=invalid-name,unused-argument
+        """
+        Retrieve the list of entitlements available to this learner.
+
+        Only those entitlements are returned that satisfy enterprise customer's data sharing setting.
+
+        Arguments:
+            request (HttpRequest): Reference to in progress request instance.
+            pk (Int): Primary key value of the selected enterprise learner.
+
+        Returns:
+            (HttpResponse): Response object containing a list of learner's entitlements.
+        """
+        enterprise_customer_user = self.get_object()
+
+        instance = {"entitlements": enterprise_customer_user.entitlements}
+        serializer = serializers.EnterpriseCustomerUserEntitlementSerializer(instance, context={'request': request})
+        return Response(serializer.data)
 
 
 class EnterpriseCustomerBrandingConfigurationViewSet(EnterpriseReadOnlyModelViewSet):

--- a/tests/api/test_serializers.py
+++ b/tests/api/test_serializers.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for the `edx-enterprise` serializer module.
+"""
+
+from __future__ import absolute_import, unicode_literals
+
+from pytest import mark
+
+from enterprise.api.v1.serializers import EnterpriseCustomerUserEntitlementSerializer
+from test_utils import APITest, factories
+
+
+@mark.django_db
+class TestEnterpriseCustomerUserEntitlementSerializer(APITest):
+    """
+    Tests for enterprise API serializers.
+    """
+
+    def setUp(self):
+        """
+        Perform operations common for all tests.
+
+        Populate data base for api testing.
+        """
+        super(TestEnterpriseCustomerUserEntitlementSerializer, self).setUp()
+
+        self.instance = factories.EnterpriseCustomerEntitlementFactory.create()
+        self.validated_data = {"entitlements": [1, 2, 3]}
+
+        self.serializer = EnterpriseCustomerUserEntitlementSerializer(
+            {"entitlements": [1, 2, 3, 4, 5]}
+        )
+
+    def test_update(self):
+        """
+        Test update method of EnterpriseCustomerUserEntitlementSerializer.
+
+        Verify that update for EnterpriseCustomerUserEntitlementSerializer returns
+        successfully without making any changes.
+        """
+        with self.assertNumQueries(0):
+            self.serializer.update(self.instance, self.validated_data)
+
+    def test_create(self):
+        """
+        Test create method of EnterpriseCustomerUserEntitlementSerializer.
+
+        Verify that create for EnterpriseCustomerUserEntitlementSerializer returns
+        successfully without making any changes.
+        """
+        with self.assertNumQueries(0):
+            self.serializer.create(self.validated_data)

--- a/tests/api/test_views.py
+++ b/tests/api/test_views.py
@@ -12,6 +12,7 @@ from rest_framework.reverse import reverse
 
 from django.conf import settings
 
+from enterprise.models import EnterpriseCustomer, UserDataSharingConsentAudit
 from test_utils import APITest, factories
 
 
@@ -199,8 +200,228 @@ class TestEnterpriseAPIViews(APITest):
         Make sure API end point returns all of the expected fields.
         """
         self.create_items(factory, model_items)
-        # import pdb; pdb.set_trace()
         response = self.client.get(settings.TEST_SERVER + url)
         response = self.load_json(response.content)
 
         assert sorted(expected_json, key=sorting_key) == sorted(response['results'], key=sorting_key)
+
+    @ddt.data(
+        (
+            True, EnterpriseCustomer.AT_LOGIN, UserDataSharingConsentAudit.ENABLED,
+            [1, 2, 3],
+            {"entitlements": [
+                {"entitlement_id": 1, "requires_consent": False},
+                {"entitlement_id": 2, "requires_consent": False},
+                {"entitlement_id": 3, "requires_consent": False},
+            ]},
+        ),
+        (
+            True, EnterpriseCustomer.AT_LOGIN, UserDataSharingConsentAudit.DISABLED,
+            [1, 2, 3], {"entitlements": []},
+        ),
+        (
+            True, EnterpriseCustomer.AT_LOGIN, UserDataSharingConsentAudit.NOT_SET,
+            [1, 2, 3], {"entitlements": []},
+        ),
+        (
+            True, EnterpriseCustomer.AT_ENROLLMENT, UserDataSharingConsentAudit.ENABLED,
+            [1, 2, 3], {"entitlements": [
+                {"entitlement_id": 1, "requires_consent": False},
+                {"entitlement_id": 2, "requires_consent": False},
+                {"entitlement_id": 3, "requires_consent": False},
+            ]},
+        ),
+        (
+            True, EnterpriseCustomer.AT_ENROLLMENT, UserDataSharingConsentAudit.DISABLED,
+            [1, 2, 3], {"entitlements": [
+                {"entitlement_id": 1, "requires_consent": True},
+                {"entitlement_id": 2, "requires_consent": True},
+                {"entitlement_id": 3, "requires_consent": True},
+            ]},
+        ),
+        (
+            True, EnterpriseCustomer.AT_ENROLLMENT, UserDataSharingConsentAudit.NOT_SET,
+            [1, 2, 3], {"entitlements": [
+                {"entitlement_id": 1, "requires_consent": True},
+                {"entitlement_id": 2, "requires_consent": True},
+                {"entitlement_id": 3, "requires_consent": True},
+            ]},
+        ),
+        (
+            True, EnterpriseCustomer.DATA_CONSENT_OPTIONAL, UserDataSharingConsentAudit.ENABLED,
+            [1, 2, 3], {"entitlements": [
+                {"entitlement_id": 1, "requires_consent": False},
+                {"entitlement_id": 2, "requires_consent": False},
+                {"entitlement_id": 3, "requires_consent": False},
+            ]},
+        ),
+        (
+            True, EnterpriseCustomer.DATA_CONSENT_OPTIONAL, UserDataSharingConsentAudit.DISABLED,
+            [1, 2, 3], {"entitlements": [
+                {"entitlement_id": 1, "requires_consent": False},
+                {"entitlement_id": 2, "requires_consent": False},
+                {"entitlement_id": 3, "requires_consent": False},
+            ]},
+        ),
+        (
+            True, EnterpriseCustomer.DATA_CONSENT_OPTIONAL, UserDataSharingConsentAudit.NOT_SET,
+            [1, 2, 3], {"entitlements": [
+                {"entitlement_id": 1, "requires_consent": False},
+                {"entitlement_id": 2, "requires_consent": False},
+                {"entitlement_id": 3, "requires_consent": False},
+            ]},
+        ),
+        (
+            False, EnterpriseCustomer.AT_LOGIN, UserDataSharingConsentAudit.ENABLED,
+            [1, 2, 3], {"entitlements": [
+                {"entitlement_id": 1, "requires_consent": False},
+                {"entitlement_id": 2, "requires_consent": False},
+                {"entitlement_id": 3, "requires_consent": False},
+            ]},
+        ),
+        (
+            False, EnterpriseCustomer.AT_LOGIN, UserDataSharingConsentAudit.DISABLED,
+            [1, 2, 3], {"entitlements": [
+                {"entitlement_id": 1, "requires_consent": False},
+                {"entitlement_id": 2, "requires_consent": False},
+                {"entitlement_id": 3, "requires_consent": False},
+            ]},
+        ),
+        (
+            False, EnterpriseCustomer.AT_LOGIN, UserDataSharingConsentAudit.NOT_SET,
+            [1, 2, 3], {"entitlements": [
+                {"entitlement_id": 1, "requires_consent": False},
+                {"entitlement_id": 2, "requires_consent": False},
+                {"entitlement_id": 3, "requires_consent": False},
+            ]},
+        ),
+        (
+            False, EnterpriseCustomer.AT_ENROLLMENT, UserDataSharingConsentAudit.ENABLED,
+            [1, 2, 3], {"entitlements": [
+                {"entitlement_id": 1, "requires_consent": False},
+                {"entitlement_id": 2, "requires_consent": False},
+                {"entitlement_id": 3, "requires_consent": False},
+            ]},
+        ),
+        (
+            False, EnterpriseCustomer.AT_ENROLLMENT, UserDataSharingConsentAudit.DISABLED,
+            [1, 2, 3], {"entitlements": [
+                {"entitlement_id": 1, "requires_consent": False},
+                {"entitlement_id": 2, "requires_consent": False},
+                {"entitlement_id": 3, "requires_consent": False},
+            ]},
+        ),
+        (
+            False, EnterpriseCustomer.AT_ENROLLMENT, UserDataSharingConsentAudit.NOT_SET,
+            [1, 2, 3], {"entitlements": [
+                {"entitlement_id": 1, "requires_consent": False},
+                {"entitlement_id": 2, "requires_consent": False},
+                {"entitlement_id": 3, "requires_consent": False},
+            ]},
+        ),
+        (
+            False, EnterpriseCustomer.DATA_CONSENT_OPTIONAL, UserDataSharingConsentAudit.ENABLED,
+            [1, 2, 3], {"entitlements": [
+                {"entitlement_id": 1, "requires_consent": False},
+                {"entitlement_id": 2, "requires_consent": False},
+                {"entitlement_id": 3, "requires_consent": False},
+            ]},
+        ),
+        (
+            False, EnterpriseCustomer.DATA_CONSENT_OPTIONAL, UserDataSharingConsentAudit.DISABLED,
+            [1, 2, 3], {"entitlements": [
+                {"entitlement_id": 1, "requires_consent": False},
+                {"entitlement_id": 2, "requires_consent": False},
+                {"entitlement_id": 3, "requires_consent": False},
+            ]},
+        ),
+        (
+            False, EnterpriseCustomer.DATA_CONSENT_OPTIONAL, UserDataSharingConsentAudit.NOT_SET,
+            [1, 2, 3], {"entitlements": [
+                {"entitlement_id": 1, "requires_consent": False},
+                {"entitlement_id": 2, "requires_consent": False},
+                {"entitlement_id": 3, "requires_consent": False},
+            ]},
+        ),
+        (
+            True, EnterpriseCustomer.AT_LOGIN, UserDataSharingConsentAudit.ENABLED,
+            [], {"entitlements": []},
+        ),
+        (
+            True, EnterpriseCustomer.AT_LOGIN, UserDataSharingConsentAudit.DISABLED,
+            [], {"entitlements": []},
+        ),
+        (
+            True, EnterpriseCustomer.AT_LOGIN, UserDataSharingConsentAudit.NOT_SET,
+            [], {"entitlements": []},
+        ),
+        (
+            True, EnterpriseCustomer.AT_ENROLLMENT, UserDataSharingConsentAudit.ENABLED,
+            [], {"entitlements": []},
+        ),
+        (
+            True, EnterpriseCustomer.AT_ENROLLMENT, UserDataSharingConsentAudit.DISABLED,
+            [], {"entitlements": []},
+        ),
+        (
+            True, EnterpriseCustomer.AT_ENROLLMENT, UserDataSharingConsentAudit.NOT_SET,
+            [], {"entitlements": []},
+        ),
+        (
+            True, EnterpriseCustomer.DATA_CONSENT_OPTIONAL, UserDataSharingConsentAudit.ENABLED,
+            [], {"entitlements": []},
+        ),
+        (
+            True, EnterpriseCustomer.DATA_CONSENT_OPTIONAL, UserDataSharingConsentAudit.DISABLED,
+            [], {"entitlements": []},
+        ),
+        (
+            True, EnterpriseCustomer.DATA_CONSENT_OPTIONAL, UserDataSharingConsentAudit.NOT_SET,
+            [], {"entitlements": []},
+        ),
+    )
+    @ddt.unpack
+    def test_enterprise_learner_entitlements(
+            self, enable_data_sharing_consent, enforce_data_sharing_consent,
+            learner_consent_state, entitlements, expected_json
+    ):
+        """
+        Test that entitlement details route on enterprise learner returns correct data.
+
+        This test verifies that entitlements returned by entitlement details route on enterprise learner
+        has the expected behavior as listed down.
+            1. Empty entitlements list if enterprise customer requires data sharing consent
+                (this includes enforcing data sharing consent at login and at enrollment) and enterprise learner
+                 does not consent to share data.
+            2. Full list of entitlements for all other cases.
+
+        Arguments:
+            enable_data_sharing_consent (bool): True if enterprise customer enables data sharing consent,
+                False it does not.
+            enforce_data_sharing_consent (str): string for the location at which enterprise customer enforces
+                data sharing consent, possible values are 'at_login', 'at_enrollment' and 'optional'.
+            learner_consent_state (str): string containing the state of learner consent on data sharing,
+                possible values are 'not_set', 'enabled' and 'disabled'.
+            entitlements (list): A list of integers pointing to voucher ids generated in E-Commerce CAT tool.
+            expected_json (dict): A dict with structure and values corresponding to
+                the expected json from API endpoint.
+        """
+        user_id = 1
+        enterprise_customer = factories.EnterpriseCustomerFactory(
+            enable_data_sharing_consent=enable_data_sharing_consent,
+            enforce_data_sharing_consent=enforce_data_sharing_consent,
+        )
+        factories.UserDataSharingConsentAuditFactory(
+            user__id=user_id,
+            user__enterprise_customer=enterprise_customer,
+            state=learner_consent_state,
+        )
+        for entitlement in entitlements:
+            factories.EnterpriseCustomerEntitlementFactory(
+                enterprise_customer=enterprise_customer,
+                entitlement_id=entitlement,
+            )
+        url = reverse('enterprise-learner-entitlements', (user_id, ))
+        response = self.client.get(settings.TEST_SERVER + url)
+        response = self.load_json(response.content)
+        assert sorted(response) == sorted(expected_json)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,6 +6,7 @@ Tests for the `edx-enterprise` models module.
 from __future__ import absolute_import, unicode_literals, with_statement
 
 import unittest
+from operator import itemgetter
 
 import ddt
 import mock
@@ -19,15 +20,17 @@ from django.core.files.storage import Storage
 
 from enterprise.models import (EnrollmentNotificationEmailTemplate, EnterpriseCourseEnrollment, EnterpriseCustomer,
                                EnterpriseCustomerBrandingConfiguration, EnterpriseCustomerEntitlement,
-                               EnterpriseCustomerUser, PendingEnterpriseCustomerUser, logo_path)
+                               EnterpriseCustomerUser, PendingEnterpriseCustomerUser, UserDataSharingConsentAudit,
+                               logo_path)
 from integrated_channels.integrated_channel.models import (EnterpriseCustomerPluginConfiguration,
                                                            EnterpriseIntegratedChannel)
 from integrated_channels.sap_success_factors.models import (CatalogTransmissionAudit, LearnerDataTransmissionAudit,
                                                             SAPSuccessFactorsEnterpriseCustomerConfiguration,
                                                             SAPSuccessFactorsGlobalConfiguration)
-from test_utils.factories import (EnterpriseCustomerFactory, EnterpriseCustomerIdentityProviderFactory,
-                                  EnterpriseCustomerUserFactory, PendingEnrollmentFactory,
-                                  PendingEnterpriseCustomerUserFactory, UserDataSharingConsentAuditFactory, UserFactory)
+from test_utils.factories import (EnterpriseCustomerEntitlementFactory, EnterpriseCustomerFactory,
+                                  EnterpriseCustomerIdentityProviderFactory, EnterpriseCustomerUserFactory,
+                                  PendingEnrollmentFactory, PendingEnterpriseCustomerUserFactory,
+                                  UserDataSharingConsentAuditFactory, UserFactory)
 
 
 @mark.django_db
@@ -383,6 +386,197 @@ class TestEnterpriseCustomerUser(unittest.TestCase):
     def test_user_email_property_user_missing(self):
         enterprise_customer_user = EnterpriseCustomerUserFactory(user_id=42)
         assert enterprise_customer_user.user_email is None
+
+    @ddt.data(
+        (
+            True, EnterpriseCustomer.AT_LOGIN, UserDataSharingConsentAudit.ENABLED, [1, 2, 3],
+            [
+                {"entitlement_id": 1, "requires_consent": False},
+                {"entitlement_id": 2, "requires_consent": False},
+                {"entitlement_id": 3, "requires_consent": False},
+            ],
+        ),
+        (
+            True, EnterpriseCustomer.AT_LOGIN, UserDataSharingConsentAudit.DISABLED, [1, 2, 3], [],
+        ),
+        (
+            True, EnterpriseCustomer.AT_LOGIN, UserDataSharingConsentAudit.NOT_SET, [1, 2, 3], [],
+        ),
+        (
+            True, EnterpriseCustomer.AT_ENROLLMENT, UserDataSharingConsentAudit.ENABLED, [1, 2, 3],
+            [
+                {"entitlement_id": 1, "requires_consent": False},
+                {"entitlement_id": 2, "requires_consent": False},
+                {"entitlement_id": 3, "requires_consent": False},
+            ],
+        ),
+        (
+            True, EnterpriseCustomer.AT_ENROLLMENT, UserDataSharingConsentAudit.DISABLED, [1, 2, 3],
+            [
+                {"entitlement_id": 1, "requires_consent": True},
+                {"entitlement_id": 2, "requires_consent": True},
+                {"entitlement_id": 3, "requires_consent": True},
+            ],
+        ),
+        (
+            True, EnterpriseCustomer.AT_ENROLLMENT, UserDataSharingConsentAudit.NOT_SET, [1, 2, 3],
+            [
+                {"entitlement_id": 1, "requires_consent": True},
+                {"entitlement_id": 2, "requires_consent": True},
+                {"entitlement_id": 3, "requires_consent": True},
+            ],
+        ),
+        (
+            True, EnterpriseCustomer.DATA_CONSENT_OPTIONAL, UserDataSharingConsentAudit.ENABLED, [1, 2, 3],
+            [
+                {"entitlement_id": 1, "requires_consent": False},
+                {"entitlement_id": 2, "requires_consent": False},
+                {"entitlement_id": 3, "requires_consent": False},
+            ],
+        ),
+        (
+            True, EnterpriseCustomer.DATA_CONSENT_OPTIONAL, UserDataSharingConsentAudit.DISABLED, [1, 2, 3],
+            [
+                {"entitlement_id": 1, "requires_consent": False},
+                {"entitlement_id": 2, "requires_consent": False},
+                {"entitlement_id": 3, "requires_consent": False},
+            ],
+        ),
+        (
+            True, EnterpriseCustomer.DATA_CONSENT_OPTIONAL, UserDataSharingConsentAudit.NOT_SET, [1, 2, 3],
+            [
+                {"entitlement_id": 1, "requires_consent": False},
+                {"entitlement_id": 2, "requires_consent": False},
+                {"entitlement_id": 3, "requires_consent": False},
+            ],
+        ),
+        (
+            False, EnterpriseCustomer.AT_LOGIN, UserDataSharingConsentAudit.ENABLED, [1, 2, 3],
+            [
+                {"entitlement_id": 1, "requires_consent": False},
+                {"entitlement_id": 2, "requires_consent": False},
+                {"entitlement_id": 3, "requires_consent": False},
+            ],
+        ),
+        (
+            False, EnterpriseCustomer.AT_LOGIN, UserDataSharingConsentAudit.DISABLED, [1, 2, 3],
+            [
+                {"entitlement_id": 1, "requires_consent": False},
+                {"entitlement_id": 2, "requires_consent": False},
+                {"entitlement_id": 3, "requires_consent": False},
+            ],
+        ),
+        (
+            False, EnterpriseCustomer.AT_LOGIN, UserDataSharingConsentAudit.NOT_SET, [1, 2, 3],
+            [
+                {"entitlement_id": 1, "requires_consent": False},
+                {"entitlement_id": 2, "requires_consent": False},
+                {"entitlement_id": 3, "requires_consent": False},
+            ],
+        ),
+        (
+            False, EnterpriseCustomer.AT_ENROLLMENT, UserDataSharingConsentAudit.ENABLED, [1, 2, 3],
+            [
+                {"entitlement_id": 1, "requires_consent": False},
+                {"entitlement_id": 2, "requires_consent": False},
+                {"entitlement_id": 3, "requires_consent": False},
+            ],
+        ),
+        (
+            False, EnterpriseCustomer.AT_ENROLLMENT, UserDataSharingConsentAudit.DISABLED, [1, 2, 3],
+            [
+                {"entitlement_id": 1, "requires_consent": False},
+                {"entitlement_id": 2, "requires_consent": False},
+                {"entitlement_id": 3, "requires_consent": False},
+            ],
+        ),
+        (
+            False, EnterpriseCustomer.AT_ENROLLMENT, UserDataSharingConsentAudit.NOT_SET, [1, 2, 3],
+            [
+                {"entitlement_id": 1, "requires_consent": False},
+                {"entitlement_id": 2, "requires_consent": False},
+                {"entitlement_id": 3, "requires_consent": False},
+            ],
+        ),
+        (
+            False, EnterpriseCustomer.DATA_CONSENT_OPTIONAL, UserDataSharingConsentAudit.ENABLED, [1, 2, 3],
+            [
+                {"entitlement_id": 1, "requires_consent": False},
+                {"entitlement_id": 2, "requires_consent": False},
+                {"entitlement_id": 3, "requires_consent": False},
+            ],
+        ),
+        (
+            False, EnterpriseCustomer.DATA_CONSENT_OPTIONAL, UserDataSharingConsentAudit.DISABLED, [1, 2, 3],
+            [
+                {"entitlement_id": 1, "requires_consent": False},
+                {"entitlement_id": 2, "requires_consent": False},
+                {"entitlement_id": 3, "requires_consent": False},
+            ],
+        ),
+        (
+            False, EnterpriseCustomer.DATA_CONSENT_OPTIONAL, UserDataSharingConsentAudit.NOT_SET, [1, 2, 3],
+            [
+                {"entitlement_id": 1, "requires_consent": False},
+                {"entitlement_id": 2, "requires_consent": False},
+                {"entitlement_id": 3, "requires_consent": False},
+            ]
+        ),
+        (True, EnterpriseCustomer.AT_LOGIN, UserDataSharingConsentAudit.ENABLED, [], []),
+        (True, EnterpriseCustomer.AT_LOGIN, UserDataSharingConsentAudit.DISABLED, [], []),
+        (True, EnterpriseCustomer.AT_LOGIN, UserDataSharingConsentAudit.NOT_SET, [], []),
+        (True, EnterpriseCustomer.AT_ENROLLMENT, UserDataSharingConsentAudit.ENABLED, [], []),
+        (True, EnterpriseCustomer.AT_ENROLLMENT, UserDataSharingConsentAudit.DISABLED, [], []),
+        (True, EnterpriseCustomer.AT_ENROLLMENT, UserDataSharingConsentAudit.NOT_SET, [], []),
+        (True, EnterpriseCustomer.DATA_CONSENT_OPTIONAL, UserDataSharingConsentAudit.ENABLED, [], []),
+        (True, EnterpriseCustomer.DATA_CONSENT_OPTIONAL, UserDataSharingConsentAudit.DISABLED, [], []),
+        (True, EnterpriseCustomer.DATA_CONSENT_OPTIONAL, UserDataSharingConsentAudit.NOT_SET, [], []),
+    )
+    @ddt.unpack
+    def test_entitlements(
+            self, enable_data_sharing_consent, enforce_data_sharing_consent,
+            learner_consent_state, entitlements, expected_entitlements,
+    ):
+        """
+        Test that entitlement property on `EnterpriseCustomerUser` returns correct data.
+
+        This test verifies that entitlements returned by entitlement property on `EnterpriseCustomerUser
+        has the expected behavior as listed down.
+            1. Empty entitlements list if enterprise customer requires data sharing consent
+                (this includes enforcing data sharing consent at login and at enrollment) and enterprise learner
+                 does not consent to share data.
+            2. Full list of entitlements for all other cases.
+
+        Arguments:
+            enable_data_sharing_consent (bool): True if enterprise customer enables data sharing consent,
+                False it does not.
+            enforce_data_sharing_consent (str): string for the location at which enterprise customer enforces
+                data sharing consent, possible values are 'at_login', 'at_enrollment' and 'optional'.
+            learner_consent_state (str): string containing the state of learner consent on data sharing,
+                possible values are 'not_set', 'enabled' and 'disabled'.
+            entitlements (list): A list of integers pointing to voucher ids generated in E-Commerce CAT tool.
+            expected_entitlements (list): A list of integers pointing to voucher ids expected to be
+                returned by the model.
+        """
+        user_id = 1
+        enterprise_customer = EnterpriseCustomerFactory(
+            enable_data_sharing_consent=enable_data_sharing_consent,
+            enforce_data_sharing_consent=enforce_data_sharing_consent,
+        )
+        UserDataSharingConsentAuditFactory(
+            user__id=user_id,
+            user__enterprise_customer=enterprise_customer,
+            state=learner_consent_state,
+        )
+        for entitlement in entitlements:
+            EnterpriseCustomerEntitlementFactory(
+                enterprise_customer=enterprise_customer,
+                entitlement_id=entitlement,
+            )
+
+        enterprise_customer_user = EnterpriseCustomerUser.objects.get(id=user_id)
+        assert sorted(enterprise_customer_user.entitlements, key=itemgetter('entitlement_id')) == \
+            sorted(expected_entitlements, key=itemgetter('entitlement_id'))
 
 
 @mark.django_db


### PR DESCRIPTION
Hi @mattdrayer , @asadiqbal08 ,

Kindly take a look at the PR, it adds an API endpoint to fetch enterprise learner's entitlements.

__Instructions for Testing:__

1. Add an Enterprise Customer with the following configurations.
    1.  Enable data sharing consent: [x] (Checked)
    2.  Enforce data sharing consent: 'at_enrollment'
    3. Add an enterprise customer entitlement using section "Enterprise Customer Entitlements" at the bottom
2. Create three user accounts and associate them with the enterprise customer using enterprise learner management console at "http://localhost:8000/admin/enterprise/enterprisecustomer/{enterprise_customer_uuid}/manage_learners"
3. Make sure that user-1 has consented to data sharing, user-2 has not consented to data sharing and user-3 has not set any value. (If user is created and then associated with an enterprise customer its data sharing consent will be unset). Other User's data sharing consent can be set by logging in via enterprise SSO.
4. Open learner entitlements page at "http://localhost:8000/enterprise/api/v1/enterprise-learner/{enterprise_customer_id}/entitlements/". (Note: Replace {enterprise_customer_id} with enterprise customer user's id)
5. Verify that 
     1. for user-1 all entitlements are displayed
     2. for user-2  and user-3 entitlements returned are an empty list.
6. Now, open enterprise customer details page and update the following settings
    1.  Enable data sharing consent: [x] (Checked)
    2.  Enforce data sharing consent: 'optional'
7. Verify that entitlements are now displayed for all user-1, user-2, user-3. URL for enteprise learner entitlements is http://localhost:8000/enterprise/api/v1/enterprise-learner/{enterprise_customer_id}/entitlements/. (Note: Replace {enterprise_customer_id} with enterprise customer user's id)