### PR TITLE
[ENT-496] Migrate to new DataSharingConsent model

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.41.0] - 2017-08-24
+---------------------
+
+* Migrate the codebase to the new `consent.models.DataSharingConsent` model for when dealing with consent.
+
 [0.40.7] - 2017-08-23
 ---------------------
 

--- a/consent/migrations/0002_migrate_to_new_data_sharing_consent.py
+++ b/consent/migrations/0002_migrate_to_new_data_sharing_consent.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+"""
+Custom migration to transfer consent data from the ``enterprise`` application to the ``consent`` application's
+``DataSharingConsent`` model.
+
+This migration only does anything significant when running forward. If you would like to do a backwards-migration,
+delete all new rows that were populated in the ``DataSharingConsent`` model's tables.
+(If you have new data in the tables that weren't migrated, use timestamps as you see fit).
+
+The reason there's no backwards-migration in code is because we can't reasonably determine which
+data was transferred and which data is new at the time of the migration. In order to avoid deleting
+new data, we simply leave it to someone with DB access to manage things based on the desired timestamp.
+"""
+
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+def populate_data_sharing_consent(apps, schema_editor):
+    """
+    Populates the ``DataSharingConsent`` model with the ``enterprise`` application's consent data.
+
+    Consent data from the ``enterprise`` application come from the ``EnterpriseCourseEnrollment`` model.
+    """
+    DataSharingConsent = apps.get_model('consent', 'DataSharingConsent')
+    EnterpriseCourseEnrollment = apps.get_model('enterprise', 'EnterpriseCourseEnrollment')
+    User = apps.get_model('auth', 'User')
+    for enrollment in EnterpriseCourseEnrollment.objects.all():
+        user = User.objects.get(pk=enrollment.enterprise_customer_user.user_id)
+        data_sharing_consent, __ = DataSharingConsent.objects.get_or_create(
+            username=user.username,
+            enterprise_customer=enrollment.enterprise_customer_user.enterprise_customer,
+            course_id=enrollment.course_id,
+        )
+        if enrollment.consent_granted is not None:
+            data_sharing_consent.granted = enrollment.consent_granted
+        else:
+            # Check UDSCA instead.
+            consent_state = enrollment.enterprise_customer_user.data_sharing_consent.first()
+            if consent_state is not None:
+                data_sharing_consent.granted = consent_state.state in ['enabled', 'external']
+            else:
+                data_sharing_consent.granted = False
+        data_sharing_consent.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        # Make sure enterprise models (source) are available.
+        ('enterprise', '0024_enterprisecustomercatalog_historicalenterprisecustomercatalog'),
+        # Make sure consent models (target) are available.
+        ('consent', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            populate_data_sharing_consent,
+            reverse_code=lambda apps, schema_editor: None
+        ),
+    ]

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.40.7"
+__version__ = "0.41.0"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/tests/test_consent/api/test_permissions.py
+++ b/tests/test_consent/api/test_permissions.py
@@ -40,12 +40,12 @@ class TestConsentAPIPermissions(APITest):
         self.client.login(username=TEST_USERNAME, password=TEST_PASSWORD)
         discovery_client_class = mock.patch('enterprise.models.CourseCatalogApiServiceClient')
         self.discovery_client = discovery_client_class.start().return_value
-        self.discovery_client.course_in_catalog.return_value = True
+        self.discovery_client.is_course_in_catalog.return_value = True
         self.addCleanup(discovery_client_class.stop)
