### PR TITLE
ENT-303: Restrict entitlements to Enterprise-linked coupons

### DIFF
--- a/enterprise/admin/__init__.py
+++ b/enterprise/admin/__init__.py
@@ -85,12 +85,37 @@ class EnterpriseCustomerEntitlementInline(admin.StackedInline):
     ecommerce_coupon_url.short_description = 'Coupon URL'
 
     def get_formset(self, request, obj=None, **kwargs):
+        """
+        Retrieve the inline formset for the EnterpriseCustomerEntitlementInline admin.
+
+        Inlines don't get to have their get_form method called, like regular admins do.
+        The effect of this is that we're a bit more limited in what we can patch onto
+        that form. For a standard get_form method, we could make a call to retrieve the
+        list of allowed coupons and patch the options on directly, but we can't do that
+        here. What we _can_ do is set the formfield_callback kwarg.
+
+        What this does is provide a function that will, given a particular database field
+        that needs to be included in the inline, returns the appropriate form field widget
+        to render in the form. We provide the standard method that would be used anyway,
+        but patched with an extra kwarg containing the details of the EnterpriseCustomer
+        object that's provided to this method, but not provided to that method by default.
+        functools.partial lets us add that variable on, and then the standard logic is enough.
+        """
         kwargs['formfield_callback'] = partial(self.formfield_for_dbfield, request=request, obj=obj)
         return super(EnterpriseCustomerEntitlementInline, self).get_formset(request, obj, **kwargs)
 
     def formfield_for_dbfield(self, db_field, **kwargs):
+        """
+        For most fields, just fall through to the standard behavior. If the field is entitlement_id set up a dropdown.
+
+        This method gets wrapped with functools.partial, as described in the get_formset method. When
+        wrapped in that manner, it receives extra `request` and `obj` kwargs that can be used to get
+        additional information. For most fields, simply call super() and return the standard result;
+        for `entitlement_id`, call the EnterpriseCustomer to retrieve a list of the coupons that can
+        be associated as entitlements.
+        """
         enterprise_customer = kwargs.pop('obj', None)
-        request = kwargs.get('request', None)
+        request = kwargs.get('request')
         formfield = super(EnterpriseCustomerEntitlementInline, self).formfield_for_dbfield(db_field, **kwargs)
         if db_field.name == "entitlement_id" and enterprise_customer:
             return ChoiceField(choices=enterprise_customer.coupon_options(request.user), required=True)

--- a/enterprise/ecommerce_api.py
+++ b/enterprise/ecommerce_api.py
@@ -18,7 +18,7 @@ except ImportError:
 
 class EcommerceApiClient(object):
     """
-    Object builds an API client to make calls to the Ecommerce API.
+    Object builds an API client to make calls to the ecommerce API.
     """
 
     def __init__(self, user):
@@ -33,6 +33,12 @@ class EcommerceApiClient(object):
     def get_single_coupon(self, coupon_id):
         """
         Get the details of a single coupon, identified by ID.
+
+        If the client fails to retrieve the details of a coupon, as indicated
+        by a raised exception, catch it and simply return an empty value. Depending
+        on the exact architecture of the upstream client, an error could be of
+        any number of given base classes, so we catch broadly, as specifying the entire
+        set of exceptions that we'd need to look for would both be fragile and complex.
         """
         if self.client is None:
             return {}
@@ -45,6 +51,12 @@ class EcommerceApiClient(object):
     def get_coupons_by_enterprise_customer(self, enterprise_customer_uuid):
         """
         Get a list of the coupons associated with an EnterpriseCustomer.
+
+        If the client fails to retrieve a list of coupons, as indicated by a
+        raised exception, catch it and simply return an empty value. Depending
+        on the exact architecture of the upstream client, an error could be of
+        any number of given base classes, so we catch broadly, as specifying the entire
+        set of exceptions that we'd need to look for would both be fragile and complex.
         """
         if self.client is None:
             return []

