### PR TITLE
ENT-454 Apply session management logic to new Enterprise landing page

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.36.5] - 2017-06-23
+---------------------
+
+* Apply automatic session termination logic to enterprise landing page based on enterprise customer configuration.
+
 [0.36.4] - 2017-06-21
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.36.4"
+__version__ = "0.36.5"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -601,15 +601,29 @@ def enterprise_login_required(view):
 
         enterprise_uuid = kwargs['enterprise_uuid']
         enterprise_customer = get_enterprise_customer_or_404(enterprise_uuid)
+        provider_id = enterprise_customer.identity_provider or ''
+        sso_provider = None
 
-        # Now verify if the user is logged in. If user is not logged in then
-        # send the user to the login screen to sign in with an
-        # Enterprise-linked SSO and the pipeline will get them back here.
+        try:
+            sso_provider = get_identity_provider(provider_id)
+        except ValueError:
+            pass
+
+        decorator_already_processed = request.GET.get('session_cleared')
+
         if not request.user.is_authenticated():
-            next_url = '{current_url}?{query_string}'.format(
+            # If the user isn't logged in, send them to the log in page and redirect them
+            # back to the original view, indicating that the decorator has been processed.
+            next_url = '{current_url}?{params}'.format(
                 current_url=quote(request.get_full_path()),
-                query_string=urlencode({'tpa_hint': enterprise_customer.identity_provider})
+                params=urlencode(
+                    [
+                        ('tpa_hint', provider_id),
+                        ('session_cleared', 'yes')
+                    ]
+                )
             )
+
             return redirect(
                 '{login_url}?{params}'.format(
                     login_url='/login',
@@ -618,5 +632,21 @@ def enterprise_login_required(view):
                     )
                 )
             )
-        return view(request, *args, **kwargs)
+        elif not decorator_already_processed and sso_provider and sso_provider.drop_existing_session:
+            # If the user is logged in, this is their first time hitting the decorator,
+            # and the sso provider is configured to drop the session, send them to
+            # the logout page with a redirect back to the original view,
+            # indicating the decorator has been processed.
+            return redirect(
+                '{logout_url}?{params}'.format(
+                    logout_url='/logout',
+                    params=urlencode(
+                        {'redirect_url': quote(request.get_full_path())}
+                    )
+                )
+            )
+        else:
+            # Otherwise, they can proceed to the original view.
+            return view(request, *args, **kwargs)
+
     return wrapper

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1053,11 +1053,13 @@ class TestEnterpriseUtils(unittest.TestCase):
         with raises(Http404):
             utils.enterprise_login_required(view_function)(request, **kwargs)
 
-    def test_enterprise_login_required_redirects_for_anonymous_users(self):
+    @mock.patch('enterprise.utils.Registry')
+    def test_enterprise_login_required_redirects_for_anonymous_users(self, mock_registry):
         """
         Test that the decorator `enterprise_login_required` returns Http
         Redirect for anonymous users.
         """
