### PR TITLE
Make enrollment emails marketing site aware

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,3 +12,4 @@ Tim Krones <tim@opencraft.com>
 Matt Drayer <mattdrayer@edx.org>
 Lucas Tadeu Teixeira <lucas@opencraft.com>
 Bill Filler <bfiller@edx.org>
+Matt Tuchfarber <mtuchfarber@edx.org>

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.46.3] - 2017-09-19
+---------------------
+
+* Make bulk enrollment emails more intelligent
+
 [0.46.2] - 2017-09-19
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.46.2"
+__version__ = "0.46.3"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -594,3 +594,20 @@ def format_price(price, currency='$'):
     if int(price) == price:
         return '{}{}'.format(currency, int(price))
     return '{}{:0.2f}'.format(currency, price)
+
+
+def get_configuration_value_for_site(site, key, default=None):
+    """
+    Get the site configuration value for a key, unless a site configuration does not exist for that site.
+
+    Useful for testing when no Site Configuration exists in edx-enterprise or if a site in LMS doesn't have
+    a configuration tied to it.
+
+    :param site: A Site model object
+    :param key: The name of the value to retrieve
+    :param default: The default response if there's no key in site config or settings
+    :return: The value located at that key in the site configuration or settings file.
+    """
+    if hasattr(site, 'configuration'):
+        return site.configuration.get_value(key, default)
+    return default

--- a/tests/test_admin/test_view.py
+++ b/tests/test_admin/test_view.py
@@ -741,7 +741,12 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
     @mock.patch("enterprise.admin.views.CourseCatalogApiClient")
     @mock.patch("enterprise.admin.views.EnrollmentApiClient")
     @mock.patch("enterprise.admin.forms.CourseCatalogApiClient")
-    def test_post_enroll_user_into_program(self, catalog_client, views_client, views_catalog_client):
+    def test_post_enroll_user_into_program(
+            self,
+            catalog_client,
+            views_client,
+            views_catalog_client
+    ):
         views_catalog_instance = views_catalog_client.return_value
         views_catalog_instance.get_program_by_uuid.side_effect = fake_catalog_api.get_program_by_uuid
         views_instance = views_client.return_value
@@ -784,7 +789,12 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
     @mock.patch("enterprise.admin.views.CourseCatalogApiClient")
     @mock.patch("enterprise.admin.views.EnrollmentApiClient")
     @mock.patch("enterprise.admin.forms.CourseCatalogApiClient")
-    def test_post_enroll_user_into_program_error(self, catalog_client, views_client, views_catalog_client):
+    def test_post_enroll_user_into_program_error(
+            self,
+            catalog_client,
+            views_client,
+            views_catalog_client
+    ):
         views_catalog_instance = views_catalog_client.return_value
         views_catalog_instance.get_program_by_uuid.side_effect = fake_catalog_api.get_program_by_uuid
         views_instance = views_client.return_value


### PR DESCRIPTION
**Description:** 
Currently the enterprise emails assume they are being ran with a
marketing site. This allows for instances without a marketing site
(e.g. devstack, sandbox, WL) to send emails correctly.

**JIRA:**
[WL-1124]

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 
None

**Merge deadline:** List merge deadline (if any)
None. Sooner the better?

**Installation instructions:** List any non-trivial installation instructions.
None

**Testing instructions:**
1. Open the enterprise customer admin page in LMS
2. Click "Manage Learners" in the top right
3. Add a leaner to a program or course
4. Note in email how the link is formatted correctly based on whether the site has an admin page or not.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [ ] Translations are updated
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
It's goddamn perfect.
