### PR TITLE
Add API endpoints for checking the existence of content contained in EnterpriseCustomerCatalogs.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.50.0] - 2017-10-03
+---------------------
+
+* Add contains_content_items endpoint to EnterpriseCustomerViewSet and EnterpriseCustomerCatalogViewSet.
+
 [0.49.0] - 2017-10-02
 ---------------------
 

--- a/api-compact.yaml
+++ b/api-compact.yaml
@@ -10,10 +10,10 @@
 #   /enterprise/api/v1/catalogs/
 #   /enterprise/api/v1/catalogs/{id}/
 #   /enterprise/api/v1/catalogs/{id}/courses/
-#   /enterprise/api/v1/enterprise-catalogs/
-#   /enterprise/api/v1/enterprise-catalogs/{uuid}/
-#   /enterprise/api/v1/enterprise-catalogs/{uuid}/course-runs/{course_run_id}/
-#   /enterprise/api/v1/enterprise-catalogs/{uuid}/programs/{program_uuid}/
+#   /enterprise/api/v1/enterprise_catalogs/
+#   /enterprise/api/v1/enterprise_catalogs/{uuid}/
+#   /enterprise/api/v1/enterprise_catalogs/{uuid}/course_runs/{course_run_id}/
+#   /enterprise/api/v1/enterprise_catalogs/{uuid}/programs/{program_uuid}/
 
 apigateway_responses: &apigateway_responses
   default:
@@ -331,7 +331,7 @@ endpoints:
             <<: *apigateway_integration_with_id_and_querystring_parameters
             uri: "https://${stageVariables.enterprise_host}/enterprise/api/v1/catalogs/{id}/courses/"
 
-    # /v1/enterprise-catalogs/
+    # /v1/enterprise_catalogs/
     enterpriseCustomerCatalogs:
         get:
           produces: *produces
@@ -343,9 +343,9 @@ endpoints:
           responses: *responses
           x-amazon-apigateway-integration:
             <<: *apigateway_integration_enterprise_customer_catalog_list
-            uri: "https://${stageVariables.enterprise_host}/enterprise/api/v1/enterprise-catalogs/"
+            uri: "https://${stageVariables.enterprise_host}/enterprise/api/v1/enterprise_catalogs/"
 
-    # /v1/enterprise-catalogs/{uuid}/
+    # /v1/enterprise_catalogs/{uuid}/
     enterpriseCustomerCatalogByUuid:
         get:
           produces: *produces
@@ -358,9 +358,9 @@ endpoints:
           responses: *responses
           x-amazon-apigateway-integration:
             <<: *apigateway_integration_enterprise_customer_catalog_detail
-            uri: "https://${stageVariables.enterprise_host}/enterprise/api/v1/enterprise-catalogs/{uuid}/"
+            uri: "https://${stageVariables.enterprise_host}/enterprise/api/v1/enterprise_catalogs/{uuid}/"
 
-    # /v1/enterprise-catalogs/{uuid}/course-runs/{course_run_id}/
+    # /v1/enterprise_catalogs/{uuid}/course_runs/{course_run_id}/
     enterpriseCustomerCatalogCourseRunByUuid:
         get:
           produces: *produces
@@ -374,9 +374,9 @@ endpoints:
           responses: *responses
           x-amazon-apigateway-integration:
             <<: *apigateway_integration_with_enterprise_customer_catalog_uuid_and_course_run_id_parameters
-            uri: "https://${stageVariables.enterprise_host}/enterprise/api/v1/enterprise-catalogs/{uuid}/course-runs/{course_run_id}/"
+            uri: "https://${stageVariables.enterprise_host}/enterprise/api/v1/enterprise_catalogs/{uuid}/course_runs/{course_run_id}/"
 
-    # /v1/enterprise-catalogs/{uuid}/programs/{program_uuid}/
+    # /v1/enterprise_catalogs/{uuid}/programs/{program_uuid}/
     enterpriseCustomerCatalogProgramByUuid:
         get:
           produces: *produces
@@ -390,4 +390,4 @@ endpoints:
           responses: *responses
           x-amazon-apigateway-integration:
             <<: *apigateway_integration_with_enterprise_customer_catalog_uuid_and_program_uuid_parameters
