### PR TITLE
[WIP] ENT-356 Update enterprise api and SAP course export with landing page url

### DIFF
--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -343,15 +343,12 @@ class EnterpriseCatalogCoursesReadOnlySerializer(serializers.Serializer):
                 query_parameters=query_parameters,
             )
 
-            landing_page_url = utils.get_enterprise_landing_page_url(
-                enterprise_customer.uuid,
-                course_run.get('key'),
-            )
+            enrollment_url = enterprise_customer.get_course_enrollment_url(course_run.get('key'))
 
             # Add/update track selection url in course run metadata.
             course_run.update({
                 'track_selection_url': track_selection_url,
-                'landing_page_url': landing_page_url
+                'enrollment_url': enrollment_url
             })
 
             # Update marketing urls in course metadata to include enterprise related info.

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -256,7 +256,7 @@ class EnterpriseCatalogCoursesReadOnlySerializer(serializers.Serializer):
     previous = serializers.CharField(read_only=True, help_text=_("URL to fetch previous page of courses."))
     results = serializers.ListField(read_only=True, help_text=_("list of courses."))
 
-    def update_enterprise_courses(self, request, catalog_id):
+    def update_enterprise_courses(self, request, catalog_id, enterprise_customer=None):
         """
         This method adds enterprise specific metadata for each course.
 
@@ -264,7 +264,8 @@ class EnterpriseCatalogCoursesReadOnlySerializer(serializers.Serializer):
             tpa_hint: a string for identifying Identity Provider.
         """
         courses = []
-        enterprise_customer = utils.get_enterprise_customer_for_user(request.user)
+        if enterprise_customer is None:
+            enterprise_customer = utils.get_enterprise_customer_for_user(request.user)
 
         global_context = {
             'tpa_hint': enterprise_customer and enterprise_customer.identity_provider,
@@ -342,9 +343,15 @@ class EnterpriseCatalogCoursesReadOnlySerializer(serializers.Serializer):
                 query_parameters=query_parameters,
             )
 
