### PR TITLE
get profiling data for transmit courseware data

### DIFF
--- a/integrated_channels/integrated_channel/management/commands/transmit_courseware_data.py
+++ b/integrated_channels/integrated_channel/management/commands/transmit_courseware_data.py
@@ -5,6 +5,7 @@ Transmits information about an enterprise's course catalog to connected Integrat
 
 from __future__ import absolute_import, unicode_literals
 
+from cProfile import Profile
 from logging import getLogger
 
 from django.contrib.auth.models import User
@@ -42,6 +43,15 @@ class Command(IntegratedChannelCommandMixin, BaseCommand):
         super(Command, self).add_arguments(parser)
 
     def handle(self, *args, **options):
+        """
+        Transmit the courseware data for the EnterpriseCustomer(s) to the active integration channels.
+        """
+        profiler = Profile()
+        profiler.runcall(self._handle, *args, **options)
+        profiler.dump_stats('transmit_courses_data.pstats')
+        profiler.print_stats()
+
+    def _handle(self, *args, **options):
         """
         Transmit the courseware data for the EnterpriseCustomer(s) to the active integration channels.
         """


### PR DESCRIPTION
@saleem-latif @asadiqbal08 @douglashall 

**Description:** Get profiling data to analyze the management command "transmit_courseware_data".

**JIRA:** [ENT-607](https://openedx.atlassian.net/browse/ENT-607)

**Dependencies:** N/A

**Merge deadline:** This is just for testing. It will not be merged.

**Installation instructions:**

1. Install `edx-enterprise` from this branch `zub/ENT-607-profile-transmit-course-data-task` in `edx-platform`.
2. Install [gprof2dot](https://github.com/jrfonseca/gprof2dot) to convert the output from [cProfiler](https://docs.python.org/2/library/profile.html) into a [dot graph](http://www.graphviz.org/doc/info/lang.html).
```
pip install gprof2dot==2017.9.19
```
3. Run the profile for the management command "transmit_courseware_data". Use `--settings=devstack` for local testing on devstack. This will print the profiling stats and also generate `transmit_courses_data.pstats` file.
```
./manage.py lms transmit_courseware_data --catalog_user staff --settings=aws
```
4. Now run following command to generate profiling visual `transmit_courses_data.png` from the file `transmit_courses_data.pstats`.
```
gprof2dot -f pstats transmit_courses_data.pstats | dot -Tpng -o transmit_courses_data.png
```

