### PR TITLE
ENT-476 New enterprise endpoint for courses by enterprise

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.39.2] - 2017-07-27
+---------------------
+
+* Introduce new endpoint to the Enterprise API to query for courses by enterprise id.
+
 [0.39.1] - 2017-07-27
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.39.1"
+__version__ = "0.39.2"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/permissions.py
+++ b/enterprise/api/permissions.py
@@ -3,9 +3,14 @@ Permission classes for the Enterprise API.
 """
 from __future__ import absolute_import, unicode_literals
 
+from logging import getLogger
+
 from rest_framework import permissions
 
 from enterprise.api.utils import get_service_usernames
+from enterprise.models import EnterpriseCustomerUser
+
+logger = getLogger(__name__)  # pylint: disable=invalid-name
 
 
 class IsServiceUserOrReadOnly(permissions.IsAuthenticated):
@@ -24,3 +29,35 @@ class IsServiceUserOrReadOnly(permissions.IsAuthenticated):
             request.method in permissions.SAFE_METHODS or
             request.user.username in service_users
         )
+
+
+class IsStaffUserOrLinkedToEnterprise(permissions.IsAuthenticated):
+    """
+    This request is authenticated as a staff user, or as a user who is linked to the Enterprise Customer.
+    """
+
+    message = 'User must be a staff user or associated with the specified Enterprise.'
+
+    def has_object_permission(self, request, view, obj):
+        """
+        Enforce that the user is authenticated. If the user isn't a staff user, or isn't linked to the
+        Enterprise Customer as an Enterprise Customer user, deny the request.
+        The obj argument is expected to be an Enterprise Customer.
+        """
+
+        if not request.user.is_staff and not EnterpriseCustomerUser.objects.filter(
+                enterprise_customer=obj,
+                user_id=request.user.id,
+        ).exists():
+            error_message = (
+                "User '{username}' is not a staff user, and is not associated with "
+                "Enterprise {enterprise_name} from endpoint '{path}'.".format(
+                    username=request.user.username,
+                    enterprise_name=obj.name,
+                    path=request.get_full_path()
+                )
+            )
+            logger.error(error_message)
+            return False
+
+        return True

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -194,7 +194,6 @@ class EnterpriseCustomer(TimeStampedModel):
             course_run_key (str): The course run id for the course to be displayed.
         Returns:
             (str): Enterprise landing page url.
-
         """
         if configuration_helpers is None:
             raise NotConnectedToOpenEdX(


### PR DESCRIPTION
**Description:** The previous iteration of this endpoint took a catalog id, inferred the enterprise customer based on that catalog, and if the request user was not an EnterpriseCustomerUser associated with that enterprise, then there would be a permissions error.

This new endpoint will pull the courses in the catalog linked to the provided enterprise, which is explicitly stated in the call. There will be appropriate responses if:
*there is no catalog linked to the given enterprise
*if the request user is neither staff nor associated with the enterprise
*if the catalog api returns an empty response (different than having no courses)

On success, it will return the catalog api courses response format with augmented enterprise specific data as the earlier endpoint did.

**JIRA:** https://openedx.atlassian.net/browse/ENT-476

**Dependencies:** https://github.com/edx/edx-enterprise/pull/107 was the previous iteration of this.

**Merge deadline:** 

**Installation instructions:** 

**Testing instructions:**
Using the business sandbox (https://business.sandbox.edx.org), do the following.

_with staff user_
1. Obtain an access token for the staff user (ask me for the client id and secret)
`$ curl -X POST -d 'grant_type=client_credentials&client_id=***&client_secret=***&token_type=jwt' -H 'content-type: application/x-www-form-urlencoded' https://business.sandbox.edx.org/oauth2/access_token/`

2. Using the token obtained above, hit the endpoint for the configured Pied Piper enterprise customer. The response should be identical to hitting the courses endpoint for the catalog attached (should be catalog 1):
`$ curl -X GET \
  https://business.sandbox.edx.org/enterprise/api/v1/enterprise-customer/2b5a2956-7746-4fc9-9587-bc887ba45973/courses \
  -H 'authorization: JWT eyJhbGciOiJIUzI1NiJ9.eyJzY29wZXMiOiBbInJlYWQiLCAid3JpdGUiLCAicHJvZmlsZSIsICJlbWFpbCJdLCAiYWRtaW5pc3RyYXRvciI6IHRydWUsICJhdWQiOiAibG1zLWtleSIsICJmYW1pbHlfbmFtZSI6ICIiLCAiaXNzIjogImh0dHBzOi8vYnVzaW5lc3Muc2FuZGJveC5lZHgub3JnL29hdXRoMiIsICJwcmVmZXJyZWRfdXNlcm5hbWUiOiAic3RhZmYiLCAibmFtZSI6ICIiLCAiZ2l2ZW5fbmFtZSI6ICIiLCAiZXhwIjogMTUwMDY5NDM5OCwgImlhdCI6IDE1MDA2NTgzOTgsICJlbWFpbCI6ICJzdGFmZkBleGFtcGxlLmNvbSIsICJzdWIiOiAiMTA2ZWNkODc4ZjQxNDhhNWNhYmI2YmJiMDk3OWI3MzAifQ.NTgkSlUlqY3UxJAX17NPBac15qqJq5DoQ64JQ-3j2YE' \`

_with bexline_api_user_
I set this user up as a non staff user to test the permissions aspect of this endpoint.

1. Ensure that the user is not an enterprise customer user attached to Pied Piper. If they are, remove the association in django admin.
2. Execute the above steps with the user's client and secret (ask me). Observe that you get an error indicating not having access to this enterprise's data.
3. Go into django admin and add bexline_api_user as an enterprise customer user for Pied Piper.
4. Execute the above steps again, observe that you get the catalog courses response.

Note that there appears to be throttling on the catalog endpoint so sometimes there will be responses that indicate that the data is unavailable - if you encounter this wait a few minutes before trying again.

**Merge checklist:**

- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [ ] Translations are updated
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
