### PR TITLE
[ENT-644] Remove `require_account_level_consent` in code only. (Step 2)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.46.8] - 2017-09-21
+---------------------
+
+* Step 2 in safe deployment of removing old consent models: remove `require_account_level_consent`, but no migration.
+
 [0.46.7] - 2017-09-21
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.46.7"
+__version__ = "0.46.8"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -143,16 +143,6 @@ class EnterpriseCustomer(TimeStampedModel):
         )
     )
 
-    require_account_level_consent = models.NullBooleanField(
-        default=False,
-        blank=True,
-        null=True,
-        help_text=_(
-            "Specifies whether every consent interaction should ask for account-wide consent, rather than only "
-            "the specific scope at which the interaction is happening."
-        )
-    )
-
     @property
     def identity_provider(self):
         """

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -129,7 +129,6 @@ class TestEnterpriseUtils(unittest.TestCase):
                 "enforce_data_sharing_consent",
                 "enable_audit_enrollment",
                 "enable_audit_data_reporting",
-                "require_account_level_consent",
             ]
         ),
         (


### PR DESCRIPTION
**Description:** This PR removes `require_account_level_consent` in code only, to prepare for the last PR of making the migrations to delete all of the fields/models associated with account-level consent.

**JIRA:** [ENT-644](https://openedx.atlassian.net/browse/ENT-644)

**Merge deadline:** ASAP.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)
