### PR TITLE
[ENT-644] Remove account-level & `EnterpriseCourseEnrollment` consent.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.46.5] - 2017-09-21
+---------------------
+
+* Remove old account-level consent features as well as consent from EnterpriseCourseEnrollment.
+
 [0.46.4] - 2017-09-20
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.46.4"
+__version__ = "0.46.5"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/admin/__init__.py
+++ b/enterprise/admin/__init__.py
@@ -20,11 +20,17 @@ from enterprise.admin.forms import EnterpriseCustomerAdminForm, EnterpriseCustom
 from enterprise.admin.utils import UrlNames
 from enterprise.admin.views import EnterpriseCustomerManageLearnersView, TemplatePreviewView
 from enterprise.api_client.lms import CourseApiClient, EnrollmentApiClient
-from enterprise.models import (  # pylint:disable=no-name-in-module
-    EnrollmentNotificationEmailTemplate, EnterpriseCustomer, EnterpriseCustomerUser,
-    EnterpriseCustomerBrandingConfiguration, EnterpriseCustomerIdentityProvider,
-    HistoricalUserDataSharingConsentAudit, PendingEnrollment, PendingEnterpriseCustomerUser,
-    EnterpriseCustomerEntitlement, EnterpriseCourseEnrollment, EnterpriseCustomerCatalog
+from enterprise.models import (
+    EnrollmentNotificationEmailTemplate,
+    EnterpriseCustomer,
+    EnterpriseCustomerUser,
+    EnterpriseCustomerBrandingConfiguration,
+    EnterpriseCustomerIdentityProvider,
+    PendingEnrollment,
+    PendingEnterpriseCustomerUser,
+    EnterpriseCustomerEntitlement,
+    EnterpriseCourseEnrollment,
+    EnterpriseCustomerCatalog
 )
 from enterprise.utils import get_all_field_names, get_catalog_admin_url
 
@@ -221,36 +227,6 @@ class EnterpriseCustomerAdmin(DjangoObjectActions, SimpleHistoryAdmin):
         return customer_urls + super(EnterpriseCustomerAdmin, self).get_urls()
 
 
-class HistoricalUserDataSharingConsentAuditInlineAdmin(admin.TabularInline):
-    """
-    Inline admin view for UserDataSharingConsentAudit
-    """
-
-    model = HistoricalUserDataSharingConsentAudit
-
-    fields = (
-        'state',
-        'history_date',
-    )
-
-    readonly_fields = (
-        'state',
-        'history_date',
-    )
-
-    def has_add_permission(self, request):
-        """
-        Disable add permission for HistoricalUserDataSharingConsentAudit.
-        """
-        return False
-
-    def has_delete_permission(self, request, obj=None):
-        """
-        Disable deletability for HistoricalUserDataSharingConsentAudit.
-        """
-        return False
-
-
 @admin.register(EnterpriseCustomerUser)
 class EnterpriseCustomerUserAdmin(admin.ModelAdmin):
     """
@@ -276,10 +252,6 @@ class EnterpriseCustomerUserAdmin(admin.ModelAdmin):
         'username',
         'created',
         'enrolled_courses',
-    )
-
-    inlines = (
-        HistoricalUserDataSharingConsentAuditInlineAdmin,
     )
 
     def username(self, enterprise_customer_user):
@@ -424,13 +396,11 @@ class EnterpriseCourseEnrollmentAdmin(admin.ModelAdmin):
     readonly_fields = (
         'enterprise_customer_user',
         'course_id',
-        'consent_granted',
     )
 
     list_display = (
         'enterprise_customer_user',
         'course_id',
-        'consent_granted',
     )
 
     search_fields = ('enterprise_customer_user__user_id', 'course_id',)

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -122,7 +122,7 @@ class EnterpriseCourseEnrollmentReadOnlySerializer(serializers.ModelSerializer):
     class Meta:
         model = models.EnterpriseCourseEnrollment
         fields = (
-            'enterprise_customer_user', 'consent_granted', 'course_id'
+            'enterprise_customer_user', 'course_id'
         )
 
 
@@ -134,7 +134,7 @@ class EnterpriseCourseEnrollmentWriteSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.EnterpriseCourseEnrollment
         fields = (
-            'username', 'course_id', 'consent_granted'
+            'username', 'course_id',
         )
 
     username = serializers.CharField(max_length=30)
@@ -231,18 +231,6 @@ class EnterpriseCustomerCatalogDetailSerializer(EnterpriseCustomerCatalogSeriali
         representation['results'] = search_results
 
         return representation
-
-
-class UserDataSharingConsentAuditSerializer(serializers.ModelSerializer):
-    """
-    Serializer for UserDataSharingConsentAudit model.
-    """
-
-    class Meta:
-        model = models.UserDataSharingConsentAudit
-        fields = (
-            'user', 'state', 'enabled'
-        )
 
 
 class EnterpriseCustomerUserReadOnlySerializer(serializers.ModelSerializer):

--- a/enterprise/api/v1/urls.py
+++ b/enterprise/api/v1/urls.py
@@ -14,7 +14,6 @@ router.register("enterprise-catalogs", views.EnterpriseCustomerCatalogViewSet, '
 router.register("enterprise-course-enrollment", views.EnterpriseCourseEnrollmentViewSet, 'enterprise-course-enrollment')
 router.register("enterprise-customer", views.EnterpriseCustomerViewSet, 'enterprise-customer')
 router.register("enterprise-learner", views.EnterpriseCustomerUserViewSet, 'enterprise-learner')
-router.register("user-data-sharing-consent", views.UserDataSharingConsentAuditViewSet, 'user-data-sharing-consent')
 router.register(
     "enterprise-customer-branding",
     views.EnterpriseCustomerBrandingConfigurationViewSet,

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -152,7 +152,7 @@ class EnterpriseCourseEnrollmentViewSet(EnterpriseReadWriteModelViewSet):
     queryset = models.EnterpriseCourseEnrollment.objects.all()
 
     FIELDS = (
-        'enterprise_customer_user', 'consent_granted', 'course_id'
+        'enterprise_customer_user', 'course_id'
     )
     filter_fields = FIELDS
     ordering_fields = FIELDS
@@ -216,7 +216,6 @@ class EnterpriseCustomerUserViewSet(EnterpriseReadWriteModelViewSet):
             (HttpResponse): Response object containing a list of learner's entitlements.
         """
         enterprise_customer_user = self.get_object()
-
         instance = {"entitlements": enterprise_customer_user.entitlements}
         serializer = serializers.EnterpriseCustomerUserEntitlementSerializer(instance, context={'request': request})
         return Response(serializer.data)
@@ -232,21 +231,6 @@ class EnterpriseCustomerBrandingConfigurationViewSet(EnterpriseReadOnlyModelView
 
     FIELDS = (
         'enterprise_customer',
-    )
-    filter_fields = FIELDS
-    ordering_fields = FIELDS
-
-
-class UserDataSharingConsentAuditViewSet(EnterpriseReadOnlyModelViewSet):
-    """
-    API views for the ``user-data-sharing-consent`` API endpoint.
-    """
-
-    queryset = models.UserDataSharingConsentAudit.objects.all()
-    serializer_class = serializers.UserDataSharingConsentAuditSerializer
-
-    FIELDS = (
-        'user', 'state',
     )
     filter_fields = FIELDS
     ordering_fields = FIELDS

--- a/enterprise/migrations/0026_remove_old_consent.py
+++ b/enterprise/migrations/0026_remove_old_consent.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('enterprise', '0025_auto_20170828_1412'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='historicaluserdatasharingconsentaudit',
+            name='history_user',
+        ),
+        migrations.RemoveField(
+            model_name='historicaluserdatasharingconsentaudit',
+            name='user',
+        ),
+        migrations.RemoveField(
+            model_name='userdatasharingconsentaudit',
+            name='user',
+        ),
+        migrations.RemoveField(
+            model_name='enterprisecourseenrollment',
+            name='consent_granted',
+        ),
+        migrations.RemoveField(
+            model_name='enterprisecustomer',
+            name='require_account_level_consent',
+        ),
+        migrations.RemoveField(
+            model_name='historicalenterprisecourseenrollment',
+            name='consent_granted',
+        ),
+        migrations.RemoveField(
+            model_name='historicalenterprisecustomer',
+            name='require_account_level_consent',
+        ),
+        migrations.DeleteModel(
+            name='HistoricalUserDataSharingConsentAudit',
+        ),
+        migrations.DeleteModel(
+            name='UserDataSharingConsentAudit',
+        ),
+    ]

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -23,7 +23,7 @@ from django.utils.translation import ugettext as _
 from django.utils.translation import ungettext
 
 # pylint: disable=import-error,wrong-import-order
-from six.moves.urllib.parse import parse_qs, urlencode, urlparse, urlsplit, urlunparse, urlunsplit
+from six.moves.urllib.parse import parse_qs, urlencode, urlparse, urlsplit, urlunsplit
 
 try:
     from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
@@ -293,31 +293,6 @@ def send_email_notification_message(user, enrolled_in, enterprise_customer, emai
         html_message=html_msg,
         connection=email_connection
     )
-
-
-def get_reversed_url_by_site(request, site, *args, **kwargs):
-    """
-    Get a function to do a standard Django `reverse`, and then apply that path to another site's domain.
-
-    We use urlparse to split the url into its individual components, and then replace
-    the netloc with the domain for the site in question. We then unparse the result
-    into a URL string.
-
-    Arguments:
-        request: The Django request currently being processed
-        site (site): The site we want to apply to the URL created
-        *args: Pass to the standard reverse function
-        **kwargs: Pass to the standard reverse function
-
-    """
-    domain = site.domain
-    reversed_url = reverse(*args, **kwargs)
-    full_url = request.build_absolute_uri(reversed_url)
-    parsed = urlparse(full_url)
-    final_url = urlunparse(
-        parsed._replace(netloc=domain)
-    )
-    return final_url
 
 
 def get_enterprise_customer(uuid):

--- a/test_utils/factories.py
+++ b/test_utils/factories.py
@@ -22,7 +22,6 @@ from enterprise.models import (
     EnterpriseCustomerUser,
     PendingEnrollment,
     PendingEnterpriseCustomerUser,
-    UserDataSharingConsentAudit,
 )
 
 FAKER = FakerFactory.create()
@@ -86,24 +85,6 @@ class EnterpriseCustomerUserFactory(factory.django.DjangoModelFactory):
 
     enterprise_customer = factory.SubFactory(EnterpriseCustomerFactory)
     user_id = factory.LazyAttribute(lambda x: FAKER.pyint())  # pylint: disable=no-member
-
-
-class UserDataSharingConsentAuditFactory(factory.django.DjangoModelFactory):
-    """
-    UserDataSharingConsentAuditFactory.
-
-    Creates an instance of UserDataSharingConsentAudit with minimal boilerplate.
-    """
-
-    class Meta(object):
-        """
-        Meta for ``UserDataSharingConsentAuditFactory``.
-        """
-
-        model = UserDataSharingConsentAudit
-
-    user = factory.SubFactory(EnterpriseCustomerUserFactory)
-    state = 'not_set'
 
 
 class PendingEnterpriseCustomerUserFactory(factory.django.DjangoModelFactory):
@@ -223,7 +204,6 @@ class EnterpriseCourseEnrollmentFactory(factory.django.DjangoModelFactory):
 
     id = factory.LazyAttribute(lambda x: FAKER.random_int(min=1))  # pylint: disable=invalid-name,no-member
     course_id = factory.LazyAttribute(lambda x: FAKER.slug())  # pylint: disable=no-member
-    consent_granted = True
     enterprise_customer_user = factory.SubFactory(EnterpriseCustomerUserFactory)
 
 

--- a/tests/test_enterprise/views/test_course_enrollment_view.py
+++ b/tests/test_enterprise/views/test_course_enrollment_view.py
@@ -224,7 +224,6 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
         )
         EnterpriseCourseEnrollmentFactory(
             course_id=self.demo_course_id,
-            consent_granted=consent_granted,
             enterprise_customer_user=enterprise_customer_user
         )
         DataSharingConsentFactory(

--- a/tests/test_enterprise/views/test_grant_data_sharing_permissions.py
+++ b/tests/test_enterprise/views/test_grant_data_sharing_permissions.py
@@ -324,7 +324,6 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
         EnterpriseCourseEnrollment.objects.create(
             enterprise_customer_user=ecu,
             course_id=course_id,
-            consent_granted=True,
         )
         DataSharingConsentFactory(
             username=self.user.username,
@@ -368,12 +367,11 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
             user_id=self.user.id,
             enterprise_customer=enterprise_customer
         )
-        enrollment = EnterpriseCourseEnrollment.objects.create(
+        EnterpriseCourseEnrollment.objects.create(
             enterprise_customer_user=ecu,
             course_id=course_id,
-            consent_granted=consent_provided,
         )
-        DataSharingConsentFactory(
+        dsc = DataSharingConsentFactory(
             username=self.user.username,
             course_id=course_id,
             enterprise_customer=enterprise_customer,
@@ -398,9 +396,8 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
 
         assert resp.url.endswith(expected_redirect_url)  # pylint: disable=no-member
         assert resp.status_code == 302
-        enrollment.refresh_from_db()
         if not enrollment_deferred:
-            assert enrollment.consent_granted is consent_provided
+            assert dsc.granted is consent_provided
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.views.ProgramDataExtender')
@@ -472,14 +469,15 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
             user_id=self.user.id,
             enterprise_customer=enterprise_customer
         )
-        enrollment = EnterpriseCourseEnrollment.objects.create(
+        EnterpriseCourseEnrollment.objects.create(
             enterprise_customer_user=ecu,
             course_id=course_id
         )
-        DataSharingConsentFactory(
+        dsc = DataSharingConsentFactory(
             username=self.user.username,
             course_id=course_id,
             enterprise_customer=enterprise_customer,
+            granted=False,
         )
         client = course_api_client_mock.return_value
         client.get_course_details.return_value = None
@@ -493,8 +491,8 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
             },
         )
         assert resp.status_code == 404
-        enrollment.refresh_from_db()
-        assert enrollment.consent_granted is None
+        dsc.refresh_from_db()
+        assert dsc.granted is False
 
 
 @mark.django_db

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -329,7 +329,6 @@ class TestTransmitLearnerData(unittest.TestCase):
         self.enrollment = EnterpriseCourseEnrollmentFactory(
             enterprise_customer_user=self.enterprise_customer_user,
             course_id=self.course_id,
-            consent_granted=True,
         )
         self.consent = DataSharingConsentFactory(
             username=self.user.username,

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -5,16 +5,9 @@ Tests for migrations, especially potentially risky data migrations.
 
 from __future__ import absolute_import, unicode_literals
 
-import ddt
-from consent.models import DataSharingConsent
-
 from django.db import connection
 from django.db.migrations.executor import MigrationExecutor
 from django.test.testcases import TransactionTestCase
-
-from enterprise.decorators import ignore_warning
-from enterprise.models import UserDataSharingConsentAudit
-from test_utils import factories
 
 
 class MigrationTestCase(TransactionTestCase):
@@ -77,97 +70,3 @@ class MigrationTestCase(TransactionTestCase):
         Returns the label of the ``model``.
         """
         return self.model._meta.get_field('name')
-
-
-@ddt.ddt
-class MigrateToNewDataSharingConsentTest(MigrationTestCase):
-    """
-    Test cases for migrating data from ``EnterpriseCourseEnrollment`` and ``UserDataSharingConsentAudit`` to
-    the new Consent application's ``DataSharingConsent`` model.
-    """
-
-    migrate_origin = [('consent', '0001_initial')]
-    migrate_dest = [('consent', '0002_migrate_to_new_data_sharing_consent')]
-    model = DataSharingConsent
-
-    def setUp(self):
-        """
-        Set up EnterpriseCourseEnrollment and UserDataSharingConsentAudit with some data.
-        """
-        super(MigrateToNewDataSharingConsentTest, self).setUp()
-        self.user = factories.UserFactory(
-            username='bob',
-            id=1
-        )
-        self.enterprise_customer_user = factories.EnterpriseCustomerUserFactory(
-            user_id=1
-        )
-        self.enterprise_course_enrollment = factories.EnterpriseCourseEnrollmentFactory(
-            enterprise_customer_user=self.enterprise_customer_user
-        )
-        self.user_data_sharing_consent_audit = factories.UserDataSharingConsentAuditFactory(
-            user=self.enterprise_customer_user
-        )
-        self.migrate_to_origin()
-
-    def tearDown(self):
-        """
-        Make sure to migrate back to the origin.
-        """
-        super(MigrateToNewDataSharingConsentTest, self).setUp()
-        self.migrate_to_origin()
-
-    @ddt.data(
-        (True, UserDataSharingConsentAudit.NOT_SET),
-        (True, UserDataSharingConsentAudit.ENABLED),
-        (True, UserDataSharingConsentAudit.DISABLED),
-        (True, UserDataSharingConsentAudit.EXTERNALLY_MANAGED),
-        (False, UserDataSharingConsentAudit.NOT_SET),
-        (False, UserDataSharingConsentAudit.ENABLED),
-        (False, UserDataSharingConsentAudit.DISABLED),
-        (False, UserDataSharingConsentAudit.EXTERNALLY_MANAGED),
-        (None, UserDataSharingConsentAudit.NOT_SET),
-        (None, UserDataSharingConsentAudit.ENABLED),
-        (None, UserDataSharingConsentAudit.DISABLED),
-        (None, UserDataSharingConsentAudit.EXTERNALLY_MANAGED),
-    )
-    @ddt.unpack
-    @ignore_warning(DeprecationWarning)
-    def test_enrollment_consent_transfers(self, ece_consent_state, udsca_consent_state):
-        """
-        Test that ``EnterpriseCourseEnrollment``'s consent data transfers over to ``DataSharingConsent``.
-
-        We check ``UserDataSharingConsentAudit`` as a last resort for consent state.
-        """
-        self.enterprise_course_enrollment.consent_granted = ece_consent_state
-        self.enterprise_course_enrollment.save()
-        self.user_data_sharing_consent_audit.state = udsca_consent_state
-        self.user_data_sharing_consent_audit.save()
-
-        self.migrate_to_dest()
-
-        data_sharing_consent = DataSharingConsent.objects.all().first()
-        if self.enterprise_course_enrollment.consent_available:
-            self.assertTrue(data_sharing_consent.granted)
-        else:
-            self.assertFalse(data_sharing_consent.granted)
-
-    @ignore_warning(DeprecationWarning)
-    def test_duplicate_consent_doesnt_cause_error(self):
-        """
-        An existing ``DataSharingConsent`` row shouldn't cause a migration error -- it should update accordingly.
-        """
-        DataSharingConsent.objects.create(
-            username=self.enterprise_customer_user.username,
-            course_id=self.enterprise_course_enrollment.course_id,
-            enterprise_customer=self.enterprise_customer_user.enterprise_customer,
-            granted=False,
-        )
-
-        self.enterprise_course_enrollment.consent_granted = True
-        self.enterprise_course_enrollment.save()
-
-        self.migrate_to_dest()
-
-        data_sharing_consent = DataSharingConsent.objects.all().first()
-        assert data_sharing_consent.granted

--- a/tests/test_sap_success_factors/test_learner_data.py
+++ b/tests/test_sap_success_factors/test_learner_data.py
@@ -76,7 +76,6 @@ class TestBaseLearnerExporter(unittest.TestCase):
         EnterpriseCourseEnrollmentFactory(
             enterprise_customer_user=self.enterprise_customer_user,
             course_id=self.course_id,
-            consent_granted=False,
         )
 
         self.data_sharing_consent.granted = False
@@ -101,7 +100,6 @@ class TestBaseLearnerExporter(unittest.TestCase):
         EnterpriseCourseEnrollmentFactory(
             enterprise_customer_user=self.enterprise_customer_user,
             course_id=self.course_id,
-            consent_granted=True,
         )
 
         # Return no course details
@@ -119,7 +117,6 @@ class TestBaseLearnerExporter(unittest.TestCase):
         enrollment = EnterpriseCourseEnrollmentFactory(
             enterprise_customer_user=self.enterprise_customer_user,
             course_id=self.course_id,
-            consent_granted=True,
         )
 
         # Raise 404 - no certificate found
@@ -154,7 +151,6 @@ class TestBaseLearnerExporter(unittest.TestCase):
         enrollment = EnterpriseCourseEnrollmentFactory(
             enterprise_customer_user=self.enterprise_customer_user,
             course_id=self.course_id,
-            consent_granted=True,
         )
 
         # Return a mock certificate
@@ -196,7 +192,6 @@ class TestBaseLearnerExporter(unittest.TestCase):
         enrollment = EnterpriseCourseEnrollmentFactory(
             enterprise_customer_user=self.enterprise_customer_user,
             course_id=self.course_id,
-            consent_granted=True,
         )
 
         # Return instructor-paced course details
@@ -245,7 +240,6 @@ class TestBaseLearnerExporter(unittest.TestCase):
         enrollment = EnterpriseCourseEnrollmentFactory(
             enterprise_customer_user=self.enterprise_customer_user,
             course_id=self.course_id,
-            consent_granted=True,
         )
 
         # Mock self-paced course details
@@ -292,14 +286,12 @@ class TestBaseLearnerExporter(unittest.TestCase):
         enrollment1 = EnterpriseCourseEnrollmentFactory(
             enterprise_customer_user=self.enterprise_customer_user,
             course_id=self.course_id,
-            consent_granted=True,
         )
 
         course_id2 = 'course-v1:edX+DemoX+DemoCourse2'
         enrollment2 = EnterpriseCourseEnrollmentFactory(
             enterprise_customer_user=self.enterprise_customer_user,
             course_id=course_id2,
-            consent_granted=True,
         )
         DataSharingConsentFactory(
             username=self.enterprise_customer_user.username,
@@ -314,7 +306,6 @@ class TestBaseLearnerExporter(unittest.TestCase):
                 enterprise_customer=self.enterprise_customer,
             ),
             course_id=self.course_id,
-            consent_granted=True,
         )
         DataSharingConsentFactory(
             username='R2D2',
@@ -417,7 +408,6 @@ class TestBaseLearnerExporter(unittest.TestCase):
         enrollment = EnterpriseCourseEnrollmentFactory(
             enterprise_customer_user=self.enterprise_customer_user,
             course_id=self.course_id,
-            consent_granted=True,
         )
 
         # Set the audit track data passback configuration

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -137,13 +137,11 @@ class TestEnterpriseUtils(unittest.TestCase):
                 "enforce_data_sharing_consent",
                 "enable_audit_enrollment",
                 "enable_audit_data_reporting",
-                "require_account_level_consent",
             ]
         ),
         (
             EnterpriseCustomerUser,
             [
-                "data_sharing_consent",
                 "enterprise_enrollments",
                 "id",
                 "created",

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -26,14 +26,6 @@ from enterprise.models import (
     EnterpriseCustomerIdentityProvider,
     EnterpriseCustomerUser,
 )
-from enterprise.utils import (
-    filter_audit_course_modes,
-    get_all_field_names,
-    get_configuration_value,
-    get_enterprise_customer,
-    get_enterprise_customer_user,
-    ungettext_min_max,
-)
 from test_utils import TEST_UUID, create_items
 from test_utils.factories import (
     EnterpriseCustomerFactory,
@@ -172,7 +164,7 @@ class TestEnterpriseUtils(unittest.TestCase):
         ),
     )
     def test_get_all_field_names(self, model, expected_fields):
-        actual_field_names = get_all_field_names(model)
+        actual_field_names = utils.get_all_field_names(model)
         assert actual_field_names == expected_fields
 
     @ddt.data(
@@ -253,7 +245,7 @@ class TestEnterpriseUtils(unittest.TestCase):
     def test_get_enterprise_customer(self, factory, items, returns_obj):
         if factory:
             create_items(factory, items)
-        enterprise_customer = get_enterprise_customer(TEST_UUID)
+        enterprise_customer = utils.get_enterprise_customer(TEST_UUID)
         if returns_obj:
             self.assertIsNotNone(enterprise_customer)
         else:
@@ -263,13 +255,13 @@ class TestEnterpriseUtils(unittest.TestCase):
         user = UserFactory()
         enterprise_customer = EnterpriseCustomerFactory()
 
-        assert get_enterprise_customer_user(user.id, enterprise_customer.uuid) is None
+        assert utils.get_enterprise_customer_user(user.id, enterprise_customer.uuid) is None
 
         enterprise_customer_user = EnterpriseCustomerUserFactory(
             user_id=user.id,
             enterprise_customer=enterprise_customer
         )
-        assert get_enterprise_customer_user(user.id, enterprise_customer.uuid) == enterprise_customer_user
+        assert utils.get_enterprise_customer_user(user.id, enterprise_customer.uuid) == enterprise_customer_user
 
     @ddt.data(
         (
@@ -912,7 +904,7 @@ class TestEnterpriseUtils(unittest.TestCase):
         """
         ``ungettext_min_max`` returns the appropriate strings depending on a certain min & max.
         """
-        assert ungettext_min_max(singular, plural, range_text, min_val, max_val) == expected_output
+        assert utils.ungettext_min_max(singular, plural, range_text, min_val, max_val) == expected_output
 
     @mock.patch('enterprise.utils.configuration_helpers')
     def test_get_configuration_value_with_openedx(self, config_mock):
@@ -920,13 +912,30 @@ class TestEnterpriseUtils(unittest.TestCase):
         ``get_configuration_value`` returns the appropriate non-default value when connected to Open edX.
         """
         config_mock.get_value.return_value = 'value'
-        assert get_configuration_value('value', default='default') == 'value'
+        assert utils.get_configuration_value('value', default='default') == 'value'
 
     def test_get_configuration_value_without_openedx(self):
         """
         ``get_configuration_value`` returns a default value of 'default' when not connected to Open edX.
         """
-        assert get_configuration_value('value', default='default') == 'default'
+        assert utils.get_configuration_value('value', default='default') == 'default'
+
+    def test_get_configuration_value_for_site_with_configuration(self):
+        """
+        ``get_configuration_value_for_site`` returns the key's value or the default in the site configuration.
+
+        We do not test whether we get back the key's value or the default in particular, but just that
+        the function returns a value through the configuration, rather than the default.
+        """
+        site = SiteFactory()
+        site.configuration = mock.MagicMock(get_value=mock.MagicMock(return_value='value'))
+        assert utils.get_configuration_value_for_site(site, 'key', 'default') == 'value'
+
+    def test_get_configuration_value_for_site_without_configuration(self):
+        """
+        ``get_configuration_value_for_site`` returns the default because of no site configuration.
+        """
+        assert utils.get_configuration_value_for_site(SiteFactory(), 'key', 'default') == 'default'
 
 
 def get_transformed_course_metadata(course_id, status):
@@ -1200,7 +1209,7 @@ class TestSAPSuccessFactorsUtils(unittest.TestCase):
         # when the audit enrollment flag is disabled
         self.customer.enable_audit_enrollment = False
         # course modes are filtered out if their mode is in the ENTERPRISE_COURSE_ENROLLMENT_AUDIT_MODES setting
-        filtered_course_modes = filter_audit_course_modes(self.customer, course_modes)
+        filtered_course_modes = utils.filter_audit_course_modes(self.customer, course_modes)
         assert len(filtered_course_modes) == 2
         result = [course_mode['number'] for course_mode in filtered_course_modes]
         expected = [0, 3]
@@ -1209,7 +1218,7 @@ class TestSAPSuccessFactorsUtils(unittest.TestCase):
         # when the audit enrollment flag is enabled
         self.customer.enable_audit_enrollment = True
         # audit course modes are not filtered out
-        filtered_course_modes = filter_audit_course_modes(self.customer, course_modes)
+        filtered_course_modes = utils.filter_audit_course_modes(self.customer, course_modes)
         assert len(filtered_course_modes) == 5
 
     @override_switch('SAP_USE_ENTERPRISE_ENROLLMENT_PAGE', active=True)


### PR DESCRIPTION
**Description:** This removes any remaining traces of account-level consent and consent for courses tracked by the `EnterpriseCourseEnrollment` model.

**JIRA:** [ENT-644](https://openedx.atlassian.net/browse/ENT-644)

**Merge deadline:** N/A

**Testing instructions:**

Since account-level consent and course-level consent through `EnterpriseCourseEnrollment` were both deprecated in favor of `DataSharingConsent`, this should not have any effect on functionality. However, to be safe, it may be recommended to try out our data sharing consent flows to make sure everything still works as intended.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)
