### PR TITLE
ENT-297 Sort Enterprise Customers by names

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ----------
 
+[0.33.1] - 2017-04-17
+---------------------
+
+* Order enterprise customers by name on enterprise customer django admin
+
+
 [0.33.0] - 2017-04-11
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.33.0"
+__version__ = "0.33.1"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/admin/__init__.py
+++ b/enterprise/admin/__init__.py
@@ -99,6 +99,7 @@ class EnterpriseCustomerAdmin(DjangoObjectActions, SimpleHistoryAdmin):
     )
 
     list_filter = ("active",)
+    ordering = ("name",)
     search_fields = ("name", "uuid",)
     inlines = [
         EnterpriseCustomerBrandingConfigurationInline,


### PR DESCRIPTION
@saleem-latif @asadiqbal08 @mattdrayer 

**Description:** Display enterprise customers by name on enterprise customers django admin

**JIRA:** [ENT-297](https://openedx.atlassian.net/browse/ENT-297)

**Dependencies:** N/A

**Merge deadline:** 21 April, 2017

**Installation instructions:** Install `edx-enterprise` from this branch `zub/ENT-297-display-enterprise-customers-by-name` in `edx-platform`.

**Testing instructions:**

1. Add multiple enterprises
2. Go to enterprise customers django admin at `admin/enterprise/enterprisecustomer/`
3. Check that the enterprises are sorted by name.

**Merge checklist:**

- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [ ] Translations are updated
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
