### PR TITLE
ENT-617 Ensure that LMS_SEGMENT_KEY is passed in the context for all enterprise views

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,11 +14,15 @@ Change Log
 Unreleased
 ----------
 
+[0.43.3] - 2017-09-06
+---------------------
+
+* Ensure that segment is loaded and firing page events for all user facing enterprise views.
+
 [0.43.2] - 2017-09-06
 ---------------------
 
 * Display the enterprise discounted text on the course enrollment landing page.
-
 
 [0.43.1] - 2017-09-05
 ---------------------

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.43.2"
+__version__ = "0.43.3"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/test_settings.py
+++ b/test_settings.py
@@ -138,4 +138,4 @@ COURSE_ID_PATTERN = COURSE_KEY_PATTERN.replace('course_key_string', 'course_id')
 
 USE_TZ = True
 
-LMS_SEGMENT_KEY = ''
+LMS_SEGMENT_KEY = 'SOME_KEY'

--- a/tests/test_enterprise/views/test_course_enrollment_view.py
+++ b/tests/test_enterprise/views/test_course_enrollment_view.py
@@ -126,7 +126,8 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
             'close_modal_button_text': 'Close',
             'discount_text': 'Discount provided by <strong>Starfleet Academy</strong>',
             'no_discount_text': "Receive an instructor-signed certificate and support edX's mission to increase access"
-                                " to high-quality education for everyone."
+                                " to high-quality education for everyone.",
+            'LMS_SEGMENT_KEY': settings.LMS_SEGMENT_KEY,
         }
         default_context.update(expected_context)
         assert response.status_code == 200

--- a/tests/test_enterprise/views/test_grant_data_sharing_permissions.py
+++ b/tests/test_enterprise/views/test_grant_data_sharing_permissions.py
@@ -9,6 +9,7 @@ import ddt
 import mock
 from pytest import mark
 
+from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.test import Client, TestCase
 
@@ -173,6 +174,7 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
                 "enrollment_deferred": enrollment_deferred,
                 "welcome_text": "Welcome to My Platform.",
                 'sharable_items_note_header': 'Please note',
+                'LMS_SEGMENT_KEY': settings.LMS_SEGMENT_KEY,
         }.items():
             assert response.context[key] == value  # pylint:disable=no-member
 
@@ -705,6 +707,7 @@ class TestProgramDataSharingPermissions(TestCase):
                 "enrollment_deferred": enrollment_deferred,
                 "welcome_text": "Welcome to My Platform.",
                 'sharable_items_note_header': 'Please note',
-                "enterprise_customer": enterprise_customer
+                "enterprise_customer": enterprise_customer,
+                'LMS_SEGMENT_KEY': settings.LMS_SEGMENT_KEY,
         }.items():
             assert response.context[key] == value  # pylint:disable=no-member


### PR DESCRIPTION
**Description:** 
The reason we weren't getting page events sent to segment for the course landing page
was because the LMS_SEGMENT_KEY wasn't getting passed in the context for that view.
We should always be passing that so that we can take advantage of segment for all pages.

**JIRA:** Link to JIRA ticket

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

For the business sandbox:
Log into our test segment account (ask me for details), and go to the debug tab. Go to the course landing page, note that each new page generates a page event in segment's debug tab, particularly for the course landing page which previously generated no event.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** We need to make sure that the global context introduced in this PR is included in the program landing page so that it fires a page view event to segment.
