### PR TITLE
ENT-399: Convert enterprise templates to django template

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ----------
 
+[0.33.20] - 2017-05-23
+----------------------
+
+* Migrate from mako templates to django templates
+
+
 [0.33.19] - 2017-05-18
 ----------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.33.19"
+__version__ = "0.33.20"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/static/enterprise/grant_data_sharing_permissions.css
+++ b/enterprise/static/enterprise/grant_data_sharing_permissions.css
@@ -1,6 +1,6 @@
 * {
     font-family: "Open Sans","Helvetica Neue",Helvetica,Arial,sans-serif;
-    font-size: 16;
+    font-size: 16px;
 }
 body, .zebra-stripe > :nth-child(2n+1), .depth-0 {
     background-color: white;
@@ -43,7 +43,7 @@ body, .zebra-stripe > :nth-child(2n+1), .depth-0 {
     border-color: transparent;
     height: auto;
     width: 33%;
-    font-size: 18;
+    font-size: 18px;
     padding: 5px 2px;
     max-width: 180px;
     min-width: 125px;
@@ -80,7 +80,7 @@ body, .zebra-stripe > :nth-child(2n+1), .depth-0 {
 }
 .failure-link {
     color: #0075B4;
-    font-size: 18;
+    font-size: 18px;
     display: inline-block;
     text-decoration: underline;
     border: none;
@@ -140,8 +140,8 @@ h1 {
 
 .modal-close-button {
     position: absolute;
-    top: -27;
-    right: 3;
+    top: -27px;
+    right: 3px;
     color: white;
     font-size: 1.5em;
     border: none;
@@ -150,13 +150,13 @@ h1 {
 
 .modal-close-button:hover {
     font-size: 1.8em;
-    top: -30;
+    top: -30px;
     right: 0;
 }
 
 .modal-close-button:focus {
     font-size: 1.8em;
-    top: -30;
+    top: -30px;
     right: 0;
 }
 
@@ -172,14 +172,14 @@ h1 {
     padding: 20px;
     width: 80%;
     max-width: 450px;
-    max-height: 300px;
+    max-height: 320px;
     min-width: 300px;
     border-top: 30px solid #0075B4;
 }
 
 h2#modal-header-text {
     font-weight: bold;
-    font-size: 18;
+    font-size: 18px;
 }
 
 .data-consent-checkbox {

--- a/enterprise/templates/enterprise/base.html
+++ b/enterprise/templates/enterprise/base.html
@@ -1,0 +1,25 @@
+{% load theme_pipeline staticfiles %}
+
+<!DOCTYPE html>
+<html lang="{{ LANGUAGE_CODE|default:"en-us" }}">
+  <head>
+  {% block title %}<title>{{ page_title }} | {{ platform_name }}</title>{% endblock %}
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+
+    {% block styles %}
+      {% stylesheet 'style-vendor' %}
+      {% stylesheet 'style-main-v2' %}
+       <link rel="stylesheet" href="{% static 'css/vendor/font-awesome.css' %}"/>
+    {% endblock %}
+
+    {% block extrastyles %}{% endblock %}
+
+    {% block extrahead %}{% endblock %}
+
+    {% include "enterprise/widgets/segment-io.html" %}
+  </head>
+
+  <body>
+    {% block contents %}{% endblock %}
+  </body>
+</html>

--- a/enterprise/templates/enterprise/enterprise_course_enrollment_page.html
+++ b/enterprise/templates/enterprise/enterprise_course_enrollment_page.html
@@ -1,113 +1,81 @@
-<%namespace name='static' file='/static_content.html'/>
+{% extends 'enterprise/base.html' %}
 
-<%static:css group='style-vendor'/>
-<%! main_css = "style-main-v2" %>
-<%static:css group='${self.attr.main_css}'/>
+{% load staticfiles enterprise %}
 
-<%!
-from django.utils.translation import ugettext as _
-%>
+{% block extrastyles %}
+  <link rel="stylesheet" href="{% static 'enterprise/enterprise_course_enrollment_page.css' %}" />
+{% endblock %}
 
-<html lang="${ page_language }">
-  <title>${ page_title } | ${ platform_name }</title>
-  <head>
-    <link rel="stylesheet" href="${static.url('css/vendor/font-awesome.css')}"/>
-    <link rel="stylesheet" href="${static.url('enterprise/enterprise_course_enrollment_page.css')}"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  </head>
-  <body>
+{% block contents %}
+  <header class="logo-container" aria-label="{{ page_title }}">
+    <h1>
+      <img src="{% static 'images/logo.png' %}" alt="{{ platform_name }}"/>
+    </h1>
+  </header>
+  <hr class="pinstripe"/>
 
-    <header class="logo-container" aria-label="${ page_title }">
-      <h1>
-        <img src="${static.url('images/logo.png')}" alt="${ platform_name }"/>
-      </h1>
-    </header>
-    <hr class="pinstripe"/>
-
-    <div class="enterprise-container">
-      <div class="row">
-        <div class="col-3">
-          <img class="enterprise-logo" src="${ enterprise_customer.branding_configuration.logo.url }" alt="${ enterprise_customer.name }"/>
-          <div class="partnered-text">
-            ${ enterprise_welcome_text }
-          </div>
-        </div>
-        <div class="col-7 border-left">
-
-          % if messages:
-              <div id="messages">
-                % for message in messages:
-                  <div class="alert ${ message.tags }" aria-live="polite">
-                    % if 'success' in message.tags:
-                        <i class="fa fa-check-circle" aria-hidden="true"></i>
-                    % elif 'info' in message.tags:
-                        <i class="fa fa-info-circle" aria-hidden="true"></i>
-                    % elif 'warning' in message.tags:
-                        <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
-                    % elif 'error' in message.tags:
-                        <i class="fa fa-times-circle" aria-hidden="true"></i>
-                    % endif %}
-                    ${ message }
-                  </div>
-                % endfor
-              </div>
-          % endif
-
-          <h3 class="course-confirmation-title">${ confirmation_text }</h3>
-          <div class="media">
-            <div class="thumbnail">
-              <img class="course-image" src="${ course_image_uri }" alt="${ course_name }"/>
-            </div>
-            <div class="media-content">
-              <div class="course-title">${ course_name }</div>
-            </div>
-          </div>
-          <div class="course-detail">
-            <div class="course-org">
-              ${ course_organization }
-            </div>
-            <div class="course-info">
-              <i class="fa fa-clock-o" aria-hidden="true"></i>
-              <span>${ starts_at_text } ${ course_start_date } &nbsp;| &nbsp; ${ course_pacing } - ${ course_pace_text }</span>
-            </div>
-            ${ course_short_description }
-            <a class="text-underline" href="#!">${ view_course_details_text }</a>
-          </div>
-          <form>
-            <div class="caption">${ select_mode_text }</div>
-            % for course_mode in course_modes:
-            <div class="radio-block">
-              <div class="radio">
-                % if len(course_modes) > 1:
-                <input type="radio" name="data_sharing_consent" id="radio${loop.index}"
-                       % if loop.first:
-                       checked="checked"
-                       % endif
-                       />
-                % else:
-                <input type="hidden" name="data_sharing_consent" id="radio${loop.index}"
-                       value="${ course_mode['mode'] }" />
-                % endif
-              </div>
-              <label for="radio${loop.index}">
-                <strong class="title">${ course_mode['title'] }</strong>
-                <span class="price">
-                  ${ price_text }:
-                  % if course_mode['final_price'] and course_mode['original_price'] != course_mode['final_price']:
-                  <strike>${ course_mode['original_price'] }</strike> ${ course_mode['final_price'] }
-                  % else:
-                  ${ course_mode['original_price'] }
-                  % endif
-                </span>
-                <span class="description">${ course_mode['description'] }</span>
-              </label>
-            </div>
-            % endfor
-            <button class="btn-continue">${ continue_link_text }</button>
-          </form>
+  <div class="enterprise-container">
+    <div class="row">
+      <div class="col-3">
+        <img class="enterprise-logo" src="{{ enterprise_customer.branding_configuration.logo.url }}" alt="{{ enterprise_customer.name }}"/>
+        <div class="partnered-text">
+          {% autoescape off %}{{ enterprise_welcome_text }}{% endautoescape %}
         </div>
       </div>
-    </div>
+      <div class="col-7 border-left">
 
-  </body>
-</html>
+        {# Display success, error, warning or info messages #}
+        {% alert_messages messages %}
+
+        <h3 class="course-confirmation-title">{{ confirmation_text }}</h3>
+        <div class="media">
+          <div class="thumbnail">
+            <img class="course-image" src="{{ course_image_uri }}" alt="{{ course_name }}"/>
+          </div>
+          <div class="media-content">
+            <div class="course-title">{{ course_name }}</div>
+          </div>
+        </div>
+        <div class="course-detail">
+          <div class="course-org">
+            {{ course_organization }}
+          </div>
+          <div class="course-info">
+            <i class="fa fa-clock-o" aria-hidden="true"></i>
+            <span>{{ starts_at_text }} {{ course_start_date }} &nbsp;| &nbsp; {{ course_pacing }} - {{ course_pace_text }}</span>
+          </div>
+          {{ course_short_description }}
+          <a class="text-underline" href="#!">{{ view_course_details_text }}</a>
+        </div>
+        <form>
+          <div class="caption">{{ select_mode_text }}</div>
+          {% for course_mode in course_modes %}
+          <div class="radio-block">
+            <div class="radio">
+              {% if course_modes|length > 1 %}
+                <input type="radio" name="data_sharing_consent" id="radio${{ forloop.counter0 }}" {% if forloop.first %}checked="checked"{% endif %} />
+              {% else %}
+                <input type="hidden" name="data_sharing_consent" id="radio{{ forloop.counter0 }}" value="{{ course_mode.mode }}" />
+              {% endif %}
+            </div>
+
+            <label for="radio{{ forloop.counter0 }}">
+              <strong class="title">{{ course_mode.title }}</strong>
+              <span class="price">
+                {{ price_text }}:
+                {% if course_mode.final_price and course_mode.original_price != course_mode.final_price %}
+                  <strike>{{ course_mode.original_price }}</strike> {{ course_mode.final_price }}
+                {% else %}
+                  {{ course_mode.original_price }}
+                {% endif %}
+              </span>
+              <span class="description">{{ course_mode.description }}</span>
+            </label>
+          </div>
+          {% endfor %}
+          <button class="btn-continue">{{ continue_link_text }}</button>
+        </form>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/enterprise/templates/enterprise/grant_data_sharing_permissions.html
+++ b/enterprise/templates/enterprise/grant_data_sharing_permissions.html
@@ -1,115 +1,113 @@
-<%namespace name='static' file='/static_content.html'/>
-  <%static:css group='style-vendor'/>
-    <%! main_css = "style-main-v2" %>
-<%static:css group='${self.attr.main_css}'/>
-  <%!
-    from django.utils.translation import ugettext as _
-    %>
-<%include file="widgets/segment-io.html" />
-<html lang="${ page_language }">
-  <title>${ title_bar_prefix } | ${ platform_name }</title>
-  <head>
-    <link rel="stylesheet" href="${static.url('css/vendor/font-awesome.css')}"/>
-    <link rel="stylesheet" href="${static.url('enterprise/grant_data_sharing_permissions.css')}"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1"/>
-    <script type="text/javascript">
-      var courseId;
-      var successUrl;
-      var failureUrl;
-      var enrollmentDeferred = false;
-      % if course_specific and course_id:
-        courseId = "${ course_id }";
-      % endif
-      % if redirect_url:
-        successUrl = "${ redirect_url }";
-      % endif
-      % if failure_url:
-        failureUrl = "${ failure_url }";
-      % endif
-      % if enrollment_deferred:
-        enrollmentDeferred = true;
-      % endif
-    </script>
-    <script type="text/javascript" src="${static.url('common/js/vendor/jquery.js')}"></script>
-    <script type="text/javascript" src="${static.url('js/vendor/jquery.cookie.js')}"></script>
-    <script type="text/javascript" src="${static.url('enterprise/grant_data_sharing_permissions.js')}"></script>
-  </head>
-  <body>
-    <header class="logo-container" aria-label="${ title_bar_prefix }">
-      <h1>
-        <img src="${static.url('images/logo.png')}" alt="${ platform_name }"/>
-      </h1>
-    </header>
-    <hr class="pinstripe"/>
-    <main>
-      <div class="consent-container">
-        <h2 class="consent-title">${ consent_message_header }</h2>
-        <div class="consent-message">
-          <p>${ consent_request_prompt } ${ policy_link_template.format(start_link='<a href="#consent-policy-dropdown-bar" class="policy-dropdown-link background-input" id="policy-dropdown-link">', end_link='</a>') }</p>
-          <p>${ requested_permissions_header }
+{% extends 'enterprise/base.html' %}
+
+{% load i18n staticfiles %}
+
+{% block extrastyles %}
+  <link rel="stylesheet" href="{% static 'enterprise/grant_data_sharing_permissions.css' %}"/>
+{% endblock %}
+
+{% block extrahead %}
+  <script type="text/javascript">
+    var courseId;
+    var successUrl = {{ redirect_url|default:"null"|escapejs }};
+    var failureUrl = {{ failure_url|default:"null"|escapejs }};
+    var enrollmentDeferred = {{ enrollment_deferred|yesno:"true,false" }};
+    {% if course_specific and course_id %}
+      courseId = "{{ course_id }}";
+    {% endif %}
+  </script>
+  <script type="text/javascript" src="{% static  'common/js/vendor/jquery.js' %}"></script>
+  <script type="text/javascript" src="{% static  'js/vendor/jquery.cookie.js' %}"></script>
+  <script type="text/javascript" src="{% static  'enterprise/grant_data_sharing_permissions.js' %}"></script>
+{% endblock %}
+
+{% block contents %}
+  <header class="logo-container" aria-label="{{ page_title }}">
+    <h1>
+      <img src="{% static 'images/logo.png' %}" alt="{{ platform_name }}"/>
+    </h1>
+  </header>
+  <hr class="pinstripe"/>
+  <main>
+
+    <div class="consent-container">
+      <h2 class="consent-title">{{ consent_message_header }}</h2>
+      <div class="consent-message">
+        {% autoescape off %}
+          <p>{{ consent_request_prompt }} {{ policy_link_template }}</p>
+        {% endautoescape %}
+
+        <p>{{ requested_permissions_header }}
           <ul class="consent-items">
-            % for permission in requested_permissions:
-            <li>${ permission }</li>
-            % endfor
+            {% for permission in requested_permissions %}
+              <li>{{ permission }}</li>
+            {% endfor %}
           </ul>
+        </p>
+      </div>
+
+      <div class="consent-input-container login-register">
+        <form name="data-sharing-consent" method="POST" id="data-sharing">
+          {% csrf_token %}
+
+          <input class="background-input data-consent-checkbox" type="checkbox" name="data_sharing_consent" id="data-consent-checkbox" value="True"/>
+          <p class="agreement-text">
+            <label for="data-consent-checkbox">{{ agreement_text }}</label>
           </p>
-        </div>
-        <div class="consent-input-container login-register">
-          <form name="data-sharing-consent" method="POST" id="data-sharing">
-            <input class="background-input data-consent-checkbox" type="checkbox" name="data_sharing_consent" id="data-consent-checkbox" value="True"/>
-            <p class="agreement-text">
-              <label for="data-consent-checkbox">${agreement_text}</label>
-            </p>
-            <button type="submit" class="background-input consent-agreement-button" id="consent-button" disabled>${ continue_text }</button>
-            <button type="button" class="failure-link background-input" id="failure-link">${ abort_text }</a>
-            <input type="hidden" name="csrfmiddlewaretoken" value="${ csrf_token }" />
-            % if course_specific and course_id:
-            <input type="hidden" name="course_id" value="${ course_id }" />
-            % endif
-            % if redirect_url:
-            <input type="hidden" name="redirect_url" value="${redirect_url}" />
-            % endif
-            % if failure_url:
-            <input type="hidden" name="failure_url" value="${failure_url}" />
-            % endif
-            % if enrollment_deferred:
+          <button type="submit" class="background-input consent-agreement-button" id="consent-button" disabled>{{ continue_text }}</button>
+          <button type="button" class="failure-link background-input" id="failure-link">{{ abort_text }}</button>
+
+          {% if course_specific and course_id %}
+            <input type="hidden" name="course_id" value="{{ course_id }}" />
+          {% endif %}
+
+          {% if redirect_url %}
+            <input type="hidden" name="redirect_url" value="{{ redirect_url }}" />
+          {% endif %}
+
+          {% if failure_url %}
+            <input type="hidden" name="failure_url" value="{{ failure_url }}" />
+          {% endif %}
+
+          {% if enrollment_deferred %}
             <input type="hidden" name="enrollment_deferred" value="true" />
-            % endif
-          </form>
-        </div>
-        <br/>
-        <button type="button" id="consent-policy-dropdown-bar" class="consent-policy-dropdown-bar background-input" aria-controls="consent-policy" aria-expanded="false">
-          <span class="dropdown-text">${ policy_dropdown_header }</span>
-          <span class="fa-stack fa-lg dropdown-icon-container" aria-hidden="true">
-            <span id="consent-policy-dropdown-icon-surround" class="fa fa-circle fa-stack-2x" aria-hidden="true"></span>
-            <span id="consent-policy-dropdown-icon" class="fa fa-chevron-right fa-stack-1x" aria-hidden="true"></span>
-          </span>
-        </button>
-        <div class="consent-policy" id="consent-policy" style="display:none;">
-          <p>${ sharable_items_header }</p>
-          <ul class="consent-policy-bulletpoints">
-            % for item in sharable_items:
-              <li>${ item }</li>
-            % endfor
-          </ul>
-          <p>${ sharable_items_footer }</p>
-          <p>
-            <a href="#">${ policy_return_link_text }</a>
-          </p>
-        </div>
+          {% endif %}
+        </form>
       </div>
-      <div id="consent-confirmation-modal" class="modal">
-        <div id="consent-confirmation-modal-content" class="modal-content" role="dialog" aria-modal="true" aria-labelledby="modal-header-text">
-          <button class="fa fa-times-circle modal-close-button" id="modal-close-button" aria-label="${_('Close')}"></button>
-          <header class="modal-header">
-            <h2 id="modal-header-text">${ confirmation_modal_header}</h2>
-          </header>
-          <p>${ confirmation_alert_prompt }</p>
-          <p>${ confirmation_alert_prompt_warning }</p>
-          <button class="consent-agreement-button" id="modal-no-consent-button">${ confirmation_modal_affirm_decline_text }</button>
-          <button class="failure-link" id="review-policy-link">${ confirmation_modal_abort_decline_text }</a>
-        </div>
+
+      <br/>
+      <button type="button" id="consent-policy-dropdown-bar" class="consent-policy-dropdown-bar background-input" aria-controls="consent-policy" aria-expanded="false">
+        <span class="dropdown-text">{{ policy_dropdown_header }}</span>
+        <span class="fa-stack fa-lg dropdown-icon-container" aria-hidden="true">
+          <span id="consent-policy-dropdown-icon-surround" class="fa fa-circle fa-stack-2x" aria-hidden="true"></span>
+          <span id="consent-policy-dropdown-icon" class="fa fa-chevron-right fa-stack-1x" aria-hidden="true"></span>
+        </span>
+      </button>
+
+      <div class="consent-policy" id="consent-policy" style="display:none;">
+        <p>{{ sharable_items_header }}</p>
+        <ul class="consent-policy-bulletpoints">
+          {% for item in sharable_items %}
+            <li>{{ item }}</li>
+          {% endfor %}
+        </ul>
+        <p>{{ sharable_items_footer }}</p>
+        <p>
+          <a href="#">{{ policy_return_link_text }}</a>
+        </p>
       </div>
-    </main>
-  </body>
-</html>
+    </div>
+    <div id="consent-confirmation-modal" class="modal">
+      <div id="consent-confirmation-modal-content" class="modal-content" role="dialog" aria-modal="true" aria-labelledby="modal-header-text">
+        <button class="fa fa-times-circle modal-close-button" id="modal-close-button" aria-label="{% trans "Close" %}"></button>
+        <header class="modal-header">
+          <h2 id="modal-header-text">{{ confirmation_modal_header }}</h2>
+        </header>
+        <p>{{ confirmation_alert_prompt }}</p>
+        <p>{{ confirmation_alert_prompt_warning }}</p>
+        <button class="consent-agreement-button" id="modal-no-consent-button">{{ confirmation_modal_affirm_decline_text }}</button>
+        <button class="failure-link" id="review-policy-link">{{ confirmation_modal_abort_decline_text }}</button>
+      </div>
+    </div>
+  </main>
+{% endblock %}

--- a/enterprise/templates/enterprise/templatetags/alert_messages.html
+++ b/enterprise/templates/enterprise/templatetags/alert_messages.html
@@ -1,0 +1,9 @@
+{% load enterprise %}
+
+<div id="messages">
+  {% for message in messages %}
+    <div class="alert {{ message.tags }}" aria-live="polite">
+      {% fa_icon message.level_tag %} {{ message }}
+    </div>
+  {% endfor %}
+</div>

--- a/enterprise/templates/enterprise/templatetags/fa_icon.html
+++ b/enterprise/templates/enterprise/templatetags/fa_icon.html
@@ -1,0 +1,3 @@
+{% if icon %}
+  <i class="fa {{ icon }}" aria-hidden="true"></i>
+{% endif %}

--- a/enterprise/templates/enterprise/widgets/segment-io.html
+++ b/enterprise/templates/enterprise/widgets/segment-io.html
@@ -1,0 +1,23 @@
+{% if LMS_SEGMENT_KEY %}
+  <!-- begin Segment -->
+  <script type="text/javascript">
+    // Asynchronously load Segment's analytics.js library
+    !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement("script");e.type="text/javascript";e.async=!0;e.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};analytics.SNIPPET_VERSION="3.1.0";
+    analytics.load("{{ LMS_SEGMENT_KEY|escapejs }}");
+    analytics.page();
+    }}();
+    // Note: user tracking moved to segment-io-footer.html
+  </script>
+  <!-- end Segment -->
+{% else %}
+  <!-- dummy Segment -->
+  <script type="text/javascript">
+    var analytics = {
+      track: function() { return; },
+      trackLink: function() { return; },
+      pageview: function() { return; },
+      page: function() { return; }
+    };
+  </script>
+  <!-- end dummy Segment -->
+{% endif %}

--- a/enterprise/templatetags/enterprise.py
+++ b/enterprise/templatetags/enterprise.py
@@ -1,0 +1,42 @@
+"""
+Template tags for enterprise apps.
+"""
+from __future__ import absolute_import, unicode_literals
+
+from django import template
+
+
+register = template.Library()  # pylint: disable=invalid-name
+
+MESSAGE_ICONS = {
+    'success': 'fa-check-circle',
+    'info': 'fa-info-circle',
+    'warning': 'fa-exclamation-circle',
+    'error': 'fa-times-circle'
+}
+
+
+@register.inclusion_tag('enterprise/templatetags/fa_icon.html')
+def fa_icon(message_type):
+    """
+    Django template tag that returns font awesome icon depending upon message type.
+
+    Usage:
+        {% fa_icon "success" %}
+    """
+    return {
+        'icon': MESSAGE_ICONS.get(message_type)
+    }
+
+
+@register.inclusion_tag('enterprise/templatetags/alert_messages.html')
+def alert_messages(messages):
+    """
+    Django template tag that returns font awesome icon depending upon message type.
+
+    Usage:
+        {% alert_messages messages %}
+    """
+    return {
+        'messages': messages
+    }

--- a/test_settings.py
+++ b/test_settings.py
@@ -126,3 +126,5 @@ COURSE_KEY_PATTERN = r'(?P<course_key_string>[^/+]+(/|\+)[^/+]+(/|\+)[^/?]+)'
 COURSE_ID_PATTERN = COURSE_KEY_PATTERN.replace('course_key_string', 'course_id')
 
 USE_TZ = True
+
+LMS_SEGMENT_KEY = ''

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -1,0 +1,111 @@
+"""
+Tests for django template tags.
+"""
+from __future__ import absolute_import, unicode_literals
+
+import unittest
+
+import ddt
+
+from django.contrib import messages
+from django.contrib.messages.storage import fallback
+from django.contrib.sessions.backends import cache
+from django.template import Context, Template
+from django.test import RequestFactory
+
+
+@ddt.ddt
+class EnterpriseTemplateTagsTest(unittest.TestCase):
+    """
+    Tests for enterprise template tags.
+    """
+
+    @staticmethod
+    def _add_messages(request, alert_messages):
+        """
+        Add django messages to the request context using `messages` app.
+
+        Arguments:
+            alert_messages (list): A list of tuples containing message type and message body.
+                e.g. [('success', 'This is a dummy success message.'), ]
+        """
+        for message_type, message in alert_messages:
+            messages.add_message(request, message_type, message)
+
+    @staticmethod
+    def _get_mock_request():
+        """
+        Get mock django HttpRequest object.
+        """
+        request = RequestFactory().get('/')
+        request.session = cache.SessionStore()
+        # Monkey-patch storage for messaging;   pylint: disable=protected-access
+        request._messages = fallback.FallbackStorage(request)
+
+        return request
+
+    @ddt.data(
+        ('success', '<i class="fa fa-check-circle" aria-hidden="true"></i>'),
+        ('info', '<i class="fa fa-info-circle" aria-hidden="true"></i>'),
+        ('warning', '<i class="fa fa-exclamation-circle" aria-hidden="true"></i>'),
+        ('error', '<i class="fa fa-times-circle" aria-hidden="true"></i>'),
+        ('unknown-status-tag', ''),
+    )
+    @ddt.unpack
+    def test_fa_icon(self, message_type, expected_favicon):
+        """
+        Test that fa_icon template tag returns correct favicon for status tag.
+        """
+        template = Template("{% load enterprise %} {% fa_icon '" + message_type + "' %}")
+        rendered = template.render(Context({}))
+
+        assert expected_favicon == rendered.strip()
+
+    @ddt.data(
+        (
+            [
+                (messages.INFO, 'This is a dummy info message.'),
+            ],
+            [
+                ('<i class="fa fa-info-circle" aria-hidden="true"></i>', 'This is a dummy info message.'),
+            ],
+        ),
+        (
+            [
+                (messages.SUCCESS, 'This is a dummy success message.'),
+                (messages.INFO, 'This is a dummy info message.'),
+            ],
+            [
+                ('<i class="fa fa-check-circle" aria-hidden="true"></i>', 'This is a dummy success message.'),
+                ('<i class="fa fa-info-circle" aria-hidden="true"></i>', 'This is a dummy info message.'),
+            ],
+        ),
+        (
+            [
+                (messages.SUCCESS, 'This is a dummy success message.'),
+                (messages.ERROR, 'This is a dummy error message.'),
+                (messages.INFO, 'This is a dummy info message.'),
+                (messages.WARNING, 'This is a dummy warning message.'),
+            ],
+            [
+                ('<i class="fa fa-check-circle" aria-hidden="true"></i>', 'This is a dummy success message.'),
+                ('<i class="fa fa-times-circle" aria-hidden="true"></i>', 'This is a dummy error message.'),
+                ('<i class="fa fa-info-circle" aria-hidden="true"></i>', 'This is a dummy info message.'),
+                ('<i class="fa fa-exclamation-circle" aria-hidden="true"></i>', 'This is a dummy warning message.'),
+            ],
+        ),
+    )
+    @ddt.unpack
+    def test_alert_messages(self, alert_messages, expected_messages):
+        """
+        Test that fa_icon template tag returns correct favicon for status tag.
+        """
+        request = self._get_mock_request()
+        self._add_messages(request, alert_messages)
+
+        template = Template("{% load enterprise %} {% alert_messages messages %}")
+        rendered = template.render(Context({'messages': messages.get_messages(request)}))
+
+        for expected_icon, expected_message in expected_messages:
+            assert expected_icon in rendered.strip()
+            assert expected_message in rendered.strip()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -12,7 +12,7 @@ from requests.utils import quote
 from django.contrib import messages
 from django.core.urlresolvers import NoReverseMatch, reverse
 from django.http import HttpResponseRedirect
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from django.test import Client, TestCase
 
 from enterprise.models import EnterpriseCourseEnrollment, EnterpriseCustomerUser, UserDataSharingConsentAudit
@@ -28,11 +28,11 @@ from six.moves.urllib.parse import urlencode  # pylint: disable=import-error
 from test_utils.factories import EnterpriseCustomerFactory, EnterpriseCustomerUserFactory, UserFactory
 
 
-def fake_render(template, context, request):  # pylint: disable=unused-argument
+def fake_render(request, template, context):  # pylint: disable=unused-argument
     """
-    Switch the request to use the Django rendering engine instead of Mako.
+    Switch the request to use a template that does not depend on edx-platform.
     """
-    return render_to_response('enterprise/grant_data_sharing_permissions.html', context=context)
+    return render(request, 'enterprise/emails/user_notification.html', context=context)
 
 
 @mark.django_db
@@ -124,7 +124,7 @@ class TestGrantDataSharingPermissions(TestCase):
     @mock.patch('enterprise.views.get_real_social_auth_object')
     @mock.patch('enterprise.views.get_complete_url')
     @mock.patch('enterprise.views.redirect')
-    @mock.patch('enterprise.views.render_to_response', side_effect=fake_render)
+    @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.views.get_enterprise_customer_for_request')
     @mock.patch('enterprise.views.configuration_helpers')
     def test_get_no_customer_redirect(
@@ -159,7 +159,7 @@ class TestGrantDataSharingPermissions(TestCase):
     @mock.patch('enterprise.views.quarantine_session')
     @mock.patch('enterprise.views.get_real_social_auth_object')
     @mock.patch('enterprise.views.get_complete_url')
-    @mock.patch('enterprise.views.render_to_response', side_effect=fake_render)
+    @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.views.get_enterprise_customer_for_request')
     @mock.patch('enterprise.views.configuration_helpers')
     def test_get_render_patched(
@@ -208,7 +208,7 @@ class TestGrantDataSharingPermissions(TestCase):
     @mock.patch('enterprise.views.lift_quarantine')
     @mock.patch('enterprise.views.configuration_helpers')
     @mock.patch('enterprise.views.redirect')
-    @mock.patch('enterprise.views.render_to_response')
+    @mock.patch('enterprise.views.render')
     @mock.patch('enterprise.views.get_complete_url')
     @mock.patch('enterprise.tpa_pipeline.get_enterprise_customer_for_request')
     @mock.patch('enterprise.views.get_real_social_auth_object')
@@ -243,7 +243,7 @@ class TestGrantDataSharingPermissions(TestCase):
     @mock.patch('enterprise.views.quarantine_session')
     @mock.patch('enterprise.views.lift_quarantine')
     @mock.patch('enterprise.views.configuration_helpers')
-    @mock.patch('enterprise.views.render_to_response')
+    @mock.patch('enterprise.views.render')
     @mock.patch('enterprise.views.get_complete_url')
     @mock.patch('enterprise.tpa_pipeline.get_enterprise_customer_for_request')
     @mock.patch('enterprise.views.get_real_social_auth_object')
@@ -271,7 +271,7 @@ class TestGrantDataSharingPermissions(TestCase):
     @mock.patch('enterprise.views.quarantine_session')
     @mock.patch('enterprise.views.lift_quarantine')
     @mock.patch('enterprise.views.configuration_helpers')
-    @mock.patch('enterprise.views.render_to_response')
+    @mock.patch('enterprise.views.render')
     @mock.patch('enterprise.views.get_complete_url')
     @mock.patch('enterprise.tpa_pipeline.get_enterprise_customer_for_request')
     @mock.patch('enterprise.views.get_real_social_auth_object')
@@ -312,7 +312,7 @@ class TestGrantDataSharingPermissions(TestCase):
     @mock.patch('enterprise.views.quarantine_session')
     @mock.patch('enterprise.views.lift_quarantine')
     @mock.patch('enterprise.views.configuration_helpers')
-    @mock.patch('enterprise.views.render_to_response')
+    @mock.patch('enterprise.views.render')
     @mock.patch('enterprise.views.get_complete_url')
     @mock.patch('enterprise.tpa_pipeline.get_enterprise_customer_for_request')
     @mock.patch('enterprise.views.get_real_social_auth_object')
@@ -349,7 +349,7 @@ class TestGrantDataSharingPermissions(TestCase):
     @mock.patch('enterprise.views.quarantine_session')
     @mock.patch('enterprise.views.lift_quarantine')
     @mock.patch('enterprise.views.configuration_helpers')
-    @mock.patch('enterprise.views.render_to_response')
+    @mock.patch('enterprise.views.render')
     @mock.patch('enterprise.views.get_complete_url')
     @mock.patch('enterprise.tpa_pipeline.get_enterprise_customer_for_request')
     @mock.patch('enterprise.views.get_real_social_auth_object')
@@ -393,7 +393,7 @@ class TestGrantDataSharingPermissions(TestCase):
     @mock.patch('enterprise.views.quarantine_session')
     @mock.patch('enterprise.views.lift_quarantine')
     @mock.patch('enterprise.views.configuration_helpers')
-    @mock.patch('enterprise.views.render_to_response')
+    @mock.patch('enterprise.views.render')
     @mock.patch('enterprise.views.get_complete_url')
     @mock.patch('enterprise.tpa_pipeline.get_enterprise_customer_for_request')
     @mock.patch('enterprise.views.get_real_social_auth_object')
@@ -439,7 +439,7 @@ class TestGrantDataSharingPermissions(TestCase):
     @mock.patch('enterprise.views.quarantine_session')
     @mock.patch('enterprise.views.lift_quarantine')
     @mock.patch('enterprise.views.configuration_helpers')
-    @mock.patch('enterprise.views.render_to_response', side_effect=fake_render)
+    @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.views.CourseApiClient')
     @ddt.data(
         (False, False),
@@ -524,7 +524,7 @@ class TestGrantDataSharingPermissions(TestCase):
     @mock.patch('enterprise.views.quarantine_session')
     @mock.patch('enterprise.views.lift_quarantine')
     @mock.patch('enterprise.views.configuration_helpers')
-    @mock.patch('enterprise.views.render_to_response', side_effect=fake_render)
+    @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.views.CourseApiClient')
     def test_get_course_specific_consent_invalid_params(
             self,
@@ -568,7 +568,7 @@ class TestGrantDataSharingPermissions(TestCase):
     @mock.patch('enterprise.views.quarantine_session')
     @mock.patch('enterprise.views.lift_quarantine')
     @mock.patch('enterprise.views.configuration_helpers')
-    @mock.patch('enterprise.views.render_to_response', side_effect=fake_render)
+    @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.views.CourseApiClient')
     def test_get_course_specific_consent_unauthenticated_user(
             self,
@@ -616,7 +616,7 @@ class TestGrantDataSharingPermissions(TestCase):
     @mock.patch('enterprise.views.quarantine_session')
     @mock.patch('enterprise.views.lift_quarantine')
     @mock.patch('enterprise.views.configuration_helpers')
-    @mock.patch('enterprise.views.render_to_response', side_effect=fake_render)
+    @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.views.CourseApiClient')
     def test_get_course_specific_consent_bad_api_response(
             self,
@@ -655,7 +655,7 @@ class TestGrantDataSharingPermissions(TestCase):
     @mock.patch('enterprise.views.quarantine_session')
     @mock.patch('enterprise.views.lift_quarantine')
     @mock.patch('enterprise.views.configuration_helpers')
-    @mock.patch('enterprise.views.render_to_response', side_effect=fake_render)
+    @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.views.CourseApiClient')
     def test_get_course_specific_consent_not_needed(
             self,
@@ -697,7 +697,7 @@ class TestGrantDataSharingPermissions(TestCase):
     @mock.patch('enterprise.views.quarantine_session')
     @mock.patch('enterprise.views.lift_quarantine')
     @mock.patch('enterprise.views.configuration_helpers')
-    @mock.patch('enterprise.views.render_to_response', side_effect=fake_render)
+    @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.views.CourseApiClient')
     @mock.patch('enterprise.views.reverse')
     @ddt.data(True, False)
@@ -749,7 +749,7 @@ class TestGrantDataSharingPermissions(TestCase):
     @mock.patch('enterprise.views.quarantine_session')
     @mock.patch('enterprise.views.lift_quarantine')
     @mock.patch('enterprise.views.configuration_helpers')
-    @mock.patch('enterprise.views.render_to_response', side_effect=fake_render)
+    @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.views.CourseApiClient')
     @mock.patch('enterprise.views.reverse')
     def test_post_course_specific_consent_not_provided(
@@ -797,7 +797,7 @@ class TestGrantDataSharingPermissions(TestCase):
     @mock.patch('enterprise.views.quarantine_session')
     @mock.patch('enterprise.views.lift_quarantine')
     @mock.patch('enterprise.views.configuration_helpers')
-    @mock.patch('enterprise.views.render_to_response', side_effect=fake_render)
+    @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.views.CourseApiClient')
     @mock.patch('enterprise.views.reverse')
     def test_post_course_specific_consent_no_user(
@@ -846,7 +846,7 @@ class TestGrantDataSharingPermissions(TestCase):
     @mock.patch('enterprise.views.quarantine_session')
     @mock.patch('enterprise.views.lift_quarantine')
     @mock.patch('enterprise.views.configuration_helpers')
-    @mock.patch('enterprise.views.render_to_response', side_effect=fake_render)
+    @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.views.CourseApiClient')
     @mock.patch('enterprise.views.reverse')
     def test_post_course_specific_consent_bad_api_response(
@@ -964,7 +964,7 @@ class TestCourseEnrollmentView(TestCase):
         """
         assert self.client.login(username=self.user.username, password="QWERTY")
 
-    @mock.patch('enterprise.views.render_to_response', side_effect=fake_render)
+    @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.views.configuration_helpers')
     @mock.patch('enterprise.tpa_pipeline.get_enterprise_customer_for_request')
     @mock.patch('enterprise.views.get_real_social_auth_object')
@@ -1033,7 +1033,7 @@ class TestCourseEnrollmentView(TestCase):
         for key, value in expected_context.items():
             assert response.context[key] == value  # pylint: disable=no-member
 
-    @mock.patch('enterprise.views.render_to_response', side_effect=fake_render)
+    @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.views.configuration_helpers')
     @mock.patch('enterprise.tpa_pipeline.get_enterprise_customer_for_request')
     @mock.patch('enterprise.views.get_real_social_auth_object')
@@ -1081,7 +1081,7 @@ class TestCourseEnrollmentView(TestCase):
         for key, value in expected_context.items():
             assert response.context[key] == value  # pylint: disable=no-member
 
-    @mock.patch('enterprise.views.render_to_response', side_effect=fake_render)
+    @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.views.configuration_helpers')
     @mock.patch('enterprise.tpa_pipeline.get_enterprise_customer_for_request')
     @mock.patch('enterprise.views.get_real_social_auth_object')
@@ -1118,7 +1118,7 @@ class TestCourseEnrollmentView(TestCase):
         response = self.client.get(course_enrollment_page_url)
         assert response.status_code == 404
 
-    @mock.patch('enterprise.views.render_to_response', side_effect=fake_render)
+    @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.views.configuration_helpers')
     @mock.patch('enterprise.tpa_pipeline.get_enterprise_customer_for_request')
     @mock.patch('enterprise.views.get_real_social_auth_object')
@@ -1155,7 +1155,7 @@ class TestCourseEnrollmentView(TestCase):
         response = self.client.get(course_enrollment_page_url)
         assert response.status_code == 404
 
-    @mock.patch('enterprise.views.render_to_response', side_effect=fake_render)
+    @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.views.configuration_helpers')
     @mock.patch('enterprise.tpa_pipeline.get_enterprise_customer_for_request')
     @mock.patch('enterprise.views.get_real_social_auth_object')
@@ -1187,7 +1187,7 @@ class TestCourseEnrollmentView(TestCase):
         response = self.client.get(course_enrollment_page_url)
         assert response.status_code == 404
 
-    @mock.patch('enterprise.views.render_to_response', side_effect=fake_render)
+    @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.views.configuration_helpers')
     @mock.patch('enterprise.tpa_pipeline.get_enterprise_customer_for_request')
     @mock.patch('enterprise.views.get_real_social_auth_object')


### PR DESCRIPTION
**Description:** This PR converts all mako templates in edx-enterprise to django templates

**JIRA:** [ENT-399](https://openedx.atlassian.net/browse/ENT-399)

**Dependencies:** https://github.com/edx/edx-platform/pull/15179

**Installation instructions:** Simply install edx-enterprise no other setup required.

**Testing instructions:**

1. Open data sharing consent page
2. Make sure it works as expected i.e. there are no errors
3.Open enterprise landing page
4.Make sure it works as expected i.e. there are no errors

**Merge checklist:**

- [x] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [x] Translations are updated
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)

