### PR TITLE
Added enabled_course_modes JSONField to EnterpriseCustomerCatalog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.51.5] - 2017-10-11
+---------------------
+
+* Added enabled_course_modes JSONField to EnterpriseCustomerCatalog model
+
 [0.51.4] - 2017-10-11
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.51.4"
+__version__ = "0.51.5"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/constants.py
+++ b/enterprise/constants.py
@@ -5,6 +5,8 @@ Enterprise Django application constants.
 
 from __future__ import absolute_import, unicode_literals
 
+import json
+
 from django.utils.translation import ugettext_lazy as _
 
 # We listen to the User post_save signal in order to associate new users
@@ -27,7 +29,8 @@ CONFIRMATION_ALERT_PROMPT_WARNING = _(
 )
 
 # Course mode sorting based on slug
-COURSE_MODE_SORT_ORDER = ['verified', 'professional', 'no-id-professional', 'audit', 'honor']
+COURSE_MODE_SORT_ORDER = ['verified', 'professional', 'no-id-professional', 'credit', 'audit', 'honor']
+
 
 PROGRAM_TYPE_DESCRIPTION = {
     'MicroMasters Certificate': _(
@@ -49,3 +52,10 @@ PROGRAM_TYPE_DESCRIPTION = {
         'XSeries Certificate that illustrates your achievement.'
     ),
 }
+
+
+def json_serialized_course_modes():
+    """
+    :return: serialized course modes.
+    """
+    return json.dumps(COURSE_MODE_SORT_ORDER)

--- a/enterprise/migrations/0031_auto_20171012_1249.py
+++ b/enterprise/migrations/0031_auto_20171012_1249.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import jsonfield.fields
+
+from django.db import migrations, models
+
+import enterprise.constants
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('enterprise', '0030_auto_20171005_1600'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='enterprisecustomercatalog',
+            name='enabled_course_modes',
+            field=jsonfield.fields.JSONField(default=enterprise.constants.json_serialized_course_modes, help_text='Ordered list of enrollment modes which can be displayed to learners for course runs in this catalog.'),
+        ),
+        migrations.AddField(
+            model_name='historicalenterprisecustomercatalog',
+            name='enabled_course_modes',
+            field=jsonfield.fields.JSONField(default=enterprise.constants.json_serialized_course_modes, help_text='Ordered list of enrollment modes which can be displayed to learners for course runs in this catalog.'),
+        ),
+    ]

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -32,6 +32,7 @@ from model_utils.models import TimeStampedModel
 from enterprise import utils
 from enterprise.api_client.discovery import CourseCatalogApiServiceClient
 from enterprise.api_client.lms import EnrollmentApiClient, ThirdPartyAuthApiClient, enroll_user_in_course_locally
+from enterprise.constants import json_serialized_course_modes
 from enterprise.utils import get_configuration_value
 from enterprise.validators import validate_image_extension, validate_image_size
 from six.moves.urllib.parse import urljoin  # pylint: disable=import-error,ungrouped-imports
@@ -850,6 +851,12 @@ class EnterpriseCustomerCatalog(TimeStampedModel):
             "included in the catalog."
         )
     )
+    enabled_course_modes = JSONField(
+        default=json_serialized_course_modes,
+        help_text=_('Ordered list of enrollment modes which can be displayed to learners for course runs in'
+                    ' this catalog.'),
+    )
+
     history = HistoricalRecords()
 
     class Meta(object):


### PR DESCRIPTION
**Description:** Describe in a couple of sentence what this PR adds

**JIRA:** [ENT-694](https://openedx.atlassian.net/browse/ENT-694)
[SANDBOX](https://business.sandbox.edx.org/admin/enterprise/enterprisecustomercatalog/)
**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)
