### PR TITLE
ENT-330 Add enterprise landing page

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ----------
 
+[0.33.12] - 2017-05-03
+----------------------
+
+* Add enterprise landing page
+
+
 [0.33.11] - 2017-05-02
 ----------------------
 
@@ -23,6 +29,7 @@ Unreleased
 ----------------------
 
 * Fix bug with inactivating SAP courses that are no longer in the catalog.
+
 
 [0.33.9] - 2017-04-26
 ---------------------

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.33.11"
+__version__ = "0.33.12"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/static/enterprise/enterprise_course_enrollment_page.css
+++ b/enterprise/static/enterprise/enterprise_course_enrollment_page.css
@@ -1,0 +1,204 @@
+* {
+    font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 16px;
+}
+
+body, .zebra-stripe > :nth-child(2n+1), .depth-0 {
+    background-color: white;
+    padding-bottom: 100px;
+}
+
+.consent-title {
+    font-size: 24px;
+    color: #065683;
+}
+
+.pinstripe {
+    border-top: 2px solid #0075b4;
+}
+
+.logo-container {
+    padding-top: 10px;
+    width: 70%;
+    max-width: 700px;
+    min-width: 300px;
+    height: auto;
+    margin: 0 auto;
+}
+
+.enterprise-container:after,
+.row:after {
+    clear: both;
+}
+
+.media .media-content, .radio-block .radio,
+.radio-block label {
+    display: table-cell;
+    vertical-align: middle;
+}
+
+.enterprise-container {
+    min-width: 300px;
+    max-width: 700px;
+    margin: 0 auto;
+    line-height: 1.5;
+    font-size: 14px;
+    color: #383838;
+}
+
+.enterprise-container * {
+    font-size: 14px;
+}
+
+.enterprise-container a {
+    color: #2489c2;
+}
+
+.enterprise-container a:hover {
+    color: #0b5c8a;
+}
+
+.enterprise-logo {
+    width: auto;
+    height: 60px;
+    display: none;
+}
+
+[class*='col-'] {
+    padding: 0 30px;
+}
+
+@media (min-width: 768px) {
+    [class*='col-'] {
+        float: left;
+    }
+
+    [class*='col-'].col-3 {
+        width: 30%;
+        padding-left: 0;
+    }
+
+    [class*='col-'].col-7 {
+        width: 70%;
+        padding-right: 0;
+    }
+
+    .border-left {
+        border-left: 1px solid #bcdbed;
+    }
+
+    .enterprise-logo {
+        display: block;
+    }
+}
+
+.partnered-text {
+    font-size: 16px;
+    color: #0b5c8a;
+    margin-top: 5px;
+    margin-bottom: 20px;
+}
+
+.partnered-text strong {
+    font-size: 1.05em;
+}
+
+.course-confirmation-title {
+    font-size: 20px;
+    color: #2489c2;
+    font-weight: normal;
+    margin-bottom: 6px;
+}
+
+.course-image {
+    width: auto;
+    height: 50px;
+}
+
+.media {
+    margin-bottom: 10px;
+    display: table;
+    width: 100%;
+}
+
+.media .thumbnail,
+.media .media-content {
+    display: table-cell;
+    vertical-align: top;
+}
+
+.media .thumbnail {
+    width: 55px;
+    padding-top: 6px;
+}
+
+.media .media-content {
+    padding-left: 15px;
+}
+
+.media .media-content .course-title {
+    margin-bottom: 5px;
+    font-size: 16px;
+    font-weight: bold;
+}
+
+.course-detail {
+    font-size: 14px;
+    margin-bottom: 15px;
+}
+
+.course-detail .course-org {
+    font-size: 18px;
+}
+
+.course-info,
+.course-info span {
+    font-size: 1em;
+}
+
+.course-info .fa,
+.course-info span {
+    display: inline-block;
+    vertical-align: middle;
+    margin-right: 5px;
+}
+
+.caption {
+    margin-bottom: 15px;
+    font-size: 16px;
+}
+
+.radio-block {
+    margin-bottom: 15px;
+}
+
+.radio-block .radio,
+.radio-block label {
+    vertical-align: top;
+}
+
+.radio-block .radio {
+    width: 25px;
+    padding-top: 5px;
+}
+
+.radio-block label > span {
+    display: block;
+}
+
+.btn-continue {
+    background: #0075B4;
+    border: none;
+    color: #fff;
+    border-radius: 5px;
+    margin-top: 10px;
+    padding: 10px 15px;
+    box-shadow: none;
+    font-weight: bold;
+}
+
+.btn-continue:hover,
+.btn-continue:focus {
+    cursor: pointer;
+    background: #0b5177;
+}

