### PR TITLE
ENT-472: Add page_size in querystring and Host in Header for aws gateway integration request.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ----------
 
+[0.38.5] - 2017-07-19
+---------------------
+
+* Add page_size in querystring and data mapping template to fix "next" and "previous" urls in API response.
+
+
 [0.38.4] - 2017-07-18
 ---------------------
 

--- a/api-compact.yaml
+++ b/api-compact.yaml
@@ -27,6 +27,45 @@ apigateway_responses: &apigateway_responses
   500:
     statusCode: "500"
 
+apigateway_responses_with_mapping_template: &apigateway_responses_with_mapping_template
+  default:
+    statusCode: "400"
+  200:
+    statusCode: "200"
+    responseTemplates:
+      # Response body mapping template, this template is used for updating
+      # "next" and "previous" urls (both host and url path) while preserving
+      # the protocol (http | https) and querystring parameters.
+      application/json: >
+        #set($inputRoot = $input.path('$'))
+        #set($host = $stageVariables.gateway_host)
+
+        #macro (updateURL $url)
+            #if($url != '') {
+                $url.replaceAll("(^https?://)[^/]*[^?]*(.*$)", "$1$host$context.resourcePath$2")
+            } #else {
+                none
+            }
+            #end
+        #end
+
+        {
+          "count": $inputRoot.count,
+          "next": "$updateURL$inputRoot.next",
+          "previous": "$updateURL$inputRoot.previous",
+          "results": $inputRoot.results,
+        }
+  401:
+    statusCode: "401"
+  403:
+    statusCode: "403"
+  404:
+    statusCode: "404"
+  429:
+    statusCode: "429"
+  500:
+    statusCode: "500"
+
 produces: &produces
   - "application/json"
   - "application/csv"
@@ -77,10 +116,16 @@ page_qs_parameter: &page_qs_parameter
   required: false
   type: "number"
 
+page_size_qs_parameter: &page_size_qs_parameter
+  in: "query"
+  name: "page_size"
+  required: false
+  type: "number"
+
 # AWS API Gateway vendor extension point. This information is used
 #  by https://github.com/awslabs/aws-apigateway-importer.
 x-amazon-apigateway-integration: &apigateway_integration
-  responses: *apigateway_responses
+  responses: *apigateway_responses_with_mapping_template
   httpMethod: "GET"
   type: "http"
   requestParameters:
@@ -88,6 +133,7 @@ x-amazon-apigateway-integration: &apigateway_integration
     integration.request.querystring.limit: "method.request.querystring.limit"
     integration.request.querystring.offset: "method.request.querystring.offset"
     integration.request.querystring.page: "method.request.querystring.page"
+    integration.request.querystring.page_size: "method.request.querystring.page_size"
 
 x-amazon-apigateway-integration-with-id: &apigateway_integration_with_id_parameter
   responses: *apigateway_responses
@@ -98,7 +144,7 @@ x-amazon-apigateway-integration-with-id: &apigateway_integration_with_id_paramet
     integration.request.path.id: "method.request.path.id"
 
 x-amazon-apigateway-integration-with-id-and-querystring-parameters: &apigateway_integration_with_id_and_querystring_parameters
-  responses: *apigateway_responses
+  responses: *apigateway_responses_with_mapping_template
   httpMethod: "GET"
   type: "http"
   requestParameters:
@@ -107,6 +153,7 @@ x-amazon-apigateway-integration-with-id-and-querystring-parameters: &apigateway_
     integration.request.querystring.limit: "method.request.querystring.limit"
     integration.request.querystring.offset: "method.request.querystring.offset"
     integration.request.querystring.page: "method.request.querystring.page"
+    integration.request.querystring.page_size: "method.request.querystring.page_size"
 
 endpoints:
   v1:
@@ -120,6 +167,7 @@ endpoints:
             - *limit_qs_parameter
             - *offset_qs_parameter
             - *page_qs_parameter
+            - *page_size_qs_parameter
           operationId: "get_enterprise_catalogs"
           responses: *responses
           x-amazon-apigateway-integration:
@@ -149,6 +197,7 @@ endpoints:
             - *limit_qs_parameter
             - *offset_qs_parameter
             - *page_qs_parameter
+            - *page_size_qs_parameter
           operationId: "get_enterprise_catalog_courses"
           responses: *responses
           x-amazon-apigateway-integration:

--- a/api.yaml
+++ b/api.yaml
@@ -17,6 +17,38 @@ apigateway_responses:
     statusCode: "500"
   default:
     statusCode: "400"
+apigateway_responses_with_mapping_template:
+  200:
+    responseTemplates:
+      application/json: |
+          #set($inputRoot = $input.path('$')) #set($host = $stageVariables.gateway_host)
+          #macro (updateURL $url)
+              #if($url != '') {
+                  $url.replaceAll("(^https?://)[^/]*[^?]*(.*$)", "$1$host$context.resourcePath$2")
+              } #else {
+                  none
+              }
+              #end
+          #end
+          {
+            "count": $inputRoot.count,
+            "next": "$updateURL$inputRoot.next",
+            "previous": "$updateURL$inputRoot.previous",
+            "results" : $inputRoot.results,
+          }
+    statusCode: "200"
+  401:
+    statusCode: "401"
+  403:
+    statusCode: "403"
+  404:
+    statusCode: "404"
+  429:
+    statusCode: "429"
+  500:
+    statusCode: "500"
+  default:
+    statusCode: "400"
 auth_header:
   in: header
   name: Authorization
