### PR TITLE
Allow multi-course enrollment for enterprise users in admin

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,3 +11,4 @@ Douglas Cerna <douglas@opencraft.com>
 Tim Krones <tim@opencraft.com>
 Matt Drayer <mattdrayer@edx.org>
 Lucas Tadeu Teixeira <lucas@opencraft.com>
+Bill Filler <bfiller@edx.org>

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ Change Log
 
 Unreleased
 ----------
+[0.46.0] - 2017-09-15
+---------------------
+
+* Allow multi-course enrollment for enterprise users in admin. 
 
 [0.45.0] - 2017-09-14
 ---------------------

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.45.0"
+__version__ = "0.46.0"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/admin/forms.py
+++ b/enterprise/admin/forms.py
@@ -156,6 +156,7 @@ class ManageLearnersForm(forms.Form):
                 email,
                 email_or_username,
                 ValidationMessages.INVALID_EMAIL_OR_USERNAME,
+                ignore_existing=True
             )
 
         return email

--- a/enterprise/admin/views.py
+++ b/enterprise/admin/views.py
@@ -205,7 +205,7 @@ class EnterpriseCustomerManageLearnersView(View):
         form_field_value = manage_learners_form.cleaned_data[ManageLearnersForm.Fields.EMAIL_OR_USERNAME]
         email = email_or_username__to__email(form_field_value)
         try:
-            validate_email_to_link(email, form_field_value, ValidationMessages.INVALID_EMAIL_OR_USERNAME)
+            validate_email_to_link(email, form_field_value, ValidationMessages.INVALID_EMAIL_OR_USERNAME, True)
         except ValidationError as exc:
             manage_learners_form.add_error(ManageLearnersForm.Fields.EMAIL_OR_USERNAME, exc)
         else:

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -302,9 +302,10 @@ class EnterpriseCustomerUserManager(models.Manager):
         """
         try:
             existing_user = User.objects.get(email=user_email)
-            self.create(enterprise_customer=enterprise_customer, user_id=existing_user.id)
+            self.get_or_create(enterprise_customer=enterprise_customer, user_id=existing_user.id)
         except User.DoesNotExist:
-            PendingEnterpriseCustomerUser.objects.create(enterprise_customer=enterprise_customer, user_email=user_email)
+            PendingEnterpriseCustomerUser.objects.get_or_create(enterprise_customer=enterprise_customer,
+                                                                user_email=user_email)
 
     def unlink_user(self, enterprise_customer, user_email):
         """

--- a/tests/test_admin/test_forms.py
+++ b/tests/test_admin/test_forms.py
@@ -154,27 +154,21 @@ class TestManageLearnersForm(TestWithCourseCatalogApiMixin, unittest.TestCase):
     )
     def test_clean_user_already_linked(self, form_entry, existing_username, existing_email):
         user = UserFactory(username=existing_username, email=existing_email)
-        existing_record = EnterpriseCustomerUserFactory(user_id=user.id)  # pylint: disable=no-member
+        EnterpriseCustomerUserFactory(user_id=user.id)  # pylint: disable=no-member
 
         form = self._make_bound_form(form_entry)
-        assert not form.is_valid()
-        errors = form.errors
-        error_message = ValidationMessages.USER_ALREADY_REGISTERED.format(
-            email=existing_email, ec_name=existing_record.enterprise_customer.name
-        )
-        assert errors == {ManageLearnersForm.Fields.EMAIL_OR_USERNAME: [error_message]}
+        assert form.is_valid()
+        cleaned_data = form.clean()
+        assert cleaned_data[ManageLearnersForm.Fields.EMAIL_OR_USERNAME] == existing_email
 
     @ddt.data("user1@example.com", "qwe@asd.com",)
     def test_clean_existing_pending_link(self, existing_email):
-        existing_record = PendingEnterpriseCustomerUserFactory(user_email=existing_email)
+        PendingEnterpriseCustomerUserFactory(user_email=existing_email)
 
         form = self._make_bound_form(existing_email)
-        assert not form.is_valid()
-        errors = form.errors
-        error_message = ValidationMessages.USER_ALREADY_REGISTERED.format(
-            email=existing_email, ec_name=existing_record.enterprise_customer.name
-        )
-        assert errors == {ManageLearnersForm.Fields.EMAIL_OR_USERNAME: [error_message]}
+        assert form.is_valid()
+        cleaned_data = form.clean()
+        assert cleaned_data[ManageLearnersForm.Fields.EMAIL_OR_USERNAME] == existing_email
 
     def test_clean_both_username_and_file(self):
         form = self._make_bound_form("irrelevant@example.com", file_attached=True)


### PR DESCRIPTION
This adds functionality to allow an existing enterprise customer to be
enrolled in multiple courses. The current behavior would incorectly
limit the user to only be enrolled once via the django-admin page.

WL-1221

**Dependencies:** None

**Merge deadline:** None

**Installation instructions:** Install branch

**Testing instructions:**

1. As admin, Open Enterprise Customer->Manage Learners page
2. As admin, enroll new User A into Course A, verify enrollment email sent and User A put into Pending Linked Learner
3. As admin, Enroll User A into Course B, verify enrollment email sent and User A still in Pending List
4. As User A, create an account on edX
5. As User A, verify that Course A and Course B show up in Courses Dashboard
6. As admin, verify that User A was moved from Pending to Linked Learner list
7. As admin, enroll User A into Course C, verify enrollment email sent
8. As User A, verify that Course A, B, C show up in Courses dashboard

**Merge checklist:**

- [x] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [x] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [x] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [x] Translations are updated
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** None
