### PR TITLE
[ENT-365] Move from old python-social-auth to latest, split PSA

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,13 @@ Change Log
 Unreleased
 ----------
 
+[0.36.0] - 2017-06-20
+---------------------
+
+* Migrate from old, monolithic python-social-auth to latest, split version.
+* Rework the NotConnectedToOpenEdX exception to be just one, and to say which method/dependency is missing.
+
+
 [0.35.2] - 2017-06-20
 ---------------------
 
@@ -45,7 +52,7 @@ Unreleased
 
 
 [0.34.5] - 2017-06-09
-----------------------
+---------------------
 
 * Add Django 1.10 support back
 
@@ -69,13 +76,13 @@ Unreleased
 
 
 [0.34.1] - 2017-06-06
-----------------------
+---------------------
 
 * Bug fix for Data sharing consent pop up page.
 
 
 [0.34.0] - 2017-06-05
-----------------------
+---------------------
 
 * Update data backing and behavior of enterprise landing page
 * Fix template prioritization bug

--- a/enterprise/tpa_pipeline.py
+++ b/enterprise/tpa_pipeline.py
@@ -10,7 +10,7 @@ from django.shortcuts import redirect
 from django.utils.translation import ugettext as _
 
 from enterprise.models import EnterpriseCustomer, EnterpriseCustomerUser, UserDataSharingConsentAudit
-from enterprise.utils import NotConnectedToEdX
+from enterprise.utils import NotConnectedToOpenEdX
 
 try:
     from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
@@ -18,9 +18,14 @@ except ImportError:
     configuration_helpers = None
 
 try:
-    from social.pipeline.partial import partial
+    from social_core.pipeline.partial import partial
 except ImportError:
     from enterprise.utils import null_decorator as partial  # pylint:disable=ungrouped-imports
+
+try:
+    from third_party_auth.pipeline import get as get_partial_pipeline
+except ImportError:
+    get_partial_pipeline = None
 
 try:
     from third_party_auth.provider import Registry
@@ -28,23 +33,38 @@ except ImportError:
     Registry = None
 
 
+def verify_third_party_auth_dependencies():
+    """
+    Ensure that all necessary third_party_auth dependencies are present.
+    """
+    third_party_dependencies = {
+        'Registry': Registry,
+        'get_partial_pipeline': get_partial_pipeline,
+    }
+
+    for dependency in third_party_dependencies:
+        if third_party_dependencies[dependency] is None:
+            raise NotConnectedToOpenEdX(
+                _("The following dependency must be installed in an Open edX environment to look up third-party-auth "
+                  "dependencies.")
+                + "\nUnavailable: {dependency}".format(dependency=dependency)
+            )
+
+
 def get_enterprise_customer_for_request(request):
     """
     Get the EnterpriseCustomer associated with a particular request.
     """
-    pipeline = request.session.get('partial_pipeline')
-    return get_ec_for_running_pipeline(pipeline)
+    verify_third_party_auth_dependencies()
+    pipeline = get_partial_pipeline(request)
+    return get_enterprise_customer_for_running_pipeline(pipeline)
 
 
-def get_ec_for_running_pipeline(pipeline):
+def get_enterprise_customer_for_running_pipeline(pipeline):  # pylint: disable=invalid-name
     """
     Get the EnterpriseCustomer associated with a running pipeline.
     """
-    if Registry is None:
-        raise NotConnectedToEdX(
-            _("This package must be installed in an EdX environment to look up third-party auth providers.")
-        )
-
+    verify_third_party_auth_dependencies()
     if pipeline is None:
         return None
     provider = Registry.get_from_pipeline(pipeline)
