### PR TITLE
ENT-351 Add tpa_hint to urls in SAP course export

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.33.11] - 2017-05-02
+----------------------
+
+* Add tpa hint if available for launchURLs for SAP Course metadata push.
+
 [0.33.10] - 2017-05-02
 ----------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.33.10"
+__version__ = "0.33.11"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/sap_success_factors/utils.py
+++ b/integrated_channels/sap_success_factors/utils.py
@@ -10,7 +10,7 @@ from logging import getLogger
 
 from django.apps import apps
 from django.utils import timezone
-from six.moves.urllib.parse import urlunparse  # pylint: disable=import-error,wrong-import-order
+from six.moves.urllib.parse import urlencode, urlunparse  # pylint: disable=import-error,wrong-import-order
 
 from enterprise.django_compatibility import reverse
 from enterprise.lms_api import parse_lms_api_datetime
@@ -285,8 +285,12 @@ def get_course_track_selection_url(enterprise_customer, course_id):
     """
     netloc = enterprise_customer.site.domain
     scheme = COURSE_URL_SCHEME
+    if enterprise_customer.identity_provider:
+        tpa_hint = urlencode({'tpa_hint': enterprise_customer.identity_provider})
+    else:
+        tpa_hint = ''
     path = reverse('course_modes_choose', args=[course_id])
-    return urlunparse((scheme, netloc, path, None, None, None))
+    return urlunparse((scheme, netloc, path, None, tpa_hint, None))
 
 
 def parse_datetime_to_epoch(datestamp):

--- a/tests/test_sap_successfactors.py
+++ b/tests/test_sap_successfactors.py
@@ -68,20 +68,33 @@ class TestSapSuccessFactorsUtils(unittest.TestCase):
             'https',
             'example.com',
             'course-v1:edX+DemoX+Demo_Course',
-            'https://example.com/course_modes/choose/course-v1:edX+DemoX+Demo_Course/',
+            'some_idp',
+            'https://example.com/course_modes/choose/course-v1:edX+DemoX+Demo_Course/?tpa_hint=some_idp',
         ),
         (
             'ftp',
             'otherdomain.com',
             'course-v1:Starfleet+Phaser101+Spring_2017',
+            None,
             'ftp://otherdomain.com/course_modes/choose/course-v1:Starfleet+Phaser101+Spring_2017/',
         )
     )
     @ddt.unpack
     @mock.patch('integrated_channels.sap_success_factors.utils.reverse')
-    def test_get_course_track_selection_url(self, scheme, domain, course_id, expected_url, reverse_mock):
+    def test_get_course_track_selection_url(
+            self,
+            scheme,
+            domain,
+            course_id,
+            identity_provider,
+            expected_url,
+            reverse_mock
+    ):
         reverse_mock.return_value = '/course_modes/choose/{}/'.format(course_id)
         with mock.patch('integrated_channels.sap_success_factors.utils.COURSE_URL_SCHEME', scheme):
-            enterprise_customer = mock.MagicMock(site=mock.MagicMock(domain=domain))
+            enterprise_customer = mock.MagicMock(
+                site=mock.MagicMock(domain=domain),
+                identity_provider=identity_provider
+            )
             assert get_course_track_selection_url(enterprise_customer, course_id) == expected_url
             reverse_mock.assert_called_once_with('course_modes_choose', args=[course_id])


### PR DESCRIPTION
**Description:** We weren't adding the tpa_hint of the enterprise customer identity provider to the launchURL's of the courses, which we need in order to take advantage of all of our SSO logic.

**JIRA:** https://openedx.atlassian.net/browse/ENT-351

**Dependencies:** Soft dependency on https://github.com/edx/edx-enterprise/pull/94 for sandbox testing purposes - so you will notice the code is included here, but I can separate those changes out once this is approved.

**Merge deadline:** 5/5/2017

**Installation instructions:** Requires an environment with the catalog service running.

**Testing instructions:**

Edxapp sandbox: https://brittneyexline.sandbox.edx.org

1. Set up a configuration for an enterprise customer and success factors against our test SAP instance. (This has been done already on the sandbox)
2. Make a catalog at least one course. (On the sandbox it is "One Catalog to rule them all")
3. Run the catalog export script, ensure that it has run successfully. To do this on the sandbox, ssh to the edxapp sandbox. Then run the following commands:
$ sudo -H -u edxapp bash
$ source /edx/app/edxapp/edxapp_env
$ cd /edx/app/edxapp/edx-platform/
$ /edx/bin/python.edxapp /edx/bin/manage.edxapp lms transmit_courseware_data --catalog_user staff --settings=aws

To see the courses on SAP, follow the instructions here for Importing Courses to view which courses have been sent. Verify that the launchURL that was sent has the appropriate tpa_hint as a query parameter.
https://openedx.atlassian.net/wiki/pages/viewpage.action?spaceKey=SOL&title=SAP+Testing+and+Configuration+notes

**Merge checklist:**

- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
