### PR TITLE
ENT-612: Fix 500 server error on enterprise course enrollment page.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.40.4] - 2017-08-23
+---------------------
+
+* Fix 500 server error on enterprise course enrollment page.
+
 [0.40.3] - 2017-08-21
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.40.3"
+__version__ = "0.40.4"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -637,7 +637,7 @@ class CourseEnrollmentView(View):
             ),
             'course_modes': filter_audit_course_modes(enterprise_customer, course_modes),
             'course_effort': course_effort,
-            'course_full_description': clean_html_for_template_rendering(course_run['full_description']),
+            'course_full_description': clean_html_for_template_rendering(course_run['full_description'] or ''),
             'organization_logo': organization_logo,
             'organization_name': organization_name,
             'course_level_type': course_run.get('level_type', ''),


### PR DESCRIPTION
**Description:** 
This PR fixes the 500 error appearing on enterprise landing page.

**JIRA:** [ENT-612](https://openedx.atlassian.net/browse/ENT-612)


**Testing instructions:**

1. Open enterprise landing page (preferably for a course with no `full_description`)
2. Page should open without 500 error.

**Merge checklist:**

- [x] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [x] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [x] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] All reviewers approved
- [ ] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [x] Translations are updated
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)