### PR TITLE
Fixing import of the catalog api client after change in edx-platform

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.36.3] - 2017-06-21
+---------------------
+
+* Fix for being unable to create course catalog clients due to upstream removal of the library.
+
 [0.36.2] - 2017-06-21
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.36.2"
+__version__ = "0.36.3"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/tests/test_course_catalog_api.py
+++ b/tests/test_course_catalog_api.py
@@ -29,7 +29,7 @@ class TestCourseCatalogApiInitialization(unittest.TestCase):
             CourseCatalogApiClient(mock.Mock(spec=User))
         assert message == str(excinfo.value)
 
-    @mock.patch('enterprise.course_catalog_api.course_discovery_api_client')
+    @mock.patch('enterprise.course_catalog_api.JwtBuilder')
     @mock.patch('enterprise.course_catalog_api.get_edx_api_data')
     def test_raise_error_missing_catalog_integration(self, *args):  # pylint: disable=unused-argument
         message = 'To get a CatalogIntegration object, this package must be installed in an Open edX environment.'
@@ -38,7 +38,7 @@ class TestCourseCatalogApiInitialization(unittest.TestCase):
         assert message == str(excinfo.value)
 
     @mock.patch('enterprise.course_catalog_api.CatalogIntegration')
-    @mock.patch('enterprise.course_catalog_api.course_discovery_api_client')
+    @mock.patch('enterprise.course_catalog_api.JwtBuilder')
     def test_raise_error_missing_get_edx_api_data(self, *args):  # pylint: disable=unused-argument
         message = 'To parse a Catalog API response, this package must be installed in an Open edX environment.'
         with raises(NotConnectedToOpenEdX) as excinfo:
@@ -76,7 +76,7 @@ class TestCourseCatalogApi(unittest.TestCase):
         self.user_mock = mock.Mock(spec=User)
         self.get_data_mock = self._make_patch(self._make_catalog_api_location("get_edx_api_data"))
         self.catalog_api_config_mock = self._make_patch(self._make_catalog_api_location("CatalogIntegration"))
-        self.api_factory_mock = self._make_patch(self._make_catalog_api_location("course_discovery_api_client"))
+        self.jwt_builder_mock = self._make_patch(self._make_catalog_api_location("JwtBuilder"))
 
         self.api = CourseCatalogApiClient(self.user_mock)
 


### PR DESCRIPTION
**Description:** The file that we were importing to generate catalog api clients was removed
and replaced with a mixin. In order for us to have full functionality on
the enterprise api client, we need to fix this contract change.

**JIRA:** Link to JIRA ticket

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** asap

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happend instead - check failed.

**Merge checklist:**

- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
