### PR TITLE
ENT-585 Use the catalog service API for retrieving course metadata for display on the course enrollment landing page.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.40.3] - 2017-08-21
+---------------------
+
+* Change landing page course modal to use discovery api for populating course details.
+
 [0.40.2] - 2017-08-16
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.40.2"
+__version__ = "0.40.3"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api_client/lms.py
+++ b/enterprise/api_client/lms.py
@@ -390,7 +390,7 @@ def enroll_user_in_course_locally(user, course_id, mode):
     use to create a callback. Once we're able to depend on having Django 1.9, we
     can shift over to that, but for right now, we have to do it this way.
     """
-    if CourseKey is None and CourseEnrollment is None:
+    if CourseEnrollment is None:
         raise NotConnectedToOpenEdX("This package must be installed in an OpenEdX environment.")
     CourseEnrollment.enroll(user, CourseKey.from_string(course_id), mode=mode, check_access=True)
 

--- a/enterprise/messages.py
+++ b/enterprise/messages.py
@@ -13,23 +13,23 @@ except ImportError:
     configuration_helpers = None
 
 
-def add_consent_declined_message(request, enterprise_customer, course_details):
+def add_consent_declined_message(request, enterprise_customer, course_run):
     """
     Add a message to the Django messages store indicating that the user has declined data sharing consent.
 
     Arguments:
         request (HttpRequest): The current request.
         enterprise_customer (EnterpriseCustomer): The EnterpriseCustomer associated with this request.
