### PR TITLE
ENT-277: Fix IntegrityError getting raised for existing enterprise users

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,3 +6,4 @@ Sven Marnach <sven@opencraft.com>
 Brittney Exline <bexline@edx.org>
 Jillian Vogel <jill@opencraft.com>
 Grant Goodman <ggoodman@edx.org>
+Zubair Afzal <zubair.afzal@arbisoft.com>

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ----------
 
+[0.31.2] - 2017-04-03
+---------------------
+
+* Bugfix: Resolve IntegrityError getting raised while linking existing enterprise users when data sharing consent is
+  disabled for the related enterprise.
+
 [0.31.1] - 2017-03-31
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.31.1"
+__version__ = "0.31.2"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/tpa_pipeline.py
+++ b/enterprise/tpa_pipeline.py
@@ -142,7 +142,7 @@ def handle_enterprise_logistration(backend, user, **kwargs):
     if not enterprise_customer.requests_data_sharing_consent:
         # This enterprise customer attached to this pipeline element does not request data sharing consent;
         # proceed with the creation of a link between the user and the enterprise customer, then exit.
-        EnterpriseCustomerUser.objects.create(
+        EnterpriseCustomerUser.objects.get_or_create(
             enterprise_customer=enterprise_customer,
             user_id=user.id
         )

--- a/tests/test_tpa_pipeline.py
+++ b/tests/test_tpa_pipeline.py
@@ -151,6 +151,30 @@ class TestTpaPipeline(unittest.TestCase):
                 user_id=self.user.id
             ).count() == 1
 
+    def test_handle_enterprise_logistration_consent_not_required_for_existing_enterprise_user(self):
+        """
+        Test that when consent isn't required and learner is already linked,
+        we simply return the exi    sting EnterpriseCustomerUser.
+        """
+        backend = mock.MagicMock(name=None)
+        with mock.patch('enterprise.tpa_pipeline.get_ec_for_running_pipeline') as fake_get_ec:
+            enterprise_customer = EnterpriseCustomerFactory(
+                enable_data_sharing_consent=False
+            )
+            fake_get_ec.return_value = enterprise_customer
+
+            # manually link the user with the enterprise
+            EnterpriseCustomerUser.objects.create(
+                enterprise_customer=enterprise_customer,
+                user_id=self.user.id
+            )
+
+            assert handle_enterprise_logistration(backend, self.user) is None
+            assert EnterpriseCustomerUser.objects.filter(
+                enterprise_customer=enterprise_customer,
+                user_id=self.user.id
+            ).count() == 1
+
     def test_handle_enterprise_logistration_consent_required(self):
         """
         Test that when consent is required, we redirect to the consent page.


### PR DESCRIPTION
ENT-277
@saleem-latif @asadiqbal08 @mattdrayer 

**Description:** Fixed `IntegrityError` getting raised for existing enterprise users (manually added/linked from enterprise django admin `Manage Learners`)  when the data sharing consent is disabled for the related enterprise.

**JIRA:** [ENT-277](https://openedx.atlassian.net/browse/ENT-277)

**Dependencies:** N/A

**Merge deadline:** 7 April 2017

**Installation instructions:** 
1. Setup edx-platform (master) with enterprise branch set to this.
2. Set up a TestShib SAML integration with the instructions [found here](http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/tpa/tpa_SAML_SP.html).
3. Create an EnterpriseCustomer in the Django admin.

**Testing instructions:**
1. Link the EnterpriseCustomer to the TestShib SAML integration
2. Verify that data sharing consent is set to disabled on the EnterpriseCustomer
3. Link learner account with enterprise through manage learner page in Django admin
4. In an incognito window, browse to the LMS registration page
5. Clicking on the `TestShib` button will redirect learner to the `TestShib` auth page (third party)
6. After entering credentials on `TestShib` auth page it will redirect learner back to LMS logistration page.
7. Provide the credentials of already linked learner with enterprise(that linked in step-3) in login form.
8. Press login button and user will be redirected to LMS dashboard.
9. Observe that your SAML user is linked as an Enterprise Learner and also a new social auth entry is added in `Python Social Auth` for that user.

**Merge checklist:**

- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [ ] Translations are updated
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
