### PR TITLE
add django admin for enterprise course enrollment models

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ----------
 
+[0.33.17] - 2017-05-16
+----------------------
+
+* Add django admin for enterprise course enrollment models
+
+
 [0.33.16] - 2017-05-15
 ----------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.33.16"
+__version__ = "0.33.17"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/admin/__init__.py
+++ b/enterprise/admin/__init__.py
@@ -23,8 +23,8 @@ from enterprise.lms_api import CourseApiClient, EnrollmentApiClient
 from enterprise.models import (  # pylint:disable=no-name-in-module
     EnrollmentNotificationEmailTemplate, EnterpriseCustomer, EnterpriseCustomerUser,
     EnterpriseCustomerBrandingConfiguration, EnterpriseCustomerIdentityProvider,
-    HistoricalUserDataSharingConsentAudit, PendingEnterpriseCustomerUser,
-    EnterpriseCustomerEntitlement
+    HistoricalUserDataSharingConsentAudit, PendingEnrollment, PendingEnterpriseCustomerUser,
+    EnterpriseCustomerEntitlement, EnterpriseCourseEnrollment
 )
 from enterprise.utils import get_all_field_names, get_catalog_admin_url, get_catalog_admin_url_template
 
@@ -410,3 +410,75 @@ class EnrollmentNotificationEmailTemplateAdmin(DjangoObjectActions, admin.ModelA
     preview_as_program.short_description = _(
         "Preview the HTML template rendered in the context of a program enrollment."
     )
+
+
+@admin.register(EnterpriseCourseEnrollment)
+class EnterpriseCourseEnrollmentAdmin(admin.ModelAdmin):
+    """
+    Django admin model for EnterpriseCourseEnrollment
+    """
+
+    class Meta(object):
+        model = EnterpriseCourseEnrollment
+
+    readonly_fields = (
+        'enterprise_customer_user',
+        'course_id',
+        'consent_granted',
+    )
+
+    list_display = (
+        'enterprise_customer_user',
+        'course_id',
+        'consent_granted',
+    )
+
+    search_fields = ('enterprise_customer_user__user_id', 'course_id',)
+
+    def has_add_permission(self, request):
+        """
+        Disable add permission for EnterpriseCourseEnrollment.
+        """
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        """
+        Disable deletion for EnterpriseCourseEnrollment.
+        """
+        return False
+
+
+@admin.register(PendingEnrollment)
+class PendingEnrollmentAdmin(admin.ModelAdmin):
+    """
+    Django admin model for PendingEnrollment
+    """
+
+    class Meta(object):
+        model = PendingEnrollment
+
+    readonly_fields = (
+        'user',
+        'course_id',
+        'course_mode',
+    )
+
+    list_display = (
+        'user',
+        'course_id',
+        'course_mode',
+    )
+
+    search_fields = ('user__user_email', 'course_id',)
+
+    def has_add_permission(self, request):
+        """
+        Disable add permission for PendingEnrollment.
+        """
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        """
+        Disable deletion for PendingEnrollment.
+        """
+        return False


### PR DESCRIPTION
@asadiqbal08 @saleem-latif @zrana @douglashall 

This PR is to support the QA for the story [ENT-39](https://openedx.atlassian.net/browse/ENT-390)

**Description:** add django admin for the models "`EnterpriseCourseEnrollment`" and "`PendingEnrollment`".

**JIRA:** N/A

**Dependencies:** N/A

**Merge deadline:** 16 May, 2017

**Installation instructions:** Install `edx-enterprise` from this branch `zub/add-enterprise-course-enrollment-django-admin` in `edx-platform`.

**Testing instructions:**

1. Open enterprise django admin at `admin/enterprise/`
2. Check that you can view the 2 new django admin panels for `Enterprise course enrollments` and `Pending enrollments`

**Merge checklist:**

- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
