### PR TITLE
YONK-512: changes required to upgrade from python-social-auth to split social

### DIFF
--- a/enterprise/lms_api.py
+++ b/enterprise/lms_api.py
@@ -11,7 +11,7 @@ from edx_rest_api_client.client import EdxRestApiClient
 
 from django.conf import settings
 
-from enterprise.utils import NotConnectedToEdX
+from enterprise.utils import NotConnectedToOpenEdx
 
 try:
     from opaque_keys.edx.keys import CourseKey
@@ -131,7 +131,7 @@ def enroll_user_in_course_locally(user, course_id, mode):
     can shift over to that, but for right now, we have to do it this way.
     """
     if CourseKey is None and CourseEnrollment is None:
-        raise NotConnectedToEdX("This package must be installed in an OpenEdX environment.")
+        raise NotConnectedToOpenEdx("This package must be installed in an OpenEdX environment.")
     CourseEnrollment.enroll(user, CourseKey.from_string(course_id), mode=mode, check_access=True)
 
 

--- a/enterprise/tpa_pipeline.py
+++ b/enterprise/tpa_pipeline.py
@@ -17,9 +17,12 @@ except ImportError:
 
 try:
     from third_party_auth.provider import Registry
-    from third_party_auth.pipeline import get as get_pipeline_partial
 except ImportError:
     Registry = None
+
+try:
+    from third_party_auth.pipeline import get as get_pipeline_partial
+except ImportError:
     get_pipeline_partial = None
 
 

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -182,7 +182,7 @@ def null_decorator(func):
     """
     Decorator that does nothing to the wrapped function.
 
-    If we're unable to import social.pipeline.partial, which is the case in our CI platform,
+    If we're unable to import social_core.pipeline.partial, which is the case in our CI platform,
     we need to be able to wrap the function with something.
     """
     return func

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -35,7 +35,7 @@ except ImportError:
 LOGGER = logging.getLogger(__name__)
 
 
-class NotConnectedToEdX(Exception):
+class NotConnectedToOpenEdx(Exception):
     """
     Exception to raise when not connected to OpenEdX.
 
@@ -48,7 +48,7 @@ class NotConnectedToEdX(Exception):
         Log a warning and initialize the exception.
         """
         LOGGER.warning('edx-enterprise unexpectedly failed as if not installed in an OpenEdX platform')
-        super(NotConnectedToEdX, self).__init__(*args, **kwargs)
+        super(NotConnectedToOpenEdx, self).__init__(*args, **kwargs)
 
 
 class NotConnectedToOpenEdX(Exception):

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -24,12 +24,13 @@ except ImportError:
 
 try:
     from third_party_auth.pipeline import (get_complete_url, get_real_social_auth_object, quarantine_session,
-                                           lift_quarantine)
+                                           lift_quarantine, get as get_pipeline_partial)
 except ImportError:
     get_complete_url = None
     get_real_social_auth_object = None
     quarantine_session = None
     lift_quarantine = None
+    get_pipeline_partial = None
 
 
 # isort:imports-firstparty
@@ -50,7 +51,8 @@ def verify_edx_resources():
         get_complete_url,
         get_real_social_auth_object,
         quarantine_session,
-        lift_quarantine
+        lift_quarantine,
+        get_pipeline_partial,
     )
     if any(method is None for method in required_methods):
         raise NotConnectedToEdX(_('Methods in the Open edX platform necessary for this view are not available.'))
@@ -314,7 +316,7 @@ class GrantDataSharingPermissions(View):
         )
 
         # Resume auth pipeline
-        backend_name = request.session.get('partial_pipeline', {}).get('backend')
+        backend_name = get_pipeline_partial(request).get('backend')
         return redirect(get_complete_url(backend_name))
 
     def post(self, request):

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -38,7 +38,7 @@ from enterprise.lms_api import CourseApiClient
 from enterprise.models import (EnterpriseCourseEnrollment, EnterpriseCustomer, EnterpriseCustomerUser,
                                UserDataSharingConsentAudit)
 from enterprise.tpa_pipeline import active_provider_enforces_data_sharing, get_enterprise_customer_for_request
-from enterprise.utils import NotConnectedToEdX, consent_necessary_for_course
+from enterprise.utils import NotConnectedToOpenEdx, consent_necessary_for_course
 
 
 def verify_edx_resources():
@@ -55,7 +55,7 @@ def verify_edx_resources():
         get_pipeline_partial,
     )
     if any(method is None for method in required_methods):
-        raise NotConnectedToEdX(_('Methods in the Open edX platform necessary for this view are not available.'))
+        raise NotConnectedToOpenEdx(_('Methods in the Open edX platform necessary for this view are not available.'))
 
 
 class GrantDataSharingPermissions(View):

--- a/tests/test_lms_api.py
+++ b/tests/test_lms_api.py
@@ -13,7 +13,7 @@ from requests.compat import urljoin
 from django.conf import settings
 
 from enterprise import lms_api
-from enterprise.utils import NotConnectedToEdX
+from enterprise.utils import NotConnectedToOpenEdx
 
 URL_BASE_NAMES = {
     'enrollment': settings.ENTERPRISE_ENROLLMENT_API_URL,
@@ -121,5 +121,5 @@ def test_get_full_course_details():
 
 
 def test_enroll_locally_raises():
-    with raises(NotConnectedToEdX):
+    with raises(NotConnectedToOpenEdx):
         lms_api.enroll_user_in_course_locally(None, None, None)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -14,7 +14,7 @@ from django.shortcuts import render_to_response
 from django.test import Client
 
 from enterprise.models import EnterpriseCourseEnrollment, EnterpriseCustomerUser, UserDataSharingConsentAudit
-from enterprise.utils import NotConnectedToEdX
+from enterprise.utils import NotConnectedToOpenEdx
 from enterprise.views import GrantDataSharingPermissions, HttpClientError
 from test_utils.factories import EnterpriseCustomerFactory, EnterpriseCustomerUserFactory, UserFactory
 
@@ -94,7 +94,7 @@ class TestGrantDataSharingPermissions(unittest.TestCase):
         Test that we get the right exception when nothing is patched.
         """
         client = Client()