-        course_details (dict): A dictionary containing information about the course the user had declined consent for.
+        course_run (dict): A dictionary containing information about the course run the user had declined consent for.
     """
     messages.warning(
         request,
         _(
-            '{strong_start}We could not enroll you in {em_start}{course_name}{em_end}.{strong_end} '
+            '{strong_start}We could not enroll you in {em_start}{course_title}{em_end}.{strong_end} '
             '{span_start}If you have questions or concerns about sharing your data, please contact your learning '
             'manager at {enterprise_customer_name}, or contact {link_start}{platform_name} support{link_end}.{span_end}'
         ).format(
-            course_name=course_details.get('name'),
+            course_title=course_run['title'],
             em_start='<em>',
             em_end='</em>',
             enterprise_customer_name=enterprise_customer.name,

--- a/enterprise/static/enterprise/enterprise_course_enrollment_page.css
+++ b/enterprise/static/enterprise/enterprise_course_enrollment_page.css
@@ -320,7 +320,7 @@ h2#modal-header-text {
 }
 
 .modal-content .course-detail-modal-scrollable {
-    max-height: calc(80vh - 30px); /* account for the height of the top bar with the close button */
+    max-height: calc(70vh - 30px); /* account for the height of the top bar with the close button */
     overflow: auto;
     padding: 20px;
     width: 100%;
@@ -443,22 +443,8 @@ h2#modal-header-text {
     font-size: 16px;
 }
 
-.modal-content .body .overview .teacher {
-    padding-left: 125px;
-    position: relative;
-    min-height: 117px;
-    margin-bottom: 15px;
-}
-
-.modal-content .body .overview .teacher h3 {
-    font-weight: bold;
-    margin-bottom: 10px;
-}
-
-.modal-content .body .overview .teacher .teacher-image {
-    position: absolute;
-    left: 0;
-    top: 0;
+.modal-content .body .overview .col-7 {
+    padding-left: 0;
 }
 
 .modal-content .body .overview h1,

--- a/enterprise/templates/enterprise/enterprise_course_enrollment_page.html
+++ b/enterprise/templates/enterprise/enterprise_course_enrollment_page.html
@@ -36,15 +36,15 @@
         <h2 class="course-confirmation-title">{{ confirmation_text }}</h2>
         <div class="media">
           <div class="thumbnail">
-            <img class="course-image" src="{{ course_image_uri }}" alt="{{ course_name }}"/>
+            <img class="course-image" src="{{ course_image_uri }}" alt="{{ course_title }}"/>
           </div>
           <div class="media-content">
-            <div class="course-title">{{ course_name }}</div>
+            <div class="course-title">{{ course_title }}</div>
           </div>
         </div>
         <div class="course-detail">
           <div class="course-org">
-            {{ course_organization }}
+            {{ organization_name }}
           </div>
           <div class="course-info">
             <i class="fa fa-clock-o" aria-hidden="true"></i>
@@ -93,10 +93,10 @@
         <header class="wrapper modal-header">
           <div class="modal-header-wrapper">
             <div class="image">
-              <img src="{{ course_image_uri }}" alt="{{ course_name }}"/>
+              <img src="{{ course_image_uri }}" alt="{{ course_title }}"/>
             </div>
             <div class="details">
-              <h1 id="modal-header-text">{{ course_name }}</h1>
+              <h1 id="modal-header-text">{{ course_title }}</h1>
               <p class="short-description">{{ course_short_description }}</p>
               {% if organization_logo and organization_name %}
                 <div class="organization">
@@ -162,7 +162,37 @@
             </ol>
           </div>
           <div class="overview">
-            {{ course_overview|safe }}
+            {% if course_full_description %}
+              <h2>{{ course_full_description_text }}</h2>
+              <div>{% autoescape off %}{{ course_full_description }}{% endautoescape %}</div>
+            {% endif %}
+            {% if expected_learning_items %}
+              <h2>{{ expected_learning_items_text }}</h2>
+              <ul>
+              {% for item in expected_learning_items %}
+                <li>{{ item }}</li>
+              {% endfor %}
+              </ul>
+            {% endif %}
+            {% if staff %}
+              <h2>{{ staff_text }}</h2>
+              <div class="staff-container">
+                {% for person in staff %}
+                  <div class="row">
+                    <div class="col-3">
+                      <img src="{{ person.profile_image_url }}" alt="{{ person.given_name }} {{ person.family_name }}" />
+                    </div>
+                    <div class="col-7">
+                      <h2>{{ person.given_name }} {{ person.family_name }}</h2>
+                      {% if person.position %}
+                        <p>{{ person.position.title }} at {{ person.position.organization_name }}</p>
+                      {% endif %}
+                      <p>{{ person.bio }}</p>
+                    </div>
+                  </div>
+                {% endfor %}
+              </div>
+            {% endif %}
           </div>
         </div>
 

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -8,6 +8,8 @@ import logging
 import re
 from uuid import UUID
 
+from opaque_keys.edx.keys import CourseKey
+
 from django.apps import apps
 from django.conf import settings
 from django.core import mail
@@ -533,3 +535,31 @@ def get_enterprise_customer_or_404(enterprise_uuid):
         LOGGER.error('Unable to find enterprise customer for UUID: %s', enterprise_uuid)
         raise Http404
     return enterprise_customer
+
+
+def get_course_id_from_course_run_id(course_run_id):
+    """
+    Given a course run id, return the corresponding course id.
+
+    Args:
+        course_run_id (str): The course run ID.
+
+    Returns:
+        (str): The course ID.
+    """
+    course_run_key = CourseKey.from_string(course_run_id)
+    return '{org}+{course}'.format(org=course_run_key.org, course=course_run_key.course)
+
+
+def clean_html_for_template_rendering(text):
+    """
+    Given html text that will be rendered as a variable in a template, strip out characters that impact rendering.
+
+    Arguments:
+        text (str): The text to clean.
+
+    Returns:
+        (str): The cleaned text.
+    """
+    # Sometimes there are random new lines between tags that don't render nicely.
+    return text.replace('>\\n<', '><')

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -32,6 +32,7 @@ edx-django-oauth2-provider==1.1.4
 edx-drf-extensions==1.2.3
 edx-i18n-tools==0.3.9
 edx-lint==0.5.4
+edx-opaque-keys==0.4.0
 edx-rest-api-client==1.7.1
 enum34==1.1.6             # via astroid
 first==2.0.1              # via pip-tools
@@ -46,6 +47,7 @@ markupsafe==1.0           # via jinja2
 mccabe==0.6.1             # via pylint
 packaging==16.8           # via caniusepython3
 path.py==10.3.1           # via edx-i18n-tools
+pbr==3.1.1                # via stevedore
 pillow==3.4
 pip-tools==1.9.0
 pkginfo==1.4.1            # via twine
@@ -60,6 +62,7 @@ pylint-celery==0.3        # via edx-lint
 pylint-django==0.7.2      # via edx-lint
 pylint-plugin-utils==0.2.6  # via pylint-celery, pylint-django
 pylint==1.7.1             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pymongo==3.5.0            # via edx-opaque-keys
 pyparsing==2.2.0          # via packaging
 python-dateutil==2.6.1    # via edx-drf-extensions
 pytz==2017.2              # via celery
@@ -68,9 +71,10 @@ requests-toolbelt==0.8.0  # via twine
 requests==2.9.1
 shortuuid==0.5.0          # via edx-django-oauth2-provider
 singledispatch==3.4.0.3   # via astroid, pylint
-six==1.10.0               # via astroid, diff-cover, django-extensions, edx-i18n-tools, edx-lint, packaging, pip-tools, pydocstyle, pylint, python-dateutil, singledispatch
+six==1.10.0               # via astroid, diff-cover, django-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, packaging, pip-tools, pydocstyle, pylint, python-dateutil, singledispatch, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==1.2.1    # via pydocstyle
+stevedore==1.25.0         # via edx-opaque-keys
 tox-battery==0.2.0
 tox==2.7.0
 tqdm==4.15.0              # via twine

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -27,6 +27,7 @@ doc8==0.8.0
 docutils==0.14            # via doc8, readme-renderer, restructuredtext-lint, sphinx
 edx-django-oauth2-provider==1.1.4
 edx-drf-extensions==1.2.3
+edx-opaque-keys==0.4.0
 edx-rest-api-client==1.7.1
 edx-sphinx-theme==1.2.0
 html5lib==0.999999999     # via bleach
@@ -39,19 +40,20 @@ pillow==3.4
 pockets==0.5.1            # via sphinxcontrib-napoleon
 pygments==2.2.0           # via readme-renderer, sphinx
 pyjwt==1.5.2              # via djangorestframework-jwt, edx-rest-api-client
+pymongo==3.5.0            # via edx-opaque-keys
 python-dateutil==2.6.1    # via edx-drf-extensions
 pytz==2017.2              # via babel, celery
 readme-renderer==17.2
 requests==2.9.1
 restructuredtext-lint==1.1.1  # via doc8
 shortuuid==0.5.0          # via edx-django-oauth2-provider
-six==1.10.0               # via bleach, django-extensions, doc8, edx-sphinx-theme, html5lib, pockets, python-dateutil, readme-renderer, sphinx, sphinxcontrib-napoleon, stevedore
+six==1.10.0               # via bleach, django-extensions, doc8, edx-opaque-keys, edx-sphinx-theme, html5lib, pockets, python-dateutil, readme-renderer, sphinx, sphinxcontrib-napoleon, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==1.2.1    # via sphinx
 sphinx==1.6.3             # via edx-sphinx-theme
 sphinxcontrib-napoleon==0.6.1
 sphinxcontrib-websupport==1.0.1  # via sphinx
-stevedore==1.25.0         # via doc8
+stevedore==1.25.0         # via doc8, edx-opaque-keys
 typing==3.6.2             # via sphinx
 unicodecsv==0.14.1
 webencodings==0.5.1       # via html5lib

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -41,6 +41,7 @@ edx-django-oauth2-provider==1.1.4
 edx-drf-extensions==1.2.3
 edx-i18n-tools==0.3.9
 edx-lint==0.5.4
+edx-opaque-keys==0.4.0
 edx-rest-api-client==1.7.1
 edx-sphinx-theme==1.2.0
 enum34==1.1.6             # via astroid
@@ -80,6 +81,7 @@ pylint-celery==0.3        # via edx-lint
 pylint-django==0.7.2      # via edx-lint
 pylint-plugin-utils==0.2.6  # via pylint-celery, pylint-django
 pylint==1.7.1             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pymongo==3.5.0            # via edx-opaque-keys
 pyparsing==2.2.0          # via packaging
 pytest-catchlog==1.2.2
 pytest-cov==2.5.1
@@ -95,13 +97,13 @@ responses==0.7.0
 restructuredtext-lint==1.1.1  # via doc8
 shortuuid==0.5.0          # via edx-django-oauth2-provider
 singledispatch==3.4.0.3   # via astroid, pylint
-six==1.10.0               # via astroid, bleach, diff-cover, django-extensions, doc8, edx-i18n-tools, edx-lint, edx-sphinx-theme, faker, freezegun, html5lib, mock, packaging, pip-tools, pockets, pydocstyle, pylint, python-dateutil, readme-renderer, responses, singledispatch, sphinx, sphinxcontrib-napoleon, stevedore
+six==1.10.0               # via astroid, bleach, diff-cover, django-extensions, doc8, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, faker, freezegun, html5lib, mock, packaging, pip-tools, pockets, pydocstyle, pylint, python-dateutil, readme-renderer, responses, singledispatch, sphinx, sphinxcontrib-napoleon, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==1.2.1    # via pydocstyle, sphinx
 sphinx==1.6.3             # via edx-sphinx-theme
 sphinxcontrib-napoleon==0.6.1
 sphinxcontrib-websupport==1.0.1  # via sphinx
-stevedore==1.25.0         # via doc8
+stevedore==1.25.0         # via doc8, edx-opaque-keys
 tox-battery==0.2.0
 tox==2.7.0
 tqdm==4.15.0              # via twine

--- a/requirements/test-ficus.in
+++ b/requirements/test-ficus.in
@@ -20,3 +20,4 @@ django-simple-history==1.6.3            # History for Django models
 edx-rest-api-client==1.6.0              # For accessing the Enrollment API (and possibly other edX APIs)
 django-config-models==0.1.5
 requests==2.9.1                         # Required for SAPSuccessFactorsAPIClient
+edx-opaque-keys==0.4.0                  # Helpers for parsing course run IDs

--- a/requirements/test-ficus.txt
+++ b/requirements/test-ficus.txt
@@ -24,6 +24,7 @@ djangorestframework-oauth==1.1.0
 djangorestframework==3.2.3
 edx-django-oauth2-provider==1.1.4
 edx-drf-extensions==1.2.2
+edx-opaque-keys==0.4.0
 edx-rest-api-client==1.6.0
 factory-boy==2.9.2
 faker==0.7.18             # via factory-boy
@@ -32,10 +33,11 @@ funcsigs==1.0.2           # via mock
 ipaddress==1.0.18         # via faker
 kombu==3.0.37             # via celery
 mock==2.0.0
-pbr==3.1.1                # via mock
+pbr==3.1.1                # via mock, stevedore
 pillow==3.4
 py==1.4.34                # via pytest, pytest-catchlog
 pyjwt==1.5.2              # via djangorestframework-jwt, edx-rest-api-client
+pymongo==3.5.0            # via edx-opaque-keys
 pytest-catchlog==1.2.2
 pytest-cov==2.5.1
 pytest-django==3.1.2
@@ -45,6 +47,7 @@ pytz==2017.2              # via celery
 requests==2.9.1
 responses==0.7.0
 shortuuid==0.5.0          # via edx-django-oauth2-provider
-six==1.10.0               # via django-extensions, faker, freezegun, mock, python-dateutil, responses
+six==1.10.0               # via django-extensions, edx-opaque-keys, faker, freezegun, mock, python-dateutil, responses, stevedore
 slumber==0.7.1            # via edx-rest-api-client
+stevedore==1.25.0         # via edx-opaque-keys
 unicodecsv==0.14.1

--- a/requirements/test-ginkgo.in
+++ b/requirements/test-ginkgo.in
@@ -21,3 +21,4 @@ edx-rest-api-client==1.7.1              # For accessing the Enrollment API (and 
 django-config-models==0.1.5
 requests==2.9.1                         # Required for SAPSuccessFactorsAPIClient
 django-waffle==0.12.0                   # Allows ability to add and control flags and switches for features
+edx-opaque-keys==0.4.0                  # Helpers for parsing course run IDs

--- a/requirements/test-ginkgo.txt
+++ b/requirements/test-ginkgo.txt
@@ -24,6 +24,7 @@ djangorestframework-oauth==1.1.0
 djangorestframework==3.2.3
 edx-django-oauth2-provider==1.1.4
 edx-drf-extensions==1.2.2
+edx-opaque-keys==0.4.0
 edx-rest-api-client==1.7.1
 factory-boy==2.9.2
 faker==0.7.18             # via factory-boy
@@ -32,10 +33,11 @@ funcsigs==1.0.2           # via mock
 ipaddress==1.0.18         # via faker
 kombu==3.0.37             # via celery
 mock==2.0.0
-pbr==3.1.1                # via mock
+pbr==3.1.1                # via mock, stevedore
 pillow==3.4
 py==1.4.34                # via pytest, pytest-catchlog
 pyjwt==1.5.2              # via djangorestframework-jwt, edx-rest-api-client
+pymongo==3.5.0            # via edx-opaque-keys
 pytest-catchlog==1.2.2
 pytest-cov==2.5.1
 pytest-django==3.1.2
@@ -45,6 +47,7 @@ pytz==2017.2              # via celery
 requests==2.9.1
 responses==0.7.0
 shortuuid==0.5.0          # via edx-django-oauth2-provider
-six==1.10.0               # via django-extensions, faker, freezegun, mock, python-dateutil, responses
+six==1.10.0               # via django-extensions, edx-opaque-keys, faker, freezegun, mock, python-dateutil, responses, stevedore
 slumber==0.7.1            # via edx-rest-api-client
+stevedore==1.25.0         # via edx-opaque-keys
 unicodecsv==0.14.1

--- a/requirements/test-hawthorn.in
+++ b/requirements/test-hawthorn.in
@@ -19,3 +19,4 @@ edx-rest-api-client==1.7.1              # For accessing the Enrollment API (and 
 django-config-models==0.1.8
 requests==2.9.1                         # Required for SAPSuccessFactorsAPIClient
 django-waffle==0.12.0                   # Allows ability to add and control flags and switches for features
+edx-opaque-keys==0.4.0                  # Helpers for parsing course run IDs

--- a/requirements/test-hawthorn.txt
+++ b/requirements/test-hawthorn.txt
@@ -24,6 +24,7 @@ djangorestframework-oauth==1.1.0
 djangorestframework==3.6.3
 edx-django-oauth2-provider==1.1.4
 edx-drf-extensions==1.2.3
+edx-opaque-keys==0.4.0
 edx-rest-api-client==1.7.1
 factory-boy==2.9.2
 faker==0.7.18             # via factory-boy
@@ -32,10 +33,11 @@ funcsigs==1.0.2           # via mock
 ipaddress==1.0.18         # via faker
 kombu==3.0.37             # via celery
 mock==2.0.0
-pbr==3.1.1                # via mock
+pbr==3.1.1                # via mock, stevedore
 pillow==3.4
 py==1.4.34                # via pytest, pytest-catchlog
 pyjwt==1.5.2              # via djangorestframework-jwt, edx-rest-api-client
+pymongo==3.5.0            # via edx-opaque-keys
 pytest-catchlog==1.2.2
 pytest-cov==2.5.1
 pytest-django==3.1.2
@@ -45,6 +47,7 @@ pytz==2017.2              # via celery, django
 requests==2.9.1
 responses==0.7.0
 shortuuid==0.5.0          # via edx-django-oauth2-provider
-six==1.10.0               # via django-extensions, faker, freezegun, mock, python-dateutil, responses
+six==1.10.0               # via django-extensions, edx-opaque-keys, faker, freezegun, mock, python-dateutil, responses, stevedore
 slumber==0.7.1            # via edx-rest-api-client
+stevedore==1.25.0         # via edx-opaque-keys
 unicodecsv==0.14.1

--- a/requirements/test-master.in
+++ b/requirements/test-master.in
@@ -17,3 +17,4 @@ edx-rest-api-client==1.7.1              # For accessing the Enrollment API (and 
 django-config-models==0.1.8
 requests==2.9.1                         # Required for SAPSuccessFactorsAPIClient
 django-waffle==0.12.0                   # Allows ability to add and control flags and switches for features
+edx-opaque-keys==0.4.0                  # Helpers for parsing course run IDs

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -24,6 +24,7 @@ djangorestframework-oauth==1.1.0
 djangorestframework==3.6.3
 edx-django-oauth2-provider==1.1.4
 edx-drf-extensions==1.2.3
+edx-opaque-keys==0.4.0
 edx-rest-api-client==1.7.1
 factory-boy==2.9.2
 faker==0.7.18             # via factory-boy
@@ -32,10 +33,11 @@ funcsigs==1.0.2           # via mock
 ipaddress==1.0.18         # via faker
 kombu==3.0.37             # via celery
 mock==2.0.0
-pbr==3.1.1                # via mock
+pbr==3.1.1                # via mock, stevedore
 pillow==3.4
 py==1.4.34                # via pytest, pytest-catchlog
 pyjwt==1.5.2              # via djangorestframework-jwt, edx-rest-api-client
+pymongo==3.5.0            # via edx-opaque-keys
 pytest-catchlog==1.2.2
 pytest-cov==2.5.1
 pytest-django==3.1.2
@@ -45,6 +47,7 @@ pytz==2017.2              # via celery
 requests==2.9.1
 responses==0.7.0
 shortuuid==0.5.0          # via edx-django-oauth2-provider
-six==1.10.0               # via django-extensions, faker, freezegun, mock, python-dateutil, responses
+six==1.10.0               # via django-extensions, edx-opaque-keys, faker, freezegun, mock, python-dateutil, responses, stevedore
 slumber==0.7.1            # via edx-rest-api-client
+stevedore==1.25.0         # via edx-opaque-keys
 unicodecsv==0.14.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -24,6 +24,7 @@ djangorestframework-oauth==1.1.0
 djangorestframework==3.6.3
 edx-django-oauth2-provider==1.1.4
 edx-drf-extensions==1.2.3
+edx-opaque-keys==0.4.0
 edx-rest-api-client==1.7.1
 factory-boy==2.9.2
 faker==0.7.18             # via factory-boy
@@ -32,10 +33,11 @@ funcsigs==1.0.2           # via mock
 ipaddress==1.0.18         # via faker
 kombu==3.0.37             # via celery
 mock==2.0.0
-pbr==3.1.1                # via mock
+pbr==3.1.1                # via mock, stevedore
 pillow==3.4
 py==1.4.34                # via pytest, pytest-catchlog
 pyjwt==1.5.2              # via djangorestframework-jwt, edx-rest-api-client
+pymongo==3.5.0            # via edx-opaque-keys
 pytest-catchlog==1.2.2
 pytest-cov==2.5.1
 pytest-django==3.1.2
@@ -45,6 +47,7 @@ pytz==2017.2              # via celery
 requests==2.9.1
 responses==0.7.0
 shortuuid==0.5.0          # via edx-django-oauth2-provider
-six==1.10.0               # via django-extensions, faker, freezegun, mock, python-dateutil, responses
+six==1.10.0               # via django-extensions, edx-opaque-keys, faker, freezegun, mock, python-dateutil, responses, stevedore
 slumber==0.7.1            # via edx-rest-api-client
+stevedore==1.25.0         # via edx-opaque-keys
 unicodecsv==0.14.1

--- a/test_utils/fake_catalog_api.py
+++ b/test_utils/fake_catalog_api.py
@@ -8,6 +8,119 @@ from __future__ import absolute_import, unicode_literals
 from six.moves import reduce as six_reduce
 from test_utils import FAKE_UUIDS
 
+FAKE_COURSE_RUN = {
+    'key': 'course-v1:edX+DemoX+Demo_Course',
+    'uuid': '785b11f5-fad5-4ce1-9233-e1a3ed31aadb',
+    'title': 'edX Demonstration Course',
+    'image': {
+        'description': None,
+        'height': None,
+        'src': 'http://edx.devstack.lms:18000/asset-v1:edX+DemoX+Demo_Course+type@asset+block@images_course_image.jpg',
+        'width': None
+    },
+    'short_description': 'This course demonstrates many features of the edX platform.',
+    'marketing_url': 'course/demo-course?utm_source=edx&utm_medium=affiliate_partner',
+    'seats': [
+        {
+            'type': 'audit',
+            'price': '0.00',
+            'currency': 'USD',
+            'upgrade_deadline': None,
+            'credit_provider': None,
+            'credit_hours': None,
+            'sku': '68EFFFF'
+        },
+        {
+            'type': 'verified',
+            'price': '149.00',
+            'currency': 'USD',
+            'upgrade_deadline': '2018-08-03T16:44:26.595896Z',
+            'credit_provider': None,
+            'credit_hours': None,
+            'sku': '8CF08E5'
+        }
+    ],
+    'start': '2013-02-05T05:00:00Z',
+    'end': '2017-12-31T18:00:00Z',
+    'enrollment_start': None,
+    'enrollment_end': None,
+    'pacing_type': 'instructor_paced',
+    'type': 'verified',
+    'status': 'published',
+    'course': 'edX+DemoX',
+    'full_description': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+    'announcement': None,
+    'video': None,
+    'content_language': None,
+    'transcript_languages': [],
+    'instructors': [],
+    'staff': [
+        {
+            'uuid': '51df1077-1b8d-4f86-8305-8adbc82b72e9',
+            'given_name': 'Anant',
+            'family_name': 'Agarwal',
+            'bio': "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+            'profile_image_url': 'https://www.edx.org/sites/default/files/executive/photo/anant-agarwal.jpg',
+            'slug': 'anant-agarwal',
+            'position': {
+                'title': 'CEO',
+                'organization_name': 'edX'
+            },
+            'profile_image': {},
+            'works': [],
+            'urls': {
+                'twitter': None,
+                'facebook': None,
+                'blog': None
+            },
+            'email': None
+        }
+    ],
+    'min_effort': 5,
+    'max_effort': 6,
+    'modified': '2017-08-18T00:32:33.754662Z',
+    'level_type': 'Type 1',
+    'availability': 'Current',
+    'mobile_available': False,
+    'hidden': False,
+    'reporting_type': 'mooc',
+    'eligible_for_financial_aid': True
+}
+FAKE_COURSE = {
+    'key': 'edX+DemoX',
+    'uuid': 'a9e8bb52-0c8d-4579-8496-1a8becb0a79c',
+    'title': 'edX Demonstration Course',
+    'course_runs': [FAKE_COURSE_RUN],
+    'owners': [
+        {
+            'uuid': '2bd367cf-c58e-400c-ac99-fb175405f7fa',
+            'key': 'edX',
+            'name': 'edX',
+            'certificate_logo_image_url': None,
+            'description': '',
+            'homepage_url': None,
+            'tags': [],
+            'logo_image_url': 'https://foo.com/bar.png',
+            'marketing_url': None
+        }
+    ],
+    'image': None,
+    'short_description': 'This course demonstrates many features of the edX platform.',
+    'full_description': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+    'level_type': None,
+    'subjects': [],
+    'prerequisites': [],
+    'expected_learning_items': [
+        'XBlocks',
+        'Peer Assessment'
+    ],
+    'video': None,
+    'sponsors': [],
+    'modified': '2017-08-18T00:23:21.111991Z',
+    'marketing_url': None,
+    'programs': []
+}
+
 FAKE_PROGRAM_RESPONSE1 = {
     "uuid": "40782a06-1c37-4779-86aa-0a081f014d4d",
     "title": "Program1",
@@ -810,3 +923,28 @@ def get_common_course_modes(course_runs):
     ]
 
     return six_reduce(lambda left, right: left & right, course_run_modes)
+
+
+def setup_course_catalog_api_client_mock(mock, course_overrides=None, course_run_overrides=None):
+    """
+    Set up the Course Catalog API client mock.
+
+    Arguments:
+        mock (Mock): The mock course catalog api client.
+        course_overrides (dict): Dictionary containing overrides of the fake course metadata values.
+        course_run_overrides (dict): Dictionary containing overrides of the fake course run metadata values.
+    """
+    client = mock.return_value
+
+    fake_course = FAKE_COURSE.copy()
+    fake_course_run = FAKE_COURSE_RUN.copy()
+
+    # Apply overrides to default fake course catalog metadata.
+    if course_overrides:
+        fake_course.update(course_overrides)
+    if course_run_overrides:
+        fake_course_run.update(course_run_overrides)
+
+    # Mock course catalog api functions.
+    client.get_course_run.return_value = fake_course_run
+    client.get_course_and_course_run.return_value = (fake_course, fake_course_run)

--- a/tests/test_enterprise/api_client/test_discovery.py
+++ b/tests/test_enterprise/api_client/test_discovery.py
@@ -12,8 +12,9 @@ import mock
 from pytest import raises
 
 from django.contrib.auth.models import User
+from django.core.exceptions import ImproperlyConfigured, ObjectDoesNotExist
 
-from enterprise.api_client.discovery import CourseCatalogApiClient
+from enterprise.api_client.discovery import CourseCatalogApiClient, CourseCatalogApiServiceClient
 from enterprise.utils import CourseCatalogApiError, NotConnectedToOpenEdX
 
 
@@ -193,7 +194,7 @@ class TestCourseCatalogApi(unittest.TestCase):
         Verify get_course_details of CourseCatalogApiClient works as expected for empty responses.
         """
         self.get_data_mock.return_value = response