--- a/enterprise/ecommerce_api.py
+++ b/enterprise/ecommerce_api.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+"""
+Utilities to get details from the ecommerce API.
+"""
+from __future__ import absolute_import, unicode_literals
+
+try:
+    from openedx.core.djangoapps.commerce.utils import ecommerce_api_client, is_commerce_service_configured
+except ImportError:
+    def is_commerce_service_configured():
+        """
+        When we call this name, return False, since we couldn't import.
+        """
+        return False
+
+    ecommerce_api_client = None
+
+
+class EcommerceApiClient(object):
+    """
+    Object builds an API client to make calls to the Ecommerce API.
+    """
+
+    def __init__(self, user):
+        """
+        Create an EcommerceApiClient, initialized with a JWT from the user passed in.
+        """
+        if ecommerce_api_client is not None and is_commerce_service_configured():
+            self.client = ecommerce_api_client(user)
+        else:
+            self.client = None
+
+    def get_single_coupon(self, coupon_id):
+        """
+        Get the details of a single coupon, identified by ID.
+        """
+        if self.client is None:
+            return {}
+        try:
+            response = self.client.coupons(coupon_id).get()
+        except Exception:  # pylint: disable=broad-except
+            response = {}
+        return response
+
+    def get_coupons_by_enterprise_customer(self, enterprise_customer_uuid):
+        """
+        Get a list of the coupons associated with an EnterpriseCustomer.
+        """
+        if self.client is None:
+            return []
+        results = []
+        page = 1
+        next_page = True
+        try:
+            while next_page:
+                response = self.client.coupons.get(enterprise_customer=enterprise_customer_uuid, page=page)
+                results += response.get('results', [])
+                next_page = response.get('next')
+                page += 1
+        except Exception:  # pylint: disable=broad-except
+            pass
+        return results

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -25,6 +25,7 @@ from django.utils.translation import ugettext_lazy as _
 from model_utils.models import TimeStampedModel
 
 from enterprise import utils
+from enterprise.ecommerce_api import EcommerceApiClient
 from enterprise.lms_api import ThirdPartyAuthApiClient, enroll_user_in_course_locally
 from enterprise.validators import validate_image_extension, validate_image_size
 
@@ -118,6 +119,16 @@ class EnterpriseCustomer(TimeStampedModel):
             "at login, or is required at enrollment."
         )
     )
+
+    def coupon_options(self, user):
+        """
+        Given a user to use for authentication, fetch a list of the coupons linked to this EnterpriseCustomer.
+        """
+        client = EcommerceApiClient(user)
+        coupons = client.get_coupons_by_enterprise_customer(self.uuid)
+        return models.fields.BLANK_CHOICE_DASH + [
+            (coupon['id'], coupon['title'],) for coupon in coupons
+        ]
 
     @property
     def identity_provider(self):