+            landing_page_url = utils.get_enterprise_landing_page_url(
+                enterprise_customer.uuid,
+                course_run.get('key'),
+            )
+
             # Add/update track selection url in course run metadata.
             course_run.update({
                 'track_selection_url': track_selection_url,
+                'landing_page_url': landing_page_url
             })
 
             # Update marketing urls in course metadata to include enterprise related info.

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -74,13 +74,12 @@ class EnterpriseCustomerViewSet(EnterpriseReadOnlyModelViewSet):
         ---
         serializer: serializers.CourseSerializerExcludingClosedRuns
         """
-        page = request.GET.get('page', 1)
         enterprise_customer = self.get_object()
 
         # Make sure there is a catalog associated with the enterprise
         if not enterprise_customer.catalog:
             error_message = ("No catalog is associated with the given enterprise from endpoint "
-                             "'/enterprise-customer/{}/courses?page={}'.".format(pk, page))
+                             "'/enterprise-customer/{}/courses'.".format(pk))
             logger.error(error_message)
             raise NotFound("The resource you are looking for does not exist: " + error_message)
 
@@ -93,18 +92,18 @@ class EnterpriseCustomerViewSet(EnterpriseReadOnlyModelViewSet):
                 )
             except models.ObjectDoesNotExist:
                 error_message = ("User is not associated with enterprise from endpoint "
-                                 "'/enterprise-customer/{}/courses?page={}'.".format(pk, page))
+                                 "'/enterprise-customer/{}/courses'.".format(pk))
                 logger.error(error_message)
                 raise PermissionDenied("The user does not have permission to access this resource: " + error_message)
 
         catalog_api = CourseCatalogApiClient(request.user)
-        courses = catalog_api.get_paginated_catalog_courses(enterprise_customer.catalog, page)
+        courses = catalog_api.get_catalog_courses(enterprise_customer.catalog)
 
         # if API returned an empty response, that means pagination has ended.
         # An empty response can also means that there was a problem fetching data from catalog API.
         if not courses:
             error_message = ("Unable to fetch API response for catalog courses from endpoint "
-                             "'/enterprise-customer/{}/courses?page={}'.".format(pk, page))
+                             "'/enterprise-customer/{}/courses'.".format(pk))
             logger.error(error_message)
             raise NotFound("The resource you are looking for does not exist: " + error_message)
 

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -90,17 +90,16 @@ class EnterpriseCustomerViewSet(EnterpriseReadOnlyModelViewSet):
                     enterprise_customer=enterprise_customer,
                     user_id=request.user.id,
                 )
-            except models.ObjectDoesNotExist:
-                error_message = ("User is not associated with enterprise from endpoint "
-                                 "'/enterprise-customer/{}/courses'.".format(pk))
+            except models.EnterpriseCustomerUser.DoesNotExist:
+                error_message = ("User '{}' is not associated with enterprise from endpoint "
+                                 "'/enterprise-customer/{}/courses'.".format(request.user.username, pk))
                 logger.error(error_message)
                 raise PermissionDenied("The user does not have permission to access this resource: " + error_message)
 
         catalog_api = CourseCatalogApiClient(request.user)
         courses = catalog_api.get_catalog_courses(enterprise_customer.catalog)
 
-        # if API returned an empty response, that means pagination has ended.
-        # An empty response can also means that there was a problem fetching data from catalog API.
+        # An empty response can mean that there was a problem fetching data from catalog API.
         if not courses:
             error_message = ("Unable to fetch API response for catalog courses from endpoint "
                              "'/enterprise-customer/{}/courses'.".format(pk))

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -481,30 +481,6 @@ def get_course_track_selection_url(course_run, query_parameters):
     return course_run_url
 
 
-def get_enterprise_landing_page_url(enterprise_uuid, course_run_key):
-    """
-    Return enterprise landing page url for the given course.
-
-    Arguments:
-        enterprise_uuid (str): The enterprise uuid.
-        course_run_key (str): The course run id for the course to be displayed.
-
-    Returns:
-        (str): Enterprise landing page url.
-    """
-    course_root = reverse(
-        'enterprise_course_enrollment_page',
-        kwargs={'enterprise_uuid': enterprise_uuid, 'course_id': course_run_key}
-    )
-
-    url = '{}{}'.format(
-        settings.LMS_ROOT_URL,
-        course_root
-    )
-
-    return url
-
-
 def update_query_parameters(url, query_parameters):
     """
     Return url with updated query parameters.

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -481,6 +481,30 @@ def get_course_track_selection_url(course_run, query_parameters):
     return course_run_url
 
 
+def get_enterprise_landing_page_url(enterprise_uuid, course_run_key):
+    """
+    Return enterprise landing page url for the given course.
+
+    Arguments:
+        enterprise_uuid (str): The enterprise uuid.
+        course_run_key (str): The course run id for the course to be displayed.
+
+    Returns:
+        (str): Enterprise landing page url.
+    """
+    course_root = reverse(
+        'enterprise_course_enrollment_page',
+        kwargs={'enterprise_uuid': enterprise_uuid, 'course_id': course_run_key}
+    )
+
+    url = '{}{}'.format(
+        settings.LMS_ROOT_URL,
+        course_root
+    )
+
+    return url
+
+
 def update_query_parameters(url, query_parameters):
     """
     Return url with updated query parameters.

--- a/integrated_channels/integrated_channel/course_metadata.py
+++ b/integrated_channels/integrated_channel/course_metadata.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import, unicode_literals
 import json
 from logging import getLogger
 
-from enterprise.course_catalog_api import CourseCatalogApiClient
+from integrated_channels.integrated_channel.enterprise_api import EnterpriseApiClient
 
 
 EXCLUDED_COURSE_DETAIL_KEYS = [
@@ -48,18 +48,14 @@ def get_course_runs(user, enterprise_customer):
     Returns:
         iterable: An iterable containing the details of each course run.
     """
-    catalog_id = enterprise_customer.catalog
+    client = EnterpriseApiClient(user)
 
-    client = CourseCatalogApiClient(user)
-
-    catalog_courses = client.get_catalog_courses(catalog_id)
-    LOGGER.info('Retrieving course list for catalog %s', catalog_id)
+    catalog_courses = client.get_enterprise_courses(enterprise_customer.uuid)
+    LOGGER.info('Retrieving course list for enterprise %s', enterprise_customer.name)
 
     for course in catalog_courses:
-        course_key = course.get('key')
-        course_details = client.get_course_details(course_key)
-        for run in course_details.get('course_runs', []):
-            yield get_complete_course_run_details(course_details, run)
+        for run in course.get('course_runs', []):
+            yield get_complete_course_run_details(course, run)
 
 
 class BaseCourseExporter(object):

--- a/integrated_channels/integrated_channel/enterprise_api.py
+++ b/integrated_channels/integrated_channel/enterprise_api.py
@@ -1,0 +1,59 @@
+"""
+APIs providing support for enterprise functionality.
+"""
+from __future__ import absolute_import, unicode_literals
+
+import logging
+
+from django.conf import settings
+from slumber.exceptions import HttpClientError, HttpServerError
+
+from edx_rest_api_client.client import EdxRestApiClient
+from enterprise.utils import NotConnectedToOpenEdX
+
+try:
+    from openedx.core.lib.token_utils import JwtBuilder
+except ImportError:
+    JwtBuilder = None
+
+
+CONSENT_FAILED_PARAMETER = 'consent_failed'
+ENTERPRISE_CUSTOMER_BRANDING_OVERRIDE_DETAILS = 'enterprise_customer_branding_override_details'
+LOGGER = logging.getLogger("edx.enterprise_helpers")
+
+
+class EnterpriseApiClient(object):
+    """
+    Class for producing an Enterprise service API client.
+    """
+
+    def __init__(self, user):
+        """
+        Initialize an Enterprise service API client.
+        """
+        self.user = user
+        if JwtBuilder is None:
+            raise NotConnectedToOpenEdX("This package must be installed in an OpenEdX environment.")
+
+        jwt = JwtBuilder(self.user).build_token([])
+        self.client = EdxRestApiClient(
+            settings.ENTERPRISE_API_URL,
+            jwt=jwt
+        )
+
+    def get_enterprise_courses(self, enterprise_id):
+        """
+        Fetch course data related to the enterprise's catalog from the Enterprise Service.
+        """
+        try:
+            api_resource_name = 'enterprise-customer-courses'
+            endpoint = getattr(self.client, api_resource_name)
+            response = endpoint(enterprise_id).get()
+        except (HttpClientError, HttpServerError):
+            message = ("An error occurred while getting Enterprise Course data for enterprise {}".format(
+                enterprise_id
+            ))
+            LOGGER.exception(message)
+            raise
+
+        return response['results']

--- a/integrated_channels/sap_success_factors/utils.py
+++ b/integrated_channels/sap_success_factors/utils.py
@@ -253,7 +253,9 @@ class SapCourseExporter(BaseCourseExporter):  # pylint: disable=abstract-method
                     'sap_success_factors',
                     'SAPSuccessFactorsGlobalConfiguration'
                 ).current().provider_id,
-                'launchURL': get_course_track_selection_url(x['enterprise_customer'], x['key']),
+                'launchURL': safe_extract_key(
+                    x, 'landing_page_url', get_course_track_selection_url(x['enterprise_customer'], x['key'])
+                ),
                 'contentTitle': safe_extract_key(x, 'title'),
                 'contentID': x['key'],
                 'launchType': 3,

--- a/test_utils/fake_catalog_api.py
+++ b/test_utils/fake_catalog_api.py
@@ -473,6 +473,179 @@ FAKE_CATALOG_COURSE_DETAILS_RESPONSES = {
     }
 }
 