-            uri: "https://${stageVariables.enterprise_host}/enterprise/api/v1/enterprise-catalogs/{uuid}/programs/{program_uuid}/"
+            uri: "https://${stageVariables.enterprise_host}/enterprise/api/v1/enterprise_catalogs/{uuid}/programs/{program_uuid}/"

--- a/api.yaml
+++ b/api.yaml
@@ -403,7 +403,7 @@ endpoints:
             default:
               statusCode: "400"
           type: http
-          uri: "https://${stageVariables.enterprise_host}/enterprise/api/v1/enterprise-catalogs/{uuid}/"
+          uri: "https://${stageVariables.enterprise_host}/enterprise/api/v1/enterprise_catalogs/{uuid}/"
     enterpriseCustomerCatalogCourseRunByUuid:
       get:
         operationId: get_enterprise_customer_catalog_course_run_by_id
@@ -475,7 +475,7 @@ endpoints:
             default:
               statusCode: "400"
           type: http
-          uri: "https://${stageVariables.enterprise_host}/enterprise/api/v1/enterprise-catalogs/{uuid}/course-runs/{course_run_id}/"
+          uri: "https://${stageVariables.enterprise_host}/enterprise/api/v1/enterprise_catalogs/{uuid}/course_runs/{course_run_id}/"
     enterpriseCustomerCatalogProgramByUuid:
       get:
         operationId: get_enterprise_customer_catalog_program_by_uuid
@@ -547,7 +547,7 @@ endpoints:
             default:
               statusCode: "400"
           type: http
-          uri: "https://${stageVariables.enterprise_host}/enterprise/api/v1/enterprise-catalogs/{uuid}/programs/{program_uuid}/"
+          uri: "https://${stageVariables.enterprise_host}/enterprise/api/v1/enterprise_catalogs/{uuid}/programs/{program_uuid}/"
     enterpriseCustomerCatalogs:
       get:
         operationId: get_enterprise_customer_catalogs
@@ -617,7 +617,7 @@ endpoints:
             default:
               statusCode: "400"
           type: http
-          uri: "https://${stageVariables.enterprise_host}/enterprise/api/v1/enterprise-catalogs/"
+          uri: "https://${stageVariables.enterprise_host}/enterprise/api/v1/enterprise_catalogs/"
 id_parameter:
   in: path
   name: id

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.49.0"
+__version__ = "0.50.0"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/v1/decorators.py
+++ b/enterprise/api/v1/decorators.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, unicode_literals
 
 from functools import wraps
 
-from rest_framework.exceptions import PermissionDenied
+from rest_framework.exceptions import PermissionDenied, ValidationError
 
 from enterprise.utils import get_enterprise_customer_for_user
 
@@ -50,3 +50,42 @@ def enterprise_customer_required(view):
                 )
             )
     return wrapper
+
+
+def require_at_least_one_query_parameter(*query_parameter_names):
+    """
+    Ensure at least one of the specified query parameters are included in the request.
+
+    This decorator checks for the existence of at least one of the specified query
+    parameters and passes the values as function parameters to the decorated view.
+    If none of the specified query parameters are included in the request, a
+    ValidationError is raised.
+
+    Usage::
+        @require_at_least_one_query_parameter('program_uuids', 'course_run_ids')
+        def my_view(request, program_uuids, course_run_ids):
+            # Some functionality ...
+    """
+    def outer_wrapper(view):
+        """ Allow the passing of parameters to require_at_least_one_query_parameter. """
+        @wraps(view)
+        def wrapper(request, *args, **kwargs):
+            """
+            Checks for the existence of the specified query parameters, raises a
+            ValidationError if none of them were included in the request.
+            """
+            requirement_satisfied = False
+            for query_parameter_name in query_parameter_names:
+                query_parameter_values = request.query_params.getlist(query_parameter_name)
+                kwargs[query_parameter_name] = query_parameter_values
+                if query_parameter_values:
+                    requirement_satisfied = True
+            if not requirement_satisfied:
+                raise ValidationError(
+                    detail='You must provide at least one of the following query parameters: {params}.'.format(
+                        params=', '.join(query_parameter_names)
+                    )
+                )
+            return view(request, *args, **kwargs)
+        return wrapper
+    return outer_wrapper

