### PR TITLE
Display account created/linked message on enterprise landing page

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ----------
 
+[0.33.19] - 2017-05-18
+----------------------
+
+* Display account created/linked messages on enterprise landing page
+
+
 [0.33.18] - 2017-05-17
 ----------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.33.18"
+__version__ = "0.33.19"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/static/enterprise/enterprise_course_enrollment_page.css
+++ b/enterprise/static/enterprise/enterprise_course_enrollment_page.css
@@ -207,3 +207,48 @@ body, .zebra-stripe > :nth-child(2n+1), .depth-0 {
     cursor: pointer;
     background: #0b5177;
 }
+
+#messages .alert {
+    position: relative;
+    padding: 10px 10px 10px 35px;
+    border: 1px solid transparent;
+    box-shadow: none;
+    border-radius: 2px;
+    margin-bottom: 8px;
+}
+
+#messages .fa {
+    position: absolute;
+    left: 11px;
+    top: 13px;
+    font-size: 16px;
+}
+
+#messages .alert > span {
+    display: block;
+    font-weight: 600;
+}
+
+#messages .success {
+  background-color: #ecfaec;
+  border-color: #b9edb9;
+  color: #3c763d;
+}
+
+#messages .info {
+  background-color: #f2f8fb;
+  border-color: #cce3f0;
+  color: #31708f;
+}
+
+#messages .warning {
+  background-color: #fcf8e3;
+  border-color: #faebcc;
+  color: #8a6d3b;
+}
+
+#messages .error {
+  background-color: #f2dede;
+  border-color: #ebccd1;
+  color: #a94442;
+}

--- a/enterprise/templates/enterprise/enterprise_course_enrollment_page.html
+++ b/enterprise/templates/enterprise/enterprise_course_enrollment_page.html
@@ -33,6 +33,26 @@ from django.utils.translation import ugettext as _
           </div>
         </div>
         <div class="col-7 border-left">
+
+          % if messages:
+              <div id="messages">
+                % for message in messages:
+                  <div class="alert ${ message.tags }" aria-live="polite">
+                    % if 'success' in message.tags:
+                        <i class="fa fa-check-circle" aria-hidden="true"></i>
+                    % elif 'info' in message.tags:
+                        <i class="fa fa-info-circle" aria-hidden="true"></i>
+                    % elif 'warning' in message.tags:
+                        <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
+                    % elif 'error' in message.tags:
+                        <i class="fa fa-times-circle" aria-hidden="true"></i>
+                    % endif %}
+                    ${ message }
+                  </div>
+                % endfor
+              </div>
+          % endif
+
           <h3 class="course-confirmation-title">${ confirmation_text }</h3>
           <div class="media">
             <div class="thumbnail">

--- a/test_settings.py
+++ b/test_settings.py
@@ -33,6 +33,8 @@ INSTALLED_APPS = (
     "django.contrib.sites",
     "django.contrib.sessions",
     "django.contrib.admin",  # only used in DEBUG mode
+    "django.contrib.messages",
+
     "enterprise",
     "integrated_channels.integrated_channel",
     "integrated_channels.sap_success_factors",


### PR DESCRIPTION
ENT-347
@asadiqbal08 @saleem-latif @douglashall 

**Description:**  	Display account created/linked message on enterprise course enrollment page (enterprise landing page).

**JIRA:** [ENT-347](https://openedx.atlassian.net/browse/ENT-347)

**Dependencies:** N/A

**Merge deadline:** 19 May, 2017

**Installation instructions:** Install `edx-enterprise` from this branch `zub/ENT-347-enterprise-landing-page-display-messages` in `edx-platform`.

**Testing instructions:**

1. Go to enterprise customers django admin at `admin/enterprise/enterprisecustomer/`
2. Add enterprise customer with logo and with consent disabled and link it with an `idp`.
3. Create/publish a course in studio
4. As an anonymous user view the enterprise landing page for the enterprise course by accessing the enterprise course enrollment url with enterprise customer uuid from step no 2, e.g: http://zubair.localhost:8000/enterprise/72416e52-8c77-4860-9584-15e5b06220fb/course/course-v1:edX+TEST_01+2016_R1/enroll/
5. The learner will be redirected to `idp` login page related to the enterprise and on successful login if learner will create a new account at edX for linking with enterprise then learner will view both **success** and **info** messages. If the learner links and existing activated account at edX then the learner will only see **success** message on enterprise landing page
6. Repeat from step **2** by enabling consent. The difference in flow will be that now learner will have to accept the consent after successful linking of account with the enterprise.

**Merge checklist:**

- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
