### PR TITLE
ENT-454 Refactor session management logic.

### DIFF
--- a/enterprise/decorators.py
+++ b/enterprise/decorators.py
@@ -1,0 +1,134 @@
+# -*- coding: utf-8 -*-
+"""
+Decorators for enterprise app.
+"""
+from __future__ import absolute_import, unicode_literals
+
+from functools import wraps
+
+from requests.utils import quote
+
+from django.http import Http404
+from django.shortcuts import redirect
+
+from enterprise.utils import get_enterprise_customer_or_404, get_identity_provider
+from six.moves.urllib.parse import urlencode  # pylint: disable=import-error
+
+
+def disable_for_loaddata(signal_handler):
+    """
+    Use this decorator to turn off signal handlers when loading fixture data.
+
+    Django docs instruct to avoid further changes to the DB if raw=True as it might not be in a consistent state.
+    See https://docs.djangoproject.com/en/dev/ref/signals/#post-save
+    """
+    # http://stackoverflow.com/a/15625121/882918
+    @wraps(signal_handler)
+    def wrapper(*args, **kwargs):
+        """
+        Wrap the function.
+        """
+        if kwargs.get('raw', False):
+            return
+        signal_handler(*args, **kwargs)
+    return wrapper
+
+
+def null_decorator(func):
+    """
+    Use this decorator to stub out decorators for testing.
+
+    If we're unable to import social_core.pipeline.partial, which is the case in our CI platform,
+    we need to be able to wrap the function with something.
+    """
+    return func
+
+
+def enterprise_login_required(view):
+    """
+    View decorator for allowing authenticated user with valid enterprise UUID.
+
+    This decorator requires enterprise identifier as a parameter
+    `enterprise_uuid`.
+
+    This decorator will throw 404 if no kwarg `enterprise_uuid` is provided to
+    the decorated view .
+
+    If there is no enterprise in database against the kwarg `enterprise_uuid`
+    or if the user is not authenticated then it will redirect the user to the
+    enterprise-linked SSO login page.
+
+    Usage::
+        @enterprise_login_required()
+        def my_view(request, enterprise_uuid):
+            # Some functionality ...
+
+        OR
+
+        class MyView(View):
+            ...
+            @method_decorator(enterprise_login_required)
+            def get(self, request, enterprise_uuid):
+                # Some functionality ...
+
+    """
+    @wraps(view)
+    def wrapper(request, *args, **kwargs):
+        """
+        Wrap the decorator.
+        """
+        if 'enterprise_uuid' not in kwargs:
+            raise Http404
+
+        enterprise_uuid = kwargs['enterprise_uuid']
+        enterprise_customer = get_enterprise_customer_or_404(enterprise_uuid)
+        provider_id = enterprise_customer.identity_provider or ''
+        sso_provider = None
+
+        try:
+            sso_provider = get_identity_provider(provider_id)
+        except ValueError:
+            pass
+
+        decorator_already_processed = request.GET.get('session_cleared')
+
+        if not request.user.is_authenticated():
+            # If the user isn't logged in, send them to the log in page and redirect them
+            # back to the original view, indicating that the decorator has been processed.
+            next_url = '{current_url}?{params}'.format(
+                current_url=quote(request.get_full_path()),
+                params=urlencode(
+                    [
+                        ('tpa_hint', provider_id),
+                        ('session_cleared', 'yes')
+                    ]
+                )
+            )
+
+            return redirect(
+                '{login_url}?{params}'.format(
+                    login_url='/login',
+                    params=urlencode(
+                        {'next': next_url}
+                    )
+                )
+            )
+
+        if not decorator_already_processed and sso_provider and sso_provider.drop_existing_session:
+            # If the user is logged in, this is their first time hitting the decorator,
+            # and the sso provider is configured to drop the session, send them to
+            # the logout page with a redirect back to the original view,
+            # indicating the decorator has been processed.
+            return redirect(
+                '{logout_url}?{params}'.format(
+                    logout_url='/logout',
+                    params=urlencode(
+                        {'redirect_url': quote(request.get_full_path())}
+                    )
+                )
+            )
+
+        # Otherwise, they can proceed to the original view.
+        return view(request, *args, **kwargs)
+
+    return wrapper

--- a/enterprise/decorators.py
+++ b/enterprise/decorators.py
@@ -82,29 +82,15 @@ def enterprise_login_required(view):
 
         enterprise_uuid = kwargs['enterprise_uuid']
         enterprise_customer = get_enterprise_customer_or_404(enterprise_uuid)
-        provider_id = enterprise_customer.identity_provider or ''
-        sso_provider = None
 
