### PR TITLE
minor UI updates for enterprise landing page

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ----------
 
+[0.33.15] - 2017-05-10
+----------------------
+
+* Additional minor UI updates for enterprise landing page.
+
+
 [0.33.14] - 2017-05-10
 ----------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.33.14"
+__version__ = "0.33.15"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/static/enterprise/enterprise_course_enrollment_page.css
+++ b/enterprise/static/enterprise/enterprise_course_enrollment_page.css
@@ -60,7 +60,7 @@ body, .zebra-stripe > :nth-child(2n+1), .depth-0 {
 
 .enterprise-logo {
     width: auto;
-    height: 60px;
+    height: 100px;
     display: none;
 }
 
@@ -81,10 +81,11 @@ body, .zebra-stripe > :nth-child(2n+1), .depth-0 {
     [class*='col-'].col-7 {
         width: 70%;
         padding-right: 0;
+        padding-left: 35px;
     }
 
     .border-left {
-        border-left: 1px solid #bcdbed;
+        border-left: 1px solid #D9D9D9;
     }
 
     .enterprise-logo {
@@ -94,7 +95,7 @@ body, .zebra-stripe > :nth-child(2n+1), .depth-0 {
 
 .partnered-text {
     font-size: 16px;
-    color: #0b5c8a;
+    color: #414141;
     margin-top: 5px;
     margin-bottom: 20px;
 }
@@ -161,6 +162,10 @@ body, .zebra-stripe > :nth-child(2n+1), .depth-0 {
     display: inline-block;
     vertical-align: middle;
     margin-right: 5px;
+}
+
+.text-underline {
+    text-decoration: underline;
 }
 
 .caption {

--- a/enterprise/templates/enterprise/enterprise_course_enrollment_page.html
+++ b/enterprise/templates/enterprise/enterprise_course_enrollment_page.html
@@ -51,7 +51,7 @@ from django.utils.translation import ugettext as _
               <span>${ starts_at_text } ${ course_start_date } &nbsp;| &nbsp; ${ course_pacing } - ${ course_pace_text }</span>
             </div>
             ${ course_short_description }
-            <a href="#!">${ view_course_details_text }</a>
+            <a class="text-underline" href="#!">${ view_course_details_text }</a>
           </div>
           <form>
             <div class="caption">${ select_mode_text }</div>


### PR DESCRIPTION
ENT-330
@asadiqbal08 @saleem-latif @douglashall 

**Description:** Additional minor UI updates for enterprise landing page

**JIRA:** [ENT-330](https://openedx.atlassian.net/browse/ENT-330)

**Dependencies:** N/A
**Related PR (merged):** https://github.com/edx/edx-enterprise/pull/97

**Merge deadline:** 19 May, 2017

**Installation instructions:**  Install `edx-enterprise` from this branch `zub/ENT-330-enterprise-landing-page-ui-updates` in `edx-platform`.

**Testing instructions:**

1. Go to enterprise customers django admin at admin/enterprise/enterprisecustomer/
2. Add enterprise customer with logo
3. Add a course in the enterprise customer catalog
4. View the enterprise landing page for the enterprise course by accessing the enterprise course enrollment url with enterprise customer uuid from step no 2, e.g: `http://zubair.localhost:8000/enterprise/72416e52-8c77-4860-9584-15e5b06220fb/course/course-v1:edX+TEST_01+2016_R1/enroll/`


**Merge checklist:**

- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [ ] Translations are updated
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
