### PR TITLE
ENT-359 Fix a couple bugs with sending learner data

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.33.16] - 2017-05-15
+----------------------
+
+* Bug fixes for SAP learner completion data passback.
+
 [0.33.15] - 2017-05-10
 ----------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.33.15"
+__version__ = "0.33.16"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/lms_api.py
+++ b/enterprise/lms_api.py
@@ -209,7 +209,7 @@ class ThirdPartyAuthApiClient(LmsApiClient):
             string or None: the remote name of the given user.  None if not found.
         """
         try:
-            returned = self.client.providers(identity_provider).users(username).get()
+            returned = self.client.providers(identity_provider).users.get(username=username)
             results = returned.get('results', [])
         except HttpNotFoundError:
             LOGGER.error('remote_id not found for third party provider=%s, username=%s', identity_provider, username)

--- a/integrated_channels/sap_success_factors/models.py
+++ b/integrated_channels/sap_success_factors/models.py
@@ -194,7 +194,7 @@ class LearnerDataTransmissionAudit(models.Model):
         '''
         return SAPSuccessFactorsGlobalConfiguration.current().provider_id
 
-    def _payload_data(self, empty_value):
+    def _payload_data(self):
         """
         Convert the audit record's fields into SAP SuccessFactors key/value pairs.
         """
@@ -207,24 +207,26 @@ class LearnerDataTransmissionAudit(models.Model):
             completedTimestamp=self.completed_timestamp,
             grade=self.grade,
             # TODO: determine these values from the enrollment seat?
-            price=empty_value,
-            currency=empty_value,
-            creditHours=empty_value,
-            # These fields currently have no edX source, so remain empty.
-            totalHours=empty_value,
-            contactHours=empty_value,
-            cpeHours=empty_value,
-            instructorName=empty_value,
-            comments=empty_value,
+            # We might at a later date choose to send these values,
+            # but at this point we will omit them from the payload to avoid errors.
+            #
+            # price=empty_value,
+            # currency=empty_value,
+            # creditHours=empty_value,
+            # totalHours=empty_value,
+            # contactHours=empty_value,
+            # cpeHours=empty_value,
+            # instructorName=empty_value,
+            # comments=empty_value,
         )
 
-    def serialize(self, empty_value=''):
+    def serialize(self):
         """
         Return a JSON-serialized representation.
 
         Sort the keys so the result is consistent and testable.
         """
-        return json.dumps(self._payload_data(empty_value=empty_value), sort_keys=True)
+        return json.dumps(self._payload_data(), sort_keys=True)
 
 
 @python_2_unicode_compatible

--- a/tests/test_lms_api.py
+++ b/tests/test_lms_api.py
@@ -150,7 +150,10 @@ def test_get_remote_id_not_found():
     provider_id = "DeathStar"
     responses.add(
         responses.GET,
-        _url("third_party_auth", "providers/{provider}/users/{user}".format(provider=provider_id, user=username)),
+        _url("third_party_auth", "providers/{provider}/users?username={user}".format(
+            provider=provider_id, user=username
+        )),
+        match_querystring=True,
         status=404
     )
     client = lms_api.ThirdPartyAuthApiClient()
@@ -173,7 +176,10 @@ def test_get_remote_id_no_results():
     }
     responses.add(
         responses.GET,
-        _url("third_party_auth", "providers/{provider}/users/{user}".format(provider=provider_id, user=username)),
+        _url("third_party_auth", "providers/{provider}/users?username={user}".format(
+            provider=provider_id, user=username
+        )),
+        match_querystring=True,
         json=expected_response,
     )
     client = lms_api.ThirdPartyAuthApiClient()
@@ -196,7 +202,10 @@ def test_get_remote_id():
     }
     responses.add(
         responses.GET,
-        _url("third_party_auth", "providers/{provider}/users/{user}".format(provider=provider_id, user=username)),
+        _url("third_party_auth", "providers/{provider}/users?username={user}".format(
+            provider=provider_id, user=username
+        )),
+        match_querystring=True,
         json=expected_response,
     )
     client = lms_api.ThirdPartyAuthApiClient()

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -359,8 +359,9 @@ def stub_transmit_learner_data_apis(testcase, certificate, self_paced, end_date,
     responses.add(
         responses.GET,
         urljoin(lms_api.ThirdPartyAuthApiClient.API_BASE_URL,
-                "providers/{provider}/users/{user}".format(provider=testcase.identity_provider,
-                                                           user=testcase.user.username)),
+                "providers/{provider}/users?username={user}".format(provider=testcase.identity_provider,
+                                                                    user=testcase.user.username)),
+        match_querystring=True,
         json=dict(results=[
             dict(username=testcase.user.username, remote_id='remote-user-id'),
         ]),
@@ -417,19 +418,11 @@ def get_expected_output(**expected_completion):
     """
     output_template = (
         '{{'
-        '"comments": "", '
         '"completedTimestamp": {timestamp}, '
-        '"contactHours": "", '
         '"courseCompleted": "{completed}", '
         '"courseID": "{course_id}", '
-        '"cpeHours": "", '
-        '"creditHours": "", '
-        '"currency": "", '
         '"grade": "{grade}", '
-        '"instructorName": "", '
-        '"price": "", '
         '"providerID": "{provider_id}", '
-        '"totalHours": "", '
         '"userID": "{user_id}"'
         '}}'
     )


