### PR TITLE
[ENT-644] Perform migrations for removing account-level consent. (Step 3)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.47.0] - 2017-09-21
+---------------------
+
+* Step 3 in safe deployment of removing old consent models: make migrations to delete the outstanding fields/models.
+
 [0.46.8] - 2017-09-21
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.46.8"
+__version__ = "0.47.0"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/migrations/0027_remove_account_level_consent.py
+++ b/enterprise/migrations/0027_remove_account_level_consent.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('enterprise', '0026_make_require_account_level_consent_nullable'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='historicaluserdatasharingconsentaudit',
+            name='history_user',
+        ),
+        migrations.RemoveField(
+            model_name='historicaluserdatasharingconsentaudit',
+            name='user',
+        ),
+        migrations.RemoveField(
+            model_name='userdatasharingconsentaudit',
+            name='user',
+        ),
+        migrations.RemoveField(
+            model_name='enterprisecourseenrollment',
+            name='consent_granted',
+        ),
+        migrations.RemoveField(
+            model_name='enterprisecustomer',
+            name='require_account_level_consent',
+        ),
+        migrations.RemoveField(
+            model_name='historicalenterprisecourseenrollment',
+            name='consent_granted',
+        ),
+        migrations.RemoveField(
+            model_name='historicalenterprisecustomer',
+            name='require_account_level_consent',
+        ),
+        migrations.DeleteModel(
+            name='HistoricalUserDataSharingConsentAudit',
+        ),
+        migrations.DeleteModel(
+            name='UserDataSharingConsentAudit',
+        ),
+    ]


### PR DESCRIPTION
**Description:** This PR adds all the migrations to be released as a separate version for removing account-level consent.

**JIRA:** [ENT-644](https://openedx.atlassian.net/browse/ENT-644)

**Dependencies**: #197 which is step 2 in this process.

**Merge deadline:** ASAP.

**Testing instructions:**

1. Make sure the migrations run safely.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)
