### PR TITLE
enable continue button on enterprise course enrollment page

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ----------
 
+[0.34.7] - 2017-06-14
+---------------------
+
+* Enable "Continue" button flows on enterprise landing page
+
+
 [0.34.6] - 2017-06-14
 ---------------------
 

--- a/enterprise/urls.py
+++ b/enterprise/urls.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, unicode_literals
 from django.conf import settings
 from django.conf.urls import include, url
 
-from enterprise.views import CourseEnrollmentView, GrantDataSharingPermissions
+from enterprise.views import CourseEnrollmentView, GrantDataSharingPermissions, HandleConsentEnrollment
 
 
 urlpatterns = [
@@ -16,6 +16,12 @@ urlpatterns = [
         GrantDataSharingPermissions.as_view(),
         name='grant_data_sharing_permissions'
     ),
+    url(
+        r'^enterprise/handle_consent_enrollment/(?P<enterprise_uuid>[^/]+)/course/{}/$'.format(
+            settings.COURSE_ID_PATTERN
+        ),
+        HandleConsentEnrollment.as_view(),
+        name='enterprise_handle_consent_enrollment'),
     url(
         r'^enterprise/(?P<enterprise_uuid>[^/]+)/course/{}/enroll/$'.format(settings.COURSE_ID_PATTERN),
         CourseEnrollmentView.as_view(),


### PR DESCRIPTION
@asadiqbal08 @saleem-latif @douglashall 

**Description:** Enable "Continue" button on enterprise course enrollment page (enterprise landing page).

**JIRA:** [ENT-379](https://openedx.atlassian.net/browse/ENT-379)

**Dependencies:**
* ~~[ENT-348](https://openedx.atlassian.net/browse/ENT-348) https://github.com/edx/edx-enterprise/pull/109~~ **Merged**

**Merge deadline:** 16 June, 2017

**Installation instructions:** Install `edx-enterprise` from this branch `zub/ENT-379-ent-landing-page-enable-continue-button` in `edx-platform`.

**Testing instructions:**
1. Go to enterprise customers django admin at `admin/enterprise/enterprisecustomer/`
2. Add enterprise customer with logo and with/without (2 different flows) consent disabled and link it with an `idp`.
3. Create/publish a course in studio
4. Login as enterprise learner to view the enterprise course enrollment page (enterprise landing page) for the enterprise course by accessing the enterprise course enrollment url with enterprise customer uuid from step no 2, e.g: http://zubair.localhost:8000/enterprise/72416e52-8c77-4860-9584-15e5b06220fb/course/course-v1:edX+TEST_01+2016_R1/enroll/
5. On enterprise course enrollment page verify the `Continue` button flows:
    1. **User Selects Audit Track**
        * if DSC needed, display DSC. After successful DSC, enroll learner and go to Dashboard
        * if DSC not needed, enroll learner and go to Dashboard
    2. **User Selects Verified/Prof Ed Track**
    **`WITH ENROLLMENT CODE`**
        1. If DSC needed, display DSC. After successful DSC,  display Basket with redeem code
        2. IF DSC not needed, display Basket with redeem code
    **`WITH DISCOUNT CODE`**
        1. If DSC needed, display DSC. After successful DSC, display Basket with discount applied
        2. IF DSC not needed, display Basket with discount applied
    **`NO SEAT ENTITLEMENT`**
        1. If DSC needed, display DSC. After successful DSC, display Basket
        2. IF DSC not needed, display Basket

**Merge checklist:**

- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
