### PR TITLE
ENT-452 Enforce data sharing consent at login for SSO users iff data sharing consent is requested AT_LOGIN

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.36.8] - 2017-06-28
+---------------------
+
+* Enforce data sharing consent at login for SSO users only if data sharing consent is requested at login.
+
 [0.36.7] - 2017-06-25
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.36.7"
+__version__ = "0.36.8"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/tpa_pipeline.py
+++ b/enterprise/tpa_pipeline.py
@@ -137,12 +137,13 @@ def handle_enterprise_logistration(backend, user, **kwargs):
     """
     Perform tasks related to Enterprise-owned SSO signin requests.
 
-    Checks to ensure that the user has provided data sharing consent
-    if the active SSO provider requires it; if not, then the user will
-    be redirected to a page from which they can provide consent.
+    If the enterprise customer associated with the active SSO provider requires data sharing consent at login, ensure
+    that the user has provided consent.
 
-    If consent is not required, then the user in the process of logging
-    in is linked to the Enterprise Customer.
+    If consent is required, and the user has not provided consent, then the user will be redirected to a page from which
+    they can provide consent.
+
+    If consent is not required, then the user in the process of logging in is linked to the Enterprise Customer.
 
     Args:
         backend: The class handling the SSO interaction (SAML, OAuth, etc)
@@ -150,8 +151,8 @@ def handle_enterprise_logistration(backend, user, **kwargs):
         **kwargs: Any remaining pipeline variables
 
     Returns:
-        redirect: If consent is required, but has not been provided, the user
-            is redirected to a page where they can provide consent.
+        redirect: If consent is required at login, but has not been provided, the user is redirected to a page where
+            they can provide consent.
 
     """
     def redirect_to_consent():
@@ -168,8 +169,9 @@ def handle_enterprise_logistration(backend, user, **kwargs):
         # This pipeline element is not being activated as a part of an Enterprise logistration
         return
 
-    if not enterprise_customer.requests_data_sharing_consent:
-        # This enterprise customer attached to this pipeline element does not request data sharing consent;
+    if not (enterprise_customer.requests_data_sharing_consent and
+            enterprise_customer.enforce_data_sharing_consent == EnterpriseCustomer.AT_LOGIN):
+        # This enterprise customer attached to this pipeline element does not request data sharing consent at login;
         # proceed with the creation of a link between the user and the enterprise customer, then exit.
         enterprise_customer_user, __ = EnterpriseCustomerUser.objects.get_or_create(
             enterprise_customer=enterprise_customer,


### PR DESCRIPTION
**Description:** When signing in via SSO for an Enterprise customer who requires data sharing consent, this consent should only be required at login if the consent required is `AT_LOGIN`.  All other consent requirements (`AT_ENROLLMENT`, `OPTIONAL`, `EXTERNALLY_MANAGED`) will be handled at a later time.

**JIRA:** [ENT-452](https://openedx.atlassian.net/browse/ENT-452)

**Dependencies:** None.

**Merge deadline:** 04/Jul/17

**Installation instructions:**

Standard Enterprise Customer setup, with TPA/SSO enabled.

**Sandbox**

Deployed to https://business.sandbox.edx.org, and:

LMS: https://pr15359-2.sandbox.opencraft.hosting
Studio: https://studio-pr15359-2.sandbox.opencraft.hosting

**Testing instructions:**

1. As `staff` via [LMS Admin](https://pr15359-2.sandbox.opencraft.hosting/admin/enterprise/enterprisecustomer/), ensure that the `EnterpriseCustomer` is set to:
    1. Enable data sharing consent
    1. Require consent `at login`
1. Ensure that no data sharing consent has been granted for the learner you'll be using, or that no `EnterpriseCustomerUser` record exists for that learner.
1. Visit the [login page](https://pr15359-2.sandbox.opencraft.hosting/login), and click the `TestShib` button to login via SSO.  On the sandbox, I've registered the testshib `superego` user.
1. Ensure that Data Consent Sharing page is shown after the TestShib login screen.  Do not grant consent yet.
1. Logout of the TestShib/learner session.
1. As `staff` via [LMS Admin](https://pr15359-2.sandbox.opencraft.hosting/admin/enterprise/enterprisecustomer/), update the `EnterpriseCustomer` to:
    1. Enable data sharing consent
    1. Require consent `at enrollment`
1. Repeat Step 3.  Note that no Data Consent Sharing page is shown during the SSO login process. 

**Merge checklist:**

- [x] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] <strike>Documentation updated (not only docstrings)</strike> Bugfix, no need to update docs.
- [x] Commits are (reasonably) squashed
- [x] <strike>Translations are updated</strike> - user-facing strings untouched.
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)