### PR TITLE
ENT-492 Properly make the consent package installable by PyPI

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.39.0] - 2017-07-24
+---------------------
+
+* Officially include Consent application by ensuring it is installable.
+
 [0.38.7] - 2017-07-22
 ---------------------
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,4 +5,5 @@ include LICENSE.txt
 include README.rst
 recursive-include enterprise *.html *.png *.gif *js *.css *jpg *jpeg *svg *py *.txt
 recursive-include integrated_channels *.html *.png *.gif *js *.css *jpg *jpeg *svg *py *.txt
+recursive-include consent *.html *.png *.gif *js *.css *jpg *jpeg *svg *py *.txt
 recursive-include requirements *.txt

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.38.7"
+__version__ = "0.39.0"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name


### PR DESCRIPTION
**Description:** Fixes error where deploying latest version of enterprise causes requests to the application to 500.

**JIRA:** 

**Dependencies:** 

**Merge deadline:** ASAP

**Installation instructions:** 

**Testing instructions:**

1. Install the previous version of enterprise, observe that all requests 500 due to an import error.
2. Install this version of enterprise, observe that requests are returning normally.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** 
