### PR TITLE
[ENT-378] Remove code for custom header logo

### DIFF
--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -397,36 +397,6 @@ def get_reversed_url_by_site(request, site, *args, **kwargs):
     return final_url
 
 
-def get_enterprise_branding_info_by_provider_id(identity_provider_id=None):  # pylint: disable=invalid-name
-    """
-    Return the EnterpriseCustomer branding information based on provider_id.
-
-    Arguments:
-        identity_provider_id: There is 1:1 relation b/w EnterpriseCustomer and Identity provider.
-
-    Returns:
-        EnterpriseCustomerBrandingConfiguration instance associated with the customer of given identity provider.
-    """
-    return enterprise.models.EnterpriseCustomerBrandingConfiguration.objects.filter(
-        enterprise_customer__enterprise_customer_identity_provider__provider_id=identity_provider_id
-    ).first()
-
-
-def get_enterprise_branding_info_by_ec_uuid(ec_uuid=None):  # pylint: disable=invalid-name
-    """
-    Return the EnterpriseCustomer branding information based on enterprise customer uuid.
-
-    Arguments:
-        ec_uuid (UUID): a universally unique identifier for the enterprise customer.
-
-    Returns:
-        EnterpriseCustomerBrandingConfiguration instance associated with the given enterprise customer uuid.
-    """
-    return enterprise.models.EnterpriseCustomerBrandingConfiguration.objects.filter(
-        enterprise_customer__uuid=ec_uuid
-    ).first()
-
-
 def get_enterprise_customer_for_user(auth_user):
     """
     Return enterprise customer instance for given user.

--- a/test_utils/factories.py
+++ b/test_utils/factories.py
@@ -15,7 +15,6 @@ from django.utils import timezone
 from enterprise.models import (
     EnterpriseCourseEnrollment,
     EnterpriseCustomer,
-    EnterpriseCustomerBrandingConfiguration,
     EnterpriseCustomerEntitlement,
     EnterpriseCustomerIdentityProvider,
     EnterpriseCustomerUser,
@@ -153,25 +152,6 @@ class EnterpriseCustomerIdentityProviderFactory(factory.django.DjangoModelFactor
 
     enterprise_customer = factory.SubFactory(EnterpriseCustomerFactory)
     provider_id = factory.LazyAttribute(lambda x: FAKER.slug())
-
-
-class EnterpriseCustomerBrandingFactory(factory.django.DjangoModelFactory):
-    """
-    EnterpriseCustomerBrandingFactory factory.
-
-    Creates an instance of EnterpriseCustomerBranding with minimal boilerplate - uses this class' attributes as
-    default parameters for EnterpriseCustomerBrandingFactory constructor.
-    """
-
-    class Meta(object):
-        """
-        Meta for EnterpriseCustomerBrandingFactory.
-        """
-
-        model = EnterpriseCustomerBrandingConfiguration
-
-    id = factory.LazyAttribute(lambda x: FAKER.random_int(min=1))  # pylint: disable=invalid-name
-    enterprise_customer = factory.SubFactory(EnterpriseCustomerFactory)
 
 
 class PendingEnrollmentFactory(factory.django.DjangoModelFactory):

--- a/tests/api/test_throttles.py
+++ b/tests/api/test_throttles.py
@@ -31,9 +31,6 @@ class TestEnterpriseAPIThrottling(APITest):
         user = factories.UserFactory()
         enterprise_customer = factories.EnterpriseCustomerFactory()
         factories.EnterpriseCustomerUserFactory(enterprise_customer=enterprise_customer, user_id=user.id)
-        factories.EnterpriseCustomerBrandingFactory(
-            enterprise_customer=enterprise_customer, logo='/static/images/logo.png',
-        )
 
         self.url = settings.TEST_SERVER + reverse('site-list')
 

--- a/tests/api/test_views.py
+++ b/tests/api/test_views.py
@@ -116,19 +116,6 @@ class TestEnterpriseAPIViews(APITest):
             [{'domain': 'example.com', 'name': 'example.com'}],
         ),
         (
-            factories.EnterpriseCustomerBrandingFactory,
-            reverse('enterprise-customer-branding-list'),
-            itemgetter('enterprise_customer'),
-            [{
-                'enterprise_customer__uuid': 'd1098bfb-2c78-44f1-9eb2-b94475356a3f',
-                'logo': '/static/images/logo.png'
-            }],
-            [{
-                'enterprise_customer': 'd1098bfb-2c78-44f1-9eb2-b94475356a3f',
-                'logo': settings.TEST_SERVER + settings.MEDIA_URL + 'static/images/logo.png'
-            }],
-        ),
-        (
             factories.EnterpriseCustomerFactory,
             reverse('enterprise-customer-list'),
             itemgetter('uuid'),

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -744,6 +744,20 @@ class TestEnterpriseCustomerBrandingConfiguration(unittest.TestCase):
             branding_config_2.save()
             self.assertEqual(EnterpriseCustomerBrandingConfiguration.objects.count(), 2)
 
+    def test_branding_configuration_editing(self):
+        """
+        Test enterprise customer branding configuration saves changes to existing instance.
+        """
+        configuration = EnterpriseCustomerBrandingConfiguration(
+            enterprise_customer=EnterpriseCustomerFactory(),
+            logo="test1.png"
+        )
+        configuration.save()
+        self.assertEqual(configuration.logo.url, '/test1.png')
+        configuration.logo = 'test2.png'
+        configuration.save()
+        self.assertEqual(configuration.logo.url, '/test2.png')
+
     @ddt.data(
         (False, 2048),
         (False, 1024),

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -753,10 +753,10 @@ class TestEnterpriseCustomerBrandingConfiguration(unittest.TestCase):
             logo="test1.png"
         )
         configuration.save()
-        self.assertEqual(configuration.logo.url, '/test1.png')
+        self.assertEqual(configuration.logo.url, '/test1.png')  # pylint: disable=no-member
         configuration.logo = 'test2.png'
         configuration.save()
-        self.assertEqual(configuration.logo.url, '/test2.png')
+        self.assertEqual(configuration.logo.url, '/test2.png')  # pylint: disable=no-member
 
     @ddt.data(
         (False, 2048),

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -39,7 +39,6 @@ from enterprise.utils import (
     get_all_field_names,
 )
 from test_utils.factories import (
-    EnterpriseCustomerBrandingFactory,
     EnterpriseCustomerFactory,
     EnterpriseCustomerIdentityProviderFactory,
     EnterpriseCustomerUserFactory,
@@ -807,49 +806,6 @@ class TestEnterpriseUtils(unittest.TestCase):
             for field, val in expected_fields.items():
                 assert getattr(mail.outbox[0], field) == val
             assert mail.outbox[0].connection is conn
-
-    def test_enterprise_branding_info_by_provider_id(self):
-        """
-        Test `get_enterprise_branding_info_by_provider_id` helper method.
-        """
-        EnterpriseCustomerBrandingFactory(
-            enterprise_customer=self.customer,
-            logo='/test_1.png/'
-        )
-        self.assertEqual(
-            utils.get_enterprise_branding_info_by_provider_id(),
-            None,
-        )
-        self.assertEqual(
-            utils.get_enterprise_branding_info_by_provider_id(identity_provider_id=self.provider_id).logo,
-            '/test_1.png/',
-        )
-        self.assertEqual(
-            utils.get_enterprise_branding_info_by_provider_id(identity_provider_id='fake'),
-            None,
-        )
-
-    def test_enterprise_branding_info_by_ec_uuid(self):
-        """
-        Test `get_enterprise_branding_info_by_ec_uuid` helper method.
-        """
-        EnterpriseCustomerBrandingFactory(
-            enterprise_customer=self.customer,
-            logo='/test_2.png/'
-        )
-
-        self.assertEqual(
-            utils.get_enterprise_branding_info_by_ec_uuid(),
-            None,
-        )
-        self.assertEqual(
-            utils.get_enterprise_branding_info_by_ec_uuid(ec_uuid=self.uuid).logo,
-            '/test_2.png/',
-        )
-        self.assertEqual(
-            utils.get_enterprise_branding_info_by_ec_uuid(ec_uuid=FakerFactory.create().uuid4()),
-            None,
-        )
 
     def test_get_enterprise_customer_for_user(self):
         """


### PR DESCRIPTION
**Description:** This PR removes the code introduced in [ENT-32](https://openedx.atlassian.net/browse/ENT-32) where the enteprise logo was displayed. The PRs associated with that work were https://github.com/edx/edx-enterprise/pull/18 and https://github.com/edx/edx-enterprise/pull/20

**JIRA:** [ENT-378](https://openedx.atlassian.net/browse/ENT-378)

**Merge deadline:** None

**Installation instructions:** Standard Enterprise installation

**Testing instructions:**

These were mostly helper methods used for displaying the enterprise customer logo in the platform when the enterprise learner logged in so, there's no UI testing to do on the enteprise side. See https://github.com/edx/edx-platform/pull/15187 which removes the associated UI code in edx-platform.

**Merge checklist:**

- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)

**Reviewers**
- [x] @mtyaka