### PR TITLE
ENT-696 update course enrollment view for enterprise enabled course modes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.52.7] - 2017-10-20
+---------------------
+
+* Update course enrollment view for enterprise enabled course modes.
+
 [0.52.6] - 2017-10-19
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.52.6"
+__version__ = "0.52.7"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/messages.py
+++ b/enterprise/messages.py
@@ -101,3 +101,26 @@ def add_unenrollable_item_message(request, item):
             span_end='</span>',
         )
     )
+
+
+def add_generic_info_message_for_error(request):
+    """
+    Add message to request indicating that there was an issue processing request.
+
+    Arguments:
+        request: The current request.
+
+    """
+    messages.info(
+        request,
+        _(
+            '{strong_start}Something happened.{strong_end} '
+            '{span_start}This course is not available. '
+            'Please start over and select a different course.{span_end}'
+        ).format(
+            span_start='<span>',
+            span_end='</span>',
+            strong_start='<strong>',
+            strong_end='</strong>',
+        )
+    )

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -963,6 +963,25 @@ class EnterpriseCustomerCatalog(TimeStampedModel):
             return None
         return CourseCatalogApiServiceClient(self.enterprise_customer.site).get_course_run(course_run_id)
 
+    def get_course_and_course_run(self, course_run_id):
+        """
+        Get course data and all of the metadata for the given course run.
+
+        Arguments:
+            course_run_id (str): The course run key which identifies the course run.
+
+        Returns:
+            tuple(course, course_run): The course and course run metadata.
+
+        Raises:
+            ImproperlyConfigured: Missing or invalid catalog integration.
+
+        """
+        if not self.contains_content_items('key', [course_run_id]):
+            return None, None
+
+        return CourseCatalogApiServiceClient(self.enterprise_customer.site).get_course_and_course_run(course_run_id)
+
     def get_program(self, program_uuid):
         """
         Get all of the metadata for the given program.

--- a/enterprise/templates/enterprise/enterprise_course_enrollment_page.html
+++ b/enterprise/templates/enterprise/enterprise_course_enrollment_page.html
@@ -33,48 +33,56 @@
             <div class="course-title">{{ course_title }}</div>
           </div>
         </div>
-        <div class="course-detail">
-          <div class="course-org">
-            {{ organization_name }}
-          </div>
-          <div class="course-info">
-            <i class="fa fa-clock-o" aria-hidden="true"></i>
-            <span>{{ starts_at_text }} {{ course_start_date }} &nbsp;| &nbsp; {{ course_pacing }}</span>
-          </div>
-          {{ course_short_description }}
-          {{ view_course_details_text|link_to_modal:0 }}
-        </div>
-        {% if course_enrollable %}
-          <form method="POST">
-            <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}" />
-            {% if course_modes|length > 1 %}<div class="caption">{{ select_mode_text }}</div>{% endif %}
-            {% for course_mode in course_modes %}
-            <div class="radio-block">
-              <div class=" {% if course_modes|length > 1 %}radio{% endif %}">
-                {% if course_modes|length > 1 %}
-                  <input type="radio" name="course_mode" id="radio{{ forloop.counter0 }}"{% if forloop.first %} checked="checked"{% endif %} value="{{ course_mode.mode }}" />
-                {% else %}
-                  <input type="hidden" name="course_mode" id="radio{{ forloop.counter0 }}" value="{{ course_mode.mode }}" />
-                {% endif %}
-              </div>
-
-              <label for="radio{{ forloop.counter0 }}">
-                <strong class="title">{{ course_mode.title }}</strong>
-                <span class="price">
-                  {{ price_text }}:
-                  {% if course_mode.final_price and course_mode.original_price != course_mode.final_price %}
-                    <strike>{{ course_mode.original_price }}</strike> {{ course_mode.final_price }}
-                    <div>{{discount_text|safe }}</div>
-                  {% else %}
-                    {{ course_mode.original_price }}
-                  {% endif %}
-                </span>
-                <span class="description">{{ course_mode.description }}</span>
-              </label>
+        {% if course_modes|length == 0 %}
+          <div class="course-detail">
+            <div class="course-org">
+              {{ organization_name }}
             </div>
-            {% endfor %}
-            <button class="btn-confirm">{{ continue_link_text }}</button>
-          </form>
+          </div>
+        {% else %}
+          <div class="course-detail">
+            <div class="course-org">
+              {{ organization_name }}
+            </div>
+            <div class="course-info">
+              <i class="fa fa-clock-o" aria-hidden="true"></i>
+              <span>{{ starts_at_text }} {{ course_start_date }} &nbsp;| &nbsp; {{ course_pacing }}</span>
+            </div>
+            {{ course_short_description }}
+            {{ view_course_details_text|link_to_modal:0 }}
+          </div>
+          {% if course_enrollable %}
+            <form method="POST">
+              <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}" />
+              {% if course_modes|length > 1 %}<div class="caption">{{ select_mode_text }}</div>{% endif %}
+              {% for course_mode in course_modes %}
+              <div class="radio-block">
+                <div class="{% if course_modes|length > 1 %}radio{% endif %}">
+                  {% if course_modes|length > 1 %}
+                    <input type="radio" name="course_mode" id="radio{{ forloop.counter0 }}"{% if forloop.first %} checked="checked"{% endif %} value="{{ course_mode.mode }}" />
+                  {% else %}
+                    <input type="hidden" name="course_mode" id="radio{{ forloop.counter0 }}" value="{{ course_mode.mode }}" />
+                  {% endif %}
+                </div>
+
+                <label for="radio{{ forloop.counter0 }}">
+                  <strong class="title">{{ course_mode.title }}</strong>
+                  <span class="price">
+                    {{ price_text }}:
+                    {% if course_mode.final_price and course_mode.original_price != course_mode.final_price %}
+                      <strike>{{ course_mode.original_price }}</strike> {{ course_mode.final_price }}
+                      <div>{{discount_text|safe }}</div>
+                    {% else %}
+                      {{ course_mode.original_price }}
+                    {% endif %}
+                  </span>
+                  <span class="description">{{ course_mode.description }}</span>
+                </label>
+              </div>
+              {% endfor %}
+              <button class="btn-confirm">{{ continue_link_text }}</button>
+            </form>
+          {% endif %}
         {% endif %}
       </div>
     </div>

--- a/test_utils/mixins.py
+++ b/test_utils/mixins.py
@@ -29,6 +29,15 @@ class MessagesMixin(object):
         self.assertEqual(request_message.tags, expected_message_tags)
         self.assertEqual(request_message.message, expected_message_text)
 
+    def _assert_django_test_client_messages(self, test_client_response, expected_log_messages):
+        """
+        Verify that expected messages are included in the context of response.
+        """
+        response_messages = [
+            (msg.level, msg.message) for msg in test_client_response.context['messages']  # pylint: disable=no-member
+        ]
+        assert response_messages == expected_log_messages
+
 
 class ConsentMixin(object):
     """


