### PR TITLE
[ENT-428] Remove hard requirement on `configuration_helpers`.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.46.4] - 2017-09-20
+---------------------
+
+* Abstract away usage of `configuration_helpers`.
+
 [0.46.3] - 2017-09-19
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.46.3"
+__version__ = "0.46.4"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/messages.py
+++ b/enterprise/messages.py
@@ -8,10 +8,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.utils.translation import ugettext as _
 
-try:
-    from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
-except ImportError:
-    configuration_helpers = None
+from enterprise.utils import get_configuration_value
 
 
 def add_consent_declined_message(request, enterprise_customer, item):
@@ -35,12 +32,12 @@ def add_consent_declined_message(request, enterprise_customer, item):
             em_end='</em>',
             enterprise_customer_name=enterprise_customer.name,
             link_start='<a href="{support_link}" target="_blank">'.format(
-                support_link=configuration_helpers.get_value(
+                support_link=get_configuration_value(
                     'ENTERPRISE_SUPPORT_URL',
                     getattr(settings, 'ENTERPRISE_SUPPORT_URL', '')  # Remove the `getattr` when setting is upstreamed.
                 ),
             ),
-            platform_name=configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME),
+            platform_name=get_configuration_value('PLATFORM_NAME', settings.PLATFORM_NAME),
             link_end='</a>',
             span_start='<span>',
             span_end='</span>',
@@ -68,12 +65,12 @@ def add_missing_price_information_message(request, item):
             em_start='<em>',
             em_end='</em>',
             link_start='<a href="{support_link}" target="_blank">'.format(
-                support_link=configuration_helpers.get_value(
+                support_link=get_configuration_value(
                     'ENTERPRISE_SUPPORT_URL',
                     getattr(settings, 'ENTERPRISE_SUPPORT_URL', '')  # Remove the `getattr` when setting is upstreamed.
                 ),
             ),
-            platform_name=configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME),
+            platform_name=get_configuration_value('PLATFORM_NAME', settings.PLATFORM_NAME),
             link_end='</a>',
             span_start='<span>',
             span_end='</span>',
