### PR TITLE
ENT-356 Simple version of using the new landing page url

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ----------
 
+[0.34.3] - 2017-06-07
+---------------------
+
+* Make enterprise landing page url available in the enterprise api and SAP course export.
+
+
 [0.34.2] - 2017-06-06
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.34.2"
+__version__ = "0.34.3"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -342,9 +342,12 @@ class EnterpriseCatalogCoursesReadOnlySerializer(serializers.Serializer):
                 query_parameters=query_parameters,
             )
 
+            enrollment_url = enterprise_customer.get_course_enrollment_url(course_run.get('key'))
+
             # Add/update track selection url in course run metadata.
             course_run.update({
                 'track_selection_url': track_selection_url,
+                'enrollment_url': enrollment_url
             })
 
             # Update marketing urls in course metadata to include enterprise related info.

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -11,10 +11,12 @@ from uuid import uuid4
 import six
 from simple_history.models import HistoricalRecords
 
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.contrib.sites.models import Site
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.files.storage import default_storage
+from django.core.urlresolvers import reverse
 from django.db import models
 from django.template import Context, Template
 from django.utils.encoding import python_2_unicode_compatible
@@ -26,7 +28,14 @@ from model_utils.models import TimeStampedModel
 
 from enterprise import utils
 from enterprise.lms_api import ThirdPartyAuthApiClient, enroll_user_in_course_locally
+from enterprise.utils import NotConnectedToOpenEdX
 from enterprise.validators import validate_image_extension, validate_image_size
+from six.moves.urllib.parse import urljoin  # pylint: disable=import-error,ungrouped-imports
+
+try:
+    from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+except ImportError:
+    configuration_helpers = None
 
 logger = getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -168,6 +177,28 @@ class EnterpriseCustomer(TimeStampedModel):
         Determine whether the enterprise customer has enabled the data sharing consent request.
         """
         return self.enable_data_sharing_consent and self.enforce_data_sharing_consent != self.EXTERNALLY_MANAGED
+
+    def get_course_enrollment_url(self, course_run_key):
+        """
+        Return enterprise landing page url for the given course.
+
+        Arguments:
+            course_run_key (str): The course run id for the course to be displayed.
+        Returns:
+            (str): Enterprise landing page url.
+        """
+        if configuration_helpers is None:
+            raise NotConnectedToOpenEdX(
+                _("This package must be installed in an EdX environment to look up configuration.")
+            )
+
+        return urljoin(
+            configuration_helpers.get_value('LMS_ROOT_URL', settings.LMS_ROOT_URL),
+            reverse(
+                'enterprise_course_enrollment_page',
+                kwargs={'enterprise_uuid': self.uuid, 'course_id': course_run_key}
+            )
+        )
 
 
 class EnterpriseCustomerUserManager(models.Manager):

--- a/test_utils/fake_catalog_api.py
+++ b/test_utils/fake_catalog_api.py
@@ -303,7 +303,7 @@ FAKE_CATALOG_COURSES_RESPONSE = {
             "marketing_url": "http://localhost:8000/course/foobarfb1?utm_source=admin&utm_medium=affiliate_partner"
         },
         {
-            "key": "test_course_3",
+            "key": "test+course3",
             "uuid": "c08c1e43-307c-444b-acc7-aea4a7b9f8f7",
             "title": "Test Course for unexpected data",
             "course_runs": [],
@@ -501,13 +501,13 @@ FAKE_CATALOG_COURSE_DETAILS_RESPONSES = {
         "marketing_url": "http://localhost:8000/course/foobarfb1?utm_source=admin&utm_medium=affiliate_partner",
         "programs": []
     },
-    'test_course_3': {
-        "key": "test_course_3",
+    'test+course3': {
+        "key": "test+course3",
         "uuid": "c08c1e43-307c-444b-acc7-aea4a7b9f8f6",
         "title": "Test Course with unexpected data",
         "course_runs": [
             {
-                "key": "course-v1:test_course_3+fbv1",
+                "key": "course-v1:test+course3+fbv1",
                 "uuid": "3550853f-e65a-492e-8781-d0eaa16dd538",
                 "title": "Other Course Name",
                 "image": None,
@@ -561,7 +561,7 @@ FAKE_CATALOG_COURSE_DETAILS_RESPONSES = {
         "video": None,
         "sponsors": [],
         "modified": "2017-03-07T18:37:45.238722Z",
-        "marketing_url": "http://localhost:8000/course/test_course_3?utm_source=admin&utm_medium=affiliate_partner",
+        "marketing_url": "http://localhost:8000/course/test+course3?utm_source=admin&utm_medium=affiliate_partner",
         "programs": []
     }
 }

--- a/tests/api/test_serializers.py
+++ b/tests/api/test_serializers.py
@@ -310,9 +310,17 @@ class TestEnterpriseCatalogCoursesSerializer(APITest):
         ),
     )
     @ddt.unpack
+    @mock.patch('enterprise.models.configuration_helpers')
     @override_settings(LMS_ROOT_URL='http://testserver/')
     def test_update_course_runs(
-            self, course_run, catalog_id, provider_id, enterprise_customer_uuid, expected_fields, expected_urls,
+            self,
+            course_run,
+            catalog_id,
+            provider_id,
+            enterprise_customer_uuid,
+            expected_fields,
+            expected_urls,
+            mock_config_helpers,
     ):
         """
         Test update_course_runs method of EnterpriseCatalogCoursesReadOnlySerializer.
