### PR TITLE
ENT-442: Fix query string parameters in next and previous pages of enterprise catalog courses endpoint.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ----------
 
+[0.35.2] - 2017-06-20
+---------------------
+
+* Fix Next and Previous page urls for enterprise catalog courses.
+
+
 [0.35.1] - 2017-06-15
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.35.1"
+__version__ = "0.35.2"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/pagination.py
+++ b/enterprise/api/pagination.py
@@ -21,7 +21,8 @@ def get_paginated_response(data, request):
     Returns:
         (Response): DRF response object containing pagination links.
     """
-    url = request.build_absolute_uri().rstrip('/') + '/'
+    url = urlparse(request.build_absolute_uri())._replace(query=None).geturl()
+
     next_page = None
     previous_page = None
 

--- a/tests/api/test_pagination.py
+++ b/tests/api/test_pagination.py
@@ -124,3 +124,22 @@ class TestEnterpriseAPIPagination(APITest):
 
         assert response.data.get('next') == expected_next
         assert response.data.get('previous') == expected_previous
+
+    def test_get_paginated_response_correct_query_parameters(self):
+        """
+        Verify get_paginated_response returns correct response.
+        """
+        self.data['next'] = '{discovery_uri}?page=3'.format(discovery_uri=DISCOVERY_URI)
+        self.data['previous'] = '{discovery_uri}?page=1'.format(discovery_uri=DISCOVERY_URI)
+        expected_next = '{enterprise_uri}?page=3'.format(enterprise_uri=ENTERPRISE_URI)
+        expected_previous = '{enterprise_uri}?page=1'.format(enterprise_uri=ENTERPRISE_URI)
+        request = APIRequestFactory().get(
+            reverse('catalogs-list') + "?page=2",
+            SERVER_NAME="testserver.enterprise",
+        )
+
+        # Update authentication parameters based in ddt data.
+        response = get_paginated_response(self.data, request)
+
+        assert response.data.get('next') == expected_next
+        assert response.data.get('previous') == expected_previous


### PR DESCRIPTION
Hi @douglashall , @zubair-arbi , @asadiqbal08 

Please take a look at the changes. 

**Description:** 
The "next" and "previous" fields appear to be returning invalid page references when requesting pages other than the first (ie, no page value specified). This also happens when other parameters are specified, such as "limit" and "offset".
This PR fixes this problem for next and previous urls in API response.

**JIRA:** [ENT-442](https://openedx.atlassian.net/browse/ENT-442)

**Testing instructions:**
1. In Postman, with a valid authentication code for a staff user, attempt to access: /enterprise/api/v1/catalogs/124/courses/?page=2

**Merge checklist:**

- [x] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [x] Translations are updated
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
