### PR TITLE
ENT-220/ENT-223 Collect learner completion data for SAP SuccessFactors

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,3 +4,4 @@ Jesse Shapiro <jesse@opencraft.com>
 Saleem Latif <saleem_ee@hotmail.com>
 Sven Marnach <sven@opencraft.com>
 Brittney Exline <bexline@edx.org>
+Jillian Vogel <jill@opencraft.com>

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.27.2] - 2017-03-10
+---------------------
+
+* Added integrated_channels management command to transmit learner completion data to SAP SuccessFactors.
+
 [0.27.1] - 2017-03-13
 ---------------------
 
@@ -24,7 +29,6 @@ Unreleased
 ---------------------
 
 * Added API endpoint for fetching catalogs and catalog courses.
-
 
 [0.26.3] - 2017-03-02
 ---------------------

--- a/docs/configuration_and_usage.rst
+++ b/docs/configuration_and_usage.rst
@@ -99,6 +99,77 @@ to the help strings provided by the form.
 You can preview emails in the template edit view using the "Preview (program)" and "Preview (course)" buttons in
 top-right corner.
 
+Integrated Channels
+-------------------
+
+SAP SuccessFactors Configuration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+One of the integrated channels available for an ``EnterpriseCustomer`` is `SAP SuccessFactors`_.
+
+To integrate an ``EnterpriseCustomer`` with SAP SuccessFactors:
+
+* Set up a `TPA SAML Integration`_ for the SAP SuccessFactors endpoint.
+* From the LMS Admin, ensure that your ``EnterpriseCustomer`` record has its ``identity_provider`` field pointing to the
+  SAML Integration created in the previous step.
+
+  This allows learners to create accounts using Single Sign-On from SAP SuccessFactors, and to have their course
+  completion records sent back to SAP SuccessFactors.
+* From the LMS Admin, create an ``SAP SuccessFactors Enterprise Customer Configuration`` record, and link it to your
+  ``EnterpriseCustomer``.
+
+  Ensure that the record is marked ``Active`` to allow the management commands below to send data via this channel.
+
+.. _SAP SuccessFactors: https://www.successfactors.com
+.. _TPA SAML Integration: http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/tpa/tpa_SAML_SP.html
+
+Management Commands
+^^^^^^^^^^^^^^^^^^^
+
+These Django management commands send data to ``EnterpriseCustomer``'s active, integrated channels.
+
+They must be run from the command line on a server with the Open edX environment installed.
+
+.. note::
+
+   If data sharing consent is enabled for your ``EnterpriseCustomer``, then any Enterprise learners enrolled in the
+   associated courses must consent to data sharing, thus permitting their data to be sent back to SAP SuccessFactors.
+
+   If data sharing consent is *not* enabled for your ``EnterpriseCustomer``, then learner data may be sent to SAP
+   SuccessFactors without their explicit consent, so use these settings with care.
+
+
+Transmit Learner Data
+_____________________
+
+The ``transmit_learner_data`` command sends course completion data for each ``EnterpriseCustomerCourseEnrollment`` where
+evidence of course completion exists for an enrolled learner.
+
+.. note::
+
+   Currently, "course completion" is determined by the presence of a certificate for a given learner and course
+
+   This means that audit learners in self-paced courses will not yet have their course completion data sent to the
+   integrated channels.
+
+Usage
+~~~~~
+
+.. code-block:: bash
+
+   # View command help
+   $ ./manage.py lms transmit_learner_data --help --settings=$EDX_PLATFORM_SETTINGS
+
+   # Transmit learner data for all EnterpriseCustomers, to all active integrated channels.
+   $ ./manage.py lms transmit_learner_data --settings=$EDX_PLATFORM_SETTINGS
+
+   # Transmit learner data for a single EnterpriseCustomer, e.g. with uuid 12
+   $ ./manage.py lms transmit_learner_data --enterprise-customer 12 --settings=$EDX_PLATFORM_SETTINGS
+
+   # Transmit learner data only to SAP SuccessFactors
+   $ ./manage.py lms transmit_learner_data --channel SAP --settings=$EDX_PLATFORM_SETTINGS
+
+
 .. rubric:: Footnotes
 
 .. [#f1] Course Catalog Service API does not expose any means to get a list of modes supported by *all* courses in the

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.27.1"
+__version__ = "0.27.2"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -25,7 +25,7 @@ from django.utils.translation import ugettext_lazy as _
 from model_utils.models import TimeStampedModel
 
 from enterprise import utils
-from enterprise.lms_api import enroll_user_in_course_locally
+from enterprise.lms_api import ThirdPartyAuthApiClient, enroll_user_in_course_locally
 from enterprise.validators import validate_image_extension, validate_image_size
 
 logger = getLogger(__name__)  # pylint: disable=invalid-name
@@ -339,6 +339,22 @@ class EnterpriseCustomerUser(TimeStampedModel):
         Return uniquely identifying string representation.
         """
         return self.__str__()
+
+    def get_remote_id(self):
+        """
+        Retrieve the SSO provider's identifier for this user from the LMS Third Party API.
+
+        Returns None if:
+        * the user doesn't exist, or
+        * the associated EnterpriseCustomer has no identity_provider, or
+        * the remote identity is not found.
+        """
+        user = self.user
+        identity_provider = self.enterprise_customer.identity_provider
+        if user and identity_provider:
+            client = ThirdPartyAuthApiClient()
+            return client.get_remote_id(self.enterprise_customer.identity_provider, user.username)
+        return None
 
 
 @python_2_unicode_compatible

--- a/integrated_channels/integrated_channel/management/__init__.py
+++ b/integrated_channels/integrated_channel/management/__init__.py
@@ -1,0 +1,3 @@
+"""
+Enterprise Integrated Channel management commands and related functions.
+"""

--- a/integrated_channels/integrated_channel/management/commands/__init__.py
+++ b/integrated_channels/integrated_channel/management/commands/__init__.py
@@ -1,0 +1,101 @@
+"""
+Enterprise Integrated Channel management commands.
+"""
+from __future__ import absolute_import, unicode_literals
+
+from django.core.management.base import CommandError
+from django.utils.translation import ugettext as _
+
+from enterprise.models import EnterpriseCustomer
+from integrated_channels.sap_success_factors.models import SAPSuccessFactorsEnterpriseCustomerConfiguration
+
+
+# Import djcelery, or stub it if not available.
+try:
+    from djcelery.celery import task as celery_task
+except ImportError:
+    def celery_task(func):
+        """Use a no-op decorator if djcelery is not available."""
+        def no_delay(*args, **kwargs):
+            """
+            Provides the celery.task.delay function, which can be used to spawn an asynchronous celery task.
+            Here, it just calls the function.
+            """
+            func(*args, **kwargs)
+        func.delay = no_delay
+        return func
+
+# Mapping between the channel code and the channel configuration class
+INTEGRATED_CHANNEL_CHOICES = {
+    channel_class.channel_code(): channel_class
+    for channel_class in (SAPSuccessFactorsEnterpriseCustomerConfiguration, )
+}
+
+
+class IntegratedChannelCommandMixin(object):
+    """
+    Contains common functionality for the IntegratedChannel management commands.
+    """
+    def add_arguments(self, parser):
+        """
+        Adds the optional arguments: ``--enterprise_customer``, ``--channel``
+        """
+        parser.add_argument(
+            '--enterprise_customer',
+            dest='enterprise_customer',
+            default=None,
+            metavar=_('ENTERPRISE_CUSTOMER_UUID'),
+            help=_('Transmit data for only this EnterpriseCustomer. '
+                   'Omit this option to transmit to all EnterpriseCustomers with active integrated channels.'),
+        )
+        parser.add_argument(
+            '--channel',
+            dest='channel',
+            default='',
+            metavar=_('INTEGRATED_CHANNEL'),
+            help=_('Transmit data to this IntegrateChannel. '
+                   'Omit this option to transmit to all configured, active integrated channels.'),
+            choices=INTEGRATED_CHANNEL_CHOICES.keys(),
+        )
+
+    def get_integrated_channels(self, options):
+        """
+        Generates a list of active integrated channels, filtered from the given options.
+
+        Raises errors when invalid options are encountered.
+
+        See ``add_arguments`` for the accepted options.
+        """
+        # If a valid enterprise customer uuid was provided, transmit for that customer.
+        # Otherwise, transmit for all customers.
+        enterprise_customer = None
+        enterprise_customer_uuid = options['enterprise_customer']
+        if enterprise_customer_uuid:
+            try:
+                enterprise_customer = EnterpriseCustomer.active_customers.get(uuid=enterprise_customer_uuid)
+            except EnterpriseCustomer.DoesNotExist:
+                raise CommandError(
+                    _('Enterprise customer {uuid} not found, or not active').format(uuid=enterprise_customer_uuid))
+
+        # Assemble a list of integrated channel classes to transmit to.
+        # If a valid channel type was provided, use it.
+        # Otherwise, use all the available channel types.
+        channel_code = options['channel'].upper()
+        if channel_code:
+            if channel_code not in INTEGRATED_CHANNEL_CHOICES:
+                raise CommandError(_('Invalid integrated channel: {channel}').format(channel=channel_code))
+
+            channel_classes = [INTEGRATED_CHANNEL_CHOICES[channel_code]]
+        else:
+            channel_classes = INTEGRATED_CHANNEL_CHOICES.values()
+
+        # Loop through each channel class (optionally for a specific enterprise customer)
+        for channel_class in channel_classes:
+            # Use Active channels only
+            integrated_channels = channel_class.objects.filter(active=True)
+            if enterprise_customer:
+                integrated_channels = integrated_channels.filter(enterprise_customer=enterprise_customer)
+
+            # Gen the learner data to each integrated channel
+            for integrated_channel in integrated_channels:
+                yield integrated_channel

--- a/integrated_channels/integrated_channel/management/commands/transmit_learner_data.py
+++ b/integrated_channels/integrated_channel/management/commands/transmit_learner_data.py
@@ -1,0 +1,38 @@
+"""
+Transmits consenting enterprise learner data to the integrated channels.
+"""
+from __future__ import absolute_import, unicode_literals
+
+from django.core.management.base import BaseCommand
+from django.utils.translation import ugettext as _
+from . import IntegratedChannelCommandMixin, celery_task, INTEGRATED_CHANNEL_CHOICES
+
+
+class Command(IntegratedChannelCommandMixin, BaseCommand):
+    """
+    Management command which transmits learner course completion data to the IntegratedChannel(s) configured for the
+    given EnterpriseCustomer.
+
+    Collect the enterprise learner data for enrollments with data sharing consent, and transmit each to the
+    EnterpriseCustomer's configured IntegratedChannel(s).
+    """
+    help = _('''
+    Transmit Enterprise learner course completion data for the given EnterpriseCustomer.
+    ''')
+
+    def handle(self, *args, **options):
+        """
+        Transmit the learner data for the EnterpriseCustomer(s) to the active integration channels.
+        """
+        # Transmit the learner data to each integrated channel
+        for integrated_channel in self.get_integrated_channels(options):
+            self.transmit_learner_data.delay(integrated_channel.channel_code(), integrated_channel.pk)
+
+    @staticmethod
+    @celery_task
+    def transmit_learner_data(channel_code, channel_pk):
+        """
+        Allows each enterprise customer's integrated channel to collect and transmit data within its own celery task.
+        """
+        integrated_channel = INTEGRATED_CHANNEL_CHOICES[channel_code].objects.get(pk=channel_pk)
+        integrated_channel.transmit_learner_data()

--- a/integrated_channels/integrated_channel/models.py
+++ b/integrated_channels/integrated_channel/models.py
@@ -8,7 +8,18 @@ from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from model_utils.models import TimeStampedModel
 
-from enterprise.models import EnterpriseCustomer
+from enterprise.models import EnterpriseCustomer, EnterpriseCourseEnrollment
+from enterprise.utils import NotConnectedToOpenEdX
+
+try:
+    from certificates.api import GeneratedCertificate
+except ImportError:
+    GeneratedCertificate = None
+
+try:
+    from opaque_keys.edx.keys import CourseKey
+except ImportError:
+    CourseKey = None
 
 
 @python_2_unicode_compatible
@@ -62,3 +73,70 @@ class EnterpriseCustomerPluginConfiguration(TimeStampedModel):
 
     class Meta:
         abstract = True
+
+    @staticmethod
+    def channel_code():
+        """
+        Returns an capitalized identifier for this channel class, unique among subclasses.
+        """
+        raise NotImplementedError(_('Implemented in concrete subclass.'))
+
+    def transmit_learner_data(self):
+        """
+        Collect and transmit learner data for the ``EnterpriseCustomer``.
+        """
+        transmitter = self.get_learner_data_transmitter()
+        for learner_data in self.collect_learner_data():
+            transmitter.transmit(learner_data)
+
+    def collect_learner_data(self):
+        """
+        Collect learner data for the ``EnterpriseCustomer`` where data sharing consent is granted.
+
+        Yields a learner data object for each enrollment, containing:
+
+        * ``enterprise_enrollment``: ``EnterpriseCourseEnrollment`` object.
+        * ``certificate``: ``GeneratedCertificate`` for the user+course; None if not found.
+          "Course completion" occurs when course certificates are issued.
+        """
+
+        if CourseKey is None or GeneratedCertificate is None:
+            raise NotConnectedToOpenEdX(_('This package must be installed in an OpenEdX environment.'))
+
+        # Fetch the consenting enrollment data, including the enterprise_customer_user
+        enrollment_queryset = EnterpriseCourseEnrollment.objects.select_related(
+            'enterprise_customer_user'
+        ).filter(
+            enterprise_customer_user__enterprise_customer=self.enterprise_customer,
+        )
+        for enterprise_enrollment in enrollment_queryset:
+
+            # Omit any enrollments where consent has not been granted
+            if not enterprise_enrollment.consent_available():
+                continue
+
+            # Fetch the user+course certificate, if found
+            try:
+                certificate = GeneratedCertificate.eligible_certificates.get(
+                    user__id=enterprise_enrollment.enterprise_customer_user.user_id,
+                    course_id=CourseKey.from_string(enterprise_enrollment.course_id),
+                )
+            except GeneratedCertificate.DoesNotExist:
+                certificate = None
+
+            yield self.get_learner_data(
+                enterprise_enrollment=enterprise_enrollment,
+                certificate=certificate,
+            )
+
+    def get_learner_data(self, enterprise_enrollment, certificate):
+        """
+        Returns the class that can serialize the learner completion data to the integrated channel.
+        """
+        raise NotImplementedError(_('Implemented in concrete subclass.'))
+
+    def get_learner_data_transmitter(self):
+        """
+        Returns the class that can transmit the learner completion data to the integrated channel.
+        """
+        raise NotImplementedError(_('Implemented in concrete subclass.'))

--- a/integrated_channels/sap_success_factors/models.py
+++ b/integrated_channels/sap_success_factors/models.py
@@ -4,15 +4,19 @@ Database models for Enterprise Integrated Channel SAP SuccessFactors.
 
 from __future__ import absolute_import, unicode_literals
 
+import json
+from datetime import datetime
 from config_models.models import ConfigurationModel
 from simple_history.models import HistoricalRecords
 
 from django.db import models
+from django.utils import timezone
 from django.utils.encoding import python_2_unicode_compatible
 
 from model_utils.models import TimeFramedModel
 
 from integrated_channels.integrated_channel.models import EnterpriseCustomerPluginConfiguration
+from .transmitters.learner_data import SuccessFactorsLearnerDataTransmitter
 
 
 @python_2_unicode_compatible
@@ -75,6 +79,30 @@ class SAPSuccessFactorsEnterpriseCustomerConfiguration(EnterpriseCustomerPluginC
         """
         return self.__str__()
 
+    @staticmethod
+    def channel_code():
+        """
+        Returns an capitalized identifier for this channel class, unique among subclasses.
+        """
+        return 'SAP'
+
+    def get_learner_data(self, enterprise_enrollment, certificate):
+        """
+        Returns a LearnerDataTransmissionAudit initialized from the given enrollment and certificate data.
+        """
+        return LearnerDataTransmissionAudit(
+            enterprise_enrollment=enterprise_enrollment,
+            certificate=certificate,
+            # Used only if certificate is None
+            course_completed=False,
+        )
+
+    def get_learner_data_transmitter(self):
+        """
+        Returns a SuccessFactorsLearnerDataTransmitter instance.
+        """
+        return SuccessFactorsLearnerDataTransmitter()
+
 
 @python_2_unicode_compatible
 class LearnerDataTransmissionAudit(models.Model):
@@ -93,8 +121,36 @@ class LearnerDataTransmissionAudit(models.Model):
     error_message = models.TextField(blank=True)
     created = models.DateTimeField(auto_now_add=True)
 
+    epoch = datetime(1970, 1, 1, tzinfo=timezone.utc)
+
     class Meta:
         app_label = 'sap_success_factors'
+
+    def __init__(self, *args, **kwargs):
+        """
+        Return a new ``LearnerDataTransmissionAudit`` object.
+
+        Optional arguments:
+        * ``enterprise_enrollment``: If provided, then ``enterprise_course_enrollment_id``, ``user_id``, * ``course_id``
+          are pulled from this EnterpriseCourseEnrollment object.
+        * ``certificate``: If provided, then ``course_completed=True``; ``completed_timestamp`, ``grade``
+          are pulled from this GeneratedCertificate object.
+
+        Otherwise, the field values are pulled directly from the kwargs, as usual.
+        """
+        enterprise_enrollment = kwargs.pop('enterprise_enrollment', None)
+        if enterprise_enrollment is not None:
+            kwargs['enterprise_course_enrollment_id'] = enterprise_enrollment.id
+            kwargs['sapsf_user_id'] = enterprise_enrollment.enterprise_customer_user.get_remote_id()
+            kwargs['course_id'] = enterprise_enrollment.course_id
+
+        certificate = kwargs.pop('certificate', None)
+        if certificate is not None:
+            kwargs['course_completed'] = True
+            kwargs['completed_timestamp'] = int((certificate.created_date - self.epoch).total_seconds())
+            kwargs['grade'] = certificate.grade
+
+        super(LearnerDataTransmissionAudit, self).__init__(*args, **kwargs)
 
     def __str__(self):
         """
@@ -112,6 +168,45 @@ class LearnerDataTransmissionAudit(models.Model):
         Return uniquely identifying string representation.
         """
         return self.__str__()
+
+    @property
+    def provider_id(self):
+        '''
+        Fetch ``provider_id`` from global configuration settings
+        '''
+        return SAPSuccessFactorsGlobalConfiguration.current().provider_id
+
+    def _payload_data(self, empty_value):
+        """
+        Convert the audit record's fields into SAP SuccessFactors key/value pairs.
+        """
+        return dict(
+            userID=self.sapsf_user_id,
+            courseID=self.course_id,
+            providerID=self.provider_id,
+            # SAP SuccessFactors requires strings, not boolean values.
+            courseCompleted="true" if self.course_completed else "false",
+            completedTimestamp=self.completed_timestamp,
+            grade=self.grade,
+            # TODO: determine these values from the enrollment seat?
+            price=empty_value,
+            currency=empty_value,
+            creditHours=empty_value,
+            # These fields currently have no edX source, so remain empty.
+            totalHours=empty_value,
+            contactHours=empty_value,
+            cpeHours=empty_value,
+            instructorName=empty_value,
+            comments=empty_value,
+        )
+
+    def serialize(self, empty_value=''):
+        """
+        Return a JSON-serialized representation.
+
+        Sort the keys so the result is consistent and testable.
+        """
+        return json.dumps(self._payload_data(empty_value=empty_value), sort_keys=True)
 
 
 @python_2_unicode_compatible

--- a/integrated_channels/sap_success_factors/transmitters/learner_data.py
+++ b/integrated_channels/sap_success_factors/transmitters/learner_data.py
@@ -2,7 +2,11 @@
 Class for transmitting learner data to SuccessFactors.
 """
 from __future__ import absolute_import, unicode_literals
+import logging
 from integrated_channels.sap_success_factors.transmitters import SuccessFactorsTransmitterBase
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 class SuccessFactorsLearnerDataTransmitter(SuccessFactorsTransmitterBase):
@@ -28,5 +32,13 @@ class SuccessFactorsLearnerDataTransmitter(SuccessFactorsTransmitterBase):
     (taken from OCNWebServicesConfiguration and OCNWebServicesEnterpriseCustomerConfiguration) and the oauth token.
 
     Record information about the success/failure of posting the learner data to SuccessFactors in
-     CompletionStatusEventAudit
+    the LearnerDataTransmissionAudit object provided, and save it to the database.
+
     """
+    def transmit(self, learner_data):
+        """
+        Transmit the learner data payload to the SAP SuccessFactors channel.
+        """
+        # TODO ENT-221 will handle transmitting the learner data payload to the channel
+        # We only want to transmit if learner_data.course_completed == True.
+        LOGGER.info(learner_data.serialize())

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -13,7 +13,7 @@ caniusepython3==5.0.0
 click==6.7                # via pip-tools
 clint==0.5.1              # via twine
 configparser==3.5.0       # via pylint
-diff-cover==0.9.10
+diff-cover==0.9.11
 distlib==0.2.4            # via caniusepython3
 django-config-models==0.1.5
 django-extensions==1.7.7
@@ -35,9 +35,9 @@ futures==3.0.5            # via caniusepython3
 inflect==0.2.5            # via jinja2-pluralize
 isort==4.2.5
 jinja2-pluralize==0.3.0   # via diff-cover
-Jinja2==2.9.5             # via diff-cover, jinja2-pluralize
+jinja2==2.9.5             # via diff-cover, jinja2-pluralize
 lazy-object-proxy==1.2.2  # via astroid
-MarkupSafe==0.23          # via jinja2
+MarkupSafe==1.0           # via jinja2
 mccabe==0.6.1             # via pylint
 olefile==0.44             # via pillow
 packaging==16.8           # via caniusepython3, setuptools

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -6,7 +6,7 @@
 #
 alabaster==0.7.10         # via sphinx
 babel==2.3.4              # via sphinx
-bleach==1.5.0             # via readme-renderer
+bleach==2.0.0             # via readme-renderer
 chardet==2.3.0            # via doc8
 django-config-models==0.1.5
 django-extensions==1.7.7
@@ -24,27 +24,33 @@ edx-django-oauth2-provider==1.1.4
 edx-drf-extensions==1.2.2
 edx-rest-api-client==1.7.1
 edx-sphinx-theme==1.0.2
-html5lib==0.9999999       # via bleach
+html5lib==0.999999999     # via bleach
 imagesize==0.7.1          # via sphinx
 Jinja2==2.9.5             # via sphinx
-MarkupSafe==0.23          # via jinja2
+MarkupSafe==1.0           # via jinja2
 olefile==0.44             # via pillow
+packaging==16.8           # via setuptools
 pbr==2.0.0                # via stevedore
 Pillow==4.0.0
 pockets==0.3.2            # via sphinxcontrib-napoleon
 Pygments==2.2.0           # via readme-renderer, sphinx
 PyJWT==1.4.2              # via djangorestframework-jwt, edx-rest-api-client
+pyparsing==2.2.0          # via packaging
 python-dateutil==2.6.0    # via edx-drf-extensions
 pytz==2016.10             # via babel
-readme-renderer==16.0
+readme-renderer==17.1
 requests==2.13.0
 restructuredtext-lint==1.0.1  # via doc8
 shortuuid==0.5.0          # via edx-django-oauth2-provider
 simplejson==3.10.0
-six==1.10.0               # via bleach, django-extensions, doc8, edx-sphinx-theme, html5lib, pockets, python-dateutil, readme-renderer, sphinx, sphinxcontrib-napoleon, stevedore
+six==1.10.0               # via bleach, django-extensions, doc8, edx-sphinx-theme, html5lib, packaging, pockets, python-dateutil, readme-renderer, setuptools, sphinx, sphinxcontrib-napoleon, stevedore
 slumber==0.7.1
 snowballstemmer==1.2.1    # via sphinx
 Sphinx==1.5.3             # via edx-sphinx-theme
 sphinxcontrib-napoleon==0.6.1
 stevedore==1.21.0         # via doc8
 unicodecsv==0.14.1
+webencodings==0.5         # via html5lib
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools                # via html5lib

--- a/requirements/js_test.txt
+++ b/requirements/js_test.txt
@@ -14,7 +14,7 @@ itsdangerous==0.24        # via flask
 jasmine-core==2.5.2       # via jasmine
 jasmine==2.5.0
 Jinja2==2.9.5             # via flask, jasmine
-MarkupSafe==0.23          # via jinja2
+MarkupSafe==1.0           # via jinja2
 ordereddict==1.1          # via jasmine-core
 PyYAML==3.10              # via jasmine
 selenium==2.53.6          # via jasmine

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -1,0 +1,148 @@
+"""
+Test the Enterprise management commands and related functions.
+"""
+from __future__ import absolute_import, unicode_literals, with_statement
+
+import logging
+import unittest
+from datetime import datetime
+
+import mock
+from faker import Factory as FakerFactory
+from integrated_channels.sap_success_factors.models import SAPSuccessFactorsEnterpriseCustomerConfiguration
+from pytest import mark, raises
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.utils import timezone
+
+from test_utils.factories import (EnterpriseCourseEnrollmentFactory, EnterpriseCustomerFactory,
+                                  EnterpriseCustomerIdentityProviderFactory, EnterpriseCustomerUserFactory,
+                                  UserFactory)
+
+
+@mark.django_db
+class TestTransmitLearnerData(unittest.TestCase):
+    """
+    Test the transmit_learner_data management command.
+    """
+    def setUp(self):
+        self.user = UserFactory(username='R2D2')
+        self.course_id = 'course-v1:edX+DemoX+DemoCourse'
+        self.enterprise_customer = EnterpriseCustomerFactory()
+        EnterpriseCustomerIdentityProviderFactory(provider_id=FakerFactory.create().slug(),
+                                                  enterprise_customer=self.enterprise_customer)
+        self.enterprise_customer_user = EnterpriseCustomerUserFactory(
+            user_id=self.user.id,
+            enterprise_customer=self.enterprise_customer,
+        )
+        self.enrollment = EnterpriseCourseEnrollmentFactory(
+            enterprise_customer_user=self.enterprise_customer_user,
+            course_id=self.course_id,
+            consent_granted=True,
+        )
+        self.integrated_channel = SAPSuccessFactorsEnterpriseCustomerConfiguration(
+            enterprise_customer=self.enterprise_customer,
+            sapsf_base_url='enterprise.successfactors.com',
+            key='key',
+            secret='secret',
+        )
+
+        super(TestTransmitLearnerData, self).setUp()
+
+    def test_enterprise_customer_not_found(self):
+        faker = FakerFactory.create()
+        invalid_customer_id = faker.uuid4()
+        error = 'Enterprise customer {} not found, or not active.'.format(invalid_customer_id)
+        with raises(CommandError, message=error):
+            call_command('transmit_learner_data', enterprise_customer=invalid_customer_id)
+
+    def test_invalid_integrated_channel(self):
+        channel_code = 'abc'
+        error = 'Invalid integrated channel: {}'.format(channel_code)
+        with raises(CommandError, message=error):
+            call_command('transmit_learner_data',
+                         enterprise_customer=self.enterprise_customer.uuid,
+                         channel=channel_code)
+
+
+@mark.django_db
+@mark.parametrize('command_args', [
+    dict(),
+    dict(channel='sap'),  # channel code is case-insensitive
+    dict(channel='SAP'),
+    dict(enterprise_customer=None),  # enterprise_customer UUID gets filled in below
+    dict(enterprise_customer=None, channel='sap'),
+])
+def test_transmit_learner_data(caplog, command_args):
+    """
+    Test the log output from a successful run of the transmit_learner_data management command,
+    using all the ways we can invoke it.
+    """
+    caplog.set_level(logging.INFO)
+
+    # Borrow the test data from TestTransmitLearnerData
+    testcase = TestTransmitLearnerData(methodName='setUp')
+    testcase.setUp()
+
+    # Activate the integrated channel
+    testcase.integrated_channel.active = True
+    testcase.integrated_channel.save()
+
+    # Expect the learner data record to be sent to the logger
+    output_template = (
+        '{{'
+        '"comments": "", '
+        '"completedTimestamp": {timestamp}, '
+        '"contactHours": "", '
+        '"courseCompleted": "{completed}", '
+        '"courseID": "{course_id}", '
+        '"cpeHours": "", '
+        '"creditHours": "", '
+        '"currency": "", '
+        '"grade": "{grade}", '
+        '"instructorName": "", '
+        '"price": "", '
+        '"providerID": "{provider_id}", '
+        '"totalHours": "", '
+        '"userID": "{user_id}"'
+        '}}'
+    )
+    expected_output = output_template.format(
+        user_id='remote-r2d2',
+        course_id=testcase.course_id,
+        provider_id="EDX",
+        completed="true",
+        timestamp=1483326245,
+        grade="A-",
+    )
+
+    # Populate the command arguments
+    if 'enterprise_customer' in command_args:
+        command_args['enterprise_customer'] = testcase.enterprise_customer.uuid
+
+    with mock.patch('enterprise.models.ThirdPartyAuthApiClient') as mock_third_party_api:
+        mock_third_party_api.return_value.get_remote_id.return_value = 'remote-r2d2'
+
+        with mock.patch('integrated_channels.integrated_channel.models.CourseKey') as mock_course_key:
+            mock_course_key.from_string.return_value = None
+
+            with mock.patch('integrated_channels.integrated_channel.models.GeneratedCertificate') as mock_certificate:
+                # Mark course completion with a mock certificate.
+                mock_certificate.eligible_certificates.get.return_value = mock.MagicMock(
+                    user=testcase.user,
+                    course_id=testcase.course_id,
+                    grade="A-",
+                    created_date=datetime(2017, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+                    status="downloadable",
+                )
+
+                # Call the management command
+                call_command('transmit_learner_data', **command_args)
+
+    # Ensure the correct learner_data record was logged
+    assert len(caplog.records) == 1
+    assert expected_output in caplog.records[0].message
+
+    # Clean up the testcase data
+    testcase.tearDown()


### PR DESCRIPTION
**Description:** Adds a management command and updates supporting classes to collect learner completion data records, and prepare them for submission to the SAP SuccessFactors integration channel.

**JIRA:** [ENT-220](https://openedx.atlassian.net/browse/ENT-220), [ENT-223](https://openedx.atlassian.net/browse/ENT-223)

**Dependencies:** 

* https://github.com/edx/edx-platform/pull/14563
* https://github.com/edx/edx-enterprise/pull/61 (merged here)

**Sandbox:**

* LMS: https://ent-pr59.sandbox.opencraft.hosting/
* Studio: https://studio-ent-pr59.sandbox.opencraft.hosting/

Also created an edX Sandbox: https://ent-220-ent-223-pomegranited.sandbox.edx.org
I've added github keys for @haikuginger , @brittneyexline , @mattdrayer , so you can shell in as `pomegranited` and test the management command.  

**Merge deadline:** 13 March 2017

**Installation instructions:** 

1. Ensure edx-platform is running with changes from https://github.com/edx/edx-platform/pull/14563.
1. Install this branch's latest commit on your edxapp devstack:

    ```
    pip uninstall -y edx-enterprise && pip install "git+https://github.com/open-craft/edx-enterprise.git@jill/sap_learner_completion#egg=edx-enterprise"
    ```
1. You may have to run data migrations:

   ```
    ./manage.py lms migrate --settings=devstack
   ```
1. Restart the LMS without clobbering the installed `edx-enterprise`:

    ```
    NO_PREREQ_INSTALL=1 paver run_all_servers --fast
    ```
1. Set up a [TestShib SAML integration](http://testshib.org) with [these instructions](http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/tpa/tpa_SAML_SP.html).

**Testing instructions:**

1. In Studio, create a new course.
1. From the Admin, create a course mode for the course under `Course_Modes › Course modes`.  Choose a mode other than Audit.
1. In Studio,  navigate to the Settings > Certificates page, and create a certificate.  Don't worry about adding signatories.  Activate the certificate.
1. Run Testing instruction steps 1-4 from https://github.com/edx/edx-platform/pull/14400.  Use a new learner, so that it can be registered via TestShib.  Enrol the new learner in your course.
1. Link the `EnterpriseCustomer` to the TestShib SAML integration as the EC's `Identity Provider`.
1. From the Admin, add an [Enterprise SAP SuccessFactors Integration › Sap success factors enterprise customer configurations](http://localhost:8000/admin/sap_success_factors/sapsuccessfactorsenterprisecustomerconfiguration/) for the `EnterpriseCustomer`.  The only crucial field is `enabled=True`.  The other fields do't matter yet, because no actually communication is being done.
1. Run the new management command.  No output expected, unless any of your enrolled learners have granted consent.

    ```
    # For all enterprise customers
    ./manage.py lms transmit_learner_data  --settings=devstack

    # Or just one.
    ./manage.py lms transmit_learner_data --enterprise_customer=<enterprise_customer.uuid>  --settings=devstack
    ```
1. Register your enrolled learner via TestShib, and grant data sharing consent.
1. Re-run the `transmit_learner_data` management command to see the learner data record logged. Note that it reports `courseCompleted: "false"`.
1. Generate a certificate for your course.  

    ```
    ./manage.py lms ungenerated_certs --course="<course_id>" --settings=devstack
    ```
    *Note*: I got a lot of `VersionConflict` errors when I ran this, which didn't seem to matter.  And the log line that indicates the certificate has been generated may say something like "Student 5 has certificate status 'unavailable'".  But that seems to be ok too?
1. Re-run the `transmit_learner_data` management command, and check that the output now says `courseCompleted: "true"`, and the `grade` field has a value.

**Author notes and concerns:**

* `grade` field value may change, depending on discussion.  Currently using the `certificate.grade`, but may provide `Pass/Fail` instead.
* What to do about audit modes, in self-paced courses with no certificates to indicate completion and/or final grade?  Currently, we can only send learner completion data when a certificate has been issued.

**Reviewers:**

- [x] @haikuginger 
- [x] @brittneyexline 

**Merge checklist:**

- [x] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped - to `0.27.0`
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [ ] Translations are updated - [see comment](https://github.com/edx/edx-enterprise/pull/59#issuecomment-285582381)
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)