-        factories.EnterpriseCourseEnrollmentFactory.create(
+        factories.DataSharingConsentFactory.create(
             course_id=TEST_COURSE,
-            enterprise_customer_user__user_id=TEST_USER_ID,
-            enterprise_customer_user__enterprise_customer__uuid=TEST_UUID
+            username=TEST_USERNAME,
+            enterprise_customer__uuid=TEST_UUID
         )
 
     @ddt.data(

--- a/tests/test_consent/test_helpers.py
+++ b/tests/test_consent/test_helpers.py
@@ -10,7 +10,7 @@ from consent import helpers
 
 from django.test import testcases
 
-from test_utils import TEST_COURSE, TEST_USER_ID, TEST_USERNAME, TEST_UUID, create_items, factories
+from test_utils import TEST_USER_ID, TEST_USERNAME, create_items, factories
 
 
 @ddt.ddt
@@ -18,6 +18,26 @@ class ConsentHelpersTest(testcases.TestCase):
     """
     Test cases for helper functions for the Consent application.
     """
+
+    @ddt.data(
+        True, False
+    )
+    def test_consent_exists_proxy_enrollment(self, user_exists):
+        """
+        If we did proxy enrollment, we return ``True`` for the consent existence question.
+        """
+        if user_exists:
+            factories.UserFactory(id=1)
+        ece = factories.EnterpriseCourseEnrollmentFactory(enterprise_customer_user__user_id=1)
+        consent_exists = helpers.consent_exists(
+            ece.enterprise_customer_user.username,
+            ece.course_id,
+            ece.enterprise_customer_user.enterprise_customer.uuid,
+        )
+        if user_exists:
+            assert consent_exists
+        else:
+            assert not consent_exists
 
     @ddt.data(
         (factories.UserFactory, [{'id': TEST_USER_ID, 'username': TEST_USERNAME}], True),
@@ -32,91 +52,3 @@ class ConsentHelpersTest(testcases.TestCase):
             self.assertEqual(user_id, TEST_USER_ID)
         else:
             self.assertIsNone(user_id)
-
-    @ddt.data(
-        (factories.EnterpriseCustomerFactory, [{'uuid': TEST_UUID}], True),
-        (None, [{}], False)
-    )
-    @ddt.unpack
-    def test_get_enterprise_customer(self, factory, items, returns_obj):
-        if factory:
-            create_items(factory, items)
-        enterprise_customer = helpers.get_enterprise_customer(TEST_UUID)
-        if returns_obj:
-            self.assertIsNotNone(enterprise_customer)
-        else:
-            self.assertIsNone(enterprise_customer)
-
-    @ddt.data(
-        (
-            factories.EnterpriseCustomerUserFactory,
-            [{'user_id': TEST_USER_ID, 'enterprise_customer__uuid': TEST_UUID}],
-            True
-        ),
-        (
-            None, [{}], False
-        )
-    )
-    @ddt.unpack
-    def test_get_enterprise_customer_user(self, factory, items, returns_obj):
-        if factory:
-            create_items(factory, items)
-        enterprise_customer = helpers.get_enterprise_customer(TEST_UUID)
-        enterprise_customer_user = helpers.get_enterprise_customer_user(enterprise_customer, TEST_USER_ID)
-        if returns_obj:
-            self.assertIsNotNone(enterprise_customer_user)
-        else:
-            self.assertIsNone(enterprise_customer_user)
-
-    @ddt.data(
-        (
-            factories.EnterpriseCourseEnrollmentFactory,
-            [{
-                'course_id': TEST_COURSE,
-                'enterprise_customer_user__user_id': TEST_USER_ID,
-                'enterprise_customer_user__enterprise_customer__uuid': TEST_UUID,
-            }],
-            True
-        ),
-        (
-            None, [{}], False
-        )
-    )
-    @ddt.unpack
-    def test_get_enterprise_course_enrollment(self, factory, items, returns_obj):
-        if factory:
-            create_items(factory, items)
-        enterprise_customer = helpers.get_enterprise_customer(TEST_UUID)
-        enterprise_course_enrollment = helpers.get_enterprise_course_enrollment(
-            TEST_USER_ID,
-            TEST_COURSE,
-            enterprise_customer
-        )
-        if returns_obj:
-            self.assertIsNotNone(enterprise_course_enrollment)
-        else:
-            self.assertIsNone(enterprise_course_enrollment)
-
-    @ddt.data(
-        (
-            factories.UserDataSharingConsentAuditFactory,
-            [{
-                'user__user_id': TEST_USER_ID,
-                'user__enterprise_customer__uuid': TEST_UUID
-            }],
-            True
-        ),
-        (
-            None, [{}], False
-        )
-    )
-    @ddt.unpack
-    def test_get_user_dsc_audit(self, factory, items, returns_obj):
-        if factory:
-            create_items(factory, items)
-        enterprise_customer = helpers.get_enterprise_customer(TEST_UUID)
-        user_dsc_audit = helpers.get_user_dsc_audit(TEST_USER_ID, enterprise_customer)
-        if returns_obj:
-            self.assertIsNotNone(user_dsc_audit)
-        else:
-            self.assertIsNone(user_dsc_audit)

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -16,6 +16,7 @@ from django.test import override_settings
 from django.utils import timezone
 
 from enterprise.api_client.lms import LMS_API_DATETIME_FORMAT
+from enterprise.decorators import ignore_warning
 from enterprise.models import EnterpriseCustomer, EnterpriseCustomerIdentityProvider, UserDataSharingConsentAudit
 from test_utils import FAKE_UUIDS, TEST_USERNAME, APITest, factories, fake_catalog_api
 
@@ -318,6 +319,7 @@ class TestEnterpriseAPIViews(APITest):
         ),
     )
     @ddt.unpack
+    @ignore_warning(DeprecationWarning)
     def test_enterprise_learner_entitlements(
             self, enable_data_sharing_consent, enforce_data_sharing_consent,
             learner_consent_state, entitlements, expected_json

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -26,6 +26,7 @@ from django.utils import timezone
 
 from enterprise.api_client import lms as lms_api
 from test_utils.factories import (
+    DataSharingConsentFactory,
     EnterpriseCourseEnrollmentFactory,
     EnterpriseCustomerFactory,
     EnterpriseCustomerIdentityProviderFactory,
@@ -251,6 +252,11 @@ class TestTransmitLearnerData(unittest.TestCase):
             enterprise_customer_user=self.enterprise_customer_user,
             course_id=self.course_id,
             consent_granted=True,
+        )
+        self.consent = DataSharingConsentFactory(
+            username=self.user.username,
+            course_id=self.course_id,
+            enterprise_customer=self.enterprise_customer
         )
         self.integrated_channel = SAPSuccessFactorsEnterpriseCustomerConfiguration(
             enterprise_customer=self.enterprise_customer,

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,173 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for migrations, especially potentially risky data migrations.
+"""
+
+from __future__ import absolute_import, unicode_literals
+
+import ddt
+from consent.models import DataSharingConsent
+
+from django.db import connection
+from django.db.migrations.executor import MigrationExecutor
+from django.test.testcases import TransactionTestCase
+
+from enterprise.decorators import ignore_warning
+from enterprise.models import UserDataSharingConsentAudit
+from test_utils import factories
+
+
+class MigrationTestCase(TransactionTestCase):
+    """
+    A base test case class for migration test cases.
+    """
+
+    migrate_origin = None
+    migrate_dest = None
+    model = None
+
+    def setUp(self):
+        super(MigrationTestCase, self).setUp()
+        self.executor = MigrationExecutor(connection)
+        self.executor.migrate(self.migrate_origin)
+
+    def migrate_to_origin(self):
+        """
+        Performs the migration to the designated origin.
+
+        This only really does anything if you have migrated forward
+        in some way or no migrations were performed at all.
+        """
+        self.executor.loader.build_graph()
+        self.executor.migrate(self.migrate_origin)
+
+    def migrate_to_dest(self):
+        """
+        Performs the migration to the designated destination.
+        """
+        self.executor.loader.build_graph()
+        self.executor.migrate(self.migrate_dest)
+
+    def migrate_to_dest_then_origin(self):
+        """
+        Migrates to the destination and back to the origin.
+
+        Can be used as a shortcut to test a forward- and backward-migration in one-go.
+        """
+        self.migrate_to_dest()
+        self.migrate_to_origin()
+
+    @property
+    def old_apps(self):
+        """
+        Returns the app in its original state -- the one that'd exist before migration.
+        """
+        return self.executor.loader.project_state(self.migrate_origin).apps
+
+    @property
+    def new_apps(self):
+        """
+        Returns the app in a future state -- the one that'd exist after migration.
+        """
+        return self.executor.loader.project_state(self.migrate_dest).apps
+
+    @property
+    def model_label(self):
+        """
+        Returns the label of the ``model``.
+        """
+        return self.model._meta.get_field('name')
+
+
+@ddt.ddt
+class MigrateToNewDataSharingConsentTest(MigrationTestCase):
+    """
+    Test cases for migrating data from ``EnterpriseCourseEnrollment`` and ``UserDataSharingConsentAudit`` to
+    the new Consent application's ``DataSharingConsent`` model.
+    """
+
+    migrate_origin = [('consent', '0001_initial')]
+    migrate_dest = [('consent', '0002_migrate_to_new_data_sharing_consent')]
+    model = DataSharingConsent
+
+    def setUp(self):
+        """
+        Set up EnterpriseCourseEnrollment and UserDataSharingConsentAudit with some data.
+        """
+        super(MigrateToNewDataSharingConsentTest, self).setUp()
+        self.user = factories.UserFactory(
+            username='bob',
+            id=1
+        )
+        self.enterprise_customer_user = factories.EnterpriseCustomerUserFactory(
+            user_id=1
+        )
+        self.enterprise_course_enrollment = factories.EnterpriseCourseEnrollmentFactory(
+            enterprise_customer_user=self.enterprise_customer_user
+        )
+        self.user_data_sharing_consent_audit = factories.UserDataSharingConsentAuditFactory(
+            user=self.enterprise_customer_user
+        )
+        self.migrate_to_origin()
+
+    def tearDown(self):
+        """
+        Make sure to migrate back to the origin.
+        """
+        super(MigrateToNewDataSharingConsentTest, self).setUp()
+        self.migrate_to_origin()
+
+    @ddt.data(
+        (True, UserDataSharingConsentAudit.NOT_SET),
+        (True, UserDataSharingConsentAudit.ENABLED),
+        (True, UserDataSharingConsentAudit.DISABLED),
+        (True, UserDataSharingConsentAudit.EXTERNALLY_MANAGED),
+        (False, UserDataSharingConsentAudit.NOT_SET),
+        (False, UserDataSharingConsentAudit.ENABLED),
+        (False, UserDataSharingConsentAudit.DISABLED),
+        (False, UserDataSharingConsentAudit.EXTERNALLY_MANAGED),
+        (None, UserDataSharingConsentAudit.NOT_SET),
+        (None, UserDataSharingConsentAudit.ENABLED),
+        (None, UserDataSharingConsentAudit.DISABLED),
+        (None, UserDataSharingConsentAudit.EXTERNALLY_MANAGED),
+    )
+    @ddt.unpack
+    @ignore_warning(DeprecationWarning)
+    def test_enrollment_consent_transfers(self, ece_consent_state, udsca_consent_state):
+        """
+        Test that ``EnterpriseCourseEnrollment``'s consent data transfers over to ``DataSharingConsent``.
+
+        We check ``UserDataSharingConsentAudit`` as a last resort for consent state.
+        """
+        self.enterprise_course_enrollment.consent_granted = ece_consent_state
+        self.enterprise_course_enrollment.save()
+        self.user_data_sharing_consent_audit.state = udsca_consent_state
+        self.user_data_sharing_consent_audit.save()
+
+        self.migrate_to_dest()
+
+        data_sharing_consent = DataSharingConsent.objects.all().first()
+        if self.enterprise_course_enrollment.consent_available:
+            self.assertTrue(data_sharing_consent.granted)
+        else:
+            self.assertFalse(data_sharing_consent.granted)
+
+    @ignore_warning(DeprecationWarning)
+    def test_duplicate_consent_doesnt_cause_error(self):
+        """
+        An existing ``DataSharingConsent`` row shouldn't cause a migration error -- it should update accordingly.
+        """
+        DataSharingConsent.objects.create(
+            username=self.enterprise_customer_user.username,
+            course_id=self.enterprise_course_enrollment.course_id,
+            enterprise_customer=self.enterprise_customer_user.enterprise_customer,
+            granted=False,
+        )
+
+        self.enterprise_course_enrollment.consent_granted = True
+        self.enterprise_course_enrollment.save()
+
+        self.migrate_to_dest()
+
+        data_sharing_consent = DataSharingConsent.objects.all().first()
+        assert data_sharing_consent.granted


### PR DESCRIPTION
**Description:** This PR migrates the codebase to use the new `DataSharingConsent` model created in #167. It also introduces a data migration in order to make that code migration meaningful, and this data migration comes with tests to build confidence.

**JIRA:** [ENT-496](https://openedx.atlassian.net/browse/ENT-496)

**Dependencies:** Not a hard dependency because I've already incorporated the changes and expect them to be merged soon -- #158.

**Merge deadline:** Before next sprint starts, hopefully

**Testing instructions:**

1. Ensure that all enterprise flows work fine as before.
1. Ensure that data sharing consent screens properly render, or don't.
1. Ensure that data sharing consent is properly saved.
1. Ensure that any management commands that depend on consent (like `transmit_learner_data`) continue to filter properly.
1. Ensure that the new `consent` application continues to work as intended (i.e. send some requests to the Consent API endpoint).

Since this touches so many parts of the codebase, it's hard to be specific here.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] All reviewers approved
- [x] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** Since we're keeping around the UDSCA and ECE models still, I've at least put up deprecation warnings on using their functionality. I've ignored those warnings in certain places where they became spammy, and if we do decide to get rid of these models some day, those suppressions will obviously have to be removed.