### PR TITLE
ENT-191 Adding all integrated channels files to be included in MANIFEST.in

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.26.3] - 2017-03-02
+---------------------
+
+* Added integrated_channels to MANIFEST.in to properly include migrations for the new packages.
+
 [0.26.2] - 2017-03-02
 ---------------------
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,4 @@ include CONTRIBUTING.rst
 include LICENSE.txt
 include README.rst
 recursive-include enterprise *.html *.png *.gif *js *.css *jpg *jpeg *svg *py *.txt
+recursive-include integrated_channels *.html *.png *.gif *js *.css *jpg *jpeg *svg *py *.txt

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.26.2"
+__version__ = "0.26.3"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name


### PR DESCRIPTION
**Description:** This file controls what gets pulled down from the package, and we were missing
our migration files for the new apps, which was causing some mild mayhem.

**JIRA:** https://openedx.atlassian.net/browse/ENT-191

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

1. In a provisioned devstack, Edit requirements/edx/base.txt, change the edx-enterprise version to 0.26.2.
2. Run  paver install_python_prereqs.
3. Run ./scripts/reset-test-db.sh from the root of edx-platform, the script should fail with an error: django.db.utils.IntegrityError: (1215, 'Cannot add foreign key constraint')
4. Edit requirements/edx/base.txt, comment out the edx-enterprise library line, and add the following line:
git+https://github.com/edx/edx-enterprise.git@86b344933678c7f270a4b96179377c91c7f3c804#egg=edx-enterprise==0.26.3
5. Run paver install_python_prereqs
6. Run ./scripts/reset-test-db.sh from the root of edx-platform, the script should complete successfully.

**Merge checklist:**

- [x] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [x] Translations are updated
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
