### PR TITLE
Adds ENTERPRISE_PUBLIC_ENROLLMENT_API_URL to settings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ----------
 
+[0.27.4] - 2017-03-17
+---------------------
+
+* Allows enterprise enrollments to be made on servers that sit behind a load balancer.
+
+
 [0.27.3] - 2017-03-16
 ---------------------
 * Added integrated_channels management command to transmit courseware metadata to SAP SuccessFactors.

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.27.3"
+__version__ = "0.27.4"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/admin/views.py
+++ b/enterprise/admin/views.py
@@ -126,7 +126,9 @@ class EnterpriseCustomerManageLearnersView(View):
             self.ContextParameters.PENDING_LEARNERS: pending_linked_learners,
             self.ContextParameters.LEARNERS: linked_learners,
             self.ContextParameters.SEARCH_KEYWORD: search_keyword or '',
-            self.ContextParameters.ENROLLMENT_URL: settings.ENTERPRISE_ENROLLMENT_API_URL,
+            self.ContextParameters.ENROLLMENT_URL: getattr(settings,
+                                                           'ENTERPRISE_PUBLIC_ENROLLMENT_API_URL',
+                                                           settings.ENTERPRISE_ENROLLMENT_API_URL),
         }
         context.update(admin.site.each_context(request))
         context.update(self._build_admin_context(request, enterprise_customer))

--- a/test_settings.py
+++ b/test_settings.py
@@ -82,11 +82,13 @@ SITE_ID = 1
 
 EDX_API_KEY = "PUT_YOUR_API_KEY_HERE"
 
-ENTERPRISE_ENROLLMENT_API_URL = "http://localhost:8000/api/enrollment/v1/"
-
 COURSE_CATALOG_API_URL = "http://localhost:18381/api/v1/"
 
 LMS_ROOT_URL = "http://localhost:8000"
+
+ENTERPRISE_ENROLLMENT_API_URL = LMS_ROOT_URL + "/api/enrollment/v1/"
+
+ENTERPRISE_PUBLIC_ENROLLMENT_API_URL = ENTERPRISE_ENROLLMENT_API_URL
 
 EMAIL_BACKEND = 'django.core.mail.backends.locmem.EmailBackend'
 


### PR DESCRIPTION
**Description:** 

This PR uses the new `settings.ENTERPRISE_PUBLIC_ENROLLMENT_API_URL` for client-side requests  to the LMS Enrollments API.  This public URL is rooted at the ENV-configured, fully-qualified `LMS_ROOT_URL`.

This allows `settings.ENTERPRISE_ENROLLMENT_API_URL` to use `localhost` as its root, for use by internal, server-side requests.

We need this because in certain situations, the edxapp server cannot contact itself over https by its fully-qualified `LMS_ROOT_URL`.

Currently, edxapp servers are configured with an [`/etc/hosts` entry which maps their FQDN hostname to `127.0.0.1`](https://github.com/edx/configuration/blob/0aa9bfa07853d319c487de1690309d2b3cf38c2b/playbooks/roles/common/templates/hosts.j2#L1), e.g.

    127.0.0.1	pr14671.sandbox.opencraft.hosting	localhost

Load balanced appservers may not terminate their own SSL, and so are unable to decrypt https connections made directly to `localhost`, which is what occurs when this hosts entry is present.  So we need a different URL for internal, server requests than what is used for the client-side, public requests.

To avoid dependency and compatibility issues, the client-side code defaults to `settings.ENTERPRISE_ENROLLMENT_API_URL` if `settings.ENTERPRISE_PUBLIC_ENROLLMENT_API_URL` isn't defined.

**JIRA:** ENT project

**Dependencies:** 

* https://github.com/edx/edx-platform/pull/14671

**Merge deadline:** ASAP

**Installation instructions:** List any non-trivial installation 
instructions.

**Sandbox URL:**

* LMS: https://pr14671.sandbox.opencraft.hosting/
* Studio: https://studio-pr14671.sandbox.opencraft.hosting/

Username: `staff`
Password: `edx`

This server is running `edx-platform/open-craft:jill/ent-test-public-enrollment-api-url`, which is based on https://github.com/edx/edx-platform/pull/14671, but installs this enterprise branch  ([compare](https://github.com/open-craft/edx-platform/compare/jill/enterprise-public-enrollment-api-url...jill/ent-test-public-enrollment-api-url))

**Testing instructions:**

1. Navigate to the LMS Admin, and add an EnterpriseCustomer.
1. Edit the EnterpriseCustomer, and click on Manage Learners
1. Enrol a user into `course-v1:edX+DemoX+Demo_Course`
1. Note that the Course enrolment mode drop-down gets populated with `Audit`.
1. Submit the enrolment, and note that it's accepted by the server.
    Prior to this change, the request would fail on the server side for load-balanced appservers like this one.

**Merge checklist:**

- [x] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped - to `0.27.4`
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [x] Translations are updated - N/A
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)