### PR TITLE
ENT-496 Posting to enterprise-course-enrollment shouldn't write consent_granted anymore

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.43.1] - 2017-09-05
+---------------------
+
+* Remove support for writing consent_granted in enterprise-course-enrollment api.
+
 [0.43.0] - 2017-08-31
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.43.0"
+__version__ = "0.43.1"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -161,12 +161,10 @@ class EnterpriseCourseEnrollmentWriteSerializer(serializers.ModelSerializer):
         Save the model with the found EnterpriseCustomerUser.
         """
         course_id = self.validated_data['course_id']
-        consent_granted = self.validated_data['consent_granted']
 
         models.EnterpriseCourseEnrollment.objects.get_or_create(
             enterprise_customer_user=self.enterprise_customer_user,
             course_id=course_id,
-            consent_granted=consent_granted,
         )
 
 


### PR DESCRIPTION
**Description:** I discovered an error on the business sandbox where the user wasn't being enrolled in the course when doing a verified purchase. The root cause was that we were calling the enterprise-course-enrollment endpoint attempting to write the consent_granted field. However, the record existed with consent_granted set to NULL, as expected from the changes from ENT-496, but the api save method used get_or_create with that and threw an DB integrity error. There is an associated edx-platform PR to address how we call this (https://github.com/edx/edx-platform/pull/15950)

**JIRA:** Link to JIRA ticket

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

Pre these changes:
Go through the enterprise landing page and select the verified track. After purchasing, return to the dashboard and see that the user is not enrolled in the course.

Apply these changes:
Go through the same flow as above, but when you come to the dashboard, you should be enrolled in the course.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