@@ -107,6 +139,11 @@ endpoints:
             name: page
             required: false
             type: number
+          -
+            in: query
+            name: page_size
+            required: false
+            type: number
         produces:
           - application/json
           - application/csv
@@ -133,8 +170,26 @@ endpoints:
             integration.request.querystring.limit: method.request.querystring.limit
             integration.request.querystring.offset: method.request.querystring.offset
             integration.request.querystring.page: method.request.querystring.page
+            integration.request.querystring.page_size: method.request.querystring.page_size
           responses:
             200:
+              responseTemplates:
+                application/json: |
+                    #set($inputRoot = $input.path('$')) #set($host = $stageVariables.gateway_host)
+                    #macro (updateURL $url)
+                        #if($url != '') {
+                            $url.replaceAll("(^https?://)[^/]*[^?]*(.*$)", "$1$host$context.resourcePath$2")
+                        } #else {
+                            none
+                        }
+                        #end
+                    #end
+                    {
+                      "count": $inputRoot.count,
+                      "next": "$updateURL$inputRoot.next",
+                      "previous": "$updateURL$inputRoot.previous",
+                      "results" : $inputRoot.results,
+                    }
               statusCode: "200"
             401:
               statusCode: "401"
@@ -174,6 +229,11 @@ endpoints:
             name: page
             required: false
             type: number
+          -
+            in: query
+            name: page_size
+            required: false
+            type: number
         produces:
           - application/json
           - application/csv
@@ -199,8 +259,26 @@ endpoints:
             integration.request.querystring.limit: method.request.querystring.limit
             integration.request.querystring.offset: method.request.querystring.offset
             integration.request.querystring.page: method.request.querystring.page
+            integration.request.querystring.page_size: method.request.querystring.page_size
           responses:
             200:
+              responseTemplates:
+                application/json: |
+                    #set($inputRoot = $input.path('$')) #set($host = $stageVariables.gateway_host)
+                    #macro (updateURL $url)
+                        #if($url != '') {
+                            $url.replaceAll("(^https?://)[^/]*[^?]*(.*$)", "$1$host$context.resourcePath$2")
+                        } #else {
+                            none
+                        }
+                        #end
+                    #end
+                    {
+                      "count": $inputRoot.count,
+                      "next": "$updateURL$inputRoot.next",
+                      "previous": "$updateURL$inputRoot.previous",
+                      "results" : $inputRoot.results,
+                    }
               statusCode: "200"
             401:
               statusCode: "401"
@@ -236,6 +314,11 @@ page_qs_parameter:
   name: page
   required: false
   type: number
+page_size_qs_parameter:
+  in: query
+  name: page_size
+  required: false
+  type: number
 produces:
   - application/json
   - application/csv
@@ -261,8 +344,26 @@ x-amazon-apigateway-integration:
     integration.request.querystring.limit: method.request.querystring.limit
     integration.request.querystring.offset: method.request.querystring.offset
     integration.request.querystring.page: method.request.querystring.page
+    integration.request.querystring.page_size: method.request.querystring.page_size
   responses:
     200:
+      responseTemplates:
+        application/json: |
+            #set($inputRoot = $input.path('$')) #set($host = $stageVariables.gateway_host)
+            #macro (updateURL $url)
+                #if($url != '') {
+                    $url.replaceAll("(^https?://)[^/]*[^?]*(.*$)", "$1$host$context.resourcePath$2")
+                } #else {
+                    none
+                }
+                #end
+            #end
+            {
+              "count": $inputRoot.count,
+              "next": "$updateURL$inputRoot.next",
+              "previous": "$updateURL$inputRoot.previous",
+              "results" : $inputRoot.results,
+            }
       statusCode: "200"
     401:
       statusCode: "401"
@@ -306,8 +407,26 @@ x-amazon-apigateway-integration-with-id-and-querystring-parameters:
     integration.request.querystring.limit: method.request.querystring.limit
     integration.request.querystring.offset: method.request.querystring.offset
     integration.request.querystring.page: method.request.querystring.page
+    integration.request.querystring.page_size: method.request.querystring.page_size
   responses:
     200:
+      responseTemplates:
+        application/json: |
+            #set($inputRoot = $input.path('$')) #set($host = $stageVariables.gateway_host)
+            #macro (updateURL $url)
+                #if($url != '') {
+                    $url.replaceAll("(^https?://)[^/]*[^?]*(.*$)", "$1$host$context.resourcePath$2")
+                } #else {
+                    none
+                }
+                #end
+            #end
+            {
+              "count": $inputRoot.count,
+              "next": "$updateURL$inputRoot.next",
+              "previous": "$updateURL$inputRoot.previous",
+              "results" : $inputRoot.results,
+            }
       statusCode: "200"
     401:
       statusCode: "401"

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.38.4"
+__version__ = "0.38.5"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name


### PR DESCRIPTION

**Description:** 
The Enterprise Service returns a "next" field in the case of a large response which requires pagination. This field contains a fully-qualified URL specifying the service host (eg, courses.edx.org), which makes sense for clients interacting directly with the service.
However, this breaks down for clients interacting with the Enterprise Service via the API Gateway. In this case, the "next" parameter must NOT specify the service host, it must instead specify the gateway host (api.gateway.com).

**JIRA:** [ENT-472](https://openedx.atlassian.net/browse/ENT-472)

**Merge checklist:**

- [x] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [x] Translations are updated
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