+FAKE_ENTERPRISE_COURSES_RESPONSE = [
+    {
+        "key": "edX+DemoX",
+        "uuid": "cf8f5cce-1370-46aa-8162-31fdff55dc7e",
+        "title": "Fancy Course",
+        "course_runs": [
+            {
+                "key": "course-v1:edX+DemoX+Demo_Course",
+                "uuid": "0a25b789-86d0-43bd-972b-3858a985462e",
+                "title": "edX Demonstration Course",
+                "image": {
+                    "src": (
+                        "http://192.168.1.187:8000/asset-v1:edX+DemoX+Demo_"
+                        "Course+type@asset+block@images_course_image.jpg"
+                    ),
+                    "height": None,
+                    "width": None,
+                    "description": None
+                },
+                "short_description": None,
+                "marketing_url": None,
+                "start": "2013-02-05T05:00:00Z",
+                "end": None,
+                "enrollment_start": None,
+                "enrollment_end": None,
+                "pacing_type": "instructor_paced",
+                "type": "audit",
+                "course": "edX+DemoX",
+                "full_description": None,
+                "announcement": None,
+                "video": None,
+                "seats": [
+                    {
+                        "type": "audit",
+                        "price": "0.00",
+                        "currency": "USD",
+                        "upgrade_deadline": None,
+                        "credit_provider": "",
+                        "credit_hours": None,
+                        "sku": ""
+                    }
+                ],
+                "content_language": 'en-us',
+                "transcript_languages": [],
+                "instructors": [],
+                "staff": [],
+                "min_effort": None,
+                "max_effort": None,
+                "modified": "2017-03-07T18:37:43.992494Z",
+                "level_type": None,
+                "availability": "Upcoming",
+                "mobile_available": False,
+                "hidden": False,
+                "reporting_type": "mooc",
+                "landing_page_url": "http://www.example.com/course-v1:edX+DemoX+Demo_Course"
+            }
+        ],
+        "owners": [
+            {
+                "uuid": "366e7739-fb3a-42d0-8351-8c3dbab3e339",
+                "key": "edX",
+                "name": "",
+                "certificate_logo_image_url": None,
+                "description": None,
+                "homepage_url": None,
+                "tags": [],
+                "logo_image_url": None,
+                "marketing_url": None
+            }
+        ],
+        "image": None,
+        "short_description": None,
+        "full_description": None,
+        "level_type": None,
+        "subjects": [],
+        "prerequisites": [],
+        "expected_learning_items": [],
+        "video": None,
+        "sponsors": [],
+        "modified": "2017-01-16T14:07:47.327605Z",
+        "marketing_url": "http://localhost:8000/course/edxdemox?utm_source=admin&utm_medium=affiliate_partner"
+    },
+    {
+        "key": "foobar+fb1",
+        "uuid": "c08c1e43-307c-444b-acc7-aea4a7b9f8f6",
+        "title": "FooBar Ventures",
+        "course_runs": [
+            {
+                "key": "course-v1:foobar+fb1+fbv1",
+                "uuid": "3550853f-e65a-492e-8781-d0eaa16dd538",
+                "title": "Other Course Name",
+                "image": {
+                    "src": (
+                        "http://192.168.1.187:8000/asset-v1:foobar+fb1+fbv1"
+                        "+type@asset+block@images_course_image.jpg"
+                    ),
+                    "height": None,
+                    "width": None,
+                    "description": None
+                },
+                "short_description": "",
+                "marketing_url": None,
+                "start": "2015-01-01T00:00:00Z",
+                "end": None,
+                "enrollment_start": None,
+                "enrollment_end": None,
+                "pacing_type": "instructor_paced",
+                "type": None,
+                "course": "foobar+fb1",
+                "full_description": "This is a really cool course. Like, we promise.",
+                "announcement": None,
+                "video": None,
+                "seats": [],
+                "content_language": None,
+                "transcript_languages": [],
+                "instructors": [],
+                "staff": [],
+                "min_effort": None,
+                "max_effort": None,
+                "modified": "2017-03-07T18:37:45.082681Z",
+                "level_type": None,
+                "availability": "Upcoming",
+                "mobile_available": False,
+                "hidden": False,
+                "reporting_type": "mooc",
+                "landing_page_url": "http://www.example.com/course-v1:foobar+fb1+fbv1"
+            }
+        ],
+        "owners": [
+            {
+                "uuid": "8d920bc3-a1b2-44db-9380-1d3ca728c275",
+                "key": "foobar",
+                "name": "",
+                "certificate_logo_image_url": None,
+                "description": None,
+                "homepage_url": None,
+                "tags": [],
+                "logo_image_url": None,
+                "marketing_url": None
+            }
+        ],
+        "image": {
+            "src": "",
+            "height": None,
+            "width": None,
+            "description": None
+        },
+        "short_description": "",
+        "full_description": "This is a really cool course.",
+        "level_type": None,
+        "subjects": [],
+        "prerequisites": [],
+        "expected_learning_items": [],
+        "video": None,
+        "sponsors": [],
+        "modified": "2017-03-07T18:37:45.238722Z",
+        "marketing_url": "http://localhost:8000/course/foobarfb1?utm_source=admin&utm_medium=affiliate_partner"
+    },
+]
+
+
+def get_enterprise_courses(enterprise_id):  # pylint: disable=unused-argument
+    """
+    Fake implementation returning courses by enterprise id.
+
+    Arguments:
+        enterprise_id (str): Enterprise ID
+
+    Returns:
+        list: Details of the courses included in the enterprise's catalog
+    """
+    return FAKE_ENTERPRISE_COURSES_RESPONSE
+
 
 def get_catalog_courses(catalog_id):
     """

--- a/tests/api/test_serializers.py
+++ b/tests/api/test_serializers.py
@@ -310,9 +310,17 @@ class TestEnterpriseCatalogCoursesSerializer(APITest):
         ),
     )
     @ddt.unpack
+    @mock.patch('enterprise.models.configuration_helpers')
     @override_settings(LMS_ROOT_URL='http://testserver/')
     def test_update_course_runs(
-            self, course_run, catalog_id, provider_id, enterprise_customer_uuid, expected_fields, expected_urls,
+            self,
+            course_run,
+            catalog_id,
+            provider_id,
+            enterprise_customer_uuid,
+            expected_fields,
+            expected_urls,
+            mock_config_helpers,
     ):
         """
         Test update_course_runs method of EnterpriseCatalogCoursesReadOnlySerializer.
