### PR TITLE
fix null site when creating new enterprise_customer

### DIFF
--- a/enterprise/admin/forms.py
+++ b/enterprise/admin/forms.py
@@ -332,7 +332,16 @@ class EnterpriseCustomerAdminForm(forms.ModelForm):
         Once retrieved, these name pairs can be used directly as a value
         for the `choices` argument to a ChoiceField.
         """
-        catalog_api = CourseCatalogApiClient(self.user, self.instance.site)
+        # TODO: We will remove the discovery service catalog implementation
+        # once we have fully migrated customer's to EnterpriseCustomerCatalogs.
+        # For now, this code will prevent an admin from creating a new
+        # EnterpriseCustomer with a discovery service catalog. They will have to first
+        # save the EnterpriseCustomer admin form and then edit the EnterpriseCustomer
+        # to add a discovery service catalog.
+        if hasattr(self.instance, 'site'):
+            catalog_api = CourseCatalogApiClient(self.user, self.instance.site)
+        else:
+            catalog_api = CourseCatalogApiClient(self.user)
         catalogs = catalog_api.get_all_catalogs()
         # order catalogs by name.
         catalogs = sorted(catalogs, key=lambda catalog: catalog.get('name', '').lower())

--- a/tests/test_admin/test_forms.py
+++ b/tests/test_admin/test_forms.py
@@ -460,6 +460,29 @@ class TestEnterpriseCustomerAdminForm(TestWithCourseCatalogApiMixin, unittest.Te
             (1, 'Other catalog!'),
         ]
 
+    def test_new_enterprise_customer(self):
+        """
+        Test that a new blank form can be created and is not valid.
+        """
+        self.catalog_api.get_all_catalogs.return_value = [
+            {
+                "id": self.catalog_id,
+                "name": "My Catalog"
+            },
+            {
+                "id": 1,
+                "name": "Other catalog!"
+            }
+        ]
+
+        form = EnterpriseCustomerAdminForm()
+        assert isinstance(form.fields['catalog'], forms.ChoiceField)
+        assert form.fields['catalog'].choices == BLANK_CHOICE_DASH + [
+            (self.catalog_id, 'My Catalog'),
+            (1, 'Other catalog!'),
+        ]
+        assert not form.is_valid()
+
     def test_with_mocked_get_edx_data(self):
         self.catalog_api.get_all_catalogs.return_value = [
             {


### PR DESCRIPTION
**Description:** fix regression caused by previous fix. Now check for null site when creating a new enterprise_customer. Added a test for this as well.

**Testing instructions:**

1. Create a new enterprise_customer via http://localhost:18000/admin/enterprise/enterprisecustomer/add/
2. Make sure the form is properly displayed

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
