### PR TITLE
ENT-316 Update Data Sharing Consent message

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ----------
 
+[0.33.2] - 2017-04-17
+---------------------
+
+* Update Data Sharing Consent message.
+
+
 [0.33.1] - 2017-04-17
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.33.1"
+__version__ = "0.33.2"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/templates/enterprise/grant_data_sharing_permissions.html
+++ b/enterprise/templates/enterprise/grant_data_sharing_permissions.html
@@ -105,6 +105,7 @@
             <h2 id="modal-header-text">${ confirmation_modal_header}</h2>
           </header>
           <p>${ confirmation_alert_prompt }</p>
+          <p>${ confirmation_alert_prompt_warning }</p>
           <button class="consent-agreement-button" id="modal-no-consent-button">${ confirmation_modal_affirm_decline_text }</button>
           <button class="failure-link" id="review-policy-link">${ confirmation_modal_abort_decline_text }</a>
         </div>

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -71,7 +71,7 @@ class GrantDataSharingPermissions(View):
     requested_permissions_header = _('{enterprise_customer_name} would like to know about:')
     agreement_text = _(
         'I agree to allow {platform_name} to share data about my enrollment, completion, and performance '
-        'in all {platform_name} courses and programs where my enrollment is sponsored by {enterprise_customer_name}'
+        'in all {platform_name} courses and programs where my enrollment is sponsored by {enterprise_customer_name}.'
     )
     continue_text = _('Yes, continue')
     abort_text = _('No, take me back.')
@@ -84,7 +84,7 @@ class GrantDataSharingPermissions(View):
         _('My email address for my {platform_name} account'),
         _('My {platform_name} ID'),
         _('My {platform_name} username'),
-        _('What courses and/or programs I\'ve enrolled in'),
+        _('What courses and/or programs I\'ve enrolled in or unenrolled from'),
         _(
             'Whether I completed specific parts of each course or program (for example, whether '
             'I watched a given video or completed a given homework assignment)'
@@ -96,7 +96,10 @@ class GrantDataSharingPermissions(View):
     ]
     sharable_items_footer = _(
         'My permission applies only to data from courses or programs that are sponsored by {enterprise_customer_name}'
-        ', and not to data from any {platform_name} courses or programs that I take on my own.'
+        ', and not to data from any {platform_name} courses or programs that I take on my own. I understand that '
+        'once I grant my permission to allow data to be shared with {enterprise_customer_name}, '
+        'I may not withdraw my permission but I may elect to unenroll from any courses or programs that are '
+        'sponsored by {enterprise_customer_name}.'
     )
     confirmation_modal_header = _('Are you aware...')
     modal_affirm_decline_msg = _('I decline')
@@ -202,18 +205,30 @@ class GrantDataSharingPermissions(View):
         platform_name = configuration_helpers.get_value("PLATFORM_NAME", settings.PLATFORM_NAME)
         course_name = course_details['name']
         context_data = self.get_default_context(customer, platform_name)
+        # Translators: bold_start and bold_end are HTML tags for specifying
+        # enterprise name in bold text.
         course_specific_context = {
             'consent_request_prompt': _(
                 'To access this course and use your discount, you must first consent to share your '
-                'learning achievements with {enterprise_customer_name}.'
+                'learning achievements with {bold_start}{enterprise_customer_name}{bold_end}.'
             ).format(
-                enterprise_customer_name=customer.name
+                enterprise_customer_name=customer.name,
+                bold_start='<b>',
+                bold_end='</b>',
             ),
             'confirmation_alert_prompt': _(
-                'In order to start this course and use your discount, you must consent to share your '
-                'course data with {enterprise_customer_name}.'
+                'In order to start this course and use your discount, {bold_start}you must{bold_end} consent '
+                'to share your course data with {enterprise_customer_name}.'
             ).format(
-                enterprise_customer_name=customer.name
+                enterprise_customer_name=customer.name,
+                bold_start='<b>',
+                bold_end='</b>',
+            ),
+            'confirmation_alert_prompt_warning': _(
+                'If you do not consent to share your course data, that information may be shared with '
+                '{enterprise_customer_name}.'
+            ).format(
+                enterprise_customer_name=customer.name,
             ),
             'page_language': get_language_from_request(request),
             'platform_name': platform_name,

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -454,11 +454,22 @@ class TestGrantDataSharingPermissions(unittest.TestCase):
                 "platform_name": "My Platform",
                 "consent_request_prompt": (
                     'To access this course and use your discount, you must first consent to share your '
-                    'learning achievements with Starfleet Academy.'
+                    'learning achievements with <b>Starfleet Academy</b>.'
                 ),
                 'confirmation_alert_prompt': (
-                    'In order to start this course and use your discount, you must consent to share your '
+                    'In order to start this course and use your discount, <b>you must</b> consent to share your '
                     'course data with Starfleet Academy.'
+                ),
+                'confirmation_alert_prompt_warning': (
+                    'If you do not consent to share your course data, that information may be shared with '
+                    'Starfleet Academy.'
+                ),
+                'sharable_items_footer': (
+                    'My permission applies only to data from courses or programs that are sponsored by '
+                    'Starfleet Academy, and not to data from any My Platform courses or programs that '
+                    'I take on my own. I understand that once I grant my permission to allow data to be shared '
+                    'with Starfleet Academy, I may not withdraw my permission but I may elect to unenroll '
+                    'from any courses or programs that are sponsored by Starfleet Academy.'
                 ),
                 "course_id": "course-v1:edX+DemoX+Demo_Course",
                 "course_name": "edX Demo Course",


### PR DESCRIPTION
@saleem-latif @asadiqbal08 @mattdrayer 

**Description:** Update Data Sharing Consent message

**JIRA:** [ENT-316](https://openedx.atlassian.net/browse/ENT-316)

**Dependencies:** N/A

**Merge deadline:** 21 April, 2017

**Installation instructions:** Install `edx-enterprise` from this branch `zub/ENT-316-update-data-sharing-consent-message` in `edx-platform`

**Testing instructions:**

1. Create and Enterprise with Data sharing consent option enabled and Enforced.
2. Create a coupon with this Enterprise containing courses in its catalog.
3. Create/link a user with this Enterprise
4. As an enterprise user login
5. Open the voucher redeem link in the coupon from step 2
6. Click on the button `Enroll Now` on any course.
7. A consent message page will show, verify the message changes on it.

**Merge checklist:**

- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [ ] Translations are updated
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.

**Screen shots of updated consent page**
<img width="544" alt="screen shot 2017-04-12 at 4 38 26 pm" src="https://cloud.githubusercontent.com/assets/5072991/24955859/9b48cc4e-1f9e-11e7-9649-5ab82b65608e.png">
<img width="595" alt="screen shot 2017-04-12 at 4 38 41 pm" src="https://cloud.githubusercontent.com/assets/5072991/24955873/a6277fca-1f9e-11e7-804c-ba734ab5a079.png">