--- a/enterprise/api/v1/urls.py
+++ b/enterprise/api/v1/urls.py
@@ -9,7 +9,7 @@ from rest_framework.routers import DefaultRouter
 from enterprise.api.v1 import views
 
 router = DefaultRouter()  # pylint: disable=invalid-name
-router.register("enterprise-catalogs", views.EnterpriseCustomerCatalogViewSet, 'enterprise-catalogs')
+router.register("enterprise_catalogs", views.EnterpriseCustomerCatalogViewSet, 'enterprise-catalogs')
 router.register("enterprise-course-enrollment", views.EnterpriseCourseEnrollmentViewSet, 'enterprise-course-enrollment')
 router.register("enterprise-customer", views.EnterpriseCustomerViewSet, 'enterprise-customer')
 router.register("enterprise-learner", views.EnterpriseCustomerUserViewSet, 'enterprise-learner')

--- a/enterprise/api_client/discovery.py
+++ b/enterprise/api_client/discovery.py
@@ -90,19 +90,24 @@ class CourseCatalogApiClient(object):
         self.user = user
         self.client = course_discovery_api_client(user)
 
-    def get_paginated_search_results(self, querystring=None):
+    def get_search_results(self, querystring=None, traverse_pagination=True):
         """
-        Return paginated search result from all data.
+        Return results from the discovery service's search/all endpoint.
 
+        Arguments:
+            querystring (dict): Querystring parameters used to filter search results.
+            traverse_pagination (bool): True to return all results, False to return the paginated response.
+                                        Defaults to True.
         Returns:
-            dict: API response with search results, as well as links to next and previous pages.
+            list or dict: The paginated response dict if traverse_pagination is False, otherwise the extracted
+                          results list.
 
         """
         return self._load_data(
             self.SEARCH_ALL_ENDPOINT,
             default=[],
             querystring=querystring,
-            traverse_pagination=False,
+            traverse_pagination=traverse_pagination,
             many=False,
         )
 

--- a/enterprise/migrations/0029_auto_20170925_1909.py
+++ b/enterprise/migrations/0029_auto_20170925_1909.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('enterprise', '0028_link_enterprise_to_enrollment_template'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='enterprisecustomercatalog',
+            name='enterprise_customer',
+            field=models.ForeignKey(related_name='enterprise_customer_catalogs', to='enterprise.EnterpriseCustomer'),
+        ),
+    ]

--- a/test_utils/__init__.py
+++ b/test_utils/__init__.py
@@ -28,7 +28,7 @@ FAKE_UUIDS = [str(uuid.uuid4()) for i in range(5)]  # pylint: disable=no-member
 TEST_USERNAME = 'api_worker'
 TEST_EMAIL = 'test@email.com'
 TEST_PASSWORD = 'QWERTY'
-TEST_COURSE = 'course-v1:edX+DemoX+DemoCourse'
+TEST_COURSE = 'course-v1:edX+DemoX+Demo_Course'
 TEST_UUID = 'd2098bfb-2c78-44f1-9eb2-b94475356a3f'
 TEST_USER_ID = 1
 

--- a/test_utils/fake_catalog_api.py
+++ b/test_utils/fake_catalog_api.py
@@ -91,6 +91,8 @@ FAKE_COURSE_RUN = {
     'reporting_type': 'mooc',
     'eligible_for_financial_aid': True
 }
+FAKE_COURSE_RUN2 = copy.deepcopy(FAKE_COURSE_RUN)
+FAKE_COURSE_RUN2['key'] = 'course-v1:edX+DemoX+Demo_Course2'
 FAKE_COURSE_RUN_WITH_ENTERPRISE_CONTEXT = copy.deepcopy(FAKE_COURSE_RUN)
 update_course_run_with_enterprise_context(FAKE_COURSE_RUN_WITH_ENTERPRISE_CONTEXT)
 

--- a/tests/test_enterprise/api_client/test_discovery.py
+++ b/tests/test_enterprise/api_client/test_discovery.py
@@ -72,14 +72,14 @@ class TestCourseCatalogApi(CourseDiscoveryApiTestMixin, unittest.TestCase):
 
     _make_run = _make_course_run.__func__  # unwrapping to use within class definition
 