@@ -321,6 +329,7 @@ class TestEnterpriseCatalogCoursesSerializer(APITest):
         successfully without errors.
         """
         # Populate database.
+        mock_config_helpers.get_value.return_value = 'http://testserver/'
         ec_identity_provider = factories.EnterpriseCustomerIdentityProviderFactory(
             enterprise_customer__uuid=enterprise_customer_uuid,
             provider_id=provider_id,
@@ -349,13 +358,15 @@ class TestEnterpriseCatalogCoursesSerializer(APITest):
                 self.assert_url(value, updated_course_run[key])
 
     @mock.patch('enterprise.utils.reverse', return_value='')
-    def test_update_course(self, _):
+    @mock.patch('enterprise.models.configuration_helpers')
+    def test_update_course(self, mock_config_helpers, _):
         """
         Test update_course method of EnterpriseCatalogCoursesReadOnlySerializer.
 
         Verify that update_course for EnterpriseCatalogCoursesReadOnlySerializer returns
         successfully without errors.
         """
+        mock_config_helpers.return_value = ''
         global_context = {
             'tpa_hint': self.provider_id
         }
@@ -442,13 +453,15 @@ class TestEnterpriseCatalogCoursesSerializer(APITest):
             assert expected_course == updated_course
 
     @mock.patch('enterprise.utils.reverse', return_value='/course_modes/choose/')
-    def test_update_enterprise_courses(self, _):
+    @mock.patch('enterprise.models.configuration_helpers')
+    def test_update_enterprise_courses(self, mock_config_helpers, _):
         """
         Test update_enterprise_courses method of EnterpriseCatalogCoursesReadOnlySerializer.
 
         Verify that update_enterprise_courses for EnterpriseCatalogCoursesReadOnlySerializer updates
         serializer data successfully without errors.
         """
+        mock_config_helpers.return_value = ''
         self.serializer.update_enterprise_courses(self.request, 1)
 
         # Make sure global context passed in to update_course is added to the course.

--- a/tests/api/test_views.py
+++ b/tests/api/test_views.py
@@ -655,7 +655,7 @@ class TestEnterpriseAPIViews(APITest):
             {},
             {'detail': (
                 "The user does not have permission to access this resource: "
-                "User is not associated with enterprise from endpoint "
+                "User 'api_worker' is not associated with enterprise from endpoint "
                 "'/enterprise-customer/d2098bfb-2c78-44f1-9eb2-b94475356a3f/courses'."
             )}
         ),

--- a/tests/api/test_views.py
+++ b/tests/api/test_views.py
@@ -644,7 +644,7 @@ class TestEnterpriseAPIViews(APITest):
             {'detail': (
                 "The resource you are looking for does not exist: "
                 "No catalog is associated with the given enterprise from endpoint "
-                "'/enterprise-customer/d2098bfb-2c78-44f1-9eb2-b94475356a3f/courses?page=1'."
+                "'/enterprise-customer/d2098bfb-2c78-44f1-9eb2-b94475356a3f/courses'."
             )}
         ),
         (
@@ -656,7 +656,7 @@ class TestEnterpriseAPIViews(APITest):
             {'detail': (
                 "The user does not have permission to access this resource: "
                 "User is not associated with enterprise from endpoint "
-                "'/enterprise-customer/d2098bfb-2c78-44f1-9eb2-b94475356a3f/courses?page=1'."
+                "'/enterprise-customer/d2098bfb-2c78-44f1-9eb2-b94475356a3f/courses'."
             )}
         ),
         (
@@ -668,7 +668,7 @@ class TestEnterpriseAPIViews(APITest):
             {'detail': (
                 "The resource you are looking for does not exist: "
                 "Unable to fetch API response for catalog courses from endpoint "
-                "'/enterprise-customer/d2098bfb-2c78-44f1-9eb2-b94475356a3f/courses?page=1'."
+                "'/enterprise-customer/d2098bfb-2c78-44f1-9eb2-b94475356a3f/courses'."
             )},
         ),
         (
@@ -679,8 +679,10 @@ class TestEnterpriseAPIViews(APITest):
             MOCK_CATALOG_COURSE_RESPONSE,
             {
                 'count': 3,
-                'next': 'http://testserver/enterprise/api/v1/enterprise-customer/d2098bfb-2c78-44f1-9eb2-b94475356a3f/courses/?page=3',
-                'previous': 'http://testserver/enterprise/api/v1/enterprise-customer/d2098bfb-2c78-44f1-9eb2-b94475356a3f/courses/?page=1',
+                'next': ('http://testserver/enterprise/api/v1/enterprise-customer/'
+                         'd2098bfb-2c78-44f1-9eb2-b94475356a3f/courses/?page=3'),
+                'previous': ('http://testserver/enterprise/api/v1/enterprise-customer/'
+                             'd2098bfb-2c78-44f1-9eb2-b94475356a3f/courses/?page=1'),
                 'results': [
                     {
                         'owners': [
@@ -751,7 +753,7 @@ class TestEnterpriseAPIViews(APITest):
             )
 
         mock_catalog_api_client.return_value = mock.Mock(
-            get_paginated_catalog_courses=mock.Mock(return_value=mocked_catalog_courses),
+            get_catalog_courses=mock.Mock(return_value=mocked_catalog_courses),
         )
         response = self.client.get(url)
         response = self.load_json(response.content)

--- a/tests/api/test_views.py
+++ b/tests/api/test_views.py
@@ -16,8 +16,47 @@ from django.test import override_settings
 from django.utils import timezone
 
 from enterprise.lms_api import LMS_API_DATETIME_FORMAT
-from enterprise.models import EnterpriseCustomer, UserDataSharingConsentAudit
+from enterprise.models import EnterpriseCustomer, EnterpriseCustomerIdentityProvider, UserDataSharingConsentAudit
 from test_utils import TEST_USERNAME, APITest, factories
+
+
+MOCK_CATALOG_COURSE_RESPONSE = {
+    'count': 3,
+    'next': 'http://testserver/api/v1/catalogs/1/courses?page=3',
+    'previous': 'http://testserver/api/v1/catalogs/1/courses?page=1',
+    'results': [
+        {
+            'owners': [
+                {
+                    'description': None,
+                    'tags': [],
+                    'name': '',
+                    'homepage_url': None,
+                    'key': 'edX',
+                    'certificate_logo_image_url': None,
+                    'marketing_url': None,
+                    'logo_image_url': None,
+                    'uuid': 'aa4aaad0-2ff0-44ce-95e5-1121d02f3b27'
+                }
+            ],
+            'uuid': 'd2fb4cb0-b538-4934-ba60-684d48ff5865',
+            'title': 'edX Demonstration Course',
+            'prerequisites': [],
+            'image': None,
+            'expected_learning_items': [],
+            'sponsors': [],
+            'modified': '2017-03-03T07:34:19.322916Z',
+            'full_description': None,
+            'subjects': [],
+            'video': None,
+            'key': 'edX+DemoX',
+            'short_description': None,
+            'marketing_url': None,
+            'level_type': None,
+            'course_runs': []
+        }
+    ]
+}
 
 
 @ddt.ddt
@@ -595,6 +634,130 @@ class TestEnterpriseAPIViews(APITest):
         response = self.client.post(settings.TEST_SERVER + reverse('enterprise-learner-list'), data=data)
         assert response.status_code == 401
 
+    @ddt.data(
+        (
+            'd2098bfb-2c78-44f1-9eb2-b94475356a3f',
+            None,
+            reverse('enterprise-customer-courses', ('d2098bfb-2c78-44f1-9eb2-b94475356a3f',)),
+            False,
+            {},
+            {'detail': (
+                "The resource you are looking for does not exist: "
+                "No catalog is associated with the given enterprise from endpoint "
+                "'/enterprise-customer/d2098bfb-2c78-44f1-9eb2-b94475356a3f/courses?page=1'."
+            )}
+        ),
+        (
+            'd2098bfb-2c78-44f1-9eb2-b94475356a3f',
+            1,
+            reverse('enterprise-customer-courses', ('d2098bfb-2c78-44f1-9eb2-b94475356a3f',)),
+            False,
+            {},
+            {'detail': (
+                "The user does not have permission to access this resource: "
+                "User is not associated with enterprise from endpoint "
+                "'/enterprise-customer/d2098bfb-2c78-44f1-9eb2-b94475356a3f/courses?page=1'."
+            )}
+        ),
+        (
+            'd2098bfb-2c78-44f1-9eb2-b94475356a3f',
+            1,
+            reverse('enterprise-customer-courses', ('d2098bfb-2c78-44f1-9eb2-b94475356a3f',)),
+            True,
+            {},
+            {'detail': (
+                "The resource you are looking for does not exist: "
+                "Unable to fetch API response for catalog courses from endpoint "
+                "'/enterprise-customer/d2098bfb-2c78-44f1-9eb2-b94475356a3f/courses?page=1'."
+            )},
+        ),
+        (
+            'd2098bfb-2c78-44f1-9eb2-b94475356a3f',
+            1,
+            reverse('enterprise-customer-courses', ('d2098bfb-2c78-44f1-9eb2-b94475356a3f',)),
+            True,
+            MOCK_CATALOG_COURSE_RESPONSE,
+            {
+                'count': 3,
+                'next': 'http://testserver/enterprise/api/v1/enterprise-customer/d2098bfb-2c78-44f1-9eb2-b94475356a3f/courses/?page=3',
+                'previous': 'http://testserver/enterprise/api/v1/enterprise-customer/d2098bfb-2c78-44f1-9eb2-b94475356a3f/courses/?page=1',
+                'results': [
+                    {
+                        'owners': [
+                            {
+                                'description': None,
+                                'tags': [],
+                                'name': '',
+                                'homepage_url': None,
+                                'key': 'edX',
+                                'certificate_logo_image_url': None,
+                                'marketing_url': None,
+                                'logo_image_url': None,
+                                'uuid': 'aa4aaad0-2ff0-44ce-95e5-1121d02f3b27'
+                            }
+                        ],
+                        'tpa_hint': None,
+                        'catalog_id': 1,
+                        'enterprise_id': 'd2098bfb-2c78-44f1-9eb2-b94475356a3f',
+                        'uuid': 'd2fb4cb0-b538-4934-ba60-684d48ff5865',
+                        'title': 'edX Demonstration Course',
+                        'prerequisites': [],
+                        'image': None,
+                        'expected_learning_items': [],
+                        'sponsors': [],
+                        'modified': '2017-03-03T07:34:19.322916Z',
+                        'full_description': None,
+                        'subjects': [],
+                        'video': None,
+                        'key': 'edX+DemoX',
+                        'short_description': None,
+                        'marketing_url': None,
+                        'level_type': None,
+                        'course_runs': []
+                    }
+                ]
+            }
+        ),
+    )
+    @ddt.unpack
+    @mock.patch('enterprise.api.v1.views.CourseCatalogApiClient')
+    def test_enterprise_customer_courses(
+            self,
+            enterprise_uuid,
+            catalog,
+            url,
+            link_user,
+            mocked_catalog_courses,
+            expected,
+            mock_catalog_api_client
+    ):
+        """
+        Make sure if an enterprise does not exist for this call, we return a descriptive error.
+        """
+        enterprise_customer = factories.EnterpriseCustomerFactory(
+            uuid=enterprise_uuid,
+            catalog=catalog,
+        )
+
+        if link_user:
+            factories.EnterpriseCustomerUserFactory(
+                user_id=self.user.id,
+                enterprise_customer=enterprise_customer,
+            )
+
+            EnterpriseCustomerIdentityProvider(
+                enterprise_customer=enterprise_customer,
+                provider_id='saml-testshib',
+            )
+
+        mock_catalog_api_client.return_value = mock.Mock(
+            get_paginated_catalog_courses=mock.Mock(return_value=mocked_catalog_courses),
+        )
+        response = self.client.get(url)
+        response = self.load_json(response.content)
+
+        assert response == expected
+
 
 @ddt.ddt
 class TestEnterpriseCatalogAPIViews(APITest):
@@ -736,43 +899,7 @@ class TestEnterpriseCatalogAPIViews(APITest):
             reverse('catalogs-courses', (1, )),
             'saml-testshib',
             'd2fb4cb0-b538-4934-1926-684d48ff5865',
-            {
-                'count': 3,
-                'next': 'http://testserver/api/v1/catalogs/1/courses?page=3',
-                'previous': 'http://testserver/api/v1/catalogs/1/courses?page=1',
-                'results': [
-                    {
-                        'owners': [
-                            {
-                                'description': None,
-                                'tags': [],
-                                'name': '',
-                                'homepage_url': None,
-                                'key': 'edX',
-                                'certificate_logo_image_url': None,
-                                'marketing_url': None,
-                                'logo_image_url': None,
-                                'uuid': 'aa4aaad0-2ff0-44ce-95e5-1121d02f3b27'
-                            }
-                        ],
-                        'uuid': 'd2fb4cb0-b538-4934-ba60-684d48ff5865',
-                        'title': 'edX Demonstration Course',
-                        'prerequisites': [],
-                        'image': None,
-                        'expected_learning_items': [],
-                        'sponsors': [],
-                        'modified': '2017-03-03T07:34:19.322916Z',
-                        'full_description': None,
-                        'subjects': [],
-                        'video': None,
-                        'key': 'edX+DemoX',
-                        'short_description': None,
-                        'marketing_url': None,
-                        'level_type': None,
-                        'course_runs': []
-                    }
-                ]
-            },
+            MOCK_CATALOG_COURSE_RESPONSE,
             {
                 'count': 3,
                 'next': 'http://testserver/enterprise/api/v1/catalogs/1/courses/?page=3',


### PR DESCRIPTION
**Description:** There are several things going on in this PR:
1. Adding the landing page url to the course data responses from the enterprise api.
2. Adding a new endpoint to the enterprise api to get courses by enterprise uuid. I added this because the courses endpoint by catalog id inferred the enterprise by whether or not the request's user was linked to an enterprise, which wasn't sufficient if we were to switch over the course export job to use the enterprise api.
3. Switch over the course export job to use the new enterprise courses endpoint, and to use the landing page url returned in the response as the launchURL to SAP.

**JIRA:** https://openedx.atlassian.net/browse/ENT-356

**Dependencies:** n/a

**Merge deadline:** 5/17/2017 would be nice

**Installation instructions:** Standard enterprise installation/set up.

**Testing instructions:**

TBD - I haven't tested this on a sandbox yet.

**Merge checklist:**

- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