@@ -78,7 +98,7 @@ def active_provider_enforces_data_sharing(request, enforcement_location):
         enforcement_location (str): the point where to see data sharing consent state.
         argument can either be "optional", 'at_login' or 'at_enrollment'
     """
-    running_pipeline = request.session.get('partial_pipeline')
+    running_pipeline = request.session.get('partial_pipeline_token')
     if running_pipeline:
         customer = get_enterprise_customer_for_request(request)
         return customer and customer.enforces_data_sharing_consent(enforcement_location)
@@ -89,7 +109,7 @@ def active_provider_requests_data_sharing(request):
     """
     Determine if the active EnterpriseCustomer requests data sharing consent.
     """
-    running_pipeline = request.session.get('partial_pipeline')
+    running_pipeline = request.session.get('partial_pipeline_token')
     if running_pipeline:
         customer = get_enterprise_customer_for_request(request)
         return customer and customer.requests_data_sharing_consent
@@ -100,7 +120,7 @@ def get_consent_status_for_pipeline(pipeline):
     """
     Get the consent object for the current pipeline.
     """
-    customer = get_ec_for_running_pipeline(pipeline)
+    customer = get_enterprise_customer_for_running_pipeline(pipeline)
     user = pipeline.kwargs['user']
     try:
         return UserDataSharingConsentAudit.objects.get(
@@ -141,7 +161,7 @@ def handle_enterprise_logistration(backend, user, **kwargs):
         """
         return redirect(reverse('grant_data_sharing_permissions'))
 
-    enterprise_customer = get_ec_for_running_pipeline({'backend': backend.name, 'kwargs': kwargs})
+    enterprise_customer = get_enterprise_customer_for_running_pipeline({'backend': backend.name, 'kwargs': kwargs})
     if enterprise_customer is None:
         # This pipeline element is not being activated as a part of an Enterprise logistration
         return

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -34,7 +34,7 @@ except ImportError:
 LOGGER = logging.getLogger(__name__)
 
 
-class NotConnectedToEdX(Exception):
+class NotConnectedToOpenEdX(Exception):
     """
     Exception to raise when not connected to OpenEdX.
 
@@ -47,19 +47,7 @@ class NotConnectedToEdX(Exception):
         Log a warning and initialize the exception.
         """
         LOGGER.warning('edx-enterprise unexpectedly failed as if not installed in an OpenEdX platform')
-        super(NotConnectedToEdX, self).__init__(*args, **kwargs)
-
-
-class NotConnectedToOpenEdX(Exception):
-    """
-    Exception to raise when we weren't able to import needed resources.
-
-    This is raised when we try to use the resources, rather than on
-    import, so that during testing we can load the module
-    and mock out the resources we need.
-    """
-
-    pass
+        super(NotConnectedToOpenEdX, self).__init__(*args, **kwargs)
 
 
 class CourseCatalogApiError(Exception):
@@ -148,7 +136,7 @@ def null_decorator(func):
     """
     Decorator that does nothing to the wrapped function.
 
-    If we're unable to import social.pipeline.partial, which is the case in our CI platform,
+    If we're unable to import social_core.pipeline.partial, which is the case in our CI platform,
     we need to be able to wrap the function with something.
     """
     return func

--- a/tests/test_lms_api.py
+++ b/tests/test_lms_api.py
@@ -18,6 +18,7 @@ from django.conf import settings
 from enterprise import lms_api
 from enterprise.utils import NotConnectedToOpenEdX
 
+
 URL_BASE_NAMES = {
     'enrollment': lms_api.EnrollmentApiClient,
     'courses': lms_api.CourseApiClient,


### PR DESCRIPTION
**Description:** Old [python-social-auth](https://github.com/python-social-auth) was a monolithic repository and the version we utilize is almost a year old. We are looking to upgrade to the latest, split version of python-social-auth which is more modular, and provides several new features, including a configurable maximum session length, a DB-packed partial pipeline, utilizing the latest backend (provider) versions, and so on.

**JIRA:** Implements [ENT-365](https://openedx.atlassian.net/browse/ENT-365).

**Dependencies:** [Complementary PR at edx-platform](https://github.com/edx/edx-platform/pull/15135).

**Merge deadline:** Mostly handles technical debt, so not that urgent.

**Installation instructions:** N/A for now.

**Testing instructions:** See [edx-platform PR](https://github.com/edx/edx-platform/pull/15135) for now.

**Merge checklist:**

- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [x] Translations are updated
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** This **must** be merged at the **same time** as the corresponding [edx-platform PR](https://github.com/edx/edx-platform/pull/15135), or else things will break.
