### PR TITLE
Update EnterpriseCustomer.catalog_contains_course to take EnterpriseCustomerCatalogs into account.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.51.2] - 2017-10-10
+---------------------
+
+* Modify EnterpriseCustomer.catalog_contains_course to check EnterpriseCustomerCatalogs.
+
 [0.51.1] - 2017-10-06
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.51.1"
+__version__ = "0.51.2"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -225,21 +225,26 @@ class EnterpriseCustomer(TimeStampedModel):
             )
         )
 
-    def catalog_contains_course(self, course_id):
+    def catalog_contains_course(self, course_run_id):
         """
-        Determine if the course or course run in question is contained in this enterprise's catalog.
+        Determine if the specified course run is contained in at least one of the enterprise's catalogs.
 
-        Args:
-            request_user (User): A user with which to access the course catalog API
+        Arguments:
             course_run_id (str): The string ID of the course or course run in question
 
         Returns:
             bool: Whether the enterprise catalog includes the given course run.
         """
-        if self.catalog is None:
-            return False
-        client = CourseCatalogApiServiceClient(self.site)
-        return client.is_course_in_catalog(self.catalog, course_id)
+        if self.catalog:
+            client = CourseCatalogApiServiceClient(self.site)
+            if client.is_course_in_catalog(self.catalog, course_run_id):
+                return True
+
+        for catalog in self.enterprise_customer_catalogs.all():
+            if catalog.contains_content_items('key', [course_run_id]):
+                return True
+
+        return False
 
 
 class EnterpriseCustomerUserManager(models.Manager):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -44,9 +44,11 @@ from enterprise.models import (
     PendingEnterpriseCustomerUser,
     logo_path,
 )
+from test_utils import fake_catalog_api
 from test_utils.factories import (
     DataSharingConsentFactory,
     EnterpriseCourseEnrollmentFactory,
+    EnterpriseCustomerCatalogFactory,
     EnterpriseCustomerEntitlementFactory,
     EnterpriseCustomerFactory,
     EnterpriseCustomerIdentityProviderFactory,
@@ -219,6 +221,29 @@ class TestEnterpriseCustomer(unittest.TestCase):
 
         catalogless_customer = EnterpriseCustomerFactory(catalog=None)
         assert catalogless_customer.catalog_contains_course(course_id) is False
+
+    @mock.patch('enterprise.models.CourseCatalogApiServiceClient')
+    def test_catalog_contains_course_with_enterprise_customer_catalog(self, mock_catalog_api_class):
+        """
+        Test EnterpriseCustomer.catalog_contains_course with a related EnterpriseCustomerCatalog.
+        """
+        mock_catalog_api = mock_catalog_api_class.return_value
+        mock_catalog_api.is_course_in_catalog.return_value = False
+        mock_catalog_api.get_search_results.return_value = [fake_catalog_api.FAKE_COURSE_RUN]
+
+        # Test with no discovery service catalog.
+        enterprise_customer = EnterpriseCustomerFactory(catalog=None)
+        EnterpriseCustomerCatalogFactory(enterprise_customer=enterprise_customer)
+        assert enterprise_customer.catalog_contains_course(fake_catalog_api.FAKE_COURSE_RUN['key']) is True
+
+        # Test with existing discovery service catalog.
+        enterprise_customer = EnterpriseCustomerFactory()
+        EnterpriseCustomerCatalogFactory(enterprise_customer=enterprise_customer)
+        assert enterprise_customer.catalog_contains_course(fake_catalog_api.FAKE_COURSE_RUN['key']) is True
+
+        # Test when EnterpriseCustomerCatalogs do not contain the course run.
+        mock_catalog_api.get_search_results.return_value = None
+        assert enterprise_customer.catalog_contains_course(fake_catalog_api.FAKE_COURSE_RUN['key']) is False
 
 
 @mark.django_db


### PR DESCRIPTION
**Description:** This updates the EnterpriseCustomer.catalog_contains_course method to check related EnterpriseCustomerCatalogs for the existence of the specified course run as well as the discovery service catalog. This method is used by the data sharing consent code when determining if consent is required for a given EnterpriseCustomer/user/course run combination.

**Testing instructions:**

1. Visit https://business.sandbox.edx.org/enterprise/1b542b06-d353-45e6-9867-9579d9e12745/course/course-v1:edX+Test101+course/enroll/.
2. Verify that you are redirected to the DSC page during the onboarding workflow.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)
