### PR TITLE
[ENT-341] Update requirements and add geckodriver for new Jasmine.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ log/
 logs/
 chromedriver.log
 ghostdriver.log
+geckodriver.log
 
 # Complexity
 output/*.html

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,17 @@ matrix:
     - python: 2.7
       env:
         - TOXENV=jasmine
+      before_install:
+        - wget https://github.com/mozilla/geckodriver/releases/download/v0.11.1/geckodriver-v0.11.1-linux64.tar.gz
+        - mkdir geckodriver
+        - tar -xzf geckodriver-v0.11.1-linux64.tar.gz -C geckodriver
+        - export PATH=$PATH:$PWD/geckodriver
       before_script:
         - "export DISPLAY=:99.0"
         - "sh -e /etc/init.d/xvfb start"
         - sleep 3 # give xvfb some time to start
       addons:
-        firefox: "45.0"
+        firefox: "49.0.2"
     - python: 2.7
       env:
         - RUNJSHINT=true

--- a/requirements/js_test.txt
+++ b/requirements/js_test.txt
@@ -5,18 +5,17 @@
 #    pip-compile --output-file requirements/js_test.txt requirements/js_test.in
 #
 argparse==1.4.0           # via jasmine
-chardet==2.3              # via jasmine
-cherrypy==3.8.2           # via jasmine
-click==6.7                # via flask
-flask==0.12.2             # via jasmine
+cheroot==5.8.0            # via cherrypy
+cherrypy==11.0.0          # via jasmine
 glob2==0.5                # via jasmine-core
-itsdangerous==0.24        # via flask
-jasmine-core==2.6.4       # via jasmine
-jasmine==2.6.0
-jinja2==2.9.6             # via flask, jasmine
+jasmine-core==2.7.0       # via jasmine
+jasmine==2.7.0
+jinja2==2.9.6             # via jasmine
 markupsafe==1.0           # via jinja2
 ordereddict==1.1          # via jasmine-core
+portend==2.1.2            # via cherrypy
+pytz==2017.2              # via tempora
 pyyaml==3.10              # via jasmine
-selenium==2.53.6          # via jasmine
-six==1.10.0               # via jasmine
-werkzeug==0.11.1          # via flask, jasmine
+selenium==3.4.3           # via jasmine
+six==1.10.0               # via cheroot, cherrypy, jasmine, tempora
+tempora==1.8              # via portend

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -44,7 +44,7 @@ edx-lint==0.5.4
 edx-rest-api-client==1.7.1
 edx-sphinx-theme==1.2.0
 enum34==1.1.6             # via astroid
-factory-boy==2.8.1
+factory-boy==2.9.1
 faker==0.7.18             # via factory-boy
 first==2.0.1              # via pip-tools
 freezegun==0.3.9
@@ -84,7 +84,7 @@ pyparsing==2.2.0          # via packaging
 pytest-catchlog==1.2.2
 pytest-cov==2.5.1
 pytest-django==3.1.2
-pytest==3.1.3             # via pytest-catchlog, pytest-cov, pytest-django
+pytest==3.2.0             # via pytest-catchlog, pytest-cov, pytest-django
 python-dateutil==2.6.1    # via edx-drf-extensions, faker, freezegun
 pytz==2017.2              # via babel, celery
 pyyaml==3.12              # via edx-i18n-tools

--- a/requirements/test-ficus.txt
+++ b/requirements/test-ficus.txt
@@ -25,7 +25,7 @@ djangorestframework==3.2.3
 edx-django-oauth2-provider==1.1.4
 edx-drf-extensions==1.2.2
 edx-rest-api-client==1.6.0
-factory-boy==2.8.1
+factory-boy==2.9.1
 faker==0.7.18             # via factory-boy
 freezegun==0.3.9
 funcsigs==1.0.2           # via mock
@@ -39,7 +39,7 @@ pyjwt==1.5.2              # via djangorestframework-jwt, edx-rest-api-client
 pytest-catchlog==1.2.2
 pytest-cov==2.5.1
 pytest-django==3.1.2
-pytest==3.1.3             # via pytest-catchlog, pytest-cov, pytest-django
+pytest==3.2.0             # via pytest-catchlog, pytest-cov, pytest-django
 python-dateutil==2.6.1    # via edx-drf-extensions, faker, freezegun
 pytz==2017.2              # via celery
 requests==2.9.1

--- a/requirements/test-ginkgo.txt
+++ b/requirements/test-ginkgo.txt
@@ -25,7 +25,7 @@ djangorestframework==3.2.3
 edx-django-oauth2-provider==1.1.4
 edx-drf-extensions==1.2.2
 edx-rest-api-client==1.7.1
-factory-boy==2.8.1
+factory-boy==2.9.1
 faker==0.7.18             # via factory-boy
 freezegun==0.3.9
 funcsigs==1.0.2           # via mock
@@ -39,7 +39,7 @@ pyjwt==1.5.2              # via djangorestframework-jwt, edx-rest-api-client
 pytest-catchlog==1.2.2
 pytest-cov==2.5.1
 pytest-django==3.1.2
-pytest==3.1.3             # via pytest-catchlog, pytest-cov, pytest-django
+pytest==3.2.0             # via pytest-catchlog, pytest-cov, pytest-django
 python-dateutil==2.6.1    # via edx-drf-extensions, faker, freezegun
 pytz==2017.2              # via celery
 requests==2.9.1

--- a/requirements/test-hawthorn.txt
+++ b/requirements/test-hawthorn.txt
@@ -18,14 +18,14 @@ django-model-utils==2.3.1
 django-object-actions==0.10.0
 django-simple-history==1.8.2
 django-waffle==0.12.0
-django==1.11.3
+django==1.11.4
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework-oauth==1.1.0
 djangorestframework==3.6.3
 edx-django-oauth2-provider==1.1.4
 edx-drf-extensions==1.2.3
 edx-rest-api-client==1.7.1
-factory-boy==2.8.1
+factory-boy==2.9.1
 faker==0.7.18             # via factory-boy
 freezegun==0.3.9
 funcsigs==1.0.2           # via mock
@@ -39,7 +39,7 @@ pyjwt==1.5.2              # via djangorestframework-jwt, edx-rest-api-client
 pytest-catchlog==1.2.2
 pytest-cov==2.5.1
 pytest-django==3.1.2
-pytest==3.1.3             # via pytest-catchlog, pytest-cov, pytest-django
+pytest==3.2.0             # via pytest-catchlog, pytest-cov, pytest-django
 python-dateutil==2.6.1    # via edx-drf-extensions, faker, freezegun
 pytz==2017.2              # via celery, django
 requests==2.9.1

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -25,7 +25,7 @@ djangorestframework==3.6.3
 edx-django-oauth2-provider==1.1.4
 edx-drf-extensions==1.2.3
 edx-rest-api-client==1.7.1
-factory-boy==2.8.1
+factory-boy==2.9.1
 faker==0.7.18             # via factory-boy
 freezegun==0.3.9
 funcsigs==1.0.2           # via mock
@@ -39,7 +39,7 @@ pyjwt==1.5.2              # via djangorestframework-jwt, edx-rest-api-client
 pytest-catchlog==1.2.2
 pytest-cov==2.5.1
 pytest-django==3.1.2
-pytest==3.1.3             # via pytest-catchlog, pytest-cov, pytest-django
+pytest==3.2.0             # via pytest-catchlog, pytest-cov, pytest-django
 python-dateutil==2.6.1    # via edx-drf-extensions, faker, freezegun
 pytz==2017.2              # via celery
 requests==2.9.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -25,7 +25,7 @@ djangorestframework==3.6.3
 edx-django-oauth2-provider==1.1.4
 edx-drf-extensions==1.2.3
 edx-rest-api-client==1.7.1
-factory-boy==2.8.1
+factory-boy==2.9.1
 faker==0.7.18             # via factory-boy
 freezegun==0.3.9
 funcsigs==1.0.2           # via mock
@@ -39,7 +39,7 @@ pyjwt==1.5.2              # via djangorestframework-jwt, edx-rest-api-client
 pytest-catchlog==1.2.2
 pytest-cov==2.5.1
 pytest-django==3.1.2
-pytest==3.1.3             # via pytest-catchlog, pytest-cov, pytest-django
+pytest==3.2.0             # via pytest-catchlog, pytest-cov, pytest-django
 python-dateutil==2.6.1    # via edx-drf-extensions, faker, freezegun
 pytz==2017.2              # via celery
 requests==2.9.1

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -4,14 +4,14 @@
 #
 #    pip-compile --output-file requirements/travis.txt requirements/travis.in
 #
-certifi==2017.4.17        # via requests
+certifi==2017.7.27.1      # via requests
 chardet==3.0.4            # via requests
 codecov==2.0.9
 coverage==4.4.1           # via codecov
 idna==2.5                 # via requests
 pluggy==0.4.0             # via tox
 py==1.4.34                # via tox
-requests==2.18.2          # via codecov
+requests==2.18.3          # via codecov
 tox-battery==0.2.0
 tox==2.7.0
 urllib3==1.22             # via requests

--- a/tox.ini
+++ b/tox.ini
@@ -80,10 +80,6 @@ commands =
 
 [testenv:jasmine]
 passenv = JASMINE_BROWSER DISPLAY
-whitelist_externals =
-    make
-    rm
-    touch
 deps =
     -r{toxinidir}/requirements/js_test.txt
 commands =


### PR DESCRIPTION
I'm making this on a separate PR because someone might be dumbfounded as to why jasmine tests aren't passing.

**Description:** Jasmine 2.7 uses a Selenium that requires geckodriver for Firefox. `jasmine-py` downloads the driver and puts it into the path, so we mirror that solution.

**JIRA Ticket**: [ENT-341](https://openedx.atlassian.net/browse/ENT-341)

**Merge deadline:** asap.

**Testing instructions:**

1. See that travis builds of PRs with updated requirements fail for jasmine without the geckodriver addition, but this one doesn't.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [x] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] All reviewers approved
- [x] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

