### PR TITLE
Update calls to get_edx_api_data as its signature has changed in openedx

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.33.8] - 2017-04-26
+---------------------
+
+* Updated calls to get_edx_api_data as its signature has changed in openedx.
+
 [0.33.7] - 2017-04-24
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.33.7"
+__version__ = "0.33.8"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/course_catalog_api.py
+++ b/enterprise/course_catalog_api.py
@@ -222,9 +222,8 @@ class CourseCatalogApiClient(object):
         """
         default_val = default if default != self.DEFAULT_VALUE_SAFEGUARD else {}
         result = get_edx_api_data(
-            CatalogIntegration.current(),
-            self.user,
-            resource,
+            api_config=CatalogIntegration.current(),
+            resource=resource,
             api=self.client,
             **kwargs
         )

--- a/tests/test_course_catalog_api.py
+++ b/tests/test_course_catalog_api.py
@@ -83,10 +83,16 @@ class TestCourseCatalogApi(unittest.TestCase):
     @staticmethod
     def _get_important_parameters(get_data_mock):
         """
-        Return important (i.e. varying) parmaameters to get_edx_api_data
+        Return important (i.e. varying) parameters to get_edx_api_data
         """
         args, kwargs = get_data_mock.call_args
-        return args[2], kwargs.get('resource_id', None)
+
+        # This test is to make sure that all calls to get_edx_api_data are made using kwargs
+        # and there is no positional argument. This is required as changes in get_edx_api_data's
+        # signature are breaking edx-enterprise and using kwargs would reduce that.
+        assert args == ()
+
+        return kwargs.get('resource', None), kwargs.get('resource_id', None)
 
     @staticmethod
     def _make_course_run(key, *seat_types):


### PR DESCRIPTION
**Description:** This PR fixes a bug that was causing 500 errors on enterprise customer admin.

**Testing instructions:**

1. Go to enterprise customer admin page at /admin/enterprise/enterprisecustomer/ 
2. Click on any enterprise customer to open its details page.
3. There should not be a 500 error.

**Merge checklist:**

- [x] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [x] Translations are updated
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)