### PR TITLE
Fix course enrollment landing page when the course does not have a course image configured.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.40.7] - 2017-08-23
+---------------------
+
+* Fix bug causing 500 error on course enrollment page when the course does not have a course image configured.
+
 [0.40.6] - 2017-08-23
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.40.6"
+__version__ = "0.40.7"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -599,6 +599,9 @@ class CourseEnrollmentView(View):
                 effort_hours,
             ).format(hours=effort_hours)
 
+        # Parse course run image.
+        course_run_image = course_run['image'] or {}
+
         # Retrieve the enterprise-discounted price from ecommerce.
         course_modes = self.set_final_prices(course_modes, request)
         premium_modes = [mode for mode in course_modes if mode['premium']]
@@ -626,7 +629,7 @@ class CourseEnrollmentView(View):
             'course_short_description': course_run['short_description'] or '',
             'course_pacing': self.PACING_FORMAT.get(course_run['pacing_type'], ''),
             'course_start_date': course_start_date,
-            'course_image_uri': course_run['image']['src'],
+            'course_image_uri': course_run_image.get('src', ''),
             'enterprise_customer': enterprise_customer,
             'welcome_text': self.WELCOME_TEXT_FORMAT.format(platform_name=platform_name),
             'enterprise_welcome_text': self.ENT_WELCOME_TEXT_FORMAT.format(

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -886,7 +886,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
     @mock.patch('enterprise.views.EnrollmentApiClient')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
     @mock.patch('enterprise.utils.Registry')
-    def test_get_course_enrollment_page_no_effort_no_owners(
+    def test_get_course_enrollment_page_with_empty_fields(
             self,
             registry_mock,
             ecommerce_api_client_mock,
@@ -897,7 +897,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
     ):  # pylint: disable=unused-argument
         setup_course_catalog_api_client_mock(
             course_catalog_client_mock,
-            course_run_overrides={'min_effort': None, 'max_effort': None},
+            course_run_overrides={'min_effort': None, 'max_effort': None, 'image': None},
             course_overrides={'owners': []}
         )
         self._setup_ecommerce_client(ecommerce_api_client_mock, 30.1)
@@ -936,7 +936,8 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
             'premium_modes': course_modes,
             'course_effort': '',
             'organization_name': '',
-            'organization_logo': ''
+            'organization_logo': '',
+            'course_image_uri': '',
         }
 
         self._login()


### PR DESCRIPTION
ENT-612

**Description:** We need to be careful about checking for null values returned from the discovery API.

**JIRA:** https://openedx.atlassian.net/browse/ENT-612

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)
