### PR TITLE
[ENT-695] Added catalog UUID as query parameter on enrollment URLs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.52.5] - 2017-10-19
+---------------------
+
+* Add EnterpriseCustomerCatalog UUID as query parameter "catalog" in enterprise course and program enrollment URL's.
+
 [0.52.4] - 2017-10-18
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.52.4"
+__version__ = "0.52.5"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -977,6 +977,32 @@ class EnterpriseCustomerCatalog(TimeStampedModel):
             return None
         return CourseCatalogApiServiceClient(self.enterprise_customer.site).get_program_by_uuid(program_uuid)
 
+    def get_course_run_enrollment_url(self, course_run_key):
+        """
+        Return enterprise course enrollment page url with the catalog information for the given course.
+
+        Arguments:
+            course_run_key (str): The course run id for the course to be displayed.
+
+        Returns:
+            (str): Enterprise landing page url.
+        """
+        url = self.enterprise_customer.get_course_run_enrollment_url(course_run_key)
+        return utils.update_query_parameters(url, {'catalog': self.uuid})
+
+    def get_program_enrollment_url(self, program_uuid):
+        """
+        Return enterprise program enrollment page url with the catalog information for the given program.
+
+        Arguments:
+            program_uuid (str): The program UUID.
+
+        Returns:
+            (str): Enterprise program landing page url.
+        """
+        url = self.enterprise_customer.get_program_enrollment_url(program_uuid)
+        return utils.update_query_parameters(url, {'catalog': self.uuid})
+
 
 @python_2_unicode_compatible
 class EnrollmentNotificationEmailTemplate(TimeStampedModel):


### PR DESCRIPTION
**Description:** Added EnterpriseCustomerCatalog UUID as query parameter on enrollment URLs

**JIRA:** [ENT-695](https://openedx.atlassian.net/browse/ENT-695)
**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)
