### PR TITLE
Fix requirements installation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.38.3] - 2017-07-14
+---------------------
+
+* Fix dependency installation process in setup.py.
+
 [0.38.2] - 2017-07-14
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.38.2"
+__version__ = "0.38.3"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ base_path = os.path.dirname(__file__)
 
 README = open(os.path.join(base_path, "README.rst")).read()
 CHANGELOG = open(os.path.join(base_path, "CHANGELOG.rst")).read()
-REQUIREMENTS = open(os.path.join(base_path, 'requirements', 'base.txt'))
+REQUIREMENTS = open(os.path.join(base_path, 'requirements', 'base.txt')).read().splitlines()
 
 setup(
     name="edx-enterprise",


### PR DESCRIPTION
**Description:**

Due to a failure to think properly on my part, the current version of edx-enterprise does not actually install its requirements - rather than having a list of requirements, it has an open file pointer to the relevant requirements file. This change fixes that.

**Merge deadline:** ASAP

**Testing instructions:**

1. Checkout this version, and then, in a clean virtual environment, do `pip install /path/to/enterprise/repo`. Verify that in addition to `edx-enterprise`, `django-object-actions` and `django-waffle` are installed.

**Merge checklist:**

- [x] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [x] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [x] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [x] All reviewers approved
- [ ] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [x] Translations are updated
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)
