### PR TITLE
Move from old python-social-auth to latest, split PSA

### DIFF
--- a/enterprise/course_catalog_api.py
+++ b/enterprise/course_catalog_api.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, unicode_literals
 
 from django.utils.translation import ugettext_lazy as _
 
-from enterprise.utils import MultipleProgramMatchError, NotConnectedToOpenEdX
+from enterprise.utils import MultipleProgramMatchError, NotConnectedToOpenEdx
 
 try:
     from openedx.core.djangoapps.api_admin.utils import course_discovery_api_client
@@ -40,17 +40,17 @@ class CourseCatalogApiClient(object):
         a higher level if the package doesn't have OpenEdX resources available.
         """
         if CatalogIntegration is None:
-            raise NotConnectedToOpenEdX(
+            raise NotConnectedToOpenEdx(
                 _("To get a CatalogIntegration object, this package must be "
                   "installed in an Open edX environment.")
             )
         if get_edx_api_data is None:
-            raise NotConnectedToOpenEdX(
+            raise NotConnectedToOpenEdx(
                 _("To parse a Catalog API response, this package must be "
                   "installed in an Open edX environment.")
             )
         if course_discovery_api_client is None:
-            raise NotConnectedToOpenEdX(
+            raise NotConnectedToOpenEdx(
                 _("To get a Catalog API client, this package must be "
                   "installed in an Open edX environment.")
             )

--- a/enterprise/lms_api.py
+++ b/enterprise/lms_api.py
@@ -16,7 +16,7 @@ from slumber.exceptions import HttpNotFoundError
 from django.conf import settings
 from django.utils import timezone
 
-from enterprise.utils import NotConnectedToOpenEdX
+from enterprise.utils import NotConnectedToOpenEdx
 
 try:
     from opaque_keys.edx.keys import CourseKey
@@ -81,7 +81,7 @@ class JwtLmsApiClient(object):
         Connect to the REST API, authenticating with a JWT for the current user.
         """
         if JwtBuilder is None:
-            raise NotConnectedToOpenEdX("This package must be installed in an OpenEdX environment.")
+            raise NotConnectedToOpenEdx("This package must be installed in an OpenEdX environment.")
 
         now = int(time())
         scopes = ['profile', 'email']
@@ -316,7 +316,7 @@ def enroll_user_in_course_locally(user, course_id, mode):
     can shift over to that, but for right now, we have to do it this way.
     """
     if CourseKey is None and CourseEnrollment is None:
-        raise NotConnectedToOpenEdX("This package must be installed in an OpenEdX environment.")
+        raise NotConnectedToOpenEdx("This package must be installed in an OpenEdX environment.")
     CourseEnrollment.enroll(user, CourseKey.from_string(course_id), mode=mode, check_access=True)
 
 

--- a/enterprise/tpa_pipeline.py
+++ b/enterprise/tpa_pipeline.py
@@ -8,12 +8,17 @@ from django.shortcuts import redirect
 from django.utils.translation import ugettext as _
 
 from enterprise.models import EnterpriseCustomer, EnterpriseCustomerUser, UserDataSharingConsentAudit
-from enterprise.utils import NotConnectedToEdX
+from enterprise.utils import NotConnectedToOpenEdx
 
 try:
-    from social.pipeline.partial import partial
+    from social_core.pipeline.partial import partial
 except ImportError:
     from enterprise.utils import null_decorator as partial  # pylint:disable=ungrouped-imports
+
+try:
+    from third_party_auth.pipeline import get as get_pipeline_partial
+except ImportError:
+    get_pipeline_partial = None
 
 try:
     from third_party_auth.provider import Registry
@@ -21,23 +26,35 @@ except ImportError:
     Registry = None
 
 
+def verify_third_party_auth_dependencies():
+    """
+    Ensure that all necessary third_party_auth dependencies are present.
+    """
+    third_party_dependencies = (
+        Registry,
+        get_pipeline_partial,
+    )
+
+    if any(third_party_dependency is None for third_party_dependency in third_party_dependencies):
+        raise NotConnectedToOpenEdx(
+            _("This package must be installed in an Open edX environment to look up third-party auth dependencies.")
+        )
+
+
 def get_enterprise_customer_for_request(request):
     """
     Get the EnterpriseCustomer associated with a particular request.
     """
-    pipeline = request.session.get('partial_pipeline')
-    return get_ec_for_running_pipeline(pipeline)
+    verify_third_party_auth_dependencies()
+    pipeline = get_pipeline_partial(request)
+    return get_enterprise_customer_for_running_pipeline(pipeline)
 
 
-def get_ec_for_running_pipeline(pipeline):
+def get_enterprise_customer_for_running_pipeline(pipeline):  # pylint: disable=invalid-name
     """
     Get the EnterpriseCustomer associated with a running pipeline.
     """
-    if Registry is None:
-        raise NotConnectedToEdX(
-            _("This package must be installed in an EdX environment to look up third-party auth providers.")
-        )
-
+    verify_third_party_auth_dependencies()
     if pipeline is None:
         return None
     provider = Registry.get_from_pipeline(pipeline)
@@ -71,7 +88,7 @@ def active_provider_enforces_data_sharing(request, enforcement_location):
         enforcement_location (str): the point where to see data sharing consent state.
         argument can either be "optional", 'at_login' or 'at_enrollment'
     """