--- a/enterprise/templates/enterprise/enterprise_course_enrollment_page.html
+++ b/enterprise/templates/enterprise/enterprise_course_enrollment_page.html
@@ -1,0 +1,85 @@
+<%namespace name='static' file='/static_content.html'/>
+
+<%static:css group='style-vendor'/>
+<%! main_css = "style-main-v2" %>
+<%static:css group='${self.attr.main_css}'/>
+
+<%!
+from django.utils.translation import ugettext as _
+%>
+
+<html lang="${ page_language }">
+  <title>${ page_title } | ${ platform_name }</title>
+  <head>
+    <link rel="stylesheet" href="${static.url('css/vendor/font-awesome.css')}"/>
+    <link rel="stylesheet" href="${static.url('enterprise/enterprise_course_enrollment_page.css')}"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  </head>
+  <body>
+
+    <header class="logo-container" aria-label="${ page_title }">
+      <h1>
+        <img src="${static.url('images/logo.png')}" alt="${ platform_name }"/>
+      </h1>
+    </header>
+    <hr class="pinstripe"/>
+
+    <div class="enterprise-container">
+      <div class="row">
+        <div class="col-3">
+          <img class="enterprise-logo" src="${ enterprise_customer.branding_configuration.logo.url }" alt="${ enterprise_customer.name }"/>
+          <div class="partnered-text">
+            ${ enterprise_welcome_text }
+          </div>
+        </div>
+        <div class="col-7 border-left">
+          <h3 class="course-confirmation-title">${ confirmation_text }</h3>
+          <div class="media">
+            <div class="thumbnail">
+              <img class="course-image" src="${ course_image_uri }" alt="${ course_name }"/>
+            </div>
+            <div class="media-content">
+              <div class="course-title">${ course_name }</div>
+            </div>
+          </div>
+          <div class="course-detail">
+            <div class="course-org">
+              ${ course_organization }
+            </div>
+            <div class="course-info">
+              <i class="fa fa-clock-o" aria-hidden="true"></i>
+              <span>${ starts_at_text } ${ course_start_date } &nbsp;| &nbsp; ${ course_pacing } - ${ course_pace_text }</span>
+            </div>
+            ${ course_short_description }
+            <a href="#!">${ view_course_details_text }</a>
+          </div>
+          <form>
+            <div class="caption">${ select_mode_text }</div>
+            <div class="radio-block">
+              <div class="radio">
+                <input type="radio" name="data_sharing_consent" id="radio1" checked="checked"/>
+              </div>
+              <label for="radio1">
+                <strong class="title">${ enroll_text }</strong>
+                <span class="price">${ price_text }: <strike>$200</strike> $190</span>
+                ${ discount_text }
+              </label>
+            </div>
+            <div class="radio-block">
+              <div class="radio">
+                <input type="radio" name="data_sharing_consent" id="radio2"/>
+              </div>
+              <label for="radio2">
+                <strong class="title">${ audit_text }</strong>
+                <span class="price">${ price_text }: ${ free_price_text }</span>
+                ${ not_eligible_for_certificate_text }
+              </label>
+            </div>
+            <button class="btn-continue">${ continue_link_text }</button>
+          </form>
+        </div>
+      </div>
+    </div>
+
+  </body>
+</html>

--- a/enterprise/urls.py
+++ b/enterprise/urls.py
@@ -4,9 +4,11 @@ URLs for enterprise.
 """
 from __future__ import absolute_import, unicode_literals
 
+from django.conf import settings
 from django.conf.urls import include, url
 
-from enterprise.views import GrantDataSharingPermissions
+from enterprise.views import CourseEnrollmentView, GrantDataSharingPermissions
+
 
 urlpatterns = [
     url(
@@ -14,6 +16,10 @@ urlpatterns = [
         GrantDataSharingPermissions.as_view(),
         name='grant_data_sharing_permissions'
     ),
+    url(
+        r'^enterprise/(?P<enterprise_uuid>[^/]+)/course/{}/enroll/$'.format(settings.COURSE_ID_PATTERN),
+        CourseEnrollmentView.as_view(),
+        name='enterprise_course_enrollment_page'),
     url(
         r'^enterprise/api/',
         include('enterprise.api.urls'),

--- a/test_settings.py
+++ b/test_settings.py
@@ -119,4 +119,8 @@ ENTERPRISE_SERVICE_WORKER_USERNAME = 'enterprise_worker'
 
 ENTERPRISE_CUSTOMER_LOGO_IMAGE_SIZE = 512   # Enterprise logo image size limit in KB's
 
+# These are standard regexes for pulling out info like course_ids, usage_ids, etc.
+COURSE_KEY_PATTERN = r'(?P<course_key_string>[^/+]+(/|\+)[^/+]+(/|\+)[^/?]+)'
+COURSE_ID_PATTERN = COURSE_KEY_PATTERN.replace('course_key_string', 'course_id')
+
 USE_TZ = True


### PR DESCRIPTION
**WIP**
@saleem-latif @asadiqbal08 @mattdrayer @douglashall 

**Description:** Add static enterprise landing page with course mode selection.

**JIRA:** [ENT-330](https://openedx.atlassian.net/browse/ENT-330)

**Dependencies:** N/A

**Merge deadline:** 5 May, 2017

**Installation instructions:**  Install `edx-enterprise` from this branch `zub/ENT-330-enterprise-landing-page` in `edx-platform`.

**Testing instructions:**

1. Go to enterprise customers django admin at `admin/enterprise/enterprisecustomer/`
2. Add enterprise customer with logo
3. Add a course in the enterprise customer catalog
4. View the enterprise landing page for the enterprise course by accessing the url with enterprise customer uuid `ec_uuid` from step no 2, e.g: `http://zubair.localhost:8000/enterprise/course/course-v1:edX+TEST_01+2016_R1/?ec_uuid=72416e52-8c77-4860-9584-15e5b06220fb`

**Merge checklist:**

- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
