### PR TITLE
ENT-364 fix enterprise logo validation message

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,10 +14,17 @@ Change Log
 Unreleased
 ----------
 
+[0.33.9] - 2017-04-26
+---------------------
+
+* Fix enterprise logo validation message for max image size limit
+
+
 [0.33.8] - 2017-04-26
 ---------------------
 
 * Updated calls to get_edx_api_data as its signature has changed in openedx.
+
 
 [0.33.7] - 2017-04-24
 ---------------------

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.33.8"
+__version__ = "0.33.9"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/validators.py
+++ b/enterprise/validators.py
@@ -36,4 +36,4 @@ def validate_image_size(image):
     valid_max_image_size_in_bytes = config.valid_max_image_size * 1024
     if config and not image.size <= valid_max_image_size_in_bytes:
         raise ValidationError(
-            _("The logo image file size must be less than or equal to %s KB.") % getattr(config, "image_size", 0))
+            _("The logo image file size must be less than or equal to %s KB.") % config.valid_max_image_size)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -752,8 +752,11 @@ class TestEnterpriseCustomerBrandingConfiguration(unittest.TestCase):
         )
 
         if not is_valid_image_size:
-            with self.assertRaises(ValidationError):
+            with self.assertRaises(ValidationError) as validation_error:
                 branding_configuration.full_clean()
+
+            expected_validation_message = 'The logo image file size must be less than or equal to 512 KB.'
+            self.assertEqual(validation_error.exception.messages[0], expected_validation_message)
         else:
             branding_configuration.full_clean()  # exception here will fail the test
 


### PR DESCRIPTION
@saleem-latif @asadiqbal08 @mattdrayer

**Description:** Fix enterprise logo validation message for max image size limit

**JIRA:** [ENT-364](https://openedx.atlassian.net/browse/ENT-364)

**Dependencies:** N/A

**Merge deadline:** 5 May, 2017

**Installation instructions:** Install edx-enterprise from this branch `zub/ENT-364-fix-enterprise-log-validation-message` in `edx-platform`.

**Testing instructions:**

1. Go to enterprise customers django admin at `admin/enterprise/enterprisecustomer/`
2. Try to add a new enterprise with a `png` image of size upto `512 KB`
3. Verify that enterprise is saved successfully with an image of size upto `512 KB`
4. Try again to a new enterprise with a `png` image of size greater than `512 KB`
5. Verify that a validation error is raise with message: `The logo image file size must be less than or equal to 512 KB.`

**Merge checklist:**

- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [ ] Translations are updated
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
