### PR TITLE
ENT-471 Introducing waffle to enable configuration of sending SAP launchUrl

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.36.10] - 2017-06-29
+----------------------
+
+* Introducing SAP_USE_ENTERPRISE_ENROLLMENT_PAGE switch via django waffle.
+
 [0.36.9] - 2017-06-28
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.36.9"
+__version__ = "0.36.10"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/sap_success_factors/migrations/0006_sapsuccessfactors_use_enterprise_enrollment_page_waffle_flag.py
+++ b/integrated_channels/sap_success_factors/migrations/0006_sapsuccessfactors_use_enterprise_enrollment_page_waffle_flag.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+def create_switch(apps, schema_editor):
+    """Create and activate the SAP_USE_ENTERPRISE_ENROLLMENT_PAGE switch if it does not already exist."""
+    Switch = apps.get_model('waffle', 'Switch')
+    Switch.objects.get_or_create(name='SAP_USE_ENTERPRISE_ENROLLMENT_PAGE', defaults={'active': False})
+
+
+def delete_switch(apps, schema_editor):
+    """Delete the SAP_USE_ENTERPRISE_ENROLLMENT_PAGE switch."""
+    Switch = apps.get_model('waffle', 'Switch')
+    Switch.objects.filter(name='SAP_USE_ENTERPRISE_ENROLLMENT_PAGE').delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('sap_success_factors', '0005_historicalsapsuccessfactorsenterprisecustomerconfiguration_history_change_reason'),
+        ('waffle', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_switch, reverse_code=delete_switch),
+    ]

--- a/integrated_channels/sap_success_factors/utils.py
+++ b/integrated_channels/sap_success_factors/utils.py
@@ -11,16 +11,12 @@ from logging import getLogger
 from django.apps import apps
 from django.utils import timezone
 from six.moves.urllib.parse import urlencode, urlunparse  # pylint: disable=import-error,wrong-import-order
+from waffle import switch_is_active
 
 from enterprise.django_compatibility import reverse
 from enterprise.lms_api import parse_lms_api_datetime
 from enterprise.utils import safe_extract_key
 from integrated_channels.integrated_channel.course_metadata import BaseCourseExporter
-
-try:
-    from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
-except ImportError:
-    configuration_helpers = None
 
 
 LOGGER = getLogger(__name__)