### PR DESCRIPTION
@asadiqbal08 @saleem-latif @douglashall 

**Description:** update course enrollment view for enabled course mode in enterprise catalogs

**JIRA:** [ENT-696](https://openedx.atlassian.net/browse/ENT-696)

**Dependencies:** N/A

**Merge deadline:** 20 Oct, 2017

**Installation instructions:** Install `edx-enterprise` from this branch `zub/ENT-696-update-course-enrollment-for-catalog-queryparam` in `edx-platform`.

**Testing instructions:**

1. Create enterprise with a catalog
2. Add a record in table `Enterprise Customer Catalogs` against the above enterprise.
3. Provide desired course mode (in order) to display on enterprise course enrollment page
<img width="973" alt="screen shot 2017-10-13 at 6 07 46 pm" src="https://user-images.githubusercontent.com/5072991/31547815-25cac938-b042-11e7-9e99-ca90fb70359f.png">

4. Now go to enterprise course enrollment page as a learner and verify that the displayed course modes are from the list provided in table `Enterprise Customer Catalogs` against the enterprise.
5. Now update the value for `Enabled course modes:` in enterprise customer catalog record and provide course modes which don't exist for the course.
6.  Go to enterprise course enrollment page as a learner and verify that learner sees a generic info message `Something happened. This course is not available. Please start over and select a different course.` and there are no course modes listed on the page and also there is no `Continue` button.
<img width="829" alt="screen shot 2017-10-13 at 6 39 46 pm" src="https://user-images.githubusercontent.com/5072991/31549129-a5f8cf98-b046-11e7-8361-410afe045e2f.png">


**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [ ] Translations are updated
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