@@ -321,6 +329,7 @@ class TestEnterpriseCatalogCoursesSerializer(APITest):
         successfully without errors.
         """
         # Populate database.
+        mock_config_helpers.get_value.return_value = 'http://testserver/'
         ec_identity_provider = factories.EnterpriseCustomerIdentityProviderFactory(
             enterprise_customer__uuid=enterprise_customer_uuid,
             provider_id=provider_id,
@@ -349,13 +358,15 @@ class TestEnterpriseCatalogCoursesSerializer(APITest):
                 self.assert_url(value, updated_course_run[key])
 
     @mock.patch('enterprise.utils.reverse', return_value='')
-    def test_update_course(self, _):
+    @mock.patch('enterprise.models.configuration_helpers')
+    def test_update_course(self, mock_config_helpers, _):
         """
         Test update_course method of EnterpriseCatalogCoursesReadOnlySerializer.
 
         Verify that update_course for EnterpriseCatalogCoursesReadOnlySerializer returns
         successfully without errors.
         """
+        mock_config_helpers.get_value.return_value = ''
         global_context = {
             'tpa_hint': self.provider_id
         }
@@ -442,13 +453,15 @@ class TestEnterpriseCatalogCoursesSerializer(APITest):
             assert expected_course == updated_course
 
     @mock.patch('enterprise.utils.reverse', return_value='/course_modes/choose/')
-    def test_update_enterprise_courses(self, _):
+    @mock.patch('enterprise.models.configuration_helpers')
+    def test_update_enterprise_courses(self, mock_config_helpers, _):
         """
         Test update_enterprise_courses method of EnterpriseCatalogCoursesReadOnlySerializer.
 
         Verify that update_enterprise_courses for EnterpriseCatalogCoursesReadOnlySerializer updates
         serializer data successfully without errors.
         """
+        mock_config_helpers.get_value.return_value = ''
         self.serializer.update_enterprise_courses(self.request, 1)
 
         # Make sure global context passed in to update_course is added to the course.

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -40,6 +40,7 @@ from enterprise.models import (
     UserDataSharingConsentAudit,
     logo_path,
 )
+from enterprise.utils import NotConnectedToOpenEdX
 from test_utils.factories import (
     EnterpriseCourseEnrollmentFactory,
     EnterpriseCustomerEntitlementFactory,
@@ -242,6 +243,15 @@ class TestEnterpriseCustomer(unittest.TestCase):
         """
         customer = EnterpriseCustomerFactory()
         assert customer.identity_provider is None  # pylint: disable=no-member
+
+    def test_get_course_enrollment_url_no_site_config(self):
+        """
+        Test get_course_enrollment_url when the site_configuration package could not be imported.
+        """
+        customer = EnterpriseCustomerFactory()
+        error = 'This package must be installed in an EdX environment to look up configuration.'
+        with raises(NotConnectedToOpenEdX, message=error):
+            customer.get_course_enrollment_url('course_id')
 
 
 @mark.django_db


### PR DESCRIPTION
**Description:** This updates both the enterprise api and SAP course export to use the new
landing page url, but without transitioning the SAP course export to use
the enterprise api endpoint.

**JIRA:** https://openedx.atlassian.net/browse/ENT-356

**Dependencies:** n/a, though it is related to https://github.com/edx/edx-enterprise/pull/107

**Merge deadline:** 

**Installation instructions:** 

**Testing instructions:**

**Merge checklist:**

- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [x] Translations are updated
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