--- a/tests/test_ecommerce_api.py
+++ b/tests/test_ecommerce_api.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for the `edx-enterprise` Ecommerce API module.
+"""
+
+from __future__ import absolute_import, unicode_literals, with_statement
+
+
+import unittest
+
+import mock
+
+from django.contrib.auth.models import User
+
+from enterprise.ecommerce_api import EcommerceApiClient
+
+
+class TestEcommerceApiClientInitialization(unittest.TestCase):
+    """
+    Test the setup process for building an EcommerceApiClient instance.
+    """
+
+    @mock.patch('enterprise.ecommerce_api.ecommerce_api_client')
+    def test_init_not_configured(self, _):
+        client = EcommerceApiClient(mock.MagicMock(spec=User))
+        assert client.client is None
+
+    def test_init_no_client(self):
+        client = EcommerceApiClient(mock.MagicMock(spec=User))
+        assert client.client is None
+
+    @mock.patch('enterprise.ecommerce_api.ecommerce_api_client')
+    @mock.patch('enterprise.ecommerce_api.is_commerce_service_configured')
+    def test_init_configured(self, mock_is_configured, mock_api_client):
+        mock_is_configured.return_value = True
+        resulting_api_client_singleton = object()
+        mock_api_client.return_value = resulting_api_client_singleton
+        client = EcommerceApiClient(mock.MagicMock(spec=User))
+        assert client.client is resulting_api_client_singleton
+
+
+class TestEcommerceApiClientBehavior(unittest.TestCase):
+    """
+    Test the behavior of getting a single coupon by ID.
+    """
+
+    def setUp(self):
+        self.subclient = mock.MagicMock()
+        with mock.patch('enterprise.ecommerce_api.ecommerce_api_client') as client_getter:
+            client_getter.return_value = self.subclient
+            with mock.patch('enterprise.ecommerce_api.is_commerce_service_configured') as is_configured:
+                is_configured.return_value = True
+                self.client = EcommerceApiClient(mock.MagicMock(spec=User))
+        self.id_getter = self.subclient.coupons
+        self.get_mock = self.subclient.coupons.return_value.get
+        self.get_multiple_mock = self.subclient.coupons.get
+        super(TestEcommerceApiClientBehavior, self).setUp()
+
+    def test_single_coupon(self):
+        self.get_mock.return_value = {
+            'response': 'value'
+        }
+        response = self.client.get_single_coupon(123)
+        assert response == {'response': 'value'}
+        self.get_mock.assert_called_once()
+        self.id_getter.assert_called_once_with(123)
+
+    def test_single_coupon_fails(self):
+        self.get_mock.side_effect = ValueError
+        response = self.client.get_single_coupon(123)
+        assert response == {}
+        self.get_mock.assert_called_once()
+        self.id_getter.assert_called_once_with(123)
+
+    def test_single_coupon_no_client(self):
+        self.client.client = None
+        response = self.client.get_single_coupon(123)
+        assert response == {}
+
+    def test_get_multiple_coupons(self):
+        self.get_multiple_mock.side_effect = [
+            {"results": [1, 2, 3], "next": "url"},
+            {"results": [4, 5, 6]},
+            {"results": [7, 8, 9]}
+        ]
+        response = self.client.get_coupons_by_enterprise_customer('123-456-789-ABC-DEF-0')
+        assert response == [1, 2, 3, 4, 5, 6]
+        self.get_multiple_mock.assert_has_calls(
+            [
+                mock.call(enterprise_customer='123-456-789-ABC-DEF-0', page=1),
+                mock.call(enterprise_customer='123-456-789-ABC-DEF-0', page=2),
+            ]
+        )
+
+    def test_get_multiple_coupons_error_partway_through(self):
+        self.get_multiple_mock.side_effect = [
+            {"results": [1, 2, 3], "next": "url"},
+            ValueError,
+            {"results": [7, 8, 9]}
+        ]
+        response = self.client.get_coupons_by_enterprise_customer('123-456-789-ABC-DEF-0')
+        assert response == [1, 2, 3]
+        self.get_multiple_mock.assert_has_calls(
+            [
+                mock.call(enterprise_customer='123-456-789-ABC-DEF-0', page=1),
+                mock.call(enterprise_customer='123-456-789-ABC-DEF-0', page=2),
+            ]
+        )
+
+    def test_get_multiple_coupons_error_at_beginning(self):
+        self.get_multiple_mock.side_effect = ValueError
+        response = self.client.get_coupons_by_enterprise_customer('123-456-789-ABC-DEF-0')
+        assert response == []
+        self.get_multiple_mock.assert_has_calls(
+            [
+                mock.call(enterprise_customer='123-456-789-ABC-DEF-0', page=1),
+            ]
+        )
+
+    def test_get_multiple_coupons_no_client(self):
+        self.client.client = None
+        response = self.client.get_coupons_by_enterprise_customer('123-456-789-ABC-DEF-0')
+        assert response == []


### PR DESCRIPTION
**Description:**

This pull request updates the EnterpriseCustomer admin panel such that entitlement coupon IDs are entered via a dropdown selection, rather than via a blank field. This allows us to restrict the selection of coupons that are either linked to no EnterpriseCustomer, or coupons that are linked to a different EnterpriseCustomer, preventing an edge case where entitlements that weren't linked to an EnterpriseCustomer on the ecommerce side didn't prompt for consent.

**JIRA:** [ENT-303](https://openedx.atlassian.net/browse/ENT-303)

**Dependencies:** Depends on edx/ecommerce#1247

**Merge deadline:** 24 April 2017

**Installation instructions:**
1. Requires fully-configured ecommerce setup
2. Create multiple coupons; link some of them to your devstack's EnterpriseCustomer; leave some of them disconnected.

**Testing instructions:**

1. Go to the EnterpriseCustomer admin; click to add an entitlement.
2. In the drop-down menu, verify that only those coupons that are linked to your EnterpriseCustomer in the ecommerce database are available to select.
3. Shut down your ecommerce stack and refresh the page.
4. Observe that the widget for selecting an entitlement ID is blank and doesn't show any options.

**Merge checklist:**

- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
