### PR TITLE
Tuchfarber/enterprise email template 1

### DIFF
--- a/enterprise/migrations/0027_auto_20170921_1201.py
+++ b/enterprise/migrations/0027_auto_20170921_1201.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import migrations, models
 import django.db.models.deletion
+from django.db import migrations, models
 
 
 class Migration(migrations.Migration):

--- a/enterprise/migrations/0027_auto_20170921_1201.py
+++ b/enterprise/migrations/0027_auto_20170921_1201.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('enterprise', '0026_remove_old_consent'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='enrollmentnotificationemailtemplate',
+            name='enterprise_customer',
+            field=models.OneToOneField(related_name='enterprise_enrollment_template', default=None, to='enterprise.EnterpriseCustomer'),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='historicalenrollmentnotificationemailtemplate',
+            name='enterprise_customer',
+            field=models.ForeignKey(related_name='+', on_delete=django.db.models.deletion.DO_NOTHING, db_constraint=False, blank=True, to='enterprise.EnterpriseCustomer', null=True),
+        ),
+        migrations.AlterField(
+            model_name='enrollmentnotificationemailtemplate',
+            name='site',
+            field=models.OneToOneField(related_name='enterprise_enrollment_template', null=True, blank=True, to='sites.Site'),
+        ),
+    ]