-        try:
-            sso_provider = get_identity_provider(provider_id)
-        except ValueError:
-            pass
-
-        decorator_already_processed = request.GET.get('session_cleared')
-
+        # Now verify if the user is logged in. If user is not logged in then
+        # send the user to the login screen to sign in with an
+        # Enterprise-linked IdP and the pipeline will get them back here.
         if not request.user.is_authenticated():
-            # If the user isn't logged in, send them to the log in page and redirect them
-            # back to the original view, indicating that the decorator has been processed.
-            next_url = '{current_url}?{params}'.format(
+            next_url = '{current_url}?{query_string}'.format(
                 current_url=quote(request.get_full_path()),
-                params=urlencode(
-                    [
-                        ('tpa_hint', provider_id),
-                        ('session_cleared', 'yes')
-                    ]
-                )
+                query_string=urlencode({'tpa_hint': enterprise_customer.identity_provider})
             )
-
             return redirect(
                 '{login_url}?{params}'.format(
                     login_url='/login',
@@ -114,21 +100,76 @@ def enterprise_login_required(view):
                 )
             )
 
-        if not decorator_already_processed and sso_provider and sso_provider.drop_existing_session:
-            # If the user is logged in, this is their first time hitting the decorator,
-            # and the sso provider is configured to drop the session, send them to
-            # the logout page with a redirect back to the original view,
-            # indicating the decorator has been processed.
-            return redirect(
-                '{logout_url}?{params}'.format(
-                    logout_url='/logout',
-                    params=urlencode(
-                        {'redirect_url': quote(request.get_full_path())}
-                    )
-                )
-            )
-
         # Otherwise, they can proceed to the original view.
+        return view(request, *args, **kwargs)
+
+    return wrapper
+
+
+def force_fresh_session(view):
+    """
+    View decorator which terminates stale TPA sessions.
+
+    This decorator forces the user to obtain a new session
+    the first time they access the decorated view. This prevents
+    TPA-authenticated users from hijacking the session of another
+    user who may have been previously logged in using the same
+    browser window.
+
+    Usage::
+        @force_fresh_session()
+        def my_view(request, enterprise_uuid):
+            # Some functionality ...
+
+        OR
+
+        class MyView(View):
+            ...
+            @method_decorator(force_fresh_session)
+            def get(self, request, enterprise_uuid):
+                # Some functionality ...
+
+    """
+    @wraps(view)
+    def wrapper(request, *args, **kwargs):
+        """
+        Function wrapper.
+        """
+        if not request.session.get('is_session_fresh'):
+            if request.user.is_authenticated():
+                # If the user is logged in, the sso provider is configured
+                # to terminate existing sessions, and we have not yet
+                # restarted the session, redirect the user to the logout
+                # page to terminate the session and include a redirect URL
+                # which will send them back to the original view so they
+                # can start a new session.
+                enterprise_customer = get_enterprise_customer_or_404(kwargs.get('enterprise_uuid'))
+                provider_id = enterprise_customer.identity_provider or ''
+
+                try:
+                    sso_provider = get_identity_provider(provider_id)
+                    if sso_provider and sso_provider.drop_existing_session:
+                        return redirect(
+                            '{logout_url}?{params}'.format(
+                                logout_url='/logout',
+                                params=urlencode(
+                                    {'redirect_url': quote(request.get_full_path())}
+                                )
+                            )
+                        )
+                except ValueError:
+                    pass
+            else:
+                # If the user has not yet been authenticated,
+                # set a flag on the session to indicate that
+                # this is a fresh session.
+                request.session['is_session_fresh'] = True
+
+        else:
+            # The user was forced to log out and start a new session,
+            # so clear the session flag.
+            request.session.pop('is_session_fresh')
+
         return view(request, *args, **kwargs)
 
     return wrapper

--- a/enterprise/signals.py
+++ b/enterprise/signals.py
@@ -6,8 +6,8 @@ from __future__ import absolute_import, unicode_literals
 
 from logging import getLogger
 
+from enterprise.decorators import disable_for_loaddata
 from enterprise.models import EnterpriseCourseEnrollment, EnterpriseCustomerUser, PendingEnterpriseCustomerUser
-from enterprise.utils import disable_for_loaddata
 
 logger = getLogger(__name__)  # pylint: disable=invalid-name
 

--- a/enterprise/tpa_pipeline.py
+++ b/enterprise/tpa_pipeline.py
@@ -20,7 +20,7 @@ except ImportError:
 try:
     from social_core.pipeline.partial import partial
 except ImportError:
-    from enterprise.utils import null_decorator as partial  # pylint:disable=ungrouped-imports
+    from enterprise.decorators import null_decorator as partial  # pylint:disable=ungrouped-imports
 
 try:
     from third_party_auth.pipeline import get as get_partial_pipeline

--- a/enterprise/tpa_pipeline.py
+++ b/enterprise/tpa_pipeline.py
@@ -10,7 +10,7 @@ from django.shortcuts import redirect
 from django.utils.translation import ugettext as _
 
 from enterprise.models import EnterpriseCustomer, EnterpriseCustomerUser, UserDataSharingConsentAudit
-from enterprise.utils import NotConnectedToOpenEdX
+from enterprise.utils import NotConnectedToOpenEdX, restart_session_if_required
 
 try:
     from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
@@ -161,7 +161,7 @@ def handle_enterprise_logistration(backend, user, **kwargs):
         Method redirects the user to a page from which they can provide
         required data sharing consent before proceeding in the pipeline
         """
-        return redirect(reverse('grant_data_sharing_permissions'))
+        return restart_session_if_required(enterprise_customer, reverse('grant_data_sharing_permissions'))
 
     enterprise_customer = get_enterprise_customer_for_running_pipeline({'backend': backend.name, 'kwargs': kwargs})
     if enterprise_customer is None:

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -6,10 +6,7 @@ from __future__ import absolute_import, unicode_literals
 
 import logging
 import re
-from functools import wraps
 from uuid import UUID
-
-from requests.utils import quote
 
 from django.apps import apps
 from django.conf import settings
@@ -17,7 +14,6 @@ from django.core import mail
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.urlresolvers import reverse
 from django.http import Http404
-from django.shortcuts import redirect
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext as _
 
@@ -110,35 +106,6 @@ def get_all_field_names(model):
     .. _Django documentation: https://docs.djangoproject.com/en/1.8/ref/models/meta/
     """
     return [f.name for f in model._meta.get_fields()]
-
-
-def disable_for_loaddata(signal_handler):
-    """
-    Use this decorator to turn off signal handlers when loading fixture data.
-
-    Django docs instruct to avoid further changes to the DB if raw=True as it might not be in a consistent state.
-    See https://docs.djangoproject.com/en/dev/ref/signals/#post-save
-    """
-    # http://stackoverflow.com/a/15625121/882918
-    @wraps(signal_handler)
-    def wrapper(*args, **kwargs):
-        """
-        Wrap the function.
-        """
-        if kwargs.get('raw', False):
-            return
-        signal_handler(*args, **kwargs)
-    return wrapper
-
-
-def null_decorator(func):
-    """
-    Use this decorator to stub out decorators for testing.
-
-    If we're unable to import social_core.pipeline.partial, which is the case in our CI platform,
-    we need to be able to wrap the function with something.
-    """
-    return func
 
 
 def get_catalog_admin_url(catalog_id):
@@ -568,93 +535,3 @@ def get_enterprise_customer_or_404(enterprise_uuid):
         LOGGER.error('Unable to find enterprise customer for UUID: %s', enterprise_uuid)
         raise Http404
     return enterprise_customer
-
-
-def enterprise_login_required(view):
-    """
-    View decorator for allowing authenticated user with valid enterprise UUID.
-
-    This decorator requires enterprise identifier as a parameter
-    `enterprise_uuid`.
-
-    This decorator will throw 404 if no kwarg `enterprise_uuid` is provided to
-    the decorated view .
-
-    If there is no enterprise in database against the kwarg `enterprise_uuid`
-    or if the user is not authenticated then it will redirect the user to the
-    enterprise-linked SSO login page.
-
-    Usage::
-        @enterprise_login_required()
-        def my_view(request, enterprise_uuid):
-            # Some functionality ...
-
-        OR
-
-        class MyView(View):
-            ...
-            @method_decorator(enterprise_login_required)
-            def get(self, request, enterprise_uuid):
-                # Some functionality ...
-
-    """
-    @wraps(view)
-    def wrapper(request, *args, **kwargs):
-        """
-        Wrap the decorator.
-        """
-        if 'enterprise_uuid' not in kwargs:
-            raise Http404
-
-        enterprise_uuid = kwargs['enterprise_uuid']
-        enterprise_customer = get_enterprise_customer_or_404(enterprise_uuid)
-        provider_id = enterprise_customer.identity_provider or ''
-        sso_provider = None
-
-        try:
-            sso_provider = get_identity_provider(provider_id)
-        except ValueError:
-            pass
-
-        decorator_already_processed = request.GET.get('session_cleared')
-
-        if not request.user.is_authenticated():
-            # If the user isn't logged in, send them to the log in page and redirect them
-            # back to the original view, indicating that the decorator has been processed.
-            next_url = '{current_url}?{params}'.format(
-                current_url=quote(request.get_full_path()),
-                params=urlencode(
-                    [
-                        ('tpa_hint', provider_id),
-                        ('session_cleared', 'yes')
-                    ]
-                )
-            )
-
-            return redirect(
-                '{login_url}?{params}'.format(
-                    login_url='/login',
-                    params=urlencode(
-                        {'next': next_url}
-                    )
-                )
-            )
-
-        if not decorator_already_processed and sso_provider and sso_provider.drop_existing_session:
-            # If the user is logged in, this is their first time hitting the decorator,
-            # and the sso provider is configured to drop the session, send them to
-            # the logout page with a redirect back to the original view,
-            # indicating the decorator has been processed.
-            return redirect(
-                '{logout_url}?{params}'.format(
-                    logout_url='/logout',
-                    params=urlencode(
-                        {'redirect_url': quote(request.get_full_path())}
-                    )
-                )
-            )
-
-        # Otherwise, they can proceed to the original view.
-        return view(request, *args, **kwargs)
-
-    return wrapper

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -535,3 +535,21 @@ def get_enterprise_customer_or_404(enterprise_uuid):
         LOGGER.error('Unable to find enterprise customer for UUID: %s', enterprise_uuid)
         raise Http404
     return enterprise_customer
+
+
+def restart_session_if_required(enterprise_customer, redirect_url):
+    provider_id = enterprise_customer.identity_provider or ''
+
+    try:
+        sso_provider = get_identity_provider(provider_id)
+        if sso_provider and sso_provider.drop_existing_session:
+            return redirect(
+                '{logout_url}?{params}'.format(
+                    logout_url='/logout',
+                    params=urlencode(
+                        {'redirect_url': quote(redirect_url)}
+                    )
+                )
+            )
+    except ValueError:
+        pass

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -55,6 +55,7 @@ except ImportError:
 # isort:imports-firstparty
 from enterprise.constants import CONFIRMATION_ALERT_PROMPT, CONFIRMATION_ALERT_PROMPT_WARNING, CONSENT_REQUEST_PROMPT
 from enterprise.course_catalog_api import CourseCatalogApiClient
+from enterprise.decorators import enterprise_login_required
 from enterprise.lms_api import CourseApiClient, EnrollmentApiClient
 from enterprise.models import (
     EnterpriseCourseEnrollment,
@@ -66,7 +67,6 @@ from enterprise.tpa_pipeline import active_provider_enforces_data_sharing, get_e
 from enterprise.utils import (
     NotConnectedToOpenEdX,
     consent_necessary_for_course,
-    enterprise_login_required,
     filter_audit_course_modes,
     get_enterprise_customer_or_404,
     get_enterprise_customer_user,

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -55,7 +55,7 @@ except ImportError:
 # isort:imports-firstparty
 from enterprise.constants import CONFIRMATION_ALERT_PROMPT, CONFIRMATION_ALERT_PROMPT_WARNING, CONSENT_REQUEST_PROMPT
 from enterprise.course_catalog_api import CourseCatalogApiClient
-from enterprise.decorators import enterprise_login_required
+from enterprise.decorators import enterprise_login_required, force_fresh_session
 from enterprise.lms_api import CourseApiClient, EnrollmentApiClient
 from enterprise.models import (
     EnterpriseCourseEnrollment,
@@ -871,6 +871,7 @@ class CourseEnrollmentView(View):
         # Note: LMS start flow automatically detects the paid mode
         return redirect(LMS_START_PREMIUM_COURSE_FLOW_URL.format(course_id=course_id))
 
+    @method_decorator(force_fresh_session)
     @method_decorator(enterprise_login_required)
     def get(self, request, enterprise_uuid, course_id):
         """

--- a/test_utils/__init__.py
+++ b/test_utils/__init__.py
@@ -10,13 +10,39 @@ from __future__ import absolute_import, unicode_literals
 import json
 from pytest import mark
 
+import mock
 from rest_framework.test import APITestCase, APIClient
+import six
+from six.moves.urllib.parse import parse_qs, urlsplit  # pylint: disable=import-error
 
 from test_utils import factories
-from six.moves.urllib.parse import parse_qs, urlsplit  # pylint: disable=import-error,wrong-import-order
 
 TEST_USERNAME = 'api_worker'
 TEST_PASSWORD = 'QWERTY'
+
+
+def get_magic_name(value):
+    """
+    Return value suitable for __name__ attribute.
+
+    For python2, __name__ must be str, while for python3 it must be unicode (as there are no str at all).
+
+    Arguments:
+        value basestring: string to "convert"
+
+    Returns:
+        str or unicode
+    """
+    return str(value) if six.PY2 else value
+
+
+def mock_view_function():
+    """
+    Return mock function for views that are decorated.
+    """
+    view_function = mock.Mock()
+    view_function.__name__ = str('view_function') if six.PY2 else 'view_function'
+    return view_function
 
 
 @mark.django_db

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -5,17 +5,19 @@ Tests for the `edx-enterprise` decorators.
 from __future__ import absolute_import, unicode_literals
 
 import unittest
+from importlib import import_module
 
 import ddt
 import mock
 from faker import Factory as FakerFactory
 from pytest import mark, raises
 
+from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.http import Http404
 from django.test import RequestFactory
 
-from enterprise.decorators import disable_for_loaddata, enterprise_login_required
+from enterprise.decorators import disable_for_loaddata, enterprise_login_required, force_fresh_session
 from enterprise.django_compatibility import reverse
 from test_utils import get_magic_name, mock_view_function
 from test_utils.factories import EnterpriseCustomerFactory, EnterpriseCustomerIdentityProviderFactory, UserFactory
@@ -34,10 +36,21 @@ class TestEnterpriseDecorators(unittest.TestCase):
         """
         super(TestEnterpriseDecorators, self).setUp()
         faker = FakerFactory.create()
-        self.provider_id = faker.slug()
-        self.uuid = faker.uuid4()
+        self.provider_id = faker.slug()  # pylint: disable=no-member
+        self.uuid = faker.uuid4()  # pylint: disable=no-member
         self.customer = EnterpriseCustomerFactory(uuid=self.uuid)
         EnterpriseCustomerIdentityProviderFactory(provider_id=self.provider_id, enterprise_customer=self.customer)
+        self.session_engine = import_module(settings.SESSION_ENGINE)
+
+    def _prepare_request(self, url, user):
+        """
+        Prepare request for test.
+        """
+        request = RequestFactory().get(url)
+        request.user = user
+        session_key = request.COOKIES.get(settings.SESSION_COOKIE_NAME)
+        request.session = self.session_engine.SessionStore(session_key)
+        return request
 
     @ddt.data(True, False)
     def test_disable_for_loaddata(self, raw):
@@ -52,6 +65,7 @@ class TestEnterpriseDecorators(unittest.TestCase):
     @ddt.data(
         {},  # Missing required parameter `enterprise_uuid` arguments in kwargs
         {'enterprise_uuid': ''},  # Required parameter `enterprise_uuid` with empty value in kwargs.
+        # pylint: disable=no-member
         {'enterprise_uuid': FakerFactory.create().uuid4()},  # Invalid value of `enterprise_uuid` in kwargs.
     )
     def test_enterprise_login_required_raises_404(self, kwargs):
@@ -60,31 +74,27 @@ class TestEnterpriseDecorators(unittest.TestCase):
         error when called with invalid or missing arguments.
         """
         view_function = mock_view_function()
-        enterprise_dashboard_url = reverse(
+        enterprise_launch_url = reverse(
             'enterprise_course_enrollment_page',
             args=[self.customer.uuid, 'course-v1:edX+DemoX+Demo_Course'],
         )
-        request = RequestFactory().get(enterprise_dashboard_url)
-        request.user = UserFactory(is_active=True)
+        request = self._prepare_request(enterprise_launch_url, UserFactory(is_active=True))
 
         with raises(Http404):
             enterprise_login_required(view_function)(request, **kwargs)
 
-    @mock.patch('enterprise.utils.Registry')
-    def test_enterprise_login_required_redirects_for_anonymous_users(self, mock_registry):
+    def test_enterprise_login_required_redirects_for_anonymous_users(self):
         """
         Test that the decorator `enterprise_login_required` returns Http
         Redirect for anonymous users.
         """
-        mock_registry.get.return_value.configure_mock(provider_id=self.provider_id, drop_existing_session=False)
         view_function = mock_view_function()
         course_id = 'course-v1:edX+DemoX+Demo_Course'
-        enterprise_dashboard_url = reverse(
+        enterprise_launch_url = reverse(
             'enterprise_course_enrollment_page',
             args=[self.customer.uuid, course_id],
         )
-        request = RequestFactory().get(enterprise_dashboard_url)
-        request.user = AnonymousUser()
+        request = self._prepare_request(enterprise_launch_url, AnonymousUser())
 
         response = enterprise_login_required(view_function)(
             request, enterprise_uuid=self.customer.uuid, course_id=course_id
@@ -94,8 +104,7 @@ class TestEnterpriseDecorators(unittest.TestCase):
         # user tries to access enterprise course enrollment page.
         assert response.status_code == 302
 
-    @mock.patch('enterprise.utils.Registry')
-    def test_enterprise_login_required(self, mock_registry):
+    def test_enterprise_login_required(self):
         """
         Test that the enterprise login decorator calls the view function.
 
@@ -106,15 +115,13 @@ class TestEnterpriseDecorators(unittest.TestCase):
             2. User making the request is authenticated.
 
         """
-        mock_registry.get.return_value.configure_mock(provider_id=self.provider_id, drop_existing_session=False)
         view_function = mock_view_function()
         course_id = 'course-v1:edX+DemoX+Demo_Course'
-        enterprise_dashboard_url = reverse(
+        enterprise_launch_url = reverse(
             'enterprise_course_enrollment_page',
             args=[self.customer.uuid, course_id],
         )
-        request = RequestFactory().get(enterprise_dashboard_url)
-        request.user = UserFactory(is_active=True)
+        request = self._prepare_request(enterprise_launch_url, UserFactory(is_active=True))
 
         enterprise_login_required(view_function)(
             request, enterprise_uuid=self.customer.uuid, course_id=course_id
@@ -122,48 +129,101 @@ class TestEnterpriseDecorators(unittest.TestCase):
 
         # Assert that view function was called.
         assert view_function.called
+
+    def test_force_fresh_session_anonymous_user(self):
+        """
+        Test that the force_fresh_session decorator calls the
+        decorated view the request is made by an unauthenticated
+        user.
+        """
+        view_function = mock_view_function()
+        course_id = 'course-v1:edX+DemoX+Demo_Course'
+        enterprise_launch_url = reverse(
+            'enterprise_course_enrollment_page',
+            args=[self.customer.uuid, course_id],
+        )
+        request = self._prepare_request(enterprise_launch_url, AnonymousUser())
+
+        force_fresh_session(view_function)(
+            request, enterprise_uuid=self.customer.uuid, course_id=course_id
+        )
+
+        # Assert that view function was called and the session flag was set.
+        assert view_function.called
+        assert request.session.get('is_session_fresh')
 
     @mock.patch('enterprise.decorators.get_identity_provider', side_effect=ValueError)
-    def test_enterprise_login_required_no_sso_provider(self, mock_registry):  # pylint: disable=unused-argument
+    def test_force_fresh_session_no_sso_provider(self, mock_registry):  # pylint: disable=unused-argument
         """
-        Test that the enterprise login decorator calls the view function when no sso provider is configured.
+        Test that the force_fresh_session decorator calls the view function
+        when no sso provider is configured.
         """
 
         view_function = mock_view_function()
         course_id = 'course-v1:edX+DemoX+Demo_Course'
-        enterprise_dashboard_url = reverse(
+        enterprise_launch_url = reverse(
             'enterprise_course_enrollment_page',
             args=[self.customer.uuid, course_id],
         )
-        request = RequestFactory().get(enterprise_dashboard_url)
-        request.user = UserFactory(is_active=True)
+        request = self._prepare_request(enterprise_launch_url, UserFactory(is_active=True))
 
-        enterprise_login_required(view_function)(
+        force_fresh_session(view_function)(
             request, enterprise_uuid=self.customer.uuid, course_id=course_id
         )
 
         # Assert that view function was called.
         assert view_function.called
 
-    @mock.patch('enterprise.utils.Registry')
-    def test_enterprise_login_required_with_drop_existing_session(self, mock_registry):
+    def test_force_fresh_session_when_fresh(self):
         """
-        Test that the enterprise login decorator redirects authenticated users with the appropriate provider config.
+        Test that the force_fresh_session decorator calls the view function
+        if the session is fresh.
         """
-        mock_registry.get.return_value.configure_mock(provider_id=self.provider_id, drop_existing_session=True)
         view_function = mock_view_function()
         course_id = 'course-v1:edX+DemoX+Demo_Course'
-        enterprise_dashboard_url = reverse(
+        enterprise_launch_url = reverse(
             'enterprise_course_enrollment_page',
             args=[self.customer.uuid, course_id],
         )
-        request = RequestFactory().get(enterprise_dashboard_url)
-        request.user = UserFactory(is_active=True)
+        request = self._prepare_request(enterprise_launch_url, UserFactory(is_active=True))
+        request.session['is_session_fresh'] = True
 
-        response = enterprise_login_required(view_function)(
+        force_fresh_session(view_function)(
             request, enterprise_uuid=self.customer.uuid, course_id=course_id
         )
 
-        # Assert that redirect status code 302 is returned when a logged in user comes in
-        # with an sso provider set to drop existing sessions
-        assert response.status_code == 302
+        # Assert that view function was called.
+        assert view_function.called
+        # Assert that session flag was removed.
+        assert request.session.get('is_session_fresh') is None
+
+    @ddt.data(True, False)
+    @mock.patch('enterprise.utils.Registry')
+    def test_force_fresh_session_when_not_fresh(self, drop_exisiting_session, mock_registry):
+        """
+        Test that the force_fresh_session decorator redirects authenticated
+        users with the appropriate provider config depending on the IdPs configuration.
+        """
+        mock_registry.get.return_value.configure_mock(
+            provider_id=self.provider_id,
+            drop_existing_session=drop_exisiting_session
+        )
+        view_function = mock_view_function()
+        course_id = 'course-v1:edX+DemoX+Demo_Course'
+        enterprise_launch_url = reverse(
+            'enterprise_course_enrollment_page',
+            args=[self.customer.uuid, course_id],
+        )
+        request = self._prepare_request(enterprise_launch_url, UserFactory(is_active=True))
+
+        response = force_fresh_session(view_function)(
+            request, enterprise_uuid=self.customer.uuid, course_id=course_id
+        )
+
+        if drop_exisiting_session:
+            # Assert that redirect status code 302 is returned when a logged in user comes in
+            # with an sso provider configured to drop existing sessions
+            assert response.status_code == 302
+        else:
+            # Assert that view function was called.
+            assert view_function.called

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,0 +1,169 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for the `edx-enterprise` decorators.
+"""
+from __future__ import absolute_import, unicode_literals
+
+import unittest
+
+import ddt
+import mock
+from faker import Factory as FakerFactory
+from pytest import mark, raises
+
+from django.contrib.auth.models import AnonymousUser
+from django.http import Http404
+from django.test import RequestFactory
+
+from enterprise.decorators import disable_for_loaddata, enterprise_login_required
+from enterprise.django_compatibility import reverse
+from test_utils import get_magic_name, mock_view_function
+from test_utils.factories import EnterpriseCustomerFactory, EnterpriseCustomerIdentityProviderFactory, UserFactory
+
+
+@mark.django_db
+@ddt.ddt
+@mark.django_db
+class TestEnterpriseDecorators(unittest.TestCase):
+    """
+    Tests for enterprise decorators.
+    """
+    def setUp(self):
+        """
+        Set up test environment.
+        """
+        super(TestEnterpriseDecorators, self).setUp()
+        faker = FakerFactory.create()
+        self.provider_id = faker.slug()
+        self.uuid = faker.uuid4()
+        self.customer = EnterpriseCustomerFactory(uuid=self.uuid)
+        EnterpriseCustomerIdentityProviderFactory(provider_id=self.provider_id, enterprise_customer=self.customer)
+
+    @ddt.data(True, False)
+    def test_disable_for_loaddata(self, raw):
+        signal_handler_mock = mock.MagicMock()
+        signal_handler_mock.__name__ = get_magic_name("Irrelevant")
+        wrapped_handler = disable_for_loaddata(signal_handler_mock)
+
+        wrapped_handler(raw=raw)
+
+        assert signal_handler_mock.called != raw
+
+    @ddt.data(
+        {},  # Missing required parameter `enterprise_uuid` arguments in kwargs
+        {'enterprise_uuid': ''},  # Required parameter `enterprise_uuid` with empty value in kwargs.
+        {'enterprise_uuid': FakerFactory.create().uuid4()},  # Invalid value of `enterprise_uuid` in kwargs.
+    )
+    def test_enterprise_login_required_raises_404(self, kwargs):
+        """
+        Test that the decorator `enterprise_login_required` raises `Http404`
+        error when called with invalid or missing arguments.
+        """
+        view_function = mock_view_function()
+        enterprise_dashboard_url = reverse(
+            'enterprise_course_enrollment_page',
+            args=[self.customer.uuid, 'course-v1:edX+DemoX+Demo_Course'],
+        )
+        request = RequestFactory().get(enterprise_dashboard_url)
+        request.user = UserFactory(is_active=True)
+
+        with raises(Http404):
+            enterprise_login_required(view_function)(request, **kwargs)
+
+    @mock.patch('enterprise.utils.Registry')
+    def test_enterprise_login_required_redirects_for_anonymous_users(self, mock_registry):
+        """
+        Test that the decorator `enterprise_login_required` returns Http
+        Redirect for anonymous users.
+        """
+        mock_registry.get.return_value.configure_mock(provider_id=self.provider_id, drop_existing_session=False)
+        view_function = mock_view_function()
+        course_id = 'course-v1:edX+DemoX+Demo_Course'
+        enterprise_dashboard_url = reverse(
+            'enterprise_course_enrollment_page',
+            args=[self.customer.uuid, course_id],
+        )
+        request = RequestFactory().get(enterprise_dashboard_url)
+        request.user = AnonymousUser()
+
+        response = enterprise_login_required(view_function)(
+            request, enterprise_uuid=self.customer.uuid, course_id=course_id
+        )
+
+        # Assert that redirect status code 302 is returned when an anonymous
+        # user tries to access enterprise course enrollment page.
+        assert response.status_code == 302
+
+    @mock.patch('enterprise.utils.Registry')
+    def test_enterprise_login_required(self, mock_registry):
+        """
+        Test that the enterprise login decorator calls the view function.
+
+        Test that the decorator `enterprise_login_required` calls the view
+        function when:
+            1. `enterprise_uuid` is provided and corresponding enterprise
+                customer exists in database.
+            2. User making the request is authenticated.
+
+        """
+        mock_registry.get.return_value.configure_mock(provider_id=self.provider_id, drop_existing_session=False)
+        view_function = mock_view_function()
+        course_id = 'course-v1:edX+DemoX+Demo_Course'
+        enterprise_dashboard_url = reverse(
+            'enterprise_course_enrollment_page',
+            args=[self.customer.uuid, course_id],
+        )
+        request = RequestFactory().get(enterprise_dashboard_url)
+        request.user = UserFactory(is_active=True)
+
+        enterprise_login_required(view_function)(
+            request, enterprise_uuid=self.customer.uuid, course_id=course_id
+        )
+
+        # Assert that view function was called.
+        assert view_function.called
+
+    @mock.patch('enterprise.decorators.get_identity_provider', side_effect=ValueError)
+    def test_enterprise_login_required_no_sso_provider(self, mock_registry):  # pylint: disable=unused-argument
+        """
+        Test that the enterprise login decorator calls the view function when no sso provider is configured.
+        """
+
+        view_function = mock_view_function()
+        course_id = 'course-v1:edX+DemoX+Demo_Course'
+        enterprise_dashboard_url = reverse(
+            'enterprise_course_enrollment_page',
+            args=[self.customer.uuid, course_id],
+        )
+        request = RequestFactory().get(enterprise_dashboard_url)
+        request.user = UserFactory(is_active=True)
+
+        enterprise_login_required(view_function)(
+            request, enterprise_uuid=self.customer.uuid, course_id=course_id
+        )
+
+        # Assert that view function was called.
+        assert view_function.called
+
+    @mock.patch('enterprise.utils.Registry')
+    def test_enterprise_login_required_with_drop_existing_session(self, mock_registry):
+        """
+        Test that the enterprise login decorator redirects authenticated users with the appropriate provider config.
+        """
+        mock_registry.get.return_value.configure_mock(provider_id=self.provider_id, drop_existing_session=True)
+        view_function = mock_view_function()
+        course_id = 'course-v1:edX+DemoX+Demo_Course'
+        enterprise_dashboard_url = reverse(
+            'enterprise_course_enrollment_page',
+            args=[self.customer.uuid, course_id],
+        )
+        request = RequestFactory().get(enterprise_dashboard_url)
+        request.user = UserFactory(is_active=True)
+
+        response = enterprise_login_required(view_function)(
+            request, enterprise_uuid=self.customer.uuid, course_id=course_id
+        )
+
+        # Assert that redirect status code 302 is returned when a logged in user comes in
+        # with an sso provider set to drop existing sessions
+        assert response.status_code == 302

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1598,8 +1598,7 @@ class TestCourseEnrollmentView(TestCase):
         response = self.client.get(enterprise_landing_page_url)
         expected_redirect_url = (
             '/login?next=%2Fenterprise%2F{enterprise_customer_uuid}%2Fcourse%2Fcourse-v1'
-            '%253AedX%252BDemoX%252BDemo_Course%2Fenroll%2F%3Ftpa_hint%3D{provider_id}'
-            '%26session_cleared%3Dyes'.format(
+            '%253AedX%252BDemoX%252BDemo_Course%2Fenroll%2F%3Ftpa_hint%3D{provider_id}'.format(
                 enterprise_customer_uuid=enterprise_customer.uuid,
                 provider_id=provider_id,
             )


### PR DESCRIPTION
**Description:** The first commit in this PR is a refactor which moves edx-enterprise decorators out of the enterprise.utils module and into an enterprise.decorators module. The second commit in this PR is a refactor of the work done in https://github.com/edx/edx-enterprise/pull/130. I have moved the session termination logic into its own decorator so that it can be applied to only the views that need it.

**JIRA:** https://openedx.atlassian.net/browse/ENT-454

**Dependencies:** None

**Merge deadline:** ASAP

**Installation instructions:** Standard Installation with this version of edx-enterprise.

**Testing instructions:**

1. Go to https://business.sandbox.edx.org/enterprise/2b5a2956-7746-4fc9-9587-bc887ba45973/course/course-v1:edX+DemoX+Demo_Course/enroll/ and register a new user, going through the normal flow until you get to the dashboard. You should be able to submit DSC consent after the course enrollment landing page without error. Do not log out.

3. Sign out of the user on the IdP or unlinking the first user from the IdP account, and revisit the page. It should redirect to the first user's account.

4. Change the Provider Configuration to enable drop existing session.

5. Revisit the page (if you have not logged out of the first account, otherwise repeat step 2 first). It should direct you to the account creation page as if you were a new user coming in. You should then be able to go through the normal flow as expected.

**Merge checklist:**

- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)

