### PR TITLE
ENT-472: Remove Macro use from swagger api config as it is not supported by AWS.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.39.3] - 2017-07-28
+---------------------
+
+* Remove Macro use from swagger api config as it is not supported by AWS.
+
 [0.39.2] - 2017-07-27
 ---------------------
 

--- a/api-compact.yaml
+++ b/api-compact.yaml
@@ -39,21 +39,17 @@ apigateway_responses_with_mapping_template: &apigateway_responses_with_mapping_t
       application/json: >
         #set($inputRoot = $input.path('$'))
         #set($host = $stageVariables.gateway_host)
+        #set($catalogId = $input.params('id'))
 
-        #macro (updateURL $url)
-            #if($url != '') {
-                $url.replaceAll("(^https?://)[^/]*[^?]*(.*$)", "$1$host$context.resourcePath$2")
-            } #else {
-                none
-            }
-            #end
-        #end
+        #set($URLMatchRegex = "(^https?://)[^/]*[^?]*(.*$)")
+        #set($updatedURL = "$1$host$context.resourcePath$2")
+        #set($resourceIdMatch = "{id}")
 
         {
           "count": $inputRoot.count,
-          "next": "$updateURL$inputRoot.next",
-          "previous": "$updateURL$inputRoot.previous",
-          "results": $inputRoot.results,
+          "next": "$inputRoot.next.replaceAll($URLMatchRegex, $updatedURL).replace($resourceIdMatch, $catalogId)",
+          "previous": "$inputRoot.previous.replaceAll($URLMatchRegex, $updatedURL).replace($resourceIdMatch, $catalogId)",
+          "results": $inputRoot.results
         }
   401:
     statusCode: "401"

--- a/api.yaml
+++ b/api.yaml
@@ -21,20 +21,13 @@ apigateway_responses_with_mapping_template:
   200:
     responseTemplates:
       application/json: |
-          #set($inputRoot = $input.path('$')) #set($host = $stageVariables.gateway_host)
-          #macro (updateURL $url)
-              #if($url != '') {
-                  $url.replaceAll("(^https?://)[^/]*[^?]*(.*$)", "$1$host$context.resourcePath$2")
-              } #else {
-                  none
-              }
-              #end
-          #end
+          #set($inputRoot = $input.path('$')) #set($host = $stageVariables.gateway_host) #set($catalogId = $input.params('id'))
+          #set($URLMatchRegex = "(^https?://)[^/]*[^?]*(.*$)") #set($updatedURL = "$1$host$context.resourcePath$2") #set($resourceIdMatch = "{id}")
           {
             "count": $inputRoot.count,
-            "next": "$updateURL$inputRoot.next",
-            "previous": "$updateURL$inputRoot.previous",
-            "results" : $inputRoot.results,
+            "next": "$inputRoot.next.replaceAll($URLMatchRegex, $updatedURL).replace($resourceIdMatch, $catalogId)",
+            "previous": "$inputRoot.previous.replaceAll($URLMatchRegex, $updatedURL).replace($resourceIdMatch, $catalogId)",
+            "results": $inputRoot.results
           }
     statusCode: "200"
   401:
@@ -175,20 +168,13 @@ endpoints:
             200:
               responseTemplates:
                 application/json: |
-                    #set($inputRoot = $input.path('$')) #set($host = $stageVariables.gateway_host)
-                    #macro (updateURL $url)
-                        #if($url != '') {
-                            $url.replaceAll("(^https?://)[^/]*[^?]*(.*$)", "$1$host$context.resourcePath$2")
-                        } #else {
-                            none
-                        }
-                        #end
-                    #end
+                    #set($inputRoot = $input.path('$')) #set($host = $stageVariables.gateway_host) #set($catalogId = $input.params('id'))
+                    #set($URLMatchRegex = "(^https?://)[^/]*[^?]*(.*$)") #set($updatedURL = "$1$host$context.resourcePath$2") #set($resourceIdMatch = "{id}")
                     {
                       "count": $inputRoot.count,
-                      "next": "$updateURL$inputRoot.next",
-                      "previous": "$updateURL$inputRoot.previous",
-                      "results" : $inputRoot.results,
+                      "next": "$inputRoot.next.replaceAll($URLMatchRegex, $updatedURL).replace($resourceIdMatch, $catalogId)",
+                      "previous": "$inputRoot.previous.replaceAll($URLMatchRegex, $updatedURL).replace($resourceIdMatch, $catalogId)",
+                      "results": $inputRoot.results
                     }
               statusCode: "200"
             401:
@@ -264,20 +250,13 @@ endpoints:
             200:
               responseTemplates:
                 application/json: |
