### PR TITLE
Only redirect to data sharing consent page if DSC is required at login.

### DIFF
--- a/enterprise/tpa_pipeline.py
+++ b/enterprise/tpa_pipeline.py
@@ -184,15 +184,16 @@ def handle_enterprise_logistration(backend, user, **kwargs):
 
         return
 
-    try:
-        # Find an existing account-level consent record for the user
-        consent = UserDataSharingConsentAudit.objects.get(
-            user__user_id=user.id,
-            user__enterprise_customer=enterprise_customer,
-        )
-    except UserDataSharingConsentAudit.DoesNotExist:
-        return redirect_to_consent()
+    if enterprise_customer.enforces_data_sharing_consent(EnterpriseCustomer.AT_LOGIN):
+        try:
+            # Find an existing account-level consent record for the user
+            consent = UserDataSharingConsentAudit.objects.get(
+                user__user_id=user.id,
+                user__enterprise_customer=enterprise_customer,
+            )
+        except UserDataSharingConsentAudit.DoesNotExist:
+            return redirect_to_consent()
 
-    if (not consent.enabled) and enterprise_customer.enforces_data_sharing_consent(EnterpriseCustomer.AT_LOGIN):
-        # If consent has been declined, and the enterprise customer requires it, redirect to get it.
-        return redirect_to_consent()
+        if not consent.enabled:
+            # If consent has been declined, and the enterprise customer requires it, redirect to get it.
+            return redirect_to_consent()


### PR DESCRIPTION
**Description:** Currently, if a user logs in using SSO, we will always show the DSC page directly after account creation/login even if the EntepriseCustomer is configured with an "Enforce data sharing consent" value of "At Enrollment". This modifies the enterprise TPA pipeline to check the "Enforce data sharing consent" value before deciding whether or not to redirect to the DSC page.

**Merge checklist:**

- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
