### PR TITLE
ENT-554: Fix 500 errors on catalog courses API endpoint for users that are not associated with any enterprise customer.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.39.1] - 2017-07-27
+---------------------
+
+* Ensure catalog courses API endpoint users are associated with an EnterpriseCustomer.
+
 [0.39.0] - 2017-07-24
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.39.0"
+__version__ = "0.39.1"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/v1/decorators.py
+++ b/enterprise/api/v1/decorators.py
@@ -1,0 +1,51 @@
+"""
+Decorators for Enterprise API views.
+"""
+from __future__ import absolute_import, unicode_literals
+
+from functools import wraps
+
+from rest_framework.exceptions import PermissionDenied
+
+from enterprise.utils import get_enterprise_customer_for_user
+
+
+def enterprise_customer_required(view):
+    """
+    Ensure the user making the API request is associated with an EnterpriseCustomer.
+
+    This decorator attempts to find an EnterpriseCustomer associated with the requesting
+    user and passes that EnterpriseCustomer to the view as a parameter. It will return a
+    PermissionDenied error if an EnterpriseCustomer cannot be found.
+
+    Usage::
+        @enterprise_customer_required()
+        def my_view(request, enterprise_customer):
+            # Some functionality ...
+
+        OR
+
+        class MyView(View):
+            ...
+            @method_decorator(enterprise_customer_required)
+            def get(self, request, enterprise_customer):
+                # Some functionality ...
+    """
+    @wraps(view)
+    def wrapper(request, *args, **kwargs):
+        """
+        Checks for an enterprise customer associated with the user, calls the view function
+        if one exists, raises PermissionDenied if not.
+        """
+        user = request.user
+        enterprise_customer = get_enterprise_customer_for_user(user)
+        if enterprise_customer:
+            args = args + (enterprise_customer,)
+            return view(request, *args, **kwargs)
+        else:
+            raise PermissionDenied(
+                'User {username} is not associated with an EnterpriseCustomer.'.format(
+                    username=user.username
+                )
+            )
+    return wrapper

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -278,7 +278,7 @@ class EnterpriseCatalogCoursesReadOnlySerializer(serializers.Serializer):
     previous = serializers.CharField(read_only=True, help_text=_("URL to fetch previous page of courses."))
     results = serializers.ListField(read_only=True, help_text=_("list of courses."))
 
-    def update_enterprise_courses(self, request, catalog_id):
+    def update_enterprise_courses(self, enterprise_customer, catalog_id):
         """
         This method adds enterprise specific metadata for each course.
 
@@ -286,7 +286,6 @@ class EnterpriseCatalogCoursesReadOnlySerializer(serializers.Serializer):
             tpa_hint: a string for identifying Identity Provider.
         """
         courses = []