@@ -288,7 +284,7 @@ def get_launch_url(enterprise_customer, course_id):
         enterprise_customer (EnterpriseCustomer): The EnterpriseCustomer that a URL needs to be built for
         course_id (str): The string identifier of the course in question
     """
-    if configuration_helpers and configuration_helpers.get_value('SAP_USE_ENTERPRISE_ENROLLMENT_PAGE'):
+    if switch_is_active('SAP_USE_ENTERPRISE_ENROLLMENT_PAGE'):
         return enterprise_customer.get_course_enrollment_url(course_id)
     return get_course_track_selection_url(enterprise_customer, course_id)
 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -16,3 +16,4 @@ django-object-actions                   # Object actions in Django admin
 edx-rest-api-client                     # For accessing the Enrollment API (and possibly other edX APIs)
 django-config-models==0.1.6
 requests                                # Required for SAPSuccessFactorsAPIClient
+django-waffle                           # Allows ability to add and control flags and switches for features

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,6 +15,7 @@ django-filter==0.15.3
 django-model-utils==3.0.0
 django-object-actions==0.10.0
 django-simple-history==1.9.0
+django-waffle==0.12.0
 django==1.10.7            # via django-config-models, django-model-utils, edx-drf-extensions
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework-oauth==1.1.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -18,6 +18,7 @@ django-filter==0.15.3
 django-model-utils==3.0.0
 django-object-actions==0.10.0
 django-simple-history==1.9.0
+django-waffle==0.12.0
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework-oauth==1.1.0
 djangorestframework==3.6.3

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
         "edx-drf-extensions",
         "Pillow>=3.1.1",
         "unicodecsv>=0.14.1",
+        "django-waffle",
     ],
     license="AGPL 3.0",
     zip_safe=False,

--- a/test_settings.py
+++ b/test_settings.py
@@ -34,6 +34,7 @@ INSTALLED_APPS = (
     "django.contrib.sessions",
     "django.contrib.admin",  # only used in DEBUG mode
     "django.contrib.messages",
+    "waffle",
 
     "enterprise",
     "integrated_channels.integrated_channel",

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -16,6 +16,7 @@ from integrated_channels.integrated_channel.learner_data import BaseLearnerExpor
 from integrated_channels.sap_success_factors.models import SAPSuccessFactorsEnterpriseCustomerConfiguration
 from pytest import mark, raises
 from requests.compat import urljoin
+from waffle.testutils import override_switch
 
 from django.core.management import call_command
 from django.core.management.base import CommandError
@@ -83,14 +84,13 @@ class TestTransmitCoursewareDataManagementCommand(unittest.TestCase):
 
 
 @mark.django_db
+@override_switch('SAP_USE_ENTERPRISE_ENROLLMENT_PAGE', active=True)
 @mock.patch('integrated_channels.sap_success_factors.utils.reverse')
 @mock.patch('integrated_channels.integrated_channel.course_metadata.CourseCatalogApiClient')
 @mock.patch('integrated_channels.sap_success_factors.transmitters.SAPSuccessFactorsAPIClient')
-@mock.patch('integrated_channels.sap_success_factors.utils.configuration_helpers')
 @mock.patch('enterprise.models.configuration_helpers')
 def test_transmit_courseware_task_success(
-        fake_config_helpers_1,
-        fake_config_helpers_2,
+        fake_config_helpers,
         fake_client,
         fake_catalog_client,
         track_selection_reverse_mock,
@@ -98,8 +98,7 @@ def test_transmit_courseware_task_success(
     """
     Test the data transmission task.
     """
-    fake_config_helpers_1.get_value.return_value = 'https://example.com'
-    fake_config_helpers_2.get_value.return_value = 1
+    fake_config_helpers.get_value.return_value = 'https://example.com'
     fake_client.get_oauth_access_token.return_value = "token", datetime.utcnow()
     fake_client.return_value.send_course_import.return_value = 200, '{}'
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -14,6 +14,7 @@ from integrated_channels.integrated_channel.course_metadata import BaseCourseExp
 from integrated_channels.sap_success_factors.models import SAPSuccessFactorsEnterpriseCustomerConfiguration
 from integrated_channels.sap_success_factors.utils import SapCourseExporter, get_launch_url
 from pytest import mark, raises
+from waffle.testutils import override_switch
 
 from django.core import mail
 from django.test import override_settings
@@ -1277,12 +1278,11 @@ class TestSAPSuccessFactorsUtils(unittest.TestCase):
         filtered_course_modes = filter_audit_course_modes(self.customer, course_modes)
         assert len(filtered_course_modes) == 5
 
-    @mock.patch('integrated_channels.sap_success_factors.utils.configuration_helpers')
+    @override_switch('SAP_USE_ENTERPRISE_ENROLLMENT_PAGE', active=True)
     @mock.patch('enterprise.models.configuration_helpers')
     def test_get_launch_url_flag_on(
             self,
-            mock_config_helpers_1,
-            mock_config_helpers_2):
+            mock_config_helpers_1):
         """
         Test `get_launch_url` helper method.
         """
@@ -1292,11 +1292,11 @@ class TestSAPSuccessFactorsUtils(unittest.TestCase):
         expected_url = ('https://www.example.com/enterprise/47432370-0a6e-4d95-90fe-77b4fe64de2c/course/'
                         'course-v1:edX+DemoX+Demo_Course/enroll/')
         enterprise_customer = EnterpriseCustomerFactory(uuid=enterprise_uuid)
-        mock_config_helpers_2.get_value.return_value = 1
 
         launch_url = get_launch_url(enterprise_customer, course_id)
         assert launch_url == expected_url
 
+    @override_switch('SAP_USE_ENTERPRISE_ENROLLMENT_PAGE', active=False)
     @mock.patch('integrated_channels.sap_success_factors.utils.reverse')
     def test_get_launch_url_flag_off(
             self,


### PR DESCRIPTION
**Description:** We attempted to use site configuration to decide which launchUrl to send to SAP, but that wasn't working because of the management command context that this code is run in. This PR introduces waffle so that we can use that to control the feature, and to use for future feature development.

**JIRA:** https://openedx.atlassian.net/browse/ENT-471

**Dependencies:** n/a

**Merge deadline:** ASAP

**Installation instructions:** 

**Testing instructions:**

Will fill out shortly.

**Merge checklist:**

- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