-                    #set($inputRoot = $input.path('$')) #set($host = $stageVariables.gateway_host)
-                    #macro (updateURL $url)
-                        #if($url != '') {
-                            $url.replaceAll("(^https?://)[^/]*[^?]*(.*$)", "$1$host$context.resourcePath$2")
-                        } #else {
-                            none
-                        }
-                        #end
-                    #end
+                    #set($inputRoot = $input.path('$')) #set($host = $stageVariables.gateway_host) #set($catalogId = $input.params('id'))
+                    #set($URLMatchRegex = "(^https?://)[^/]*[^?]*(.*$)") #set($updatedURL = "$1$host$context.resourcePath$2") #set($resourceIdMatch = "{id}")
                     {
                       "count": $inputRoot.count,
-                      "next": "$updateURL$inputRoot.next",
-                      "previous": "$updateURL$inputRoot.previous",
-                      "results" : $inputRoot.results,
+                      "next": "$inputRoot.next.replaceAll($URLMatchRegex, $updatedURL).replace($resourceIdMatch, $catalogId)",
+                      "previous": "$inputRoot.previous.replaceAll($URLMatchRegex, $updatedURL).replace($resourceIdMatch, $catalogId)",
+                      "results": $inputRoot.results
                     }
               statusCode: "200"
             401:
@@ -349,20 +328,13 @@ x-amazon-apigateway-integration:
     200:
       responseTemplates:
         application/json: |
-            #set($inputRoot = $input.path('$')) #set($host = $stageVariables.gateway_host)
-            #macro (updateURL $url)
-                #if($url != '') {
-                    $url.replaceAll("(^https?://)[^/]*[^?]*(.*$)", "$1$host$context.resourcePath$2")
-                } #else {
-                    none
-                }
-                #end
-            #end
+            #set($inputRoot = $input.path('$')) #set($host = $stageVariables.gateway_host) #set($catalogId = $input.params('id'))
+            #set($URLMatchRegex = "(^https?://)[^/]*[^?]*(.*$)") #set($updatedURL = "$1$host$context.resourcePath$2") #set($resourceIdMatch = "{id}")
             {
               "count": $inputRoot.count,
-              "next": "$updateURL$inputRoot.next",
-              "previous": "$updateURL$inputRoot.previous",
-              "results" : $inputRoot.results,
+              "next": "$inputRoot.next.replaceAll($URLMatchRegex, $updatedURL).replace($resourceIdMatch, $catalogId)",
+              "previous": "$inputRoot.previous.replaceAll($URLMatchRegex, $updatedURL).replace($resourceIdMatch, $catalogId)",
+              "results": $inputRoot.results
             }
       statusCode: "200"
     401:
@@ -412,20 +384,13 @@ x-amazon-apigateway-integration-with-id-and-querystring-parameters:
     200:
       responseTemplates:
         application/json: |
-            #set($inputRoot = $input.path('$')) #set($host = $stageVariables.gateway_host)
-            #macro (updateURL $url)
-                #if($url != '') {
-                    $url.replaceAll("(^https?://)[^/]*[^?]*(.*$)", "$1$host$context.resourcePath$2")
-                } #else {
-                    none
-                }
-                #end
-            #end
+            #set($inputRoot = $input.path('$')) #set($host = $stageVariables.gateway_host) #set($catalogId = $input.params('id'))
+            #set($URLMatchRegex = "(^https?://)[^/]*[^?]*(.*$)") #set($updatedURL = "$1$host$context.resourcePath$2") #set($resourceIdMatch = "{id}")
             {
               "count": $inputRoot.count,
-              "next": "$updateURL$inputRoot.next",
-              "previous": "$updateURL$inputRoot.previous",
-              "results" : $inputRoot.results,
+              "next": "$inputRoot.next.replaceAll($URLMatchRegex, $updatedURL).replace($resourceIdMatch, $catalogId)",
+              "previous": "$inputRoot.previous.replaceAll($URLMatchRegex, $updatedURL).replace($resourceIdMatch, $catalogId)",
+              "results": $inputRoot.results
             }
       statusCode: "200"
     401:

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.39.2"
+__version__ = "0.39.3"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name


### PR DESCRIPTION
**Description:** I have removed usages of VTL macros as they are not supported by AWS API Gateway.

**JIRA:** [ENT-472](https://openedx.atlassian.net/browse/ENT-472)

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**
1. Execute the following to get JWT access token.
    `curl -H "Content-Type:application/x-www-form-urlencoded" -X POST -d "grant_type=client_credentials&client_id=<client-id>&client_secret=<client-secret>&token_type=jwt" "https://api.stage.edx.org/oauth2/v1/access_token"`
2. Execute to get the catalogs
    `curl -H "Authorization:JWT <jwt-token>"  -X GET "https://20enjrmi05.execute-api.us-west-2.amazonaws.com/edx_api/enterprise/v1/catalogs?limit=2&offset=2"`
3. Make sure `next` and `previous` in response has correct domain i.e. `20enjrmi05.execute-api.us-west-2.amazonaws.com` and correct path i.e. `/edx_api/enterprise/v1/catalogs`

**Merge checklist:**

- [x] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [x] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [x] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [x] Translations are updated
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Dependencies:** This PR can be tested when [ENT-554](https://openedx.atlassian.net/browse/ENT-554) is fixed. I will update testing instructions when bug is fixed and we able to test endpoint for `/enterprise/v1/catalogs/{id}/courses/`