-    running_pipeline = request.session.get('partial_pipeline')
+    running_pipeline = request.session.get('partial_pipeline_token')
     if running_pipeline:
         customer = get_enterprise_customer_for_request(request)
         return customer and customer.enforces_data_sharing_consent(enforcement_location)
@@ -82,7 +99,7 @@ def active_provider_requests_data_sharing(request):
     """
     Determine if the active EnterpriseCustomer requests data sharing consent.
     """
-    running_pipeline = request.session.get('partial_pipeline')
+    running_pipeline = request.session.get('partial_pipeline_token')
     if running_pipeline:
         customer = get_enterprise_customer_for_request(request)
         return customer and customer.requests_data_sharing_consent
@@ -93,7 +110,7 @@ def get_consent_status_for_pipeline(pipeline):
     """
     Get the consent object for the current pipeline.
     """
-    customer = get_ec_for_running_pipeline(pipeline)
+    customer = get_enterprise_customer_for_running_pipeline(pipeline)
     user = pipeline.kwargs['user']
     try:
         return UserDataSharingConsentAudit.objects.get(
@@ -134,7 +151,7 @@ def handle_enterprise_logistration(backend, user, **kwargs):
         """
         return redirect(reverse('grant_data_sharing_permissions'))
 
-    enterprise_customer = get_ec_for_running_pipeline({'backend': backend.name, 'kwargs': kwargs})
+    enterprise_customer = get_enterprise_customer_for_running_pipeline({'backend': backend.name, 'kwargs': kwargs})
     if enterprise_customer is None:
         # This pipeline element is not being activated as a part of an Enterprise logistration
         return

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -36,7 +36,7 @@ except ImportError:
 LOGGER = logging.getLogger(__name__)
 
 
-class NotConnectedToEdX(Exception):
+class NotConnectedToOpenEdx(Exception):
     """
     Exception to raise when not connected to OpenEdX.
 
@@ -49,19 +49,7 @@ class NotConnectedToEdX(Exception):
         Log a warning and initialize the exception.
         """
         LOGGER.warning('edx-enterprise unexpectedly failed as if not installed in an OpenEdX platform')
-        super(NotConnectedToEdX, self).__init__(*args, **kwargs)
-
-
-class NotConnectedToOpenEdX(Exception):
-    """
-    Exception to raise when we weren't able to import needed resources.
-
-    This is raised when we try to use the resources, rather than on
-    import, so that during testing we can load the module
-    and mock out the resources we need.
-    """
-
-    pass
+        super(NotConnectedToOpenEdx, self).__init__(*args, **kwargs)
 
 
 class CourseCatalogApiError(Exception):
@@ -150,7 +138,7 @@ def null_decorator(func):
     """
     Decorator that does nothing to the wrapped function.
 
-    If we're unable to import social.pipeline.partial, which is the case in our CI platform,
+    If we're unable to import social_core.pipeline.partial, which is the case in our CI platform,
     we need to be able to wrap the function with something.
     """
     return func

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -31,12 +31,14 @@ try:
         get_real_social_auth_object,
         lift_quarantine,
         quarantine_session,
+        get as get_pipeline_partial
     )
 except ImportError:
     get_complete_url = None
     get_real_social_auth_object = None
     quarantine_session = None
     lift_quarantine = None
+    get_pipeline_partial = None
 
 
 # isort:imports-firstparty
@@ -49,7 +51,7 @@ from enterprise.models import (
     UserDataSharingConsentAudit,
 )
 from enterprise.tpa_pipeline import active_provider_enforces_data_sharing, get_enterprise_customer_for_request
-from enterprise.utils import NotConnectedToEdX, consent_necessary_for_course
+from enterprise.utils import NotConnectedToOpenEdx, consent_necessary_for_course
 
 
 def verify_edx_resources():
@@ -62,10 +64,11 @@ def verify_edx_resources():
         get_complete_url,
         get_real_social_auth_object,
         quarantine_session,
-        lift_quarantine
+        lift_quarantine,
+        get_pipeline_partial,
     )
     if any(method is None for method in required_methods):
-        raise NotConnectedToEdX(_('Methods in the Open edX platform necessary for this view are not available.'))
+        raise NotConnectedToOpenEdx(_('Methods in the Open edX platform necessary for this view are not available.'))
 
 
 class GrantDataSharingPermissions(View):
@@ -395,7 +398,7 @@ class GrantDataSharingPermissions(View):
         )
 
         # Resume auth pipeline
-        backend_name = request.session.get('partial_pipeline', {}).get('backend')
+        backend_name = get_pipeline_partial(request).get('backend')
         return redirect(get_complete_url(backend_name))
 
     def post(self, request):

--- a/tests/test_course_catalog_api.py
+++ b/tests/test_course_catalog_api.py
@@ -14,7 +14,7 @@ from pytest import raises
 from django.contrib.auth.models import User
 
 from enterprise.course_catalog_api import CourseCatalogApiClient
-from enterprise.utils import CourseCatalogApiError, NotConnectedToOpenEdX
+from enterprise.utils import CourseCatalogApiError, NotConnectedToOpenEdx
 
 
 class TestCourseCatalogApiInitialization(unittest.TestCase):
@@ -25,7 +25,7 @@ class TestCourseCatalogApiInitialization(unittest.TestCase):
     @mock.patch('enterprise.course_catalog_api.get_edx_api_data')
     def test_raise_error_missing_course_discovery_api(self, *args):  # pylint: disable=unused-argument
         message = 'To get a Catalog API client, this package must be installed in an Open edX environment.'
-        with raises(NotConnectedToOpenEdX) as excinfo:
+        with raises(NotConnectedToOpenEdx) as excinfo:
             CourseCatalogApiClient(mock.Mock(spec=User))
         assert message == str(excinfo.value)
 
@@ -33,7 +33,7 @@ class TestCourseCatalogApiInitialization(unittest.TestCase):
     @mock.patch('enterprise.course_catalog_api.get_edx_api_data')
     def test_raise_error_missing_catalog_integration(self, *args):  # pylint: disable=unused-argument
         message = 'To get a CatalogIntegration object, this package must be installed in an Open edX environment.'
-        with raises(NotConnectedToOpenEdX) as excinfo:
+        with raises(NotConnectedToOpenEdx) as excinfo:
             CourseCatalogApiClient(mock.Mock(spec=User))
         assert message == str(excinfo.value)
 
@@ -41,7 +41,7 @@ class TestCourseCatalogApiInitialization(unittest.TestCase):
     @mock.patch('enterprise.course_catalog_api.course_discovery_api_client')
     def test_raise_error_missing_get_edx_api_data(self, *args):  # pylint: disable=unused-argument
         message = 'To parse a Catalog API response, this package must be installed in an Open edX environment.'
-        with raises(NotConnectedToOpenEdX) as excinfo:
+        with raises(NotConnectedToOpenEdx) as excinfo:
             CourseCatalogApiClient(mock.Mock(spec=User))
         assert message == str(excinfo.value)
 

--- a/tests/test_lms_api.py
+++ b/tests/test_lms_api.py
@@ -16,7 +16,8 @@ from slumber.exceptions import HttpNotFoundError
 from django.conf import settings
 
 from enterprise import lms_api
-from enterprise.utils import NotConnectedToOpenEdX
+from enterprise.utils import NotConnectedToOpenEdx
+
 
 URL_BASE_NAMES = {
     'enrollment': lms_api.EnrollmentApiClient,
@@ -111,7 +112,7 @@ def test_get_enrolled_courses():
 
 
 def test_enroll_locally_raises():
-    with raises(NotConnectedToOpenEdX):
+    with raises(NotConnectedToOpenEdx):
         lms_api.enroll_user_in_course_locally(None, None, None)
 
 
@@ -205,7 +206,7 @@ def test_get_remote_id():
 
 
 def test_jwt_lms_api_client_locally_raises():
-    with raises(NotConnectedToOpenEdX):
+    with raises(NotConnectedToOpenEdx):
         client = lms_api.JwtLmsApiClient('user-goes-here')
         client.connect()
 
@@ -345,3 +346,7 @@ def test_get_course_certificate():
     client = lms_api.CertificatesApiClient('staff-user-goes-here')
     actual_response = client.get_course_certificate(course_id, username)
     assert actual_response == expected_response
+
+def test_enroll_locally_raises():
+    with raises(NotConnectedToOpenEdx):
+        lms_api.enroll_user_in_course_locally(None, None, None)

--- a/tests/test_tpa_pipeline.py
+++ b/tests/test_tpa_pipeline.py
@@ -12,16 +12,17 @@ from pytest import mark, raises
 from django.http import HttpResponseRedirect
 
 from enterprise.models import EnterpriseCustomer, EnterpriseCustomerUser, UserDataSharingConsentAudit
+
 from enterprise.tpa_pipeline import (
     active_provider_enforces_data_sharing,
     active_provider_requests_data_sharing,
     get_consent_status_for_pipeline,
-    get_ec_for_running_pipeline,
+    get_enterprise_customer_for_running_pipeline,
     get_enterprise_customer_for_request,
     get_enterprise_customer_for_sso,
     handle_enterprise_logistration,
 )
-from enterprise.utils import NotConnectedToEdX
+from enterprise.utils import NotConnectedToOpenEdx
 from test_utils.factories import EnterpriseCustomerFactory, EnterpriseCustomerIdentityProviderFactory, UserFactory
 
 
@@ -37,19 +38,22 @@ class TestTpaPipeline(unittest.TestCase):
         self.user = UserFactory(is_active=True)
         super(TestTpaPipeline, self).setUp()
 
-    def test_get_ec_for_request(self):
+    @mock.patch('enterprise.tpa_pipeline.get_pipeline_partial')
+    def test_get_ec_for_request(self, fake_pipeline):
         """
         Test that get_ec_for_request works.
         """
-        request = mock.MagicMock(session={'partial_pipeline': 'pipeline_key'})
+        request = mock.MagicMock()
+        fake_provider = mock.MagicMock()
+        fake_provider.provider_id = 'provider_slug'
+        fake_pipeline.return_value = {'kwargs': {'access_token': 'dummy'}, 'backend': 'fake_backend'}
         with mock.patch('enterprise.tpa_pipeline.Registry') as fake_registry:
-            fake_provider = mock.MagicMock()
-            fake_provider.provider_id = 'provider_slug'
             fake_registry.get_from_pipeline.return_value = fake_provider
             assert get_enterprise_customer_for_request(request) == self.customer
-        with raises(NotConnectedToEdX) as excinfo:
+        with raises(NotConnectedToOpenEdx) as excinfo:
             get_enterprise_customer_for_request(request)
-        expected_msg = "This package must be installed in an EdX environment to look up third-party auth providers."
+        expected_msg = "This package must be installed in an Open edX " \
+                       "environment to look up third-party auth dependencies."
         assert str(excinfo.value) == expected_msg
 
     def test_get_ec_for_sso(self):
@@ -63,31 +67,35 @@ class TestTpaPipeline(unittest.TestCase):
             get_mock.side_effect = EnterpriseCustomer.DoesNotExist
             assert get_enterprise_customer_for_sso(provider) is None
 
-    def test_get_ec_for_pipeline(self):
+    @mock.patch('enterprise.tpa_pipeline.get_pipeline_partial')
+    def test_get_ec_for_pipeline(self, fake_pipeline):
         """
         Test that we get the correct enterprise custoemr for a given running pipeline.
         """
+        fake_pipeline.return_value = {'kwargs': {'access_token': 'dummy'}, 'backend': 'fake_backend'}
         with mock.patch('enterprise.tpa_pipeline.Registry') as fake_registry:
             provider = mock.MagicMock(provider_id='provider_slug')
             fake_registry.get_from_pipeline.return_value = provider
-            assert get_ec_for_running_pipeline('pipeline') == self.customer
-        with raises(NotConnectedToEdX) as excinfo:
-            get_ec_for_running_pipeline('pipeline')
-        expected_msg = "This package must be installed in an EdX environment to look up third-party auth providers."
+            assert get_enterprise_customer_for_running_pipeline('pipeline') == self.customer
+        with raises(NotConnectedToOpenEdx) as excinfo:
+            get_enterprise_customer_for_running_pipeline('pipeline')
+        expected_msg = "This package must be installed in an Open edX " \
+                       "environment to look up third-party auth dependencies."
         assert str(excinfo.value) == expected_msg
 
-    def test_get_ec_for_null_pipeline(self):
+    @mock.patch('enterprise.tpa_pipeline.Registry')
+    @mock.patch('enterprise.tpa_pipeline.get_pipeline_partial')
+    def test_get_ec_for_null_pipeline(self, fake_pipeline, fake_registry):  # pylint: disable=unused-argument
         """
         Test that if we pass in an empty pipeline, we return early and don't try to use it.
         """
-        with mock.patch('enterprise.tpa_pipeline.Registry'):
-            assert get_ec_for_running_pipeline(None) is None
+        assert get_enterprise_customer_for_running_pipeline(None) is None
 
     def test_active_provider_enforces_data_sharing(self):
         """
         Test that we can correctly check whether data sharing is enforced.
         """
-        request = mock.MagicMock(session={'partial_pipeline': True})
+        request = mock.MagicMock(session={'partial_pipeline_token': True})
         with mock.patch('enterprise.tpa_pipeline.get_enterprise_customer_for_request') as fake_ec_getter:
             fake_ec_getter.return_value = self.customer
             assert active_provider_enforces_data_sharing(request, EnterpriseCustomer.AT_LOGIN)
@@ -100,7 +108,7 @@ class TestTpaPipeline(unittest.TestCase):
         """
         Test that we can correctly check whether data sharing is requested.
         """
-        request = mock.MagicMock(session={'partial_pipeline': True})
+        request = mock.MagicMock(session={'partial_pipeline_token': True})
         with mock.patch('enterprise.tpa_pipeline.get_enterprise_customer_for_request') as fake_ec_getter:
             fake_ec_getter.return_value = self.customer
             assert active_provider_requests_data_sharing(request)
@@ -117,7 +125,7 @@ class TestTpaPipeline(unittest.TestCase):
         """
         Test that we can get the correct consent status.
         """
-        with mock.patch('enterprise.tpa_pipeline.get_ec_for_running_pipeline') as fake_get_ec:
+        with mock.patch('enterprise.tpa_pipeline.get_enterprise_customer_for_running_pipeline') as fake_get_ec:
             fake_get_ec.return_value = self.customer
             pipeline = mock.MagicMock(kwargs={'user': self.user})
             assert get_consent_status_for_pipeline(pipeline) is None
@@ -135,17 +143,24 @@ class TestTpaPipeline(unittest.TestCase):
         Test that when there's no pipeline, we do nothing, then return.
         """
         backend = mock.MagicMock(name=None)
-        with mock.patch('enterprise.tpa_pipeline.get_ec_for_running_pipeline') as fake_get_ec:
+        with mock.patch('enterprise.tpa_pipeline.get_enterprise_customer_for_running_pipeline') as fake_get_ec:
             fake_get_ec.return_value = None
-            assert handle_enterprise_logistration(backend, self.user) is None
-            assert EnterpriseCustomerUser.objects.count() == 0
+            assert verify_data_sharing_consent(backend, self.user) is None
+        with mock.patch('enterprise.tpa_pipeline.get_enterprise_customer_for_running_pipeline') as fake_get_ec:
+            fake_get_ec.return_value = mock.MagicMock(
+                requests_data_sharing_consent=False
+            )  # pylint: disable=redefined-variable-type
+            assert verify_data_sharing_consent(backend, self.user) is None
+        with mock.patch('enterprise.tpa_pipeline.get_enterprise_customer_for_running_pipeline') as fake_get_ec:
+            fake_get_ec.return_value = self.customer  # pylint: disable=redefined-variable-type
+            assert isinstance(verify_data_sharing_consent(backend, self.user), HttpResponseRedirect)
 
     def test_handle_enterprise_logistration_consent_not_required(self):
         """
         Test that when consent isn't required, we create an EnterpriseCustomerUser, then return.
         """
         backend = mock.MagicMock(name=None)
-        with mock.patch('enterprise.tpa_pipeline.get_ec_for_running_pipeline') as fake_get_ec:
+        with mock.patch('enterprise.tpa_pipeline.get_enterprise_customer_for_running_pipeline') as fake_get_ec:
             enterprise_customer = EnterpriseCustomerFactory(
                 enable_data_sharing_consent=False
             )
@@ -162,7 +177,7 @@ class TestTpaPipeline(unittest.TestCase):
         we simply return the exi    sting EnterpriseCustomerUser.
         """
         backend = mock.MagicMock(name=None)
-        with mock.patch('enterprise.tpa_pipeline.get_ec_for_running_pipeline') as fake_get_ec:
+        with mock.patch('enterprise.tpa_pipeline.get_enterprise_customer_for_running_pipeline') as fake_get_ec:
             enterprise_customer = EnterpriseCustomerFactory(
                 enable_data_sharing_consent=False
             )
@@ -185,7 +200,7 @@ class TestTpaPipeline(unittest.TestCase):
         Test that when consent is required, we redirect to the consent page.
         """
         backend = mock.MagicMock(name=None)
-        with mock.patch('enterprise.tpa_pipeline.get_ec_for_running_pipeline') as fake_get_ec:
+        with mock.patch('enterprise.tpa_pipeline.get_enterprise_customer_for_running_pipeline') as fake_get_ec:
             fake_get_ec.return_value = self.customer
             assert isinstance(handle_enterprise_logistration(backend, self.user), HttpResponseRedirect)
 
@@ -194,7 +209,7 @@ class TestTpaPipeline(unittest.TestCase):
         Test that when consent is optional, but requested, we redirect to the consent page.
         """
         backend = mock.MagicMock(name=None)
-        with mock.patch('enterprise.tpa_pipeline.get_ec_for_running_pipeline') as fake_get_ec:
+        with mock.patch('enterprise.tpa_pipeline.get_enterprise_customer_for_running_pipeline') as fake_get_ec:
             self.customer.enforce_data_sharing_consent = EnterpriseCustomer.DATA_CONSENT_OPTIONAL
             fake_get_ec.return_value = self.customer
             assert isinstance(handle_enterprise_logistration(backend, self.user), HttpResponseRedirect)
@@ -204,7 +219,7 @@ class TestTpaPipeline(unittest.TestCase):
         Test that when consent is required at enrollment, but optional at logistration, we redirect to the consent page.
         """
         backend = mock.MagicMock(name=None)
-        with mock.patch('enterprise.tpa_pipeline.get_ec_for_running_pipeline') as fake_get_ec:
+        with mock.patch('enterprise.tpa_pipeline.get_enterprise_customer_for_running_pipeline') as fake_get_ec:
             self.customer.enforce_data_sharing_consent = EnterpriseCustomer.AT_ENROLLMENT
             fake_get_ec.return_value = self.customer
             assert isinstance(handle_enterprise_logistration(backend, self.user), HttpResponseRedirect)
@@ -214,7 +229,7 @@ class TestTpaPipeline(unittest.TestCase):
         Test that when consent has been previously been declined, we redirect to the consent page.
         """
         backend = mock.MagicMock(name=None)
-        with mock.patch('enterprise.tpa_pipeline.get_ec_for_running_pipeline') as fake_get_ec:
+        with mock.patch('enterprise.tpa_pipeline.get_enterprise_customer_for_running_pipeline') as fake_get_ec:
             fake_get_ec.return_value = self.customer
             ec_user = EnterpriseCustomerUser.objects.create(
                 user_id=self.user.id,  # pylint: disable=no-member
@@ -230,7 +245,7 @@ class TestTpaPipeline(unittest.TestCase):
         Test that when consent has been provided, we return and allow the pipeline to proceed.
         """
         backend = mock.MagicMock(name=None)
-        with mock.patch('enterprise.tpa_pipeline.get_ec_for_running_pipeline') as fake_get_ec:
+        with mock.patch('enterprise.tpa_pipeline.get_enterprise_customer_for_running_pipeline') as fake_get_ec:
             fake_get_ec.return_value = self.customer
             ec_user = EnterpriseCustomerUser.objects.create(
                 user_id=self.user.id,  # pylint: disable=no-member


### PR DESCRIPTION
**Description:** Old [python-social-auth](https://github.com/python-social-auth) was a monolithic repository and the version we utilize is almost a year old. We are looking to upgrade to the latest, split version of python-social-auth which is more modular, and provides several new features, including a configurable maximum session length, a DB-packed partial pipeline, utilizing the latest backend (provider) versions, and so on.

**JIRA:** Implements [ENT-365](https://openedx.atlassian.net/browse/ENT-365).

**Dependencies:** [Complementary PR at edx-platform](https://github.com/edx/edx-platform/pull/15135).

**Merge deadline:** Mostly handles technical debt, so not that urgent.

**Installation instructions:** N/A for now.

**Testing instructions:** See [edx-platform PR](https://github.com/edx/edx-platform/pull/15135) for now.

**Merge checklist:**

- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** This **must** be merged at the **same time** as the corresponding [edx-platform PR](https://github.com/edx/edx-platform/pull/15135), or else things will break.
