### PR TITLE
Update API Gateway configuration to use correct service endpoints

### DIFF
--- a/api-compact.yaml
+++ b/api-compact.yaml
@@ -1,6 +1,15 @@
 # Enterprise IDA: upstream API definitions, including vendor extensions.
-# Note, while this document is not strictly to Swagger spec, each HTTP method"s
-#  definition _must_ be to spec or the downstream ref will fail.
+# Note, while this document is not strictly to Swagger spec, each HTTP method's
+# definition _must_ be to spec or the downstream ref will fail.
+#
+# Clients must include an Authorization header with OAuth2 access token in order to communicate:
+#   Authorization: JWT {access_token}
+#
+#
+# Available service endpoints -- note that alternate endpoints may be presented at the API Gateway tier
+#   /enterprise/api/v1/catalogs/
+#   /enterprise/api/v1/catalogs/{id}/
+#   /enterprise/api/v1/catalogs/{id}/courses/
 
 apigateway_responses: &apigateway_responses
   default:
@@ -88,7 +97,7 @@ x-amazon-apigateway-integration-with-id: &apigateway_integration_with_id_paramet
 endpoints:
   v1:
 
-    # /v1/catalogs
+    # /v1/catalogs/
     enterpriseCatalogs:
         get:
           produces: *produces
@@ -101,9 +110,9 @@ endpoints:
           responses: *responses
           x-amazon-apigateway-integration:
             <<: *apigateway_integration
-            uri: "https://${stageVariables.enterprise_host}/enterprise/v1/catalogs/"
+            uri: "https://${stageVariables.enterprise_host}/enterprise/api/v1/catalogs/"
 
-    # /v1/catalogs/{id}
+    # /v1/catalogs/{id}/
     enterpriseCatalogById:
         get:
           produces: *produces
@@ -114,9 +123,9 @@ endpoints:
           responses: *responses
           x-amazon-apigateway-integration:
             <<: *apigateway_integration_with_id_parameter
-            uri: "https://${stageVariables.enterprise_host}/enterprise/v1/catalogs/{id}/"
+            uri: "https://${stageVariables.enterprise_host}/enterprise/api/v1/catalogs/{id}/"
 
-    # /v1/catalogs/{id}/courses
+    # /v1/catalogs/{id}/courses/
     enterpriseCatalogCourses:
         get:
           produces: *produces
@@ -130,4 +139,4 @@ endpoints:
           responses: *responses
           x-amazon-apigateway-integration:
             <<: *apigateway_integration_with_id_parameter
-            uri: "https://${stageVariables.enterprise_host}/enterprise/v1/catalogs/{id}/courses/"
+            uri: "https://${stageVariables.enterprise_host}/enterprise/api/v1/catalogs/{id}/courses/"

--- a/api.yaml
+++ b/api.yaml
@@ -76,7 +76,7 @@ endpoints:
             default:
               statusCode: "400"
           type: http
-          uri: "https://${stageVariables.enterprise_host}/enterprise/v1/catalogs/{id}/"
+          uri: "https://${stageVariables.enterprise_host}/enterprise/api/v1/catalogs/{id}/"
     enterpriseCatalogCourses:
       get:
         operationId: get_enterprise_catalog_courses
@@ -140,7 +140,7 @@ endpoints:
             default:
               statusCode: "400"
           type: http
-          uri: "https://${stageVariables.enterprise_host}/enterprise/v1/catalogs/{id}/courses/"
+          uri: "https://${stageVariables.enterprise_host}/enterprise/api/v1/catalogs/{id}/courses/"
     enterpriseCatalogs:
       get:
         operationId: get_enterprise_catalogs
@@ -204,4 +204,4 @@ endpoints:
             default:
               statusCode: "400"
           type: http
-          uri: "https://${stageVariables.enterprise_host}/enterprise/v1/catalogs/"
+          uri: "https://${stageVariables.enterprise_host}/enterprise/api/v1/catalogs/"


### PR DESCRIPTION
**Description:** After troubleshooting the API Gateway connection yesterday it appears that we need to specify the actual Enterprise service endpoints in `api.yaml` and `api-compact.yaml`.

**JIRA:** N/A

**Dependencies:** N/A

**Merge deadline:** ASAP

**Testing instructions:**

1. After merging we will update the API Gateway code with the new hash and try again on the stage instance -- no one is using these broken endpoints right now!

**Merge checklist:**

~~- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).~~
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
~~- [ ] Documentation updated (not only docstrings)~~
- [ ] Commits are (reasonably) squashed
~~- [ ] Translations are updated~~
- [ x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** Hopefully this is the correct fix or else we're going to have to really start tearing things apart...