-        enterprise_customer = utils.get_enterprise_customer_for_user(request.user)
 
         global_context = {
             'tpa_hint': enterprise_customer and enterprise_customer.identity_provider,

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -14,13 +14,14 @@ from rest_framework.response import Response
 
 from django.contrib.auth.models import User
 from django.contrib.sites.models import Site
+from django.utils.decorators import method_decorator
 
 from enterprise import models
 from enterprise.api.filters import EnterpriseCustomerUserFilterBackend
 from enterprise.api.pagination import get_paginated_response
 from enterprise.api.permissions import IsServiceUserOrReadOnly
 from enterprise.api.throttles import ServiceUserThrottle
-from enterprise.api.v1 import serializers
+from enterprise.api.v1 import decorators, serializers
 from enterprise.course_catalog_api import CourseCatalogApiClient
 
 logger = getLogger(__name__)  # pylint: disable=invalid-name
@@ -248,8 +249,9 @@ class EnterpriseCatalogViewSet(viewsets.ViewSet):
         serializer = self.serializer_class(catalog)
         return Response(serializer.data)
 
+    @method_decorator(decorators.enterprise_customer_required)
     @detail_route()
-    def courses(self, request, pk=None):  # pylint: disable=invalid-name
+    def courses(self, request, enterprise_customer, pk=None):  # pylint: disable=invalid-name
         """
         Retrieve the list of courses contained within this catalog.
 
@@ -273,5 +275,5 @@ class EnterpriseCatalogViewSet(viewsets.ViewSet):
         serializer = serializers.EnterpriseCatalogCoursesReadOnlySerializer(courses)
 
         # Add enterprise related context for the courses.
-        serializer.update_enterprise_courses(request, pk)
+        serializer.update_enterprise_courses(enterprise_customer, pk)
         return get_paginated_response(serializer.data, request)

--- a/tests/test_enterprise/api/test_decorators.py
+++ b/tests/test_enterprise/api/test_decorators.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for the `edx-enterprise` api decorators module.
+"""
+from __future__ import absolute_import, unicode_literals
+
+import unittest
+from importlib import import_module
+
+from faker import Factory as FakerFactory
+from pytest import mark, raises
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.reverse import reverse
+
+from django.conf import settings
+from django.test import RequestFactory
+
+from enterprise.api.v1.decorators import enterprise_customer_required
+from test_utils import mock_view_function
+from test_utils.factories import EnterpriseCustomerFactory, EnterpriseCustomerUserFactory, UserFactory
+
+
+@mark.django_db
+class TestEnterpriseAPIDecorators(unittest.TestCase):
+    """
+    Tests for enterprise API decorators.
+    """
+    def setUp(self):
+        """
+        Set up test environment.
+        """
+        super(TestEnterpriseAPIDecorators, self).setUp()
+        faker = FakerFactory.create()
+        self.provider_id = faker.slug()  # pylint: disable=no-member
+        self.uuid = faker.uuid4()  # pylint: disable=no-member
+        self.customer = EnterpriseCustomerFactory(uuid=self.uuid)
+        self.user = UserFactory()
+        self.session_engine = import_module(settings.SESSION_ENGINE)
+
+    def _prepare_request(self, url, user):
+        """
+        Prepare request for test.
+        """
+        request = RequestFactory().get(url)
+        request.user = user
+        session_key = request.COOKIES.get(settings.SESSION_COOKIE_NAME)
+        request.session = self.session_engine.SessionStore(session_key)
+        return request
+
+    def test_enterprise_customer_required_raises_403(self):
+        """
+        Test that the decorator `enterprise_customer_required` raises
+        PermissionDenied if the current user is not associated with
+        an EnterpriseCustomer.
+        """
+        view_function = mock_view_function()
+        url = reverse('catalogs-courses', (1, ))
+        request = self._prepare_request(url, self.user)
+
+        with raises(PermissionDenied):
+            enterprise_customer_required(view_function)(request)
+
+    def test_enterprise_customer_required_calls_view(self):
+        """
+        Test that the decorator `enterprise_customer_required` calls
+        the decorated function if the current user is associated
+        with an EnterpriseCustomer and passes the EnterpriseCustomer
+        to the decorated function.
+        """
+        view_function = mock_view_function()
+        url = reverse('catalogs-courses', (1,))
+        request = self._prepare_request(url, self.user)
+        EnterpriseCustomerUserFactory(
+            user_id=self.user.id,
+            enterprise_customer=self.customer,
+        )
+
+        enterprise_customer_required(view_function)(request)
+
+        call_args, __ = view_function.call_args  # pylint: disable=unpacking-non-sequence
+        assert str(call_args[1].uuid) == str(self.customer.uuid)

--- a/tests/test_enterprise/api/test_serializers.py
+++ b/tests/test_enterprise/api/test_serializers.py
@@ -519,7 +519,7 @@ class TestEnterpriseCatalogCoursesSerializer(APITest):
         serializer data successfully without errors.
         """
         mock_config_helpers.get_value.return_value = ''
-        self.serializer.update_enterprise_courses(self.request, 1)
+        self.serializer.update_enterprise_courses(self.ecu.enterprise_customer, 1)
 
         # Make sure global context passed in to update_course is added to the course.
         assert all('tpa_hint' in course for course in self.serializer.data['results'])

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -689,3 +689,18 @@ class TestEnterpriseCatalogAPIViews(APITest):
             response = self.load_json(response.content)
 
             assert response == expected
+
+    def test_enterprise_catalog_courses_unauthorized(self):
+        """
+        Make sure enterprise catalog view returns correct data.
+        Arguments:
+            mocked_catalog_courses: This is used to mock catalog courses returned by catalog api.
+            expected: This is the expected catalog courses from enterprise api.
+        """
+        response = self.client.get(reverse('catalogs-courses', (1,)))
+        response_content = self.load_json(response.content)
+
+        assert response.status_code == 403
+        assert response_content['detail'] == 'User {username} is not associated with an EnterpriseCustomer.'.format(
+            username=self.user.username
+        )


### PR DESCRIPTION
**Description:** 
If a client tries to access catalog courses through enterprise API, and the user associated with the request is not associated with any enterprise customer then the API returns a `500` error. This PR fixes that issue, now for API request with users not associated with any enterprise customer API will return a response with `200` status instead of `500`. 

**JIRA:** [ENT-554](https://openedx.atlassian.net/browse/ENT-554)

**Testing instructions:**

1. Fetch catalog courses via `http://localhost:8000/enterprise/api/v1/catalogs/{id}/courses/` request should be made using JWT credentials, use client-id and client-secret for a user that is not associated with any enterprise customer.
2. Catalog courses endpoint should return a proper response with `200` status code.

**Merge checklist:**

- [x] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [x] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [x] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] All reviewers approved
- [ ] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [x] Translations are updated
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)
