### PR TITLE
ENT-384 Fixing course export bug

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ----------
 
+[0.33.23] - 2017-06-02
+----------------------
+
+* Fix a bug with unexpected image data in SAP course export job.
+
+
 [0.33.22] - 2017-06-02
 ----------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.33.22"
+__version__ = "0.33.23"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/sap_success_factors/utils.py
+++ b/integrated_channels/sap_success_factors/utils.py
@@ -246,7 +246,7 @@ class SapCourseExporter(BaseCourseExporter):  # pylint: disable=abstract-method
                           or safe_extract_key(x, 'title')),
             },
         ],
-        'thumbnailURI': lambda x: (safe_extract_key(x['image'], 'src') if 'image' in x else ''),
+        'thumbnailURI': lambda x: safe_extract_key(safe_extract_key(x, 'image', {}), 'src'),
         'content': lambda x: [
             {
                 'providerID': apps.get_model(

--- a/test_utils/fake_catalog_api.py
+++ b/test_utils/fake_catalog_api.py
@@ -302,6 +302,36 @@ FAKE_CATALOG_COURSES_RESPONSE = {
             "modified": "2017-03-07T18:37:45.238722Z",
             "marketing_url": "http://localhost:8000/course/foobarfb1?utm_source=admin&utm_medium=affiliate_partner"
         },
+        {
+            "key": "test_course_3",
+            "uuid": "c08c1e43-307c-444b-acc7-aea4a7b9f8f7",
+            "title": "Test Course for unexpected data",
+            "course_runs": [],
+            "owners": [
+                {
+                    "uuid": "8d920bc3-a1b2-44db-9380-1d3ca728c275",
+                    "key": "foobar",
+                    "name": "",
+                    "certificate_logo_image_url": None,
+                    "description": None,
+                    "homepage_url": None,
+                    "tags": [],
+                    "logo_image_url": None,
+                    "marketing_url": None
+                }
+            ],
+            "image": None,
+            "short_description": "",
+            "full_description": "This is a really cool course.",
+            "level_type": None,
+            "subjects": [],
+            "prerequisites": [],
+            "expected_learning_items": [],
+            "video": None,
+            "sponsors": [],
+            "modified": "2017-03-07T18:37:45.238722Z",
+            "marketing_url": "http://localhost:8000/course/testcourse3?utm_source=admin&utm_medium=affiliate_partner"
+        },
     ]
 }
 
@@ -469,6 +499,69 @@ FAKE_CATALOG_COURSE_DETAILS_RESPONSES = {
         "sponsors": [],
         "modified": "2017-03-07T18:37:45.238722Z",
         "marketing_url": "http://localhost:8000/course/foobarfb1?utm_source=admin&utm_medium=affiliate_partner",
+        "programs": []
+    },
+    'test_course_3': {
+        "key": "test_course_3",
+        "uuid": "c08c1e43-307c-444b-acc7-aea4a7b9f8f6",
+        "title": "Test Course with unexpected data",
+        "course_runs": [
+            {
+                "key": "course-v1:test_course_3+fbv1",
+                "uuid": "3550853f-e65a-492e-8781-d0eaa16dd538",
+                "title": "Other Course Name",
+                "image": None,
+                "short_description": "",
+                "marketing_url": None,
+                "start": "2015-01-01T00:00:00Z",
+                "end": None,
+                "enrollment_start": None,
+                "enrollment_end": None,
+                "pacing_type": "instructor_paced",
+                "type": None,
+                "course": "foobar+fb1",
+                "full_description": "This is a really cool course. Like, we promise.",
+                "announcement": None,
+                "video": None,
+                "seats": [],
+                "content_language": None,
+                "transcript_languages": [],
+                "instructors": [],
+                "staff": [],
+                "min_effort": None,
+                "max_effort": None,
+                "modified": "2017-03-07T18:37:45.082681Z",
+                "level_type": None,
+                "availability": "Upcoming",
+                "mobile_available": False,
+                "hidden": False,
+                "reporting_type": "mooc"
+            }
+        ],
+        "owners": [
+            {
+                "uuid": "8d920bc3-a1b2-44db-9380-1d3ca728c275",
+                "key": "foobar",
+                "name": "",
+                "certificate_logo_image_url": None,
+                "description": None,
+                "homepage_url": None,
+                "tags": [],
+                "logo_image_url": None,
+                "marketing_url": None
+            }
+        ],
+        "image": None,
+        "short_description": "",
+        "full_description": "This is a really cool course.",
+        "level_type": None,
+        "subjects": [],
+        "prerequisites": [],
+        "expected_learning_items": [],
+        "video": None,
+        "sponsors": [],
+        "modified": "2017-03-07T18:37:45.238722Z",
+        "marketing_url": "http://localhost:8000/course/test_course_3?utm_source=admin&utm_medium=affiliate_partner",
         "programs": []
     }
 }

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -119,7 +119,7 @@ def test_transmit_courseware_task_success(fake_client, fake_catalog_client, trac
     call_command('transmit_courseware_data', '--catalog_user', 'C-3PO')
 
     fake_client.return_value.send_course_import.assert_called()
-    assert len(caplog.records) == 7
+    assert len(caplog.records) == 9
     expected_dump = (
         '{"ocnCourses": [{"content": [{"contentID": "course-v1:edX+DemoX+Demo_Course", '
         '"contentTitle": "edX Demonstration Course", "launchType": 3, "launchURL": "htt'
@@ -140,7 +140,15 @@ def test_transmit_courseware_task_success(fake_client, fake_catalog_client, trac
         'e": 2147483647000, "startDate": 1420070400000}], "status": "ACTIVE", "thumbna'
         'ilURI": "http://192.168.1.187:8000/asset-v1:foobar+fb1+fbv1+type@asset+block@'
         'images_course_image.jpg", "title": [{"locale": "English", "value": "Other Cou'
-        'rse Name"}]}]}'
+        'rse Name"}]}, {"content": [{"contentID": "course-v1:test_course_3+fbv1", "conte'
+        'ntTitle": "Other Course Name", "launchType": 3, "launchURL": "https://example'
+        '.com/course_modes/choose/course-v1:edX+DemoX+Demo_Course/", "mobileEnabled": '
+        'false, "providerID": "EDX"}], "courseID": "course-v1:test_course_3+fbv1", "de'
+        'scription": [{"locale": "English", "value": "This is a really cool course. Li'
+        'ke, we promise."}], "price": [], "providerID": "EDX", "revisionNumber": 1, "s'
+        'chedule": [{"active": true, "endDate": 2147483647000, "startDate": 1420070400'
+        '000}], "status": "ACTIVE", "thumbnailURI": "", "title": [{"locale": "English"'
+        ', "value": "Other Course Name"}]}]}'
     )
     expected_messages = [
         'Processing courses for integrated channel using configuration: '
@@ -150,6 +158,9 @@ def test_transmit_courseware_task_success(fake_client, fake_catalog_client, trac
         'Sending course with plugin configuration <SAPSuccessFactorsEnterprise'
         'CustomerConfiguration for Enterprise Veridian Dynamics>',
         'Processing course with ID course-v1:foobar+fb1+fbv1',
+        'Sending course with plugin configuration <SAPSuccessFactorsEnterprise'
+        'CustomerConfiguration for Enterprise Veridian Dynamics>',
+        'Processing course with ID course-v1:test_course_3+fbv1',
         'Sending course with plugin configuration <SAPSuccessFactorsEnterprise'
         'CustomerConfiguration for Enterprise Veridian Dynamics>',
         expected_dump,


### PR DESCRIPTION
**Description:** There was unexpected data in one of the catalogs on prod where an image was
explicitly set to None, and our transformation logic assumed the key would
either not exist or be an object with keys of its own. Now we are accounting
for this case.

**JIRA:** https://openedx.atlassian.net/browse/ENT-384

**Dependencies:** n/a

**Merge deadline:** 

**Installation instructions:** 

**Testing instructions:**

I am not testing against the full course export script, the unit test replicated the error with the code fix missing.

**Merge checklist:**

- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
