### PR TITLE
Remove OAuth2 authentication class from API viewsets

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,13 +6,20 @@ Change Log
    in this file.  It adheres to the structure of http://keepachangelog.com/ ,
    but in reStructuredText instead of Markdown (for ease of incorporation into
    Sphinx documentation and the PyPI description).
-   
+
    This project adheres to Semantic Versioning (http://semver.org/).
 
 .. There should always be an "Unreleased" section for changes pending release.
 
 Unreleased
 ----------
+
+
+[0.27.6] - 2017-03-21
+---------------------
+
+* Removed OAuth2Authentication class from API viewset definitions
+
 
 [0.27.5] - 2017-03-17
 ---------------------

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.27.5"
+__version__ = "0.27.6"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -11,7 +11,6 @@ from rest_framework.authentication import SessionAuthentication
 from rest_framework.decorators import detail_route
 from rest_framework.exceptions import NotFound
 from rest_framework.response import Response
-from rest_framework_oauth.authentication import OAuth2Authentication
 
 from django.contrib.auth.models import User
 from django.contrib.sites.models import Site
@@ -33,7 +32,7 @@ class EnterpriseModelViewSet(object):
     """
     filter_backends = (filters.OrderingFilter, filters.DjangoFilterBackend)
     permission_classes = (permissions.IsAuthenticated,)
-    authentication_classes = (OAuth2Authentication, SessionAuthentication, BearerAuthentication, JwtAuthentication)
+    authentication_classes = (JwtAuthentication, BearerAuthentication, SessionAuthentication,)
     throttle_classes = (ServiceUserThrottle,)
 
 
@@ -203,7 +202,7 @@ class EnterpriseCatalogViewSet(viewsets.ViewSet):
     """
     serializer_class = serializers.EnterpriseCourseCatalogReadOnlySerializer
     permission_classes = (permissions.IsAuthenticated,)
-    authentication_classes = (OAuth2Authentication, SessionAuthentication, BearerAuthentication, JwtAuthentication)
+    authentication_classes = (JwtAuthentication, BearerAuthentication, SessionAuthentication,)
     throttle_classes = (ServiceUserThrottle,)
 
     def list(self, request):


### PR DESCRIPTION
**Description:** According to @clintonb, `OAuth2Authentication` is not a DRF authentication class that we use in Open edX, so I've removed it from this project.  I've also reordered the authentication classes such that `JwtAuthentication` is the first one in the list, followed by `BearerAuthentication`, and lastly `SessionAuthentication`.

**JIRA:** ENT-264, ENT-275

**Dependencies:** N/A

**Merge deadline:** Now

**Installation instructions:** No special installation instructions.

**Testing instructions:** Unsure of how to test at the moment.

**Merge checklist:**

- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