-        assert self.api.get_course_details(course_key='edX+DemoX') == {}
+        assert self.api.get_course_details(course_id='edX+DemoX') == {}
 
     def test_get_catalog(self):
         """
@@ -416,3 +417,87 @@ class TestCourseCatalogApi(unittest.TestCase):
         assert self.api.is_course_in_catalog(catalog_id, course_id) == expected
         discovery_client.catalogs.assert_called_once_with(catalog_id)
         discovery_client.catalogs.return_value.contains.get.assert_called_once_with(course_run_id=course_id)
+
+    @ddt.data(
+        (
+            "course-v1:JediAcademy+AppliedTelekinesis+T1",
+            {"course_runs": [{"key": "course-v1:JediAcademy+AppliedTelekinesis+T1"}]},
+            "JediAcademy+AppliedTelekinesis",
+            {"key": "course-v1:JediAcademy+AppliedTelekinesis+T1"}
+        ),
+        (
+            "course-v1:JediAcademy+AppliedTelekinesis+T1",
+            {},
+            "JediAcademy+AppliedTelekinesis",
+            None
+        ),
+        (
+            "course-v1:JediAcademy+AppliedTelekinesis+T1",
+            {"course_runs": [
+                {"key": "course-v1:JediAcademy+AppliedTelekinesis+T222"},
+                {"key": "course-v1:JediAcademy+AppliedTelekinesis+T1"}
+            ]},
+            "JediAcademy+AppliedTelekinesis",
+            {"key": "course-v1:JediAcademy+AppliedTelekinesis+T1"}
+        ),
+        (
+            "course-v1:JediAcademy+AppliedTelekinesis+T1",
+            {"course_runs": []},
+            "JediAcademy+AppliedTelekinesis",
+            None
+        )
+    )
+    @ddt.unpack
+    def test_get_course_and_course_run(
+            self,
+            course_run_id,
+            response_dict,
+            expected_resource_id,
+            expected_course_run
+    ):
+        """
+        Verify get_course_and_course_run of CourseCatalogApiClient works as expected.
+        """
+        self.get_data_mock.return_value = response_dict
+        expected_result = response_dict, expected_course_run
+
+        actual_result = self.api.get_course_and_course_run(course_run_id)
+
+        assert self.get_data_mock.call_count == 1
+        resource, resource_id = self._get_important_parameters(self.get_data_mock)
+
+        assert resource == CourseCatalogApiClient.COURSES_ENDPOINT
+        assert resource_id == expected_resource_id
+        assert actual_result == expected_result
+
+
+class TestCourseCatalogApiServiceClientInitialization(unittest.TestCase):
+    """
+    Test initialization of CourseCatalogAPIServiceClient.
+    """
+    def test_raise_error_missing_catalog_integration(self, *args):  # pylint: disable=unused-argument
+        with self.assertRaises(NotConnectedToOpenEdX):
+            CourseCatalogApiServiceClient()
+
+    @mock.patch('enterprise.api_client.discovery.CatalogIntegration')
+    def test_raise_error_catalog_integration_disabled(self, mock_catalog_integration):
+        mock_catalog_integration.current.return_value = mock.Mock(enabled=False)
+        with self.assertRaises(ImproperlyConfigured):
+            CourseCatalogApiServiceClient()
+
+    @mock.patch('enterprise.api_client.discovery.CatalogIntegration')
+    def test_raise_error_object_does_not_exist(self, mock_catalog_integration):
+        mock_integration_config = mock.Mock(enabled=True)
+        mock_integration_config.get_service_user.side_effect = ObjectDoesNotExist
+        mock_catalog_integration.current.return_value = mock_integration_config
+        with self.assertRaises(ImproperlyConfigured):
+            CourseCatalogApiServiceClient()
+
+    @mock.patch('enterprise.api_client.discovery.JwtBuilder')
+    @mock.patch('enterprise.api_client.discovery.get_edx_api_data')
+    @mock.patch('enterprise.api_client.discovery.CatalogIntegration')
+    def test_success(self, mock_catalog_integration, *args):  # pylint: disable=unused-argument
+        mock_integration_config = mock.Mock(enabled=True)
+        mock_integration_config.get_service_user.return_value = mock.Mock(spec=User)
+        mock_catalog_integration.current.return_value = mock_integration_config
+        CourseCatalogApiServiceClient()


### PR DESCRIPTION
Previously we were using the LMS courses API.

ENT-585

**JIRA:** https://openedx.atlassian.net/browse/ENT-585

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happend instead - check failed.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** None