### PR DESCRIPTION
**Description:** After we retested ENT-359 with verified, I noticed the call was failing on getting the remote id, because the url was not properly formatted. I also noticed that sending some of the fields as empty strings in the call was causing issues for the SAP API, so I omitted those empty values that we don't want to send anyway from the payload.

**JIRA:** https://openedx.atlassian.net/browse/ENT-359

**Dependencies:** based on https://github.com/edx/edx-enterprise/pull/98

**Merge deadline:** ASAP

**Installation instructions:** Ideally we would test this with an environment that had the standard enterprise set up with a verified course available.

**Testing instructions:**

Sandbox: https://brittneyexline.sandbox.edx.org/

With a fully operating environment (ie stage):
1. Ensure there is an enterprise customer with SAP configured and an SAP IDP.
2. Navigate to a track selection page with a tpa hint for the enterprise customer. Make sure the course is one that has been pushed to SAP and has a verified track available. After authenticating, choose the verified path and complete the purchase.
3. Complete the course and if it is instructor paced, run certificates for the course. If it is self paced, generate the certificate from the courseware.
4. Run the jenkins job for transmit_learner_data, or run the management command on the machine in question, depending on the environment.

Without entire sandbox setup:
1. Ensure there is an enterprise customer with SAP configured and an SAP IDP (already configured on above sandbox).

2. Navigate to a track selection page with a tpa hint for the enterprise customer, eg https://brittneyexline.sandbox.edx.org/course_modes/choose/course-v1:Demo+TC1+2017/?tpa_hint=saml-bestrun. Sign in with SAP using one of the test users in the testing doc.
Note that none of the courses on my sandbox have verified tracks so it will skip track selection and go to the dashboard after authentication.

3. Enroll in a course. Note the course id. Also note that this won't create an enterprise enrollment record because of the sandbox setup.

4. ssh into the sandbox, and log into the mysql command line console.
    ```
    $ mysql -u root -p
    ```

5. Look up the enterprise customer you just linked by signing in with SAP. Note the enterprise customer user id and auth user id.
    ```
    mysql> use edxapp;
    mysql> select * from enterprise_enterprisecustomeruser
    ```

6. Now, we are going to fake some data for the script to pick up. Run the following commands:
    ```
    mysql> insert into enterprise_enterprisecourseenrollment (consent_granted, course_id, enterprise_customer_user_id) values (NULL, '<course_id>', <enterprise_user_id>);
    mysql> insert into certificates_generatedcertificate (user_id, download_url, grade, course_id, `key`, distinction, status, verify_uuid, download_uuid, name, error_reason, mode) values (<user_id>, 'https://s3.amazonaws.com/verify.edx.org/downloads/ec411520403d4db5acf5add7b9eb8d11/Certificate.pdf', 0.93, '<course_id>', 'c6b3f1cd176d7913082f5b12b3b1dbfb', 0, 'downloadable', 'a6c04f14d61d49f7981d004ff9433eea', 'ec411520403d4db5acf5add7b9eb8d11', 'some name', '', 'honor');
    ```

7. Run the learner data script by doing the following:
    ```
    $ cd /edx/app/edxapp/edx-platform/
    $ sudo -H -u edxapp bash
    $ source /edx/app/edxapp/edxapp_env
    $ /edx/bin/python.edxapp /edx/bin/manage.edxapp lms transmit_learner_data --api_user staff --settings=aws
    ```

Check that the call was successful in SAP and by looking at the sap_success_factors_learnerdatatransmissionaudit table.

**Merge checklist:**

- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** 