@@ -106,12 +103,12 @@ def add_not_one_click_purchasable_message(request, enterprise_customer, program_
             em_start='<em>',
             em_end='</em>',
             link_start='<a href="{support_link}" target="_blank">'.format(
-                support_link=configuration_helpers.get_value(
+                support_link=get_configuration_value(
                     'ENTERPRISE_SUPPORT_URL',
                     getattr(settings, 'ENTERPRISE_SUPPORT_URL', '')  # Remove the `getattr` when setting is upstreamed.
                 ),
             ),
-            platform_name=configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME),
+            platform_name=get_configuration_value('PLATFORM_NAME', settings.PLATFORM_NAME),
             link_end='</a>',
             span_start='<span>',
             span_end='</span>',

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -33,14 +33,9 @@ from enterprise import utils
 from enterprise.api_client.discovery import CourseCatalogApiServiceClient
 from enterprise.api_client.lms import EnrollmentApiClient, ThirdPartyAuthApiClient, enroll_user_in_course_locally
 from enterprise.decorators import deprecated
-from enterprise.utils import NotConnectedToOpenEdX
+from enterprise.utils import get_configuration_value
 from enterprise.validators import validate_image_extension, validate_image_size
 from six.moves.urllib.parse import urljoin  # pylint: disable=import-error,ungrouped-imports
-
-try:
-    from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
-except ImportError:
-    configuration_helpers = None
 
 LOGGER = getLogger(__name__)
 
@@ -214,13 +209,8 @@ class EnterpriseCustomer(TimeStampedModel):
         Returns:
             (str): Enterprise landing page url.
         """
-        if configuration_helpers is None:
-            raise NotConnectedToOpenEdX(
-                _("This package must be installed in an EdX environment to look up configuration.")
-            )
-
         return urljoin(
-            configuration_helpers.get_value('LMS_ROOT_URL', settings.LMS_ROOT_URL),
+            get_configuration_value('LMS_ROOT_URL', settings.LMS_ROOT_URL),
             reverse(
                 'enterprise_course_enrollment_page',
                 kwargs={'enterprise_uuid': self.uuid, 'course_id': course_run_key}
@@ -236,13 +226,8 @@ class EnterpriseCustomer(TimeStampedModel):
         Returns:
             (str): Enterprise program landing page url.
         """
-        if configuration_helpers is None:
-            raise NotConnectedToOpenEdX(
-                _("This package must be installed in an EdX environment to look up configuration.")
-            )
-
         return urljoin(
-            configuration_helpers.get_value('LMS_ROOT_URL', settings.LMS_ROOT_URL),
+            get_configuration_value('LMS_ROOT_URL', settings.LMS_ROOT_URL),
             reverse(
                 'enterprise_program_enrollment_page',
                 kwargs={'enterprise_uuid': self.uuid, 'program_uuid': program_uuid}

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -26,6 +26,11 @@ from django.utils.translation import ungettext
 from six.moves.urllib.parse import parse_qs, urlencode, urlparse, urlsplit, urlunparse, urlunsplit
 
 try:
+    from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+except ImportError:
+    configuration_helpers = None
+
+try:
     # Try to import identity provider registry if third_party_auth is present
     from third_party_auth.provider import Registry
 except ImportError:
@@ -611,3 +616,10 @@ def get_configuration_value_for_site(site, key, default=None):
     if hasattr(site, 'configuration'):
         return site.configuration.get_value(key, default)
     return default
+
+
+def get_configuration_value(val_name, default=None, **kwargs):
+    """
+    Get a configuration value, or fall back to ``default`` if it doesn't exist.
+    """
+    return configuration_helpers.get_value(val_name, default, **kwargs) if configuration_helpers else default

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -37,6 +37,7 @@ from enterprise.utils import (
     clean_html_for_template_rendering,
     filter_audit_course_modes,
     format_price,
+    get_configuration_value,
     get_enterprise_customer_for_user,
     get_enterprise_customer_or_404,
     get_enterprise_customer_user,
@@ -48,11 +49,6 @@ try:
     from openedx.core.djangoapps.programs.utils import ProgramDataExtender
 except ImportError:
     ProgramDataExtender = None
-
-try:
-    from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
-except ImportError:
-    configuration_helpers = None
 
 LOGGER = getLogger(__name__)
 BASKET_URL = urljoin(settings.ECOMMERCE_PUBLIC_URL_ROOT, '/basket/add/')
@@ -68,7 +64,6 @@ def verify_edx_resources():
     Ensure that all necessary resources to render the view are present.
     """
     required_methods = {
-        'configuration_helpers': configuration_helpers,
         'ProgramDataExtender': ProgramDataExtender,
     }
 
@@ -87,7 +82,7 @@ def get_global_context(request):
     return {
         'LMS_SEGMENT_KEY': settings.LMS_SEGMENT_KEY,
         'LANGUAGE_CODE': get_language_from_request(request),
-        'platform_name': configuration_helpers.get_value("PLATFORM_NAME", settings.PLATFORM_NAME),
+        'platform_name': get_configuration_value("PLATFORM_NAME", settings.PLATFORM_NAME),
     }
 
 
@@ -710,7 +705,7 @@ class CourseEnrollmentView(NonAtomicView):
         """
         Render enterprise specific course track selection page.
         """
-        platform_name = configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME)
+        platform_name = get_configuration_value('PLATFORM_NAME', settings.PLATFORM_NAME)
         course_start_date = ''
         if course_run['start']:
             course_start_date = parse(course_run['start']).strftime('%B %d, %Y')
@@ -1044,7 +1039,7 @@ class ProgramEnrollmentView(NonAtomicView):
         # Safely make the assumption that we can use the first authoring organization.
         organizations = program_details['authoring_organizations']
         organization = organizations[0] if organizations else {}
-        platform_name = configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME)
+        platform_name = get_configuration_value('PLATFORM_NAME', settings.PLATFORM_NAME)
         program_title = program_details['title']
 
         # Make any modifications for singular/plural-dependent text.

--- a/tests/test_enterprise/api/test_serializers.py
+++ b/tests/test_enterprise/api/test_serializers.py
@@ -232,7 +232,6 @@ class TestEnterpriseCatalogCoursesSerializer(TestImmutableStateSerializer):
         ),
     )
     @ddt.unpack
-    @mock.patch('enterprise.models.configuration_helpers')
     @override_settings(LMS_ROOT_URL='http://testserver/')
     def test_update_course_runs(
             self,
@@ -242,7 +241,6 @@ class TestEnterpriseCatalogCoursesSerializer(TestImmutableStateSerializer):
             enterprise_customer_uuid,
             expected_fields,
             expected_urls,
-            mock_config_helpers,
     ):
         """
         Test update_course_runs method of EnterpriseCatalogCoursesReadOnlySerializer.
@@ -251,7 +249,6 @@ class TestEnterpriseCatalogCoursesSerializer(TestImmutableStateSerializer):
         successfully without errors.
         """
         # Populate database.
-        mock_config_helpers.get_value.return_value = 'http://testserver/'
         ec_identity_provider = factories.EnterpriseCustomerIdentityProviderFactory(
             enterprise_customer__uuid=enterprise_customer_uuid,
             provider_id=provider_id,
@@ -285,15 +282,13 @@ class TestEnterpriseCatalogCoursesSerializer(TestImmutableStateSerializer):
                 self.assert_url(value, updated_course_run[key])
 
     @mock.patch('enterprise.utils.reverse', return_value='')
-    @mock.patch('enterprise.models.configuration_helpers')
-    def test_update_course(self, mock_config_helpers, _):
+    def test_update_course(self, _):
         """
         Test update_course method of EnterpriseCatalogCoursesReadOnlySerializer.
 
         Verify that update_course for EnterpriseCatalogCoursesReadOnlySerializer returns
         successfully without errors.
         """
-        mock_config_helpers.get_value.return_value = ''
         global_context = {
             'tpa_hint': self.provider_id,
             'catalog_id': 1,
@@ -381,15 +376,13 @@ class TestEnterpriseCatalogCoursesSerializer(TestImmutableStateSerializer):
             assert expected_course == updated_course
 
     @mock.patch('enterprise.utils.reverse', return_value='/course_modes/choose/')
-    @mock.patch('enterprise.models.configuration_helpers')
-    def test_update_enterprise_courses(self, mock_config_helpers, _):
+    def test_update_enterprise_courses(self, _):
         """
         Test update_enterprise_courses method of EnterpriseCatalogCoursesReadOnlySerializer.
 
         Verify that update_enterprise_courses for EnterpriseCatalogCoursesReadOnlySerializer updates
         serializer data successfully without errors.
         """
-        mock_config_helpers.get_value.return_value = ''
         self.serializer.update_enterprise_courses(self.ecu.enterprise_customer, catalog_id=1)
 
         # Make sure global context passed in to update_course is added to the course.

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -647,10 +647,9 @@ class TestEnterpriseAPIViews(APITest):
         ),
     )
     @ddt.unpack
-    @mock.patch('enterprise.models.configuration_helpers')
     @mock.patch('enterprise.models.CourseCatalogApiServiceClient')
     def test_enterprise_customer_catalogs_detail(self, is_staff, is_linked_to_enterprise, expected_result,
-                                                 mock_catalog_api_client, mock_configuration_helpers):
+                                                 mock_catalog_api_client):
         """
         Make sure the Enterprise Customer's Catalog view correctly returns details about specific catalogs based on
         the content filter.
@@ -676,9 +675,6 @@ class TestEnterpriseAPIViews(APITest):
                 enterprise_customer=enterprise_customer
             )
 
-        mock_configuration_helpers.get_value = mock.Mock(
-            return_value=settings.LMS_ROOT_URL
-        )
         mock_catalog_api_client.return_value = mock.Mock(
             get_paginated_search_results=mock.Mock(
                 return_value=fake_catalog_api.FAKE_SEARCH_ALL_RESULTS
@@ -689,9 +685,8 @@ class TestEnterpriseAPIViews(APITest):
 
         assert response == expected_result
 
-    @mock.patch('enterprise.models.configuration_helpers')
     @mock.patch('enterprise.models.CourseCatalogApiServiceClient')
-    def test_enterprise_customer_catalogs_detail_pagination(self, mock_catalog_api_client, mock_configuration_helpers):
+    def test_enterprise_customer_catalogs_detail_pagination(self, mock_catalog_api_client):
         """
         Verify the EnterpriseCustomerCatalog detail view returns the correct paging URLs.
         """
@@ -707,9 +702,6 @@ class TestEnterpriseAPIViews(APITest):
             enterprise_customer=enterprise_customer
         )
 
-        mock_configuration_helpers.get_value = mock.Mock(
-            return_value=settings.LMS_ROOT_URL
-        )
         mock_catalog_api_client.return_value = mock.Mock(
             get_paginated_search_results=mock.Mock(
                 return_value=fake_catalog_api.FAKE_SEARCH_ALL_RESULTS_WITH_PAGINATION
@@ -749,11 +741,9 @@ class TestEnterpriseAPIViews(APITest):
         ),
     )
     @ddt.unpack
-    @mock.patch('enterprise.models.configuration_helpers')
     @mock.patch('enterprise.models.CourseCatalogApiServiceClient')
     def test_enterprise_catalog_course_run_detail(self, is_staff, is_linked_to_enterprise, is_course_run_in_catalog,
-                                                  mocked_course_run, expected_result, mock_catalog_api_client,
-                                                  mock_configuration_helpers):
+                                                  mocked_course_run, expected_result, mock_catalog_api_client):
         """
         The ``programs`` detail endpoint should return correct results from course discovery,
         with enterprise context in courses.
@@ -775,9 +765,6 @@ class TestEnterpriseAPIViews(APITest):
         if is_course_run_in_catalog:
             search_results = fake_catalog_api.FAKE_SEARCH_ALL_RESULTS
 
-        mock_configuration_helpers.get_value = mock.Mock(
-            return_value=settings.LMS_ROOT_URL
-        )
         mock_catalog_api_client.return_value = mock.Mock(
             get_paginated_search_results=mock.Mock(return_value=search_results),
             get_course_run=mock.Mock(return_value=mocked_course_run),
@@ -812,11 +799,10 @@ class TestEnterpriseAPIViews(APITest):
         ),
     )
     @ddt.unpack
-    @mock.patch('enterprise.models.configuration_helpers')
     @mock.patch('enterprise.models.CourseCatalogApiServiceClient')
     def test_enterprise_catalog_program_detail(self, is_staff, is_linked_to_enterprise, has_existing_catalog,
                                                is_program_in_catalog, mocked_program, expected_result,
-                                               mock_catalog_api_client, mock_configuration_helpers):
+                                               mock_catalog_api_client):
         """
         The ``programs`` detail endpoint should return correct results from course discovery,
         with enterprise context in courses.
@@ -843,9 +829,6 @@ class TestEnterpriseAPIViews(APITest):
         if is_program_in_catalog:
             search_results = fake_catalog_api.FAKE_SEARCH_ALL_RESULTS
 
-        mock_configuration_helpers.get_value = mock.Mock(
-            return_value=settings.LMS_ROOT_URL
-        )
         mock_catalog_api_client.return_value = mock.Mock(
             get_paginated_search_results=mock.Mock(return_value=search_results),
             get_program_by_uuid=mock.Mock(return_value=mocked_program),

--- a/tests/test_enterprise/views/test_course_enrollment_view.py
+++ b/tests/test_enterprise/views/test_course_enrollment_view.py
@@ -101,7 +101,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
         """
         fake_organization = FAKE_COURSE['owners'][0]
         default_context = {
-            'platform_name': 'edX',
+            'platform_name': 'Test platform',
             'page_title': 'Confirm your course',
             'course_title': FAKE_COURSE_RUN['title'],
             'course_short_description': FAKE_COURSE_RUN['short_description'],
@@ -109,7 +109,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
             'course_start_date': parse(FAKE_COURSE_RUN['start']).strftime('%B %d, %Y'),
             'course_image_uri': FAKE_COURSE_RUN['image']['src'],
             'enterprise_welcome_text': (
-                '<strong>Starfleet Academy</strong> has partnered with <strong>edX</strong> to '
+                '<strong>Starfleet Academy</strong> has partnered with <strong>Test platform</strong> to '
                 "offer you high-quality learning opportunities from the world's best universities."
             ),
             'confirmation_text': 'Confirm your course',
@@ -135,7 +135,6 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.views.ProgramDataExtender')
-    @mock.patch('enterprise.views.configuration_helpers')
     @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.EnrollmentApiClient')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
@@ -146,12 +145,10 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
             ecommerce_api_client_mock,
             enrollment_api_client_mock,
             course_catalog_client_mock,
-            configuration_helpers_mock,
             *args
     ):  # pylint: disable=unused-argument
         setup_course_catalog_api_client_mock(course_catalog_client_mock)
         self._setup_ecommerce_client(ecommerce_api_client_mock, 100)
-        configuration_helpers_mock.get_value.return_value = 'edX'
         self._setup_enrollment_client(enrollment_api_client_mock)
         enterprise_customer = EnterpriseCustomerFactory(
             name='Starfleet Academy',
@@ -192,8 +189,6 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.views.ProgramDataExtender')
-    @mock.patch('enterprise.views.configuration_helpers')
-    @mock.patch('enterprise.messages.configuration_helpers')
     @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.EnrollmentApiClient')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
@@ -206,8 +201,6 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
             ecommerce_api_client_mock,
             enrollment_api_client_mock,
             course_catalog_client_mock,
-            configuration_helpers_mock_1,
-            configuration_helpers_mock_2,
             *args
     ):  # pylint: disable=unused-argument
         """
@@ -215,11 +208,6 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
         """
         setup_course_catalog_api_client_mock(course_catalog_client_mock)
         self._setup_ecommerce_client(ecommerce_api_client_mock, 100)
-        configuration_helpers_mock_1.get_value.side_effect = [
-            settings.ENTERPRISE_SUPPORT_URL,
-            settings.PLATFORM_NAME
-        ]
-        configuration_helpers_mock_2.get_value.return_value = 'foo'
         self._setup_enrollment_client(enrollment_api_client_mock)
         enterprise_customer = EnterpriseCustomerFactory(
             name='Starfleet Academy',
@@ -276,7 +264,6 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.views.ProgramDataExtender')
-    @mock.patch('enterprise.views.configuration_helpers')
     @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.EnrollmentApiClient')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
@@ -287,7 +274,6 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
             ecommerce_api_client_mock,
             enrollment_api_client_mock,
             course_catalog_client_mock,
-            configuration_helpers_mock,
             *args
     ):  # pylint: disable=unused-argument
         setup_course_catalog_api_client_mock(
@@ -296,7 +282,6 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
             course_overrides={'owners': [{'name': 'Test Organization', 'logo_image_url': 'https://fake.org/fake.png'}]}
         )
         self._setup_ecommerce_client(ecommerce_api_client_mock, 30.1)
-        configuration_helpers_mock.get_value.return_value = 'edX'
         self._setup_enrollment_client(enrollment_api_client_mock)
         enterprise_customer = EnterpriseCustomerFactory(
             name='Starfleet Academy',
@@ -340,7 +325,6 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.views.ProgramDataExtender')
-    @mock.patch('enterprise.views.configuration_helpers')
     @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.EnrollmentApiClient')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
@@ -351,7 +335,6 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
             ecommerce_api_client_mock,
             enrollment_api_client_mock,
             course_catalog_client_mock,
-            configuration_helpers_mock,
             *args
     ):  # pylint: disable=unused-argument
         setup_course_catalog_api_client_mock(
@@ -360,7 +343,6 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
             course_overrides={'owners': []}
         )
         self._setup_ecommerce_client(ecommerce_api_client_mock, 30.1)
-        configuration_helpers_mock.get_value.return_value = 'edX'
         self._setup_enrollment_client(enrollment_api_client_mock)
         enterprise_customer = EnterpriseCustomerFactory(
             name='Starfleet Academy',
@@ -405,7 +387,6 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.views.ProgramDataExtender')
-    @mock.patch('enterprise.views.configuration_helpers')
     @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.EnrollmentApiClient')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
@@ -416,12 +397,10 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
             ecommerce_api_client_mock,
             enrollment_api_client_mock,
             course_catalog_client_mock,
-            configuration_helpers_mock,
             *args
     ):  # pylint: disable=unused-argument
         setup_course_catalog_api_client_mock(course_catalog_client_mock)
         self._setup_ecommerce_client(ecommerce_api_client_mock)
-        configuration_helpers_mock.get_value.return_value = 'edX'
         self._setup_enrollment_client(enrollment_api_client_mock)
         enterprise_customer = EnterpriseCustomerFactory(
             name='Starfleet Academy',
@@ -473,7 +452,6 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.views.ProgramDataExtender')
-    @mock.patch('enterprise.views.configuration_helpers')
     @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.EnrollmentApiClient')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
@@ -484,7 +462,6 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
             ecommerce_api_client_mock,
             enrollment_api_client_mock,
             course_catalog_client_mock,
-            configuration_helpers_mock,
             *args
     ):  # pylint: disable=unused-argument
         """
@@ -494,7 +471,6 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
         setup_course_catalog_api_client_mock(course_catalog_client_mock, course_run_overrides={'start': None})
         self._setup_ecommerce_client(ecommerce_api_client_mock)
         course_id = self.demo_course_id
-        configuration_helpers_mock.get_value.return_value = 'edX'
         self._setup_enrollment_client(enrollment_api_client_mock)
         self._login()
         enterprise_customer = EnterpriseCustomerFactory(
@@ -513,7 +489,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
         response = self.client.get(course_enrollment_page_url)
         assert response.status_code == 200
         expected_context = {
-            'platform_name': 'edX',
+            'platform_name': 'Test platform',
             'page_title': 'Confirm your course',
             'course_start_date': '',
         }
@@ -522,21 +498,18 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.views.ProgramDataExtender')
-    @mock.patch('enterprise.views.configuration_helpers')
     @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.utils.Registry')
     def test_get_course_enrollment_page_for_non_existing_course(
             self,
             registry_mock,
             catalog_api_client_mock,
-            configuration_helpers_mock,
             *args
     ):  # pylint: disable=unused-argument
         """
         Verify that user will see HTTP 404 (Not Found) in case of invalid
         or non existing course.
         """
-        configuration_helpers_mock.get_value.return_value = 'edX'
         course_client = catalog_api_client_mock.return_value
         course_client.get_course_and_course_run.return_value = (None, None)
         self._login()
@@ -558,21 +531,18 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.views.ProgramDataExtender')
-    @mock.patch('enterprise.views.configuration_helpers')
     @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.utils.Registry')
     def test_get_course_enrollment_page_for_error_in_getting_course(
             self,
             registry_mock,
             catalog_api_client_mock,
-            configuration_helpers_mock,
             *args
     ):  # pylint: disable=unused-argument
         """
         Verify that user will see HTTP 404 (Not Found) in case of error while
         getting the course details from CourseApiClient.
         """
-        configuration_helpers_mock.get_value.return_value = 'edX'
         course_client = catalog_api_client_mock.return_value
         course_client.get_course_and_course_run.side_effect = ImproperlyConfigured
         self._login()
@@ -594,7 +564,6 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.views.ProgramDataExtender')
-    @mock.patch('enterprise.views.configuration_helpers')
     @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.EnrollmentApiClient')
     @mock.patch('enterprise.utils.Registry')
@@ -603,14 +572,12 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
             registry_mock,
             enrollment_api_client_mock,
             catalog_api_client_mock,
-            configuration_helpers_mock,
             *args
     ):  # pylint: disable=unused-argument
         """
         Verify that user will see HTTP 404 (Not Found) in case of invalid
         enterprise customer uuid.
         """
-        configuration_helpers_mock.get_value.return_value = 'edX'
         setup_course_catalog_api_client_mock(catalog_api_client_mock)
         enrollment_client = enrollment_api_client_mock.return_value
         enrollment_client.get_course_modes.return_value = {}
@@ -634,21 +601,18 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.views.ProgramDataExtender')
-    @mock.patch('enterprise.views.configuration_helpers')
     @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.EnrollmentApiClient')
     def test_get_course_specific_enrollment_view_for_invalid_ec_uuid(
             self,
             enrollment_api_client_mock,
             catalog_api_client_mock,
-            configuration_helpers_mock,
             *args
     ):  # pylint: disable=unused-argument
         """
         Verify that user will see HTTP 404 (Not Found) in case of invalid
         enterprise customer uuid.
         """
-        configuration_helpers_mock.get_value.return_value = 'edX'
         setup_course_catalog_api_client_mock(catalog_api_client_mock)
         self._setup_enrollment_client(enrollment_api_client_mock)
         self._login()
@@ -661,12 +625,10 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.views.ProgramDataExtender')
-    @mock.patch('enterprise.views.configuration_helpers')
     @mock.patch('enterprise.utils.Registry')
     def test_get_course_enrollment_page_for_inactive_user(
             self,
             registry_mock,
-            configuration_helpers_mock,
             *args
     ):  # pylint: disable=unused-argument
         """
@@ -674,7 +636,6 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
         enterprise-linked SSO.
         """
         course_id = self.demo_course_id
-        configuration_helpers_mock.get_value.return_value = 'edX'
 
         enterprise_customer = EnterpriseCustomerFactory(
             name='Starfleet Academy',
@@ -700,7 +661,6 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
         self.assertRedirects(response, expected_redirect_url, fetch_redirect_response=False)
 
     @mock.patch('enterprise.views.ProgramDataExtender')
-    @mock.patch('enterprise.views.configuration_helpers')
     @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.EnrollmentApiClient')
     @mock.patch('enterprise.utils.Registry')
@@ -709,7 +669,6 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
             registry_mock,
             enrollment_api_client_mock,
             catalog_api_client_mock,
-            configuration_helpers_mock,
             *args
     ):  # pylint: disable=unused-argument
         """
@@ -717,7 +676,6 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
         the user is already enrolled.
         """
         course_id = self.demo_course_id
-        configuration_helpers_mock.get_value.return_value = 'edX'
         setup_course_catalog_api_client_mock(catalog_api_client_mock)
         enrollment_client = enrollment_api_client_mock.return_value
         enrollment_client.get_course_modes.return_value = self.dummy_demo_course_modes
@@ -752,7 +710,6 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
         )
 
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
-    @mock.patch('enterprise.views.configuration_helpers')
     @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.EnrollmentApiClient')
     @mock.patch('enterprise.views.consent_required')
@@ -773,13 +730,11 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
             consent_required_mock,
             enrollment_api_client_mock,
             catalog_api_client_mock,
-            configuration_helpers_mock,
             ecommerce_api_client_mock,
             *args
     ):  # pylint: disable=unused-argument
         course_id = self.demo_course_id
         consent_required_mock.return_value = False
-        configuration_helpers_mock.get_value.return_value = 'edX'
         setup_course_catalog_api_client_mock(catalog_api_client_mock)
         enrollment_client = enrollment_api_client_mock.return_value
         enrollment_client.get_course_modes.return_value = self.dummy_demo_course_modes
@@ -817,7 +772,6 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
         if enrollment_mode == 'audit':
             enrollment_client.enroll_user_in_course.assert_called_once_with(self.user.username, course_id, 'audit')
 
-    @mock.patch('enterprise.views.configuration_helpers')
     @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.EnrollmentApiClient')
     @mock.patch('enterprise.views.consent_required')
@@ -828,12 +782,10 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
             consent_required_mock,
             enrollment_api_client_mock,
             course_catalog_client_mock,
-            configuration_helpers_mock,
             *args
     ):  # pylint: disable=unused-argument
         course_id = self.demo_course_id
         consent_required_mock.return_value = True
-        configuration_helpers_mock.get_value.return_value = 'edX'
         setup_course_catalog_api_client_mock(course_catalog_client_mock)
         enrollment_client = enrollment_api_client_mock.return_value
         enrollment_client.get_course_modes.return_value = self.dummy_demo_course_modes
@@ -882,7 +834,6 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
         )
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
-    @mock.patch('enterprise.views.configuration_helpers')
     @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.EnrollmentApiClient')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