+        mock_registry.get.return_value.configure_mock(provider_id=self.provider_id, drop_existing_session=False)
         view_function = self.mock_view_function()
         course_id = 'course-v1:edX+DemoX+Demo_Course'
         enterprise_dashboard_url = reverse(
@@ -1075,7 +1077,8 @@ class TestEnterpriseUtils(unittest.TestCase):
         # user tries to access enterprise course enrollment page.
         assert response.status_code == 302
 
-    def test_enterprise_login_required(self):
+    @mock.patch('enterprise.utils.Registry')
+    def test_enterprise_login_required(self, mock_registry):
         """
         Test that the enterprise login decorator calls the view function.
 
@@ -1086,6 +1089,7 @@ class TestEnterpriseUtils(unittest.TestCase):
             2. User making the request is authenticated.
 
         """
+        mock_registry.get.return_value.configure_mock(provider_id=self.provider_id, drop_existing_session=False)
         view_function = self.mock_view_function()
         course_id = 'course-v1:edX+DemoX+Demo_Course'
         enterprise_dashboard_url = reverse(
@@ -1101,6 +1105,51 @@ class TestEnterpriseUtils(unittest.TestCase):
 
         # Assert that view function was called.
         assert view_function.called
+
+    @mock.patch('enterprise.utils.get_identity_provider', side_effect=ValueError)
+    def test_enterprise_login_required_no_sso_provider(self, mock_registry):  # pylint: disable=unused-argument
+        """
+        Test that the enterprise login decorator calls the view function when no sso provider is configured.
+        """
+
+        view_function = self.mock_view_function()
+        course_id = 'course-v1:edX+DemoX+Demo_Course'
+        enterprise_dashboard_url = reverse(
+            'enterprise_course_enrollment_page',
+            args=[self.customer.uuid, course_id],
+        )
+        request = RequestFactory().get(enterprise_dashboard_url)
+        request.user = UserFactory(is_active=True)
+
+        utils.enterprise_login_required(view_function)(
+            request, enterprise_uuid=self.customer.uuid, course_id=course_id
+        )
+
+        # Assert that view function was called.
+        assert view_function.called
+
+    @mock.patch('enterprise.utils.Registry')
+    def test_enterprise_login_required_with_drop_existing_session(self, mock_registry):
+        """
+        Test that the enterprise login decorator redirects authenticated users with the appropriate provider config.
+        """
+        mock_registry.get.return_value.configure_mock(provider_id=self.provider_id, drop_existing_session=True)
+        view_function = self.mock_view_function()
+        course_id = 'course-v1:edX+DemoX+Demo_Course'
+        enterprise_dashboard_url = reverse(
+            'enterprise_course_enrollment_page',
+            args=[self.customer.uuid, course_id],
+        )
+        request = RequestFactory().get(enterprise_dashboard_url)
+        request.user = UserFactory(is_active=True)
+
+        response = utils.enterprise_login_required(view_function)(
+            request, enterprise_uuid=self.customer.uuid, course_id=course_id
+        )
+
+        # Assert that redirect status code 302 is returned when a logged in user comes in
+        # with an sso provider set to drop existing sessions
+        assert response.status_code == 302
 
 
 def get_transformed_course_metadata(course_id, status):


### PR DESCRIPTION
**Description:** We had to implement a decorator (https://github.com/edx/edx-platform/pull/14896/files) for the track selection page when we were testing SAP that terminated any existing session coming into the page if coming in through SSO. Since we are using this new landing page, we need the same logic here in order to stay in compliance with SAPs expectations.

**JIRA:** https://openedx.atlassian.net/browse/ENT-454

**Dependencies:** 

**Merge deadline:** ASAP

**Installation instructions:** Standard Installation with this version of edx-enterprise.

**Testing instructions:**
1. Set up a SAML Configuration and SAML IdP Provider Configuration against TestShib, and set up an Enterprise Customer linked to the Provider Configuration. Ensure that the provider configuration has the following enabled: skip hinted login dialog, skip registration form. Leave the following disabled: drop existing session.

2. Go to https://brittneyexline.sandbox.edx.org/enterprise/3d3fa892-58e0-435f-b7d2-37a45b3ce18c/course/course-v1:edX+DemoX+Demo_Course/enroll/ and register a new user, going through the normal flow until you get to the dashboard. Do not log out.

3. Sign out of the user on the IdP or unlinking the first user from the IdP account, and revisit the page. It should redirect to the first user's account.

4. Change the Provider Configuration to enable drop existing session.

5. Revisit the page (if you have not logged out of the first account, otherwise repeat step 2 first). It should direct you to the account creation page as if you were a new user coming in. You should then be able to go through the normal flow as expected.

**Merge checklist:**

- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:**
I'd like to refactor the tests for our enterprise view to avoid so much duplication - they all seem to have similar set up.
I still need to add test coverage around the specific logic I added.