-        with raises(NotConnectedToEdX) as excinfo:
+        with raises(NotConnectedToOpenEdx) as excinfo:
             client.get(self.url)
         assert str(excinfo.value) == 'Methods in the Open edX platform necessary for this view are not available.'
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -274,6 +274,7 @@ class TestGrantDataSharingPermissions(unittest.TestCase):
             mock_config,
             mock_lift,
             mock_quarantine,
+            mock_pipeline_partial,
     ):  # pylint: disable=unused-argument
         """
         Test that when there's no customer for the request, POST gives a 404.
@@ -284,6 +285,7 @@ class TestGrantDataSharingPermissions(unittest.TestCase):
         response = client.post(self.url)
         assert response.status_code == 404
 
+    @mock.patch('enterprise.views.get_pipeline_partial')
     @mock.patch('enterprise.views.quarantine_session')
     @mock.patch('enterprise.views.lift_quarantine')
     @mock.patch('enterprise.views.configuration_helpers')
@@ -527,6 +529,7 @@ class TestGrantDataSharingPermissions(unittest.TestCase):
         response = self.client.get(self.url, data=params)
         assert response.status_code == 404
 
+    @mock.patch('enterprise.views.get_pipeline_partial')
     @mock.patch('enterprise.views.get_complete_url')
     @mock.patch('enterprise.tpa_pipeline.get_enterprise_customer_for_request')
     @mock.patch('enterprise.views.get_real_social_auth_object')
@@ -797,6 +800,7 @@ class TestGrantDataSharingPermissions(unittest.TestCase):
         )
         assert resp.status_code == 404
 
+    @mock.patch('enterprise.views.get_pipeline_partial')
     @mock.patch('enterprise.views.get_complete_url')
     @mock.patch('enterprise.tpa_pipeline.get_enterprise_customer_for_request')
     @mock.patch('enterprise.views.get_real_social_auth_object')


### PR DESCRIPTION
This PR has changes required in edx-enterprise to upgrade edx-platform from python-social-auth to split social.
**JIRA:** https://openedx.atlassian.net/browse/YONK-512

**Dependencies:** [PR #14451](https://github.com/edx/edx-platform/pull/14451) in edxp-platform

**Reviewers:**
- [ ] @haikuginger 
- [x] @mattdrayer 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

