### PR TITLE
[ENT-653] Added UTM parameters to marketing/enrollment URLs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.51.4] - 2017-10-11
+---------------------
+
+* Added UTM parameters to marketing, track selection, and course/program enrollment URLs returned by Enterprise API.
+
 [0.51.3] - 2017-10-10
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.51.3"
+__version__ = "0.51.4"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/v1/mixins.py
+++ b/enterprise/api/v1/mixins.py
@@ -60,7 +60,8 @@ class EnterpriseCourseContextSerializerMixin(object):
         # Update marketing urls in course metadata to include enterprise related info (i.e. our global context).
         marketing_url = course.get('marketing_url')
         if marketing_url:
-            course.update({"marketing_url": utils.update_query_parameters(marketing_url, enterprise_context)})
+            query_parameters = dict(enterprise_context, **utils.get_enterprise_utm_context(enterprise_customer))
+            course.update({'marketing_url': utils.update_query_parameters(marketing_url, query_parameters)})
 
         # Finally, add context to the course as a whole.
         course.update(enterprise_context)
@@ -82,8 +83,9 @@ class EnterpriseCourseContextSerializerMixin(object):
         for course_run in course_runs:
             track_selection_url = utils.get_course_track_selection_url(
                 course_run=course_run,
-                query_parameters=enterprise_context,
+                query_parameters=dict(enterprise_context, **utils.get_enterprise_utm_context(enterprise_customer)),
             )
+
             enrollment_url = enterprise_customer.get_course_run_enrollment_url(course_run.get('key'))
 
             course_run.update({
@@ -94,7 +96,8 @@ class EnterpriseCourseContextSerializerMixin(object):
             # Update marketing urls in course metadata to include enterprise related info.
             marketing_url = course_run.get('marketing_url')
             if marketing_url:
-                course_run.update({"marketing_url": utils.update_query_parameters(marketing_url, enterprise_context)})
+                query_parameters = dict(enterprise_context, **utils.get_enterprise_utm_context(enterprise_customer))
+                course_run.update({'marketing_url': utils.update_query_parameters(marketing_url, query_parameters)})
 
             # Add updated course run to the list.
             updated_course_runs.append(course_run)

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -200,13 +200,14 @@ class EnterpriseCustomer(TimeStampedModel):
         Returns:
             (str): Enterprise landing page url.
         """
-        return urljoin(
+        url = urljoin(
             get_configuration_value('LMS_ROOT_URL', settings.LMS_ROOT_URL),
             reverse(
                 'enterprise_course_enrollment_page',
                 kwargs={'enterprise_uuid': self.uuid, 'course_id': course_run_key}
             )
         )
+        return utils.update_query_parameters(url, utils.get_enterprise_utm_context(self))
 
     def get_program_enrollment_url(self, program_uuid):
         """
@@ -217,13 +218,14 @@ class EnterpriseCustomer(TimeStampedModel):
         Returns:
             (str): Enterprise program landing page url.
         """
-        return urljoin(
+        url = urljoin(
             get_configuration_value('LMS_ROOT_URL', settings.LMS_ROOT_URL),
             reverse(
                 'enterprise_program_enrollment_page',
                 kwargs={'enterprise_uuid': self.uuid, 'program_uuid': program_uuid}
             )
         )
+        return utils.update_query_parameters(url, utils.get_enterprise_utm_context(self))
 
     def catalog_contains_course(self, course_run_id):
         """

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -19,6 +19,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.core.urlresolvers import reverse
 from django.http import Http404
 from django.template.loader import render_to_string
+from django.utils.text import slugify
 from django.utils.translation import ugettext as _
 from django.utils.translation import ungettext
 
@@ -636,3 +637,13 @@ def get_program_type_description(program_type):
     :return: The description associated with the program type. If none exists, then the empty string.
     """
     return PROGRAM_TYPE_DESCRIPTION.get(program_type, '')
+
+
+def get_enterprise_utm_context(enterprise_customer):
+    """
+    Get the UTM context for the enterprise.
+    """
+    return {
+        'utm_medium': 'enterprise',
+        'utm_source': slugify(enterprise_customer.name)
+    }

--- a/test_utils/fake_catalog_api.py
+++ b/test_utils/fake_catalog_api.py
@@ -23,7 +23,7 @@ FAKE_COURSE_RUN = {
         'width': None
     },
     'short_description': 'This course demonstrates many features of the edX platform.',
-    'marketing_url': 'course/demo-course?utm_source=edx&utm_medium=affiliate_partner',
+    'marketing_url': 'course/demo-course?utm_=test_enterprise&utm_medium=enterprise',
     'seats': [
         {
             'type': 'audit',

--- a/test_utils/fake_enterprise_api.py
+++ b/test_utils/fake_enterprise_api.py
@@ -206,12 +206,12 @@ class EnterpriseMockMixin(object):
 def build_fake_enterprise_catalog_detail(enterprise_catalog_uuid=FAKE_UUIDS[1], title=u'All Content',
                                          enterprise_customer_uuid=FAKE_UUIDS[0], previous_url=None, next_url=None,
                                          paginated_content=fake_catalog_api.FAKE_SEARCH_ALL_RESULTS,
-                                         include_enterprise_context=False):
+                                         include_enterprise_context=False, add_utm_info=True):
     """
     Return fake EnterpriseCustomerCatalog detail API result.
     """
     if include_enterprise_context:
-        paginated_content = update_search_with_enterprise_context(paginated_content)
+        paginated_content = update_search_with_enterprise_context(paginated_content, add_utm_info)
 
     return {
         'count': paginated_content['count'],

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -26,7 +26,7 @@ from enterprise.models import (
     EnterpriseCustomerIdentityProvider,
     EnterpriseCustomerUser,
 )
-from test_utils import TEST_UUID, create_items
+from test_utils import TEST_UUID, assert_url, create_items
 from test_utils.factories import (
     EnterpriseCustomerFactory,
     EnterpriseCustomerIdentityProviderFactory,
@@ -1280,11 +1280,11 @@ class TestSAPSuccessFactorsUtils(unittest.TestCase):
         course_id = 'course-v1:edX+DemoX+Demo_Course'
         enterprise_uuid = '47432370-0a6e-4d95-90fe-77b4fe64de2c'
         expected_url = ('http://localhost:8000/enterprise/47432370-0a6e-4d95-90fe-77b4fe64de2c/course/'
-                        'course-v1:edX+DemoX+Demo_Course/enroll/')
-        enterprise_customer = EnterpriseCustomerFactory(uuid=enterprise_uuid)
+                        'course-v1:edX+DemoX+Demo_Course/enroll/?utm_medium=enterprise&utm_source=test_enterprise')
+        enterprise_customer = EnterpriseCustomerFactory(uuid=enterprise_uuid, name='test_enterprise')
 
         launch_url = get_launch_url(enterprise_customer, course_id)
-        assert launch_url == expected_url
+        assert_url(launch_url, expected_url)
 
     @override_switch('SAP_USE_ENTERPRISE_ENROLLMENT_PAGE', active=False)
     @mock.patch('integrated_channels.sap_success_factors.utils.reverse')


### PR DESCRIPTION
@zubair-arbi @saleem-latif can you please take a look on that PR?
**Description:** Added UTM parameters to marketing/enrollment URLs returned by Enterprise API.

**JIRA:** [ENT-653](https://openedx.atlassian.net/browse/ENT-653)

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
