### PR TITLE
ENT-427  tags appear in decline DSC pop up.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ----------
 
+[0.34.1] - 2017-06-06
+----------------------
+
+* Bug fix for Data sharing consent pop up page.
+
+
 [0.34.0] - 2017-06-05
 ----------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.34.0"
+__version__ = "0.34.1"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/templates/enterprise/grant_data_sharing_permissions.html
+++ b/enterprise/templates/enterprise/grant_data_sharing_permissions.html
@@ -35,7 +35,7 @@
                  <img class="enterprise-logo" src="{{ enterprise_customer.branding_configuration.logo.url }}" alt="{{ enterprise_customer.name }}"/>
               {% endif %}
               <div class="partnered-text">
-                  {{ enterprise_welcome_text |safe }}
+                  {{ enterprise_welcome_text|safe }}
               </div>
           </div>
           <div class="col-7 border-left">
@@ -44,7 +44,7 @@
                   <h2 class="consent-title">{{ consent_message_header }}</h2>
                   <div class="consent-message">
                     {% autoescape off %}
-                      <p>{{ consent_request_prompt }} {{ policy_link_template }}</p>
+                      <p>{{ consent_request_prompt|safe }} {{ policy_link_template }}</p>
                     {% endautoescape %}
 
                     <p>{{ requested_permissions_header }}
@@ -113,7 +113,7 @@
                     <header class="modal-header">
                       <h2 id="modal-header-text">{{ confirmation_modal_header }}</h2>
                     </header>
-                    <p>{{ confirmation_alert_prompt }}</p>
+                    <p>{{ confirmation_alert_prompt|safe }}</p>
                     <p>{{ confirmation_alert_prompt_warning }}</p>
                     <button class="consent-agreement-button" id="modal-no-consent-button">{{ confirmation_modal_affirm_decline_text }}</button>
                     <button class="failure-link" id="review-policy-link">{{ confirmation_modal_abort_decline_text }}</button>


### PR DESCRIPTION
**Description:** When enterprise learner clicks "No, take me back" link from data sharing consent page, HTML tags appear in decline DSC popup.

**JIRA:** [ENT-427](https://openedx.atlassian.net/browse/ENT-427)

**Merge checklist:**

- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Commits are (reasonably) squashed