-    def test_get_paginated_search_results(self):
+    def test_get_search_results(self):
         """
-        Verify get_paginated_search_results of CourseCatalogApiClient works as expected.
+        Verify get_search_results of CourseCatalogApiClient works as expected.
         """
         querystring = 'very'
         response_dict = {"very": "complex", "json": {"with": " nested object"}}
         self.get_data_mock.return_value = response_dict
-        actual_result = self.api.get_paginated_search_results(querystring=querystring)
+        actual_result = self.api.get_search_results(querystring=querystring)
         assert self.get_data_mock.call_count == 1
         resource, resource_id = self._get_important_parameters(self.get_data_mock)
         assert resource == CourseCatalogApiClient.SEARCH_ALL_ENDPOINT
@@ -87,12 +87,12 @@ class TestCourseCatalogApi(CourseDiscoveryApiTestMixin, unittest.TestCase):
         assert actual_result == response_dict
 
     @ddt.data(*EMPTY_RESPONSES)
-    def test_get_paginated_search_results_empty_response(self, response):
+    def test_get_search_results_empty_response(self, response):
         """
-        Verify get_paginated_catalog_courses of CourseCatalogApiClient works as expected for empty responses.
+        Verify get_search_results of CourseCatalogApiClient works as expected for empty responses.
         """
         self.get_data_mock.return_value = response
-        assert self.api.get_paginated_search_results(querystring='querystring') == []
+        assert self.api.get_search_results(querystring='querystring') == []
 
     def test_get_all_catalogs(self):
         """

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -115,7 +115,7 @@ class TestEnterpriseUtils(unittest.TestCase):
                 "branding_configuration",
                 "enterprise_customer_identity_provider",
                 "enterprise_customer_entitlements",
-                "enterprise_customer_catalog",
+                "enterprise_customer_catalogs",
                 "enterprise_enrollment_template",
                 "enterprise_customer_consent",
                 "sapsuccessfactorsenterprisecustomerconfiguration",


### PR DESCRIPTION
ENT-638

**Description:** This extends both the EnterpriseCustomer and EnterpriseCustomerCatalog endpoints to include a `contains_content` detail endpoint which will return whether or not the given content items exist within the specified EnterpriseCustomerCatalog or any of the EnterpriseCustomerCatalogs associated with the given EnterpriseCustomer.

These endpoints are needed to support [Enterprise Offers](https://github.com/edx/ecommerce/pull/1475) in ecommerce.

The second commit in this PR changes the EnterpriseCustomerCatalog API endpoint paths to use underscores instead of dashes. We will follow up with the remaining Enterprise API endpoints with ENT-668.

**JIRA:** https://openedx.atlassian.net/browse/ENT-638

**Testing instructions:**

1. Login to https://business.sandbox.edx.org with a user that is linked to the Pied Piper EnterpriseCustomer.
2. Visit https://business.sandbox.edx.org/enterprise/api/v1/enterprise_catalogs/ and verify that results are returned.
3. Visit https://business.sandbox.edx.org/enterprise/api/v1/enterprise_catalogs/067dfbf1-d3d8-48e0-8dfe-d37d73f1b3ab/ and verify that results are returned.
4. Visit https://business.sandbox.edx.org/enterprise/api/v1/enterprise_catalogs/067dfbf1-d3d8-48e0-8dfe-d37d73f1b3ab/course_runs/course-v1%3AedX%2BTest101%2Bcourse/ and verify result is returned.
5. Visit https://business.sandbox.edx.org/enterprise/api/v1/enterprise_catalogs/067dfbf1-d3d8-48e0-8dfe-d37d73f1b3ab/contains_content_items/?course_run_ids=course-v1:edX+Test101+course and verify that contains_content: true is returned.
6. Visit https://business.sandbox.edx.org/enterprise/api/v1/enterprise_catalogs/067dfbf1-d3d8-48e0-8dfe-d37d73f1b3ab/contains_content_items/?program_uuids=52ad909b-c57d-4ff1-bab3-999813a2479b and verify that contains_content: true is returned.
7. Visit https://business.sandbox.edx.org/enterprise/api/v1/enterprise-customer/2b5a2956-7746-4fc9-9587-bc887ba45973/contains_content_items/?course_run_ids=course-v1:edX+Test101+course and verify that contains_content: true is returned.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