--- a/enterprise/migrations/0027_auto_20170921_1201.py
+++ b/enterprise/migrations/0027_auto_20170921_1201.py
@@ -8,7 +8,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('enterprise', '0026_remove_old_consent'),
+        ('enterprise', '0026_make_require_account_level_consent_nullable'),
     ]
 
     operations = [

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -963,7 +963,8 @@ class EnrollmentNotificationEmailTemplate(TimeStampedModel):
     plaintext_template = models.TextField(blank=True, help_text=BODY_HELP_TEXT)
     html_template = models.TextField(blank=True, help_text=BODY_HELP_TEXT)
     subject_line = models.CharField(max_length=100, blank=True, help_text=SUBJECT_HELP_TEXT)
-    site = models.OneToOneField(Site, related_name="enterprise_enrollment_template", on_delete=models.deletion.CASCADE)
+    site = models.OneToOneField(Site, blank=True, null=True, related_name="enterprise_enrollment_template", on_delete=models.deletion.CASCADE)
+    enterprise_customer = models.OneToOneField(EnterpriseCustomer, related_name="enterprise_enrollment_template", on_delete=models.deletion.CASCADE)
     history = HistoricalRecords()
 
     def render_html_template(self, kwargs):
@@ -996,8 +997,8 @@ class EnrollmentNotificationEmailTemplate(TimeStampedModel):
         """
         Return human-readable string representation.
         """
-        return '<EnrollmentNotificationEmailTemplate for site with ID {}>'.format(
-            self.site.id
+        return '<EnrollmentNotificationEmailTemplate for EnterpriseCustomer with ID {}>'.format(
+            self.enterprise_customer.uuid
         )
 
     def __repr__(self):

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -963,8 +963,18 @@ class EnrollmentNotificationEmailTemplate(TimeStampedModel):
     plaintext_template = models.TextField(blank=True, help_text=BODY_HELP_TEXT)
     html_template = models.TextField(blank=True, help_text=BODY_HELP_TEXT)
     subject_line = models.CharField(max_length=100, blank=True, help_text=SUBJECT_HELP_TEXT)
-    site = models.OneToOneField(Site, blank=True, null=True, related_name="enterprise_enrollment_template", on_delete=models.deletion.CASCADE)
-    enterprise_customer = models.OneToOneField(EnterpriseCustomer, related_name="enterprise_enrollment_template", on_delete=models.deletion.CASCADE)
+    site = models.OneToOneField(
+        Site,
+        blank=True,
+        null=True,
+        related_name="enterprise_enrollment_template",
+        on_delete=models.deletion.CASCADE
+    )
+    enterprise_customer = models.OneToOneField(
+        EnterpriseCustomer,
+        related_name="enterprise_enrollment_template",
+        on_delete=models.deletion.CASCADE
+    )
     history = HistoricalRecords()
 
     def render_html_template(self, kwargs):

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -277,13 +277,13 @@ def send_email_notification_message(user, enrolled_in, enterprise_customer, emai
         'organization_name': enterprise_customer.name,
     }
     try:
-        site_template_configuration = enterprise_customer.site.enterprise_enrollment_template
+        enterprise_template_config = enterprise_customer.enterprise_enrollment_template
     except (ObjectDoesNotExist, AttributeError):
-        site_template_configuration = None
+        enterprise_template_config = None
 
-    plain_msg, html_msg = build_notification_message(msg_context, site_template_configuration)
+    plain_msg, html_msg = build_notification_message(msg_context, enterprise_template_config)
 
-    subject_line = get_notification_subject_line(enrolled_in['name'], site_template_configuration)
+    subject_line = get_notification_subject_line(enrolled_in['name'], enterprise_template_config)
 
     return mail.send_mail(
         subject_line,

--- a/tests/test_admin/test_view.py
+++ b/tests/test_admin/test_view.py
@@ -37,7 +37,6 @@ from test_utils.factories import (
     EnterpriseCustomerFactory,
     EnterpriseCustomerUserFactory,
     PendingEnterpriseCustomerUserFactory,
-    SiteFactory,
     UserFactory,
 )
 from test_utils.fake_catalog_api import FAKE_PROGRAM_RESPONSE2
@@ -66,7 +65,7 @@ class TestPreviewTemplateView(TestCase):
                 ' Program Variant{% endif %}</body></html>'
             ),
             subject_line='Enrollment Notification',
-            site=SiteFactory(),
+            enterprise_customer=EnterpriseCustomerFactory(),
         )
         super(TestPreviewTemplateView, self).setUp()
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -28,7 +28,6 @@ from integrated_channels.sap_success_factors.models import (
 from opaque_keys.edx.keys import CourseKey
 from pytest import mark, raises
 
-from django.contrib.sites.models import Site
 from django.core.exceptions import ValidationError
 from django.core.files import File
 from django.core.files.storage import Storage
@@ -834,7 +833,7 @@ class TestEnrollmentNotificationEmailTemplate(unittest.TestCase):
 
     def setUp(self):
         self.template = EnrollmentNotificationEmailTemplate.objects.create(
-            site=Site.objects.get(id=1),
+            enterprise_customer=EnterpriseCustomerFactory(),
             plaintext_template=(
                 'This is a template - testing {{ course_name }}, {{ other_value }}'
             ),
@@ -861,7 +860,9 @@ class TestEnrollmentNotificationEmailTemplate(unittest.TestCase):
         """
         Test conversion to string.
         """
-        expected_str = '<EnrollmentNotificationEmailTemplate for site with ID 1>'
+        expected_str = '<EnrollmentNotificationEmailTemplate for EnterpriseCustomer with ID {}>'.format(
+            self.template.enterprise_customer.uuid
+        )
         assert expected_str == method(self.template)
 
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -116,6 +116,7 @@ class TestEnterpriseUtils(unittest.TestCase):
                 "enterprise_customer_identity_provider",
                 "enterprise_customer_entitlements",
                 "enterprise_customer_catalog",
+                "enterprise_enrollment_template",
                 "enterprise_customer_consent",
                 "sapsuccessfactorsenterprisecustomerconfiguration",
                 "created",
@@ -394,9 +395,7 @@ class TestEnterpriseUtils(unittest.TestCase):
         Test that we can successfully render and send an email message.
         """
         enrolled_in['start'] = datetime.datetime.strptime(enrolled_in['start'], '%Y-%m-%d')
-        enterprise_customer = mock.MagicMock(
-            site=mock.MagicMock(spec=[])
-        )
+        enterprise_customer = mock.MagicMock(spec=[])
         enterprise_customer.name = enterprise_customer_name
         if user is None:
             with raises(TypeError):
@@ -535,13 +534,11 @@ class TestEnterpriseUtils(unittest.TestCase):
         """
         enrolled_in['start'] = datetime.datetime.strptime(enrolled_in['start'], '%Y-%m-%d')
         enterprise_customer = mock.MagicMock(
-            site=mock.MagicMock(
-                enterprise_enrollment_template=mock.MagicMock(
-                    render_all_templates=mock.MagicMock(
-                        return_value=(('plaintext_value', '<b>HTML value</b>', ))
-                    ),
-                    subject_line='New course! {course_name}!'
-                )
+            enterprise_enrollment_template=mock.MagicMock(
+                render_all_templates=mock.MagicMock(
+                    return_value=(('plaintext_value', '<b>HTML value</b>', ))
+                ),
+                subject_line='New course! {course_name}!'
             )
         )
         enterprise_customer.name = enterprise_customer_name
@@ -708,15 +705,13 @@ class TestEnterpriseUtils(unittest.TestCase):
         """
         enrolled_in['start'] = datetime.datetime.strptime(enrolled_in['start'], '%Y-%m-%d')
         enterprise_customer = mock.MagicMock(
-            site=mock.MagicMock(
-                enterprise_enrollment_template=mock.MagicMock(
-                    plaintext_template='',
-                    html_template='<b>hi there</b>',
-                    render_all_templates=mock.MagicMock(
-                        return_value=(('plaintext_value', '<b>HTML value</b>', ))
-                    ),
-                    subject_line=subject_line
-                )
+            enterprise_enrollment_template=mock.MagicMock(
+                plaintext_template='',
+                html_template='<b>hi there</b>',
+                render_all_templates=mock.MagicMock(
+                    return_value=(('plaintext_value', '<b>HTML value</b>', ))
+                ),
+                subject_line=subject_line
             )
         )
         enterprise_customer.name = enterprise_customer_name


### PR DESCRIPTION
**Description:** 
First step in making the email notification template attached to the enterprise instead of the site. This makes the site field nullable, adds the enterprise_customer field, and changes all tests to reference the new field. I have verified that this is NOT being used in prod or stage currently.

**JIRA:** Link to JIRA ticket
[WL-1240]

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 
No dependencies. Will need two follow up PRs (removing field from model, running removal migration)

**Merge deadline:** List merge deadline (if any)
N/A

**Installation instructions:** List any non-trivial installation instructions.
N/A

**Testing instructions:**

(Available on the WL sandbox right now)
1. Add enrollment notification email template in django admin
2. See that it attaches to enterprise customer instead of site.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