@@ -893,12 +844,10 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
             ecommerce_api_client_mock,
             enrollment_api_client_mock,
             course_catalog_client_mock,
-            configuration_helpers_mock,
             *args
     ):  # pylint: disable=unused-argument
         setup_course_catalog_api_client_mock(course_catalog_client_mock)
         self._setup_ecommerce_client(ecommerce_api_client_mock)
-        configuration_helpers_mock.get_value.return_value = 'edX'
         self._setup_enrollment_client(enrollment_api_client_mock)
 
         enterprise_customer = EnterpriseCustomerFactory(
@@ -950,7 +899,6 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
         self._check_expected_enrollment_page(response, expected_context)
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
-    @mock.patch('enterprise.views.configuration_helpers')
     @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.EnrollmentApiClient')
     @mock.patch('enterprise.views.consent_required')
@@ -961,12 +909,10 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
             consent_required_mock,
             enrollment_api_client_mock,
             catalog_api_client_mock,
-            configuration_helpers_mock,
             *args
     ):  # pylint: disable=unused-argument
         course_id = self.demo_course_id
         consent_required_mock.return_value = False
-        configuration_helpers_mock.get_value.return_value = 'edX'
         setup_course_catalog_api_client_mock(catalog_api_client_mock)
         self._setup_enrollment_client(enrollment_api_client_mock)
         enterprise_customer = EnterpriseCustomerFactory(
@@ -995,7 +941,6 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.views.ProgramDataExtender')
-    @mock.patch('enterprise.views.configuration_helpers')
     @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.EnrollmentApiClient')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
@@ -1006,7 +951,6 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
             ecommerce_api_client_mock,
             enrollment_api_client_mock,
             course_catalog_client_mock,
-            configuration_helpers_mock,
             *args
     ):  # pylint: disable=unused-argument
         # Set up Ecommerce API client that returns an error
@@ -1018,8 +962,6 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
 
         # Set up course catalog API client
         setup_course_catalog_api_client_mock(course_catalog_client_mock)
-
-        configuration_helpers_mock.get_value.return_value = 'edX'
 
         # Set up enrollment API client
         self._setup_enrollment_client(enrollment_api_client_mock)
@@ -1065,7 +1007,6 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.views.ProgramDataExtender')
-    @mock.patch('enterprise.views.configuration_helpers')
     @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.EnrollmentApiClient')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
@@ -1074,14 +1015,11 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
             ecommerce_api_client_mock,
             enrollment_api_client_mock,
             course_catalog_client_mock,
-            configuration_helpers_mock,
             *args
     ):  # pylint: disable=unused-argument
 
         # Set up course catalog API client
         setup_course_catalog_api_client_mock(course_catalog_client_mock)
-
-        configuration_helpers_mock.get_value.return_value = 'edX'
 
         # Set up enrollment API client
         self._setup_enrollment_client(enrollment_api_client_mock)

--- a/tests/test_enterprise/views/test_grant_data_sharing_permissions.py
+++ b/tests/test_enterprise/views/test_grant_data_sharing_permissions.py
@@ -90,7 +90,6 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.views.ProgramDataExtender')
-    @mock.patch('enterprise.views.configuration_helpers')
     @mock.patch('enterprise.models.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.CourseApiClient')
     @ddt.data(
@@ -106,11 +105,9 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
             existing_course_enrollment,
             course_api_client_mock,
             course_catalog_api_client_mock,
-            mock_config,
             *args
     ):  # pylint: disable=unused-argument
         course_id = 'course-v1:edX+DemoX+Demo_Course'
