### PR TITLE
ENT-355: Address missing enterprise endpoint case and add missing changelog entry

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,13 @@ Change Log
 Unreleased
 ----------
 
+[0.33.22] - 2017-06-02
+----------------------
+
+* Add an `EnterpriseApiClient` method for getting enrollment data about a single user+course pair
+* Add logic to enterprise landing page that redirects users to the course when already registered
+
+
 [0.33.21] - 2017-06-01
 ----------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.33.21"
+__version__ = "0.33.22"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/lms_api.py
+++ b/enterprise/lms_api.py
@@ -179,7 +179,7 @@ class EnrollmentApiClient(LmsApiClient):
             return None
         # This enrollment data endpoint returns an empty string if the username and course_id is valid, but there's
         # no matching enrollment found
-        if result == '':
+        if not result:
             LOGGER.error('no course enrollment details found for username=%s, course=%s', username, course_id)
             return None
 

--- a/enterprise/lms_api.py
+++ b/enterprise/lms_api.py
@@ -168,10 +168,22 @@ class EnrollmentApiClient(LmsApiClient):
             '{username},{course_id}'.format(username=username, course_id=course_id)
         )
         try:
-            return endpoint.get()
+            result = endpoint.get()
         except HttpNotFoundError:
-            LOGGER.error('course enrollment details not found for username=%s, course=%s', username, course_id)
+            # This enrollment data endpoint returns a 404 if either the username or course_id specified isn't valid
+            LOGGER.error(
+                'course enrollment details not found for invalid username or course; username=%s, course=%s',
+                username,
+                course_id
+            )
             return None
+        # This enrollment data endpoint returns an empty string if the username and course_id is valid, but there's
+        # no matching enrollment found
+        if result == '':
+            LOGGER.error('no course enrollment details found for username=%s, course=%s', username, course_id)
+            return None
+
+        return result
 
     def get_enrolled_courses(self, username):
         """

--- a/tests/test_lms_api.py
+++ b/tests/test_lms_api.py
@@ -109,7 +109,7 @@ def test_get_course_enrollment():
 
 
 @responses.activate
-def test_get_course_enrollment_not_found():
+def test_get_course_enrollment_invalid():
     user = "some_user"
     course_id = "course-v1:edX+DemoX+Demo_Course"
     responses.add(
@@ -119,6 +119,23 @@ def test_get_course_enrollment_not_found():
             "enrollment/{username},{course_id}".format(username=user, course_id=course_id),
         ),
         status=404,
+    )
+    client = lms_api.EnrollmentApiClient()
+    actual_response = client.get_course_enrollment(user, course_id)
+    assert actual_response is None
+
+
+@responses.activate
+def test_get_course_enrollment_not_found():
+    user = "some_user"
+    course_id = "course-v1:edX+DemoX+Demo_Course"
+    responses.add(
+        responses.GET,
+        _url(
+            "enrollment",
+            "enrollment/{username},{course_id}".format(username=user, course_id=course_id),
+        ),
+        body='',
     )
     client = lms_api.EnrollmentApiClient()
     actual_response = client.get_course_enrollment(user, course_id)


### PR DESCRIPTION
**Description:** This PR adds a missing changelog for the ENT-355 PR, and addresses a missing case from that PR where in some instances, the single enrollment data endpoint may respond with an empty string without throwing a 404 when there is no enrollment data for the given user+course pair.

**JIRA:** Link to JIRA ticket

**Dependencies:** None.

**Testing instructions:**

Follow the installation and testing instructions in: https://github.com/edx/edx-enterprise/pull/105

Simply navigating to the enterprise landing page while logged in with a newly registered user not enrolled in any courses should be enough to verify this change. If it doesn't redirect to the courseware in this case, that's the correct behavior

**Merge checklist:**

- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)

