### PR TITLE
[ENT-640] Remove `auth-user` endpoint.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,12 @@ Change Log
 
 Unreleased
 ----------
+
+[0.46.1] - 2017-09-18
+---------------------
+
+* Remove the `auth-user` endpoint completely.
+
 [0.46.0] - 2017-09-15
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.46.0"
+__version__ = "0.46.1"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/v1/urls.py
+++ b/enterprise/api/v1/urls.py
@@ -10,7 +10,6 @@ from enterprise.api.v1 import views
 
 router = DefaultRouter()  # pylint: disable=invalid-name
 router.register("site", views.SiteViewSet, 'site')
-router.register("auth-user", views.UserViewSet, 'auth-user')
 router.register("enterprise-catalogs", views.EnterpriseCustomerCatalogViewSet, 'enterprise-catalogs')
 router.register("enterprise-course-enrollment", views.EnterpriseCourseEnrollmentViewSet, 'enterprise-course-enrollment')
 router.register("enterprise-customer", views.EnterpriseCustomerViewSet, 'enterprise-customer')

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -14,7 +14,6 @@ from rest_framework.exceptions import NotFound
 from rest_framework.response import Response
 
 from django.conf import settings
-from django.contrib.auth.models import User
 from django.contrib.sites.models import Site
 from django.http import Http404
 from django.utils.decorators import method_decorator
@@ -176,21 +175,6 @@ class SiteViewSet(EnterpriseReadOnlyModelViewSet):
     serializer_class = serializers.SiteSerializer
 
     FIELDS = ('domain', 'name', )
-    filter_fields = FIELDS
-    ordering_fields = FIELDS
-
-
-class UserViewSet(EnterpriseReadOnlyModelViewSet):
-    """
-    API views for the ``auth-user`` API endpoint.
-    """
-
-    queryset = User.objects.all()
-    serializer_class = serializers.UserSerializer
-
-    FIELDS = (
-        'username', 'first_name', 'last_name', 'email', 'is_staff', 'is_active'
-    )
     filter_fields = FIELDS
     ordering_fields = FIELDS
 


### PR DESCRIPTION
**Description:** Please see the [ENT-640 ticket](https://openedx.atlassian.net/browse/ENT-640) for more details.

**JIRA:** [ENT-640](https://openedx.atlassian.net/browse/ENT-640)

**Merge deadline:** ASAP

**Testing instructions:**

1. Make sure you can no longer go to `/enterprise/api/v1/auth-user/` or `/enterprise/api/v1/auth-user/{id}/` as any type of user (unauthenticated, authenticated, staff, non-staff, etc.).

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)