-        mock_config.get_value.return_value = 'My Platform'
         course_catalog_api_client_mock.return_value.course_in_catalog.return_value = True
         client = course_api_client_mock.return_value
         client.get_course_details.return_value = {
@@ -151,7 +148,7 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
         )
 
         for key, value in {
-                "platform_name": "My Platform",
+                "platform_name": "Test platform",
                 "consent_request_prompt": expected_prompt,
                 "requested_permissions_header": (
                     'Per the <a href="#consent-policy-dropdown-bar" '
@@ -162,7 +159,7 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
                 'confirmation_alert_prompt_warning': '',
                 'sharable_items_footer': (
                     'My permission applies only to data from courses or programs that are sponsored by '
-                    'Starfleet Academy, and not to data from any My Platform courses or programs that '
+                    'Starfleet Academy, and not to data from any Test platform courses or programs that '
                     'I take on my own. I understand that once I grant my permission to allow data to be shared '
                     'with Starfleet Academy, I may not withdraw my permission but I may elect to unenroll '
                     'from any courses that are sponsored by Starfleet Academy.'
@@ -172,7 +169,7 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
                 "enterprise_customer_name": ecu.enterprise_customer.name,
                 "course_specific": True,
                 "enrollment_deferred": enrollment_deferred,
-                "welcome_text": "Welcome to My Platform.",
+                "welcome_text": "Welcome to Test platform.",
                 'sharable_items_note_header': 'Please note',
                 'LMS_SEGMENT_KEY': settings.LMS_SEGMENT_KEY,
         }.items():
@@ -180,16 +177,13 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.views.ProgramDataExtender')
-    @mock.patch('enterprise.views.configuration_helpers')
     @mock.patch('enterprise.views.CourseApiClient')
     def test_get_course_specific_consent_invalid_get_params(
             self,
             course_api_client_mock,
-            mock_config,
             *args
     ):  # pylint: disable=unused-argument
         course_id = 'course-v1:edX+DemoX+Demo_Course'
-        mock_config.get_value.return_value = 'My Platform'
         client = course_api_client_mock.return_value
         client.get_course_details.return_value = {
             'name': 'edX Demo Course',
@@ -223,16 +217,13 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.views.ProgramDataExtender')
-    @mock.patch('enterprise.views.configuration_helpers')
     @mock.patch('enterprise.views.CourseApiClient')
     def test_get_course_specific_consent_unauthenticated_user(
             self,
             course_api_client_mock,
-            mock_config,
             *args
     ):  # pylint: disable=unused-argument
         course_id = 'course-v1:edX+DemoX+Demo_Course'
-        mock_config.get_value.return_value = 'My Platform'
         enterprise_customer = EnterpriseCustomerFactory(
             name='Starfleet Academy',
             enable_data_sharing_consent=True,
@@ -270,17 +261,14 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.views.ProgramDataExtender')
-    @mock.patch('enterprise.views.configuration_helpers')
     @mock.patch('enterprise.views.CourseApiClient')
     def test_get_course_specific_consent_bad_api_response(
             self,
             course_api_client_mock,
-            mock_config,
             *args
     ):  # pylint: disable=unused-argument
         self._login()
         course_id = 'course-v1:edX+DemoX+Demo_Course'
-        mock_config.get_value.return_value = 'My Platform'
         enterprise_customer = EnterpriseCustomerFactory(
             name='Starfleet Academy',
             enable_data_sharing_consent=True,
@@ -309,18 +297,15 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.views.ProgramDataExtender')
     @mock.patch('enterprise.models.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.configuration_helpers')
     @mock.patch('enterprise.views.CourseApiClient')
     def test_get_course_specific_consent_not_needed(
             self,
             course_api_client_mock,
-            mock_config,
             course_catalog_api_client_mock,
             *args
     ):  # pylint: disable=unused-argument
         self._login()
         course_id = 'course-v1:edX+DemoX+Demo_Course'
-        mock_config.get_value.return_value = 'My Platform'
         course_catalog_api_client = course_catalog_api_client_mock.return_value
         course_catalog_api_client.is_course_in_catalog.return_value = False
         enterprise_customer = EnterpriseCustomerFactory(
@@ -354,7 +339,6 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.views.ProgramDataExtender')
-    @mock.patch('enterprise.views.configuration_helpers')
     @mock.patch('enterprise.views.CourseApiClient')
     @mock.patch('enterprise.views.reverse')
     @ddt.data(
@@ -420,7 +404,6 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.views.ProgramDataExtender')
-    @mock.patch('enterprise.views.configuration_helpers')
     @mock.patch('enterprise.views.CourseApiClient')
     @mock.patch('enterprise.views.reverse')
     def test_post_course_specific_consent_no_user(
@@ -469,7 +452,6 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.views.ProgramDataExtender')
-    @mock.patch('enterprise.views.configuration_helpers')
     @mock.patch('enterprise.views.CourseApiClient')
     @mock.patch('enterprise.views.reverse')
     def test_post_course_specific_consent_bad_api_response(
@@ -543,9 +525,6 @@ class TestProgramDataSharingPermissions(TestCase):
         self.user.set_password("QWERTY")
         self.user.save()
         self.client = Client()
-        config = mock.patch('enterprise.views.configuration_helpers')
-        self.configuration_helpers = config.start()
-        self.addCleanup(config.stop)
         program_data_extender = mock.patch('enterprise.views.ProgramDataExtender')
         self.program_data_extender = program_data_extender.start()
         self.addCleanup(program_data_extender.stop)
@@ -670,7 +649,6 @@ class TestProgramDataSharingPermissions(TestCase):
         enterprise_customer.name = 'Starfleet Academy'
         self.program_exists.return_value = True
         self._login()
-        self.configuration_helpers.get_value.return_value = "My Platform"
         params = self.valid_get_params.copy()
         if enrollment_deferred:
             params.update({'enrollment_deferred': True})
@@ -687,7 +665,7 @@ class TestProgramDataSharingPermissions(TestCase):
         )
 
         for key, value in {
-                "platform_name": "My Platform",
+                "platform_name": "Test platform",
                 "consent_request_prompt": expected_prompt,
                 "requested_permissions_header": (
                     'Per the <a href="#consent-policy-dropdown-bar" '
@@ -698,7 +676,7 @@ class TestProgramDataSharingPermissions(TestCase):
                 'confirmation_alert_prompt_warning': '',
                 'sharable_items_footer': (
                     'My permission applies only to data from courses or programs that are sponsored by '
-                    'Starfleet Academy, and not to data from any My Platform courses or programs that '
+                    'Starfleet Academy, and not to data from any Test platform courses or programs that '
                     'I take on my own. I understand that once I grant my permission to allow data to be shared '
                     'with Starfleet Academy, I may not withdraw my permission but I may elect to unenroll '
                     'from any courses that are sponsored by Starfleet Academy.'
@@ -709,7 +687,7 @@ class TestProgramDataSharingPermissions(TestCase):
                 "enterprise_customer_name": enterprise_customer.name,
                 "program_specific": True,
                 "enrollment_deferred": enrollment_deferred,
-                "welcome_text": "Welcome to My Platform.",
+                "welcome_text": "Welcome to Test platform.",
                 'sharable_items_note_header': 'Please note',
                 "enterprise_customer": enterprise_customer,
                 'LMS_SEGMENT_KEY': settings.LMS_SEGMENT_KEY,

--- a/tests/test_enterprise/views/test_handle_consent_enrollment.py
+++ b/tests/test_enterprise/views/test_handle_consent_enrollment.py
@@ -66,7 +66,6 @@ class TestHandleConsentEnrollmentView(TestCase):
         registry_mock.get.return_value.configure_mock(provider_id=provider_id, drop_existing_session=False)
 
     @mock.patch('enterprise.views.ProgramDataExtender')
-    @mock.patch('enterprise.views.configuration_helpers')
     @mock.patch('enterprise.utils.Registry')
     def test_handle_consent_enrollment_without_course_mode(
             self,
@@ -98,7 +97,6 @@ class TestHandleConsentEnrollmentView(TestCase):
         self.assertRedirects(response, redirect_url, fetch_redirect_response=False)
 
     @mock.patch('enterprise.views.ProgramDataExtender')
-    @mock.patch('enterprise.views.configuration_helpers')
     @mock.patch('enterprise.views.EnrollmentApiClient')
     @mock.patch('enterprise.utils.Registry')
     def test_handle_consent_enrollment_404(
@@ -136,7 +134,6 @@ class TestHandleConsentEnrollmentView(TestCase):
         assert response.status_code == 404
 
     @mock.patch('enterprise.views.ProgramDataExtender')
-    @mock.patch('enterprise.views.configuration_helpers')
     @mock.patch('enterprise.views.EnrollmentApiClient')
     @mock.patch('enterprise.utils.Registry')
     def test_handle_consent_enrollment_no_enterprise_user(
@@ -174,7 +171,6 @@ class TestHandleConsentEnrollmentView(TestCase):
         assert response.status_code == 404
 
     @mock.patch('enterprise.views.ProgramDataExtender')
-    @mock.patch('enterprise.views.configuration_helpers')
     @mock.patch('enterprise.views.get_enterprise_customer_user')
     @mock.patch('enterprise.views.EnrollmentApiClient')
     @mock.patch('enterprise.utils.Registry')
@@ -220,7 +216,6 @@ class TestHandleConsentEnrollmentView(TestCase):
         self.assertRedirects(response, redirect_url, fetch_redirect_response=False)
 
     @mock.patch('enterprise.views.ProgramDataExtender')
-    @mock.patch('enterprise.views.configuration_helpers')
     @mock.patch('enterprise.views.EnrollmentApiClient')
     @mock.patch('enterprise.utils.Registry')
     def test_handle_consent_enrollment_with_audit_course_mode(
@@ -268,7 +263,6 @@ class TestHandleConsentEnrollmentView(TestCase):
         ).exists())
 
     @mock.patch('enterprise.views.ProgramDataExtender')
-    @mock.patch('enterprise.views.configuration_helpers')
     @mock.patch('enterprise.views.EnrollmentApiClient')
     @mock.patch('enterprise.utils.Registry')
     def test_handle_consent_enrollment_with_professional_course_mode(

--- a/tests/test_enterprise/views/test_program_enrollment_view.py
+++ b/tests/test_enterprise/views/test_program_enrollment_view.py
@@ -219,8 +219,6 @@ class TestProgramEnrollmentView(MessagesMixin, TestCase):
             assert response.context[key] == value  # pylint: disable=no-member
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
-    @mock.patch('enterprise.views.configuration_helpers')
-    @mock.patch('enterprise.messages.configuration_helpers')
     @mock.patch('consent.helpers.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.ProgramDataExtender')
@@ -229,27 +227,24 @@ class TestProgramEnrollmentView(MessagesMixin, TestCase):
             program_data_extender_mock,
             course_catalog_api_client_mock_1,
             course_catalog_api_client_mock_2,
-            configuration_helpers_mock_1,
-            configuration_helpers_mock_2,
             *args
     ):  # pylint: disable=unused-argument,invalid-name
         """
         The Enterprise Program landing page is rendered appropriately given some context.
         """
         self._setup_program_data_extender(program_data_extender_mock)
-        configuration_helpers_mock_2.get_value.return_value = 'edX'
         self._setup_course_catalog_client(course_catalog_api_client_mock_1)
         self._setup_course_catalog_client(course_catalog_api_client_mock_2)
         enterprise_customer = EnterpriseCustomerFactory(name='Starfleet Academy')
         expected_context = {
             'LMS_SEGMENT_KEY': settings.LMS_SEGMENT_KEY,
             'enterprise_customer': enterprise_customer,
-            'platform_name': 'edX',
+            'platform_name': 'Test platform',
             'organization_name': 'Authoring Organization',
             'organization_logo': 'images/logo_image_url.jpg',
-            'welcome_text': 'Welcome to edX.',
+            'welcome_text': 'Welcome to Test platform.',
             'enterprise_welcome_text': (
-                "<strong>Starfleet Academy</strong> has partnered with <strong>edX</strong> to "
+                "<strong>Starfleet Academy</strong> has partnered with <strong>Test platform</strong> to "
                 "offer you high-quality learning opportunities from the world's best universities."
             ),
             'page_title': 'Confirm your program enrollment',
@@ -346,8 +341,6 @@ class TestProgramEnrollmentView(MessagesMixin, TestCase):
         self._check_expected_enrollment_page(response, expected_context)
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
-    @mock.patch('enterprise.views.configuration_helpers')
-    @mock.patch('enterprise.messages.configuration_helpers')
     @mock.patch('consent.helpers.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.ProgramDataExtender')
@@ -356,8 +349,6 @@ class TestProgramEnrollmentView(MessagesMixin, TestCase):
             program_data_extender_mock,
             course_catalog_api_client_mock_1,
             course_catalog_api_client_mock_2,
-            configuration_helpers_mock_1,
-            configuration_helpers_mock_2,
             *args
     ):  # pylint: disable=unused-argument,invalid-name
         """
@@ -368,7 +359,6 @@ class TestProgramEnrollmentView(MessagesMixin, TestCase):
             "is_enrolled": True,
             "upgrade_url": None,
         })
-        configuration_helpers_mock_2.get_value.return_value = 'edX'
         self._setup_course_catalog_client(course_catalog_api_client_mock_1)
         self._setup_course_catalog_client(course_catalog_api_client_mock_2)
         enterprise_customer = EnterpriseCustomerFactory(name='Starfleet Academy')
@@ -436,8 +426,6 @@ class TestProgramEnrollmentView(MessagesMixin, TestCase):
         self._check_expected_enrollment_page(response, expected_context)
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
-    @mock.patch('enterprise.views.configuration_helpers')
-    @mock.patch('enterprise.messages.configuration_helpers')
     @mock.patch('consent.helpers.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.ProgramDataExtender')
@@ -448,15 +436,12 @@ class TestProgramEnrollmentView(MessagesMixin, TestCase):
             program_data_extender_mock,
             course_catalog_api_client_mock_1,
             course_catalog_api_client_mock_2,
-            configuration_helpers_mock_1,
-            configuration_helpers_mock_2,
             *args
     ):  # pylint: disable=unused-argument,invalid-name
         """
         The DSC-declined message is rendered if DSC is not given.
         """
         self._setup_program_data_extender(program_data_extender_mock)
-        configuration_helpers_mock_1.get_value.side_effect = [settings.ENTERPRISE_SUPPORT_URL, settings.PLATFORM_NAME]
         self._setup_course_catalog_client(course_catalog_api_client_mock_1)
         self._setup_course_catalog_client(course_catalog_api_client_mock_2)
         enterprise_customer = EnterpriseCustomerFactory(name='Starfleet Academy')
@@ -498,8 +483,6 @@ class TestProgramEnrollmentView(MessagesMixin, TestCase):
             )
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
-    @mock.patch('enterprise.views.configuration_helpers')
-    @mock.patch('enterprise.messages.configuration_helpers')
     @mock.patch('consent.helpers.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.ProgramDataExtender')
@@ -508,8 +491,6 @@ class TestProgramEnrollmentView(MessagesMixin, TestCase):
             program_data_extender_mock,
             course_catalog_api_client_mock_1,
             course_catalog_api_client_mock_2,
-            configuration_helpers_mock_1,
-            configuration_helpers_mock_2,
             *args
     ):  # pylint: disable=unused-argument,invalid-name
         """
@@ -517,7 +498,6 @@ class TestProgramEnrollmentView(MessagesMixin, TestCase):
         """
         program_data_extender_mock = self._setup_program_data_extender(program_data_extender_mock)
         program_data_extender_mock.return_value.extend.return_value['discount_data'] = {}
-        configuration_helpers_mock_1.get_value.side_effect = [settings.ENTERPRISE_SUPPORT_URL, settings.PLATFORM_NAME]
         self._setup_course_catalog_client(course_catalog_api_client_mock_1)
         self._setup_course_catalog_client(course_catalog_api_client_mock_2)
         enterprise_customer = EnterpriseCustomerFactory(name='Starfleet Academy')
@@ -544,8 +524,6 @@ class TestProgramEnrollmentView(MessagesMixin, TestCase):
         )
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
-    @mock.patch('enterprise.views.configuration_helpers')
-    @mock.patch('enterprise.messages.configuration_helpers')
     @mock.patch('consent.helpers.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.ProgramDataExtender')
@@ -554,8 +532,6 @@ class TestProgramEnrollmentView(MessagesMixin, TestCase):
             program_data_extender_mock,
             course_catalog_api_client_mock_1,
             course_catalog_api_client_mock_2,
-            configuration_helpers_mock_1,
-            configuration_helpers_mock_2,
             *args
     ):  # pylint: disable=unused-argument,invalid-name
         """
@@ -564,7 +540,6 @@ class TestProgramEnrollmentView(MessagesMixin, TestCase):
         program_data_extender_mock = self._setup_program_data_extender(program_data_extender_mock)
         program_data_extender_mock.return_value.extend.return_value['is_learner_eligible_for_one_click_purchase'] \
             = False
-        configuration_helpers_mock_1.get_value.side_effect = [settings.ENTERPRISE_SUPPORT_URL, settings.PLATFORM_NAME]
         self._setup_course_catalog_client(course_catalog_api_client_mock_2)
         enterprise_customer = EnterpriseCustomerFactory(name='Starfleet Academy')
         program_enrollment_page_url = reverse(
@@ -589,7 +564,6 @@ class TestProgramEnrollmentView(MessagesMixin, TestCase):
             )
         )
 
-    @mock.patch('enterprise.views.configuration_helpers')
     @mock.patch('enterprise.views.ProgramDataExtender')
     @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
     def test_get_program_enrollment_page_for_non_existing_program(
@@ -625,7 +599,6 @@ class TestProgramEnrollmentView(MessagesMixin, TestCase):
         assert response.status_code == 404
 
     @mock.patch('enterprise.views.ProgramDataExtender')
-    @mock.patch('enterprise.views.configuration_helpers')
     def test_get_program_enrollment_page_for_nonexisting_ec(self, *args):  # pylint: disable=unused-argument
         """
         The user will see the HTTP 404 (Not Found) page in case of no matching ``EnterpriseCustomer``.
@@ -640,7 +613,6 @@ class TestProgramEnrollmentView(MessagesMixin, TestCase):
         assert response.status_code == 404
 
     @mock.patch('enterprise.views.ProgramDataExtender')
-    @mock.patch('enterprise.views.configuration_helpers')
     @mock.patch('enterprise.utils.Registry')
     def test_get_program_enrollment_page_for_inactive_user(
             self,
@@ -671,8 +643,6 @@ class TestProgramEnrollmentView(MessagesMixin, TestCase):
         )
         self.assertRedirects(response, expected_redirect_url, fetch_redirect_response=False)
 
-    @mock.patch('enterprise.views.configuration_helpers')
-    @mock.patch('enterprise.messages.configuration_helpers')
     @mock.patch('consent.helpers.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.ProgramDataExtender')
@@ -708,7 +678,6 @@ class TestProgramEnrollmentView(MessagesMixin, TestCase):
             fetch_redirect_response=False,
         )
 
-    @mock.patch('enterprise.views.configuration_helpers')
     @mock.patch('enterprise.views.ProgramDataExtender')
     @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
     def test_get_program_enrollment_page_with_discovery_error(
@@ -730,7 +699,6 @@ class TestProgramEnrollmentView(MessagesMixin, TestCase):
         response = self.client.get(program_enrollment_page_url)
         assert response.status_code == 404
 
-    @mock.patch('enterprise.views.configuration_helpers')
     @mock.patch('enterprise.views.ProgramDataExtender')
     @mock.patch('consent.helpers.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
@@ -767,7 +735,6 @@ class TestProgramEnrollmentView(MessagesMixin, TestCase):
             fetch_redirect_response=False
         )
 
-    @mock.patch('enterprise.views.configuration_helpers')
     @mock.patch('enterprise.views.get_data_sharing_consent')
     @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.ProgramDataExtender')
@@ -809,7 +776,6 @@ class TestProgramEnrollmentView(MessagesMixin, TestCase):
             fetch_redirect_response=False
         )
 
-    @mock.patch('enterprise.views.configuration_helpers')
     @mock.patch('enterprise.views.get_data_sharing_consent')
     @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.ProgramDataExtender')

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -89,14 +89,12 @@ class TestTransmitCoursewareDataManagementCommand(unittest.TestCase, EnterpriseM
     @responses.activate
     @override_switch('SAP_USE_ENTERPRISE_ENROLLMENT_PAGE', active=True)
     @mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
-    @mock.patch('enterprise.models.configuration_helpers')
     @mock.patch('integrated_channels.sap_success_factors.utils.reverse')
     @mock.patch('integrated_channels.sap_success_factors.transmitters.SAPSuccessFactorsAPIClient')
     def test_transmit_courseware_task_with_error(
             self,
             fake_sap_client,
             track_selection_reverse_mock,
-            fake_config_helpers,
     ):
         """
         Verify the data transmission task for integrated channels with error.
@@ -105,7 +103,6 @@ class TestTransmitCoursewareDataManagementCommand(unittest.TestCase, EnterpriseM
         courses metadata related to other integrated channels even if an
         integrated channel fails to transmit due to some error.
         """
-        fake_config_helpers.get_value.return_value = 'https://example.com'
         fake_sap_client.get_oauth_access_token.return_value = "token", datetime.utcnow()
         fake_sap_client.return_value.send_course_import.return_value = 200, '{}'
         track_selection_reverse_mock.return_value = '/course_modes/choose/course-v1:edX+DemoX+Demo_Course/'
@@ -174,17 +171,14 @@ class TestTransmitCoursewareDataManagementCommand(unittest.TestCase, EnterpriseM
     @mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
     @mock.patch('integrated_channels.sap_success_factors.utils.reverse')
     @mock.patch('integrated_channels.sap_success_factors.transmitters.SAPSuccessFactorsAPIClient')
-    @mock.patch('enterprise.models.configuration_helpers')
     def test_transmit_courseware_task_success(
             self,
-            fake_config_helpers,
             fake_sap_client,
             track_selection_reverse_mock,
     ):
         """
         Test the data transmission task.
         """
-        fake_config_helpers.get_value.return_value = 'https://example.com'
         fake_sap_client.get_oauth_access_token.return_value = "token", datetime.utcnow()
         fake_sap_client.return_value.send_course_import.return_value = 200, '{}'
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -46,7 +46,6 @@ from enterprise.models import (
     UserDataSharingConsentAudit,
     logo_path,
 )
-from enterprise.utils import NotConnectedToOpenEdX
 from test_utils.factories import (
     DataSharingConsentFactory,
     EnterpriseCourseEnrollmentFactory,
@@ -266,24 +265,6 @@ class TestEnterpriseCustomer(unittest.TestCase):
         """
         customer = EnterpriseCustomerFactory()
         assert customer.identity_provider is None
-
-    def test_get_course_run_enrollment_url_no_site_config(self):
-        """
-        Test get_course_run_enrollment_url when the site_configuration package could not be imported.
-        """
-        customer = EnterpriseCustomerFactory()
-        error = 'This package must be installed in an EdX environment to look up configuration.'
-        with raises(NotConnectedToOpenEdX, message=error):
-            customer.get_course_run_enrollment_url('course_id')
-
-    def test_get_program_enrollment_url_no_site_config(self):
-        """
-        Test get_program_enrollment_url when the site_configuration package could not be imported.
-        """
-        customer = EnterpriseCustomerFactory()
-        error = 'This package must be installed in an EdX environment to look up configuration.'
-        with raises(NotConnectedToOpenEdX, message=error):
-            customer.get_program_enrollment_url('program_id')
 
     @ddt.data(
         ('course_exists', True),


### PR DESCRIPTION
**Description:** This PR removes our hard requirement on `configuration_helpers` by abstracting all uses of it into a single utility function which can be easily modified in the future in case we decide to officially drop the need for `configuration_helpers`.

**JIRA:** [ENT-428](https://openedx.atlassian.net/browse/ENT-428)

**Merge deadline:** N/A

**Testing instructions:**

Just see that the abstraction is occurring properly and that tests are still passing.

To be safe, go to the course enrollment landing page with this PR's code installed, and make sure the platform name and other values we get through `configuration_helpers` are still gotten.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] All reviewers approved
- [x] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)
