### PR TITLE
ENT-213 Add optional contact_email field to EnterpriseCustomer

### DIFF
--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -63,7 +63,7 @@ class EnterpriseCustomerSerializer(serializers.ModelSerializer):
         model = models.EnterpriseCustomer
         fields = (
             'uuid', 'name', 'catalog', 'active', 'site', 'enable_data_sharing_consent', 'enforce_data_sharing_consent',
-            'enterprise_customer_users', 'branding_configuration', 'enterprise_customer_entitlements'
+            'enterprise_customer_users', 'branding_configuration', 'enterprise_customer_entitlements', 'contact_email'
         )
 
     site = SiteSerializer()

--- a/enterprise/migrations/0016_auto_20170308_1738.py
+++ b/enterprise/migrations/0016_auto_20170308_1738.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('enterprise', '0015_auto_20170130_0003'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='enterprisecustomer',
+            name='contact_email',
+            field=models.EmailField(help_text='Optional contact email that is displayed to learners.', max_length=254, blank=True),
+        ),
+        migrations.AddField(
+            model_name='historicalenterprisecustomer',
+            name='contact_email',
+            field=models.EmailField(help_text='Optional contact email that is displayed to learners.', max_length=254, blank=True),
+        ),
+    ]

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -118,6 +118,13 @@ class EnterpriseCustomer(TimeStampedModel):
         )
     )
 
+    contact_email = models.EmailField(
+        blank=True,
+        help_text=_(
+            "Optional contact email that is displayed to learners."
+        )
+    )
+
     @property
     def identity_provider(self):
         """

--- a/tests/api/test_views.py
+++ b/tests/api/test_views.py
@@ -143,6 +143,7 @@ class TestEnterpriseAPIViews(APITest):
                 'site': {
                     'domain': 'example.com', 'name': 'example.com'
                 },
+                'contact_email': '',
             }],
         ),
         (
@@ -168,7 +169,6 @@ class TestEnterpriseAPIViews(APITest):
                 'enterprise_customer__active': True, 'enterprise_customer__enable_data_sharing_consent': True,
                 'enterprise_customer__enforce_data_sharing_consent': 'at_login',
                 'enterprise_customer__site__domain': 'example.com', 'enterprise_customer__site__name': 'example.com',
-
             }],
             [{
                 'id': 1, 'user_id': 0, 'user': None, 'data_sharing_consent': [],
@@ -180,6 +180,7 @@ class TestEnterpriseAPIViews(APITest):
                     'site': {
                         'domain': 'example.com', 'name': 'example.com'
                     },
+                    'contact_email': '',
                 }
             }],
         ),

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -130,6 +130,7 @@ class TestUtils(unittest.TestCase):
                 "site",
                 "enable_data_sharing_consent",
                 "enforce_data_sharing_consent",
+                "contact_email",
             ]
         ),
         (


### PR DESCRIPTION
**Description:** 
This adds a simple optional contact_email field to `EnterpriseCustomer`, which is in turn displayed to the user in messages to the user. See https://github.com/edx/ecommerce/pull/1189.

**JIRA:** Prerequisite for [ENT-213](https://openedx.atlassian.net/browse/ENT-213).

**Testing instructions:**

1. Install this version of `edx-enterprise` into a devstack.
1. Go to the [Enterprise Customer](http://localhost:8000/admin/enterprise/enterprisecustomer/add/) admin panel.
1. Verifying that the new optional "Contact email" is configurable in the Enterprise Customer form:
    ![](https://i.imgur.com/jNoY8S1.png)

**Merge checklist:**

- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)

**Reviewers**
- [ ] @pomegranited 
- [ ] edX reviewer[s] TBD