### PR TITLE
EMT-400: Update enterprise landing page for single course mode

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.33.21] - 2017-06-01
+----------------------
+
+* UI updates for course mode selection in enterprise landing page.
+
 [0.33.20] - 2017-05-23
 ----------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.33.20"
+__version__ = "0.33.21"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/static/enterprise/enterprise_course_enrollment_page.css
+++ b/enterprise/static/enterprise/enterprise_course_enrollment_page.css
@@ -174,7 +174,7 @@ body, .zebra-stripe > :nth-child(2n+1), .depth-0 {
 }
 
 .radio-block {
-    margin-bottom: 15px;
+    margin-bottom: 10px;
 }
 
 .radio-block .radio,

--- a/enterprise/templates/enterprise/enterprise_course_enrollment_page.html
+++ b/enterprise/templates/enterprise/enterprise_course_enrollment_page.html
@@ -48,10 +48,10 @@
           <a class="text-underline" href="#!">{{ view_course_details_text }}</a>
         </div>
         <form>
-          <div class="caption">{{ select_mode_text }}</div>
+          {% if course_modes|length > 1 %}<div class="caption">{{ select_mode_text }}</div>{% endif %}
           {% for course_mode in course_modes %}
           <div class="radio-block">
-            <div class="radio">
+            <div class=" {% if course_modes|length > 1 %}radio{% endif %}">
               {% if course_modes|length > 1 %}
                 <input type="radio" name="data_sharing_consent" id="radio${{ forloop.counter0 }}" {% if forloop.first %}checked="checked"{% endif %} />
               {% else %}


### PR DESCRIPTION
Hi @douglashall , @brittneyexline , @zubair-arbi , @asadiqbal08 ,

Please take a look at this PR.

**Description:** When only one course mode is available on the Enterprise Landing page, the UI of the page needs to be modified to hide certain design elements and text associated with multiple course modes.

**JIRA:**[ENT-400](https://openedx.atlassian.net/browse/ENT-400)

**Installation instructions:** Simply install edx-enterprise and enable it in edx-platform.

**Testing instructions:**

1. Create a Course that has only one mode.
2. Create an enterprise customer at /admin/enterprise/enterprisecustomer/add/
3. Open enterprise landing page at /enterprise/<enterprise-uuid>/course/<course-id>/enroll
4. Use enterprise-uuid and course-id of above created enterprise customer and course.
5. Make sure the following acceptance criteria is met.

*Acceptance Criteria*
1. Hide "Please select one:"
2. Hide radio buttons
3. Left align Price and Discount lines with main text body
4. Ensure spacing between main text body and price information matches spacing between course card image and partner name (see attached image)

**Merge checklist:**

- [ ] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [x] Translations are updated
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
