### PR TITLE
ENT-581 Record one completion event per enrollment record

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.39.5] - 2017-08-02
+---------------------
+
+* Only send one completion status per enrollment for SAP SuccessFactors.
+
 [0.39.4] - 2017-08-01
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.39.4"
+__version__ = "0.39.5"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/sap_success_factors/transmitters/learner_data.py
+++ b/integrated_channels/sap_success_factors/transmitters/learner_data.py
@@ -40,11 +40,10 @@ class SuccessFactorsLearnerDataTransmitter(SuccessFactorsTransmitterBase):
 
         previous_transmissions = LearnerDataTransmissionAudit.objects.filter(
             enterprise_course_enrollment_id=enterprise_enrollment_id,
-            completed_timestamp=payload.completed_timestamp,
             error_message=''
         )
         if previous_transmissions.exists():
-            # We've already sent a completion status call for this enrollment and certificate generation
+            # We've already sent a completion status call for this enrollment
             LOGGER.debug('Skipping previously sent enterprise enrollment {}'.format(enterprise_enrollment_id))
             return None
 


### PR DESCRIPTION
**Description:** Previously, we were allowing multiple completion events per enrollment to be sent in case something had changed that was relevant to send again. We were using the timestamp to determine whether an even has changed. However, for audit/self paced enrollments, the completed timestamp is incorrect and reflects the time the job runs. This is because the grades api doesn't return the date the grade was passing. So for now, we will send just one event per enrollment since there is no strong need to do otherwise.

**JIRA:** https://openedx.atlassian.net/browse/ENT-581

**Dependencies:** n/a

**Merge deadline:** Tomorrow (8/3/2017)

**Installation instructions:** 

**Testing instructions:**



**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
