### PR TITLE
ENT-247 Increase the max size limit for enterprise logo

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ----------
 
+[0.33.6] - 2017-04-21
+---------------------
+
+* Increase max size limit for enterprise logo
+
+
 [0.33.5] - 2017-04-20
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.33.5"
+__version__ = "0.33.6"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/apps.py
+++ b/enterprise/apps.py
@@ -17,8 +17,8 @@ class EnterpriseConfig(AppConfig):
     """
 
     name = "enterprise"
-    valid_extensions = [".png", ]
-    image_size = getattr(settings, 'ENTERPRISE_CUSTOMER_LOGO_IMAGE_SIZE', 4 * 1024)
+    valid_image_extensions = [".png", ]
+    valid_max_image_size = getattr(settings, 'ENTERPRISE_CUSTOMER_LOGO_IMAGE_SIZE', 512)  # Value in KB's
 
     @property
     def auth_user_model(self):

--- a/enterprise/validators.py
+++ b/enterprise/validators.py
@@ -24,7 +24,7 @@ def validate_image_extension(value):
     """
     config = get_app_config()
     ext = os.path.splitext(value.name)[1]
-    if config and not ext.lower() in getattr(config, "valid_extensions", []):
+    if config and not ext.lower() in config.valid_image_extensions:
         raise ValidationError(_("Unsupported file extension."))
 
 
@@ -33,5 +33,7 @@ def validate_image_size(image):
     Validate that a particular image size.
     """
     config = get_app_config()
-    if config and not image.size < getattr(config, "image_size", 0):
-        raise ValidationError(_("The logo image file size must be less than 4KB."))
+    valid_max_image_size_in_bytes = config.valid_max_image_size * 1024
+    if config and not image.size <= valid_max_image_size_in_bytes:
+        raise ValidationError(
+            _("The logo image file size must be less than or equal to %s KB.") % getattr(config, "image_size", 0))

--- a/test_settings.py
+++ b/test_settings.py
@@ -117,4 +117,6 @@ MEDIA_URL = "/"
 ECOMMERCE_SERVICE_WORKER_USERNAME = 'ecommerce_worker'
 ENTERPRISE_SERVICE_WORKER_USERNAME = 'enterprise_worker'
 
+ENTERPRISE_CUSTOMER_LOGO_IMAGE_SIZE = 512   # Enterprise logo image size limit in KB's
+
 USE_TZ = True

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -730,27 +730,28 @@ class TestEnterpriseCustomerBrandingConfiguration(unittest.TestCase):
             self.assertEqual(EnterpriseCustomerBrandingConfiguration.objects.count(), 2)
 
     @ddt.data(
-        (False, 350 * 1024),
-        (False, 251 * 1024),
-        (False, 250 * 1024),
-        (False, 4 * 1024),
-        (True, 2 * 1024),
-        (True, 3 * 1024),
+        (False, 2048),
+        (False, 1024),
+        (True, 512),
+        (True, 256),
+        (True, 128),
     )
     @ddt.unpack
-    def test_image_size(self, valid_image, image_size):
+    def test_image_size(self, is_valid_image_size, image_size):
         """
-        Test image size, image_size < (4 * 1024) e.g. 4kb. See apps.py.
+        Test image size in KB's, image_size < 512 KB.
+        Default valid max image size is 512 KB (512 * 1024 bytes).
+        See config `valid_max_image_size` in apps.py.
         """
         file_mock = mock.MagicMock(spec=File, name="FileMock")
         file_mock.name = "test1.png"
-        file_mock.size = image_size
+        file_mock.size = image_size * 1024  # image size in bytes
         branding_configuration = EnterpriseCustomerBrandingConfiguration(
             enterprise_customer=EnterpriseCustomerFactory(),
             logo=file_mock
         )
 
-        if not valid_image:
+        if not is_valid_image_size:
             with self.assertRaises(ValidationError):
                 branding_configuration.full_clean()
         else:
@@ -763,7 +764,7 @@ class TestEnterpriseCustomerBrandingConfiguration(unittest.TestCase):
         (True, ".png"),
     )
     @ddt.unpack
-    def test_image_type(self, valid_image, image_extension):
+    def test_image_type(self, is_valid_image_extension, image_extension):
         """
         Test image type, currently .png is supported in configuration. see apps.py.
         """
@@ -775,7 +776,7 @@ class TestEnterpriseCustomerBrandingConfiguration(unittest.TestCase):
             logo=file_mock
         )
 
-        if not valid_image:
+        if not is_valid_image_extension:
             with self.assertRaises(ValidationError):
                 branding_configuration.full_clean()
         else:


### PR DESCRIPTION
@saleem-latif @asadiqbal08 @mattdrayer 

**Description:** Increase the max size limit for enterprise logo

**JIRA:** [ENT-247](https://openedx.atlassian.net/browse/ENT-247)

**Dependencies:** https://github.com/edx/edx-platform/pull/14907

**Merge deadline:** 21 April, 2017

**Installation instructions:** Install `edx-enterprise` from this branch `zub/ENT-247-update-enterprise-logo-image-size` in `edx-platform`.

**Testing instructions:**

1. Go to enterprise customers django admin at `admin/enterprise/enterprisecustomer/`
2. Try to add a new enterprise with a `png` image of size upto `512 KB`
3. Verify that enterprise is saved successfully with an image of size upto `512 KB`
4. Try again to a new enterprise with a `png` image of size greater than `512 KB`
5. Verify that a validation error is raise with message: `The logo image file size must be less than or equal to 512KB.`

**Merge checklist:**

- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [ ] Translations are updated
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
