### PR TITLE
ENT-442: Add the ability to pass limit, offset and page_size parameters to enterprise catalog courses.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ----------
 
+[0.36.2] - 2017-06-21
+---------------------
+
+* Add the ability to pass limit, offset and page_size parameters to enterprise catalog courses.
+
+
 [0.36.1] - 2017-06-20
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.36.1"
+__version__ = "0.36.2"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -253,16 +253,15 @@ class EnterpriseCatalogViewSet(viewsets.ViewSet):
         ---
         serializer: serializers.CourseSerializerExcludingClosedRuns
         """
-        page = request.GET.get('page', 1)
         catalog_api = CourseCatalogApiClient(request.user)
-        courses = catalog_api.get_paginated_catalog_courses(pk, page)
+        courses = catalog_api.get_paginated_catalog_courses(pk, request.GET)
 
         # if API returned an empty response, that means pagination has ended.
         # An empty response can also means that there was a problem fetching data from catalog API.
         if not courses:
             logger.error(
-                "Unable to fetch API response for catalog courses from endpoint '/catalog/%s/courses?page=%s'.",
-                pk, page,
+                "Unable to fetch API response for catalog courses from endpoint '%s'.",
+                request.get_full_path(),
             )
             raise NotFound("The resource you are looking for does not exist.")
 

--- a/enterprise/course_catalog_api.py
+++ b/enterprise/course_catalog_api.py
@@ -76,7 +76,7 @@ class CourseCatalogApiClient(object):
         """
         return self._load_data('catalogs', default=[], resource_id=catalog_id)
 
-    def get_paginated_catalog_courses(self, catalog_id, page=1):
+    def get_paginated_catalog_courses(self, catalog_id, querystring=None):
         """
         Return paginated resopnse for all catalog courses.
 
@@ -85,7 +85,7 @@ class CourseCatalogApiClient(object):
         """
         resource = 'catalogs/{}/courses/'.format(catalog_id)
         return self._load_data(
-            resource, default=[], querystring={'page': page},
+            resource, default=[], querystring=querystring,
             traverse_pagination=False, many=False,
         )
 


### PR DESCRIPTION
Hi @mattdrayer , @douglashall , @brittneyexline , @zubair-arbi , @asadiqbal08 

This PR addresses the issue of limit, offset and page_size parameters being lost in the request.

**JIRA:** [ENT-442](https://openedx.atlassian.net/browse/ENT-442)

**Merge checklist:**

- [x] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [x] Translations are updated
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)

