### PR TITLE
[ENT-357] Display course run price with entitlement on Landing page & course description modal

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ----------
 
+[0.35.1] - 2017-06-15
+---------------------
+
+* Displayed course run price with entitlement on landing page and course information overlay
+
+
 [0.35.0] - 2017-06-15
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.35.0"
+__version__ = "0.35.1"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/templates/enterprise/enterprise_course_enrollment_page.html
+++ b/enterprise/templates/enterprise/enterprise_course_enrollment_page.html
@@ -104,8 +104,8 @@
       <div class="body">
         <div class="details">
           <ol>
-            {% if course_modes|length > 0 %}
-              {% with course_mode=course_modes.0 %}
+            {% if premium_modes|length > 0 %}
+              {% with course_mode=premium_modes.0 %}
                 {% if course_mode.original_price %}
                   <li>
                     <span class="icon fa fa-tag" aria-hidden="true"></span>


### PR DESCRIPTION
**Description:** This PR shows discounted prices for course modes in the landing page and course modal. The discounts are retrieved from the Ecommerce service.

This PR was created on top of https://github.com/edx/edx-enterprise/pull/110.

<!--
... and includes a few features/fixes from:

https://github.com/edx/edx-enterprise/pull/109
https://github.com/edx/edx-enterprise/pull/117
-->

**JIRA:** [ENT-357](https://openedx.atlassian.net/browse/ENT-357)

**Dependencies:** https://github.com/edx/ecommerce/pull/1307. 

**Merge deadline:** None.

**Installation instructions:** Standard enterprise installation.

**Screenshots:**
![coupon](https://cloud.githubusercontent.com/assets/560781/26714644/a7c188ae-472f-11e7-915a-23c8fbe3a3d2.png)
![customer](https://cloud.githubusercontent.com/assets/560781/26714650/ac1c69d2-472f-11e7-8460-fa8c0132ada1.png)
![page](https://cloud.githubusercontent.com/assets/560781/26714653/af872986-472f-11e7-92e0-667c65268b15.png)
![modal](https://cloud.githubusercontent.com/assets/560781/26714658/b233ec82-472f-11e7-9fc4-7ee6ee1db2b4.png)


**Testing instructions:**

1. Add an Enterprise Customer in the Django admin. Check its ID
2. Add a course in the customer catalog. Check its ID
3. In Ecommerce create a verified Course associated with the one in step 2. Use $500 for the price
4. In Ecommerce create a single course coupon with 25% discount and associated with the course in step 2. Check its ID
5. Go to the Enterprise Customer and set the coupon ID as entitlement
6. Create an Enterprise Customer User associated with the Enterprise Customer
7. Log in with the new Enterprise Customer User and visit the landing page by typing a URL like this:

http://localhost:8000/enterprise/7c3c286a-9834-46ae-809e-e01b114ba980/course/course-v1:edX+DemoX+Demo_Course/enroll/

where '7c3c286a-9834-46ae-809e-e01b114ba980' should be the ID of the customer and 'course-v1:edX+DemoX+Demo_Course' should be the ID of the course

8. Verify that the verified track displays the discounted price.
9. Click the "View Course Details" to display the course details modal and verify that the price of the verified track also displays the discounted price.

**Merge checklist:**

- [ ] ~Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.~
- [ ] All reviewers approved
- [X] CI build is green
- [X] Version bumped
- [X] Changelog record added
- [X] Documentation updated (not only docstrings)
- [X] Commits are (reasonably) squashed
- [X] Translations are updated
- [X] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
