### PR TITLE
ENT-638 Fix enterprise-learner API endpoint serializer.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.45.0] - 2017-09-14
+---------------------
+
+* Modified enterprise-learner API endpoint to include the new DataSharingConsent model data.
+
 [0.44.0] - 2017-09-08
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.44.0"
+__version__ = "0.45.0"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -253,12 +253,24 @@ class EnterpriseCustomerUserReadOnlySerializer(serializers.ModelSerializer):
     class Meta:
         model = models.EnterpriseCustomerUser
         fields = (
-            'id', 'enterprise_customer', 'user_id', 'user', 'data_sharing_consent'
+            'id', 'enterprise_customer', 'user_id', 'user', 'data_sharing_consent_records'
         )
 
     user = UserSerializer()
     enterprise_customer = EnterpriseCustomerSerializer()
-    data_sharing_consent = UserDataSharingConsentAuditSerializer(many=True)
+    data_sharing_consent_records = serializers.SerializerMethodField()
+
+    def get_data_sharing_consent_records(self, obj):
+        """
+        Return serialization of EnterpriseCustomerUser.data_sharing_consent_records property.
+
+        Arguments:
+            EnterpriseCustomerUser: The EnterpriseCustomerUser.
+
+        Returns:
+            list of dict: The serialized DataSharingConsent records associated with the EnterpriseCustomerUser.
+        """
+        return [record.serialize() for record in obj.data_sharing_consent_records]
 
 
 class EnterpriseCustomerUserWriteSerializer(serializers.ModelSerializer):
@@ -313,7 +325,6 @@ class EnterpriseCustomerUserEntitlementSerializer(ImmutableStateSerializer):
 
     user = UserSerializer(read_only=True)
     enterprise_customer = EnterpriseCustomerSerializer(read_only=True)
-    data_sharing_consent = UserDataSharingConsentAuditSerializer(many=True, read_only=True)
 
 
 class CourseCatalogApiResponseReadOnlySerializer(ImmutableStateSerializer):

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -439,6 +439,20 @@ class EnterpriseCustomerUser(TimeStampedModel):
             } for entitlement in entitlements.all()
             ]
 
+    @property
+    def data_sharing_consent_records(self):
+        """
+        Return the DataSharingConsent records associated with this EnterpriseCustomerUser.
+
+        Returns:
+            QuerySet (DataSharingConsent): The filtered DataSharingConsent QuerySet.
+        """
+        DataSharingConsent = apps.get_model('consent', 'DataSharingConsent')  # pylint: disable=invalid-name
+        return DataSharingConsent.objects.filter(
+            enterprise_customer=self.enterprise_customer,
+            username=self.username
+        )
+
     def __str__(self):
         """
         Return human-readable string representation.


### PR DESCRIPTION
ENT-638

**Description:** We were including the deprecated UserDataSharingConsentAudit model
data with the enterprise-learner API endpoint result payload. This
fixes that so we now return the new DataSharingConsent model data.

The Enterprise Offers feature I am adding to ecommerce will make use of the DataSharingConsent data returned via the enterprise-learner API endpoint.

**JIRA:** https://openedx.atlassian.net/browse/ENT-638

**Testing instructions:**

1. Visit https://business.sandbox.edx.org/enterprise/api/v1/enterprise-learner/?username=myself2e86.
2. Verify that the results contain a `data_sharing_consent_records` key.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)
