### PR TITLE
Upgrade django-simple-history to 1.9.0 to add Django 1.11 support.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.52.4] - 2017-10-18
+---------------------
+
+* Upgrade django-simple-history to 1.9.0. Add needed migrations.
+
 [0.52.3] - 2017-10-18
 ---------------------
 
@@ -152,7 +157,7 @@ Unreleased
 [0.46.0] - 2017-09-15
 ---------------------
 
-* Allow multi-course enrollment for enterprise users in admin. 
+* Allow multi-course enrollment for enterprise users in admin.
 
 [0.45.0] - 2017-09-14
 ---------------------

--- a/consent/migrations/0003_historicaldatasharingconsent_history_change_reason.py
+++ b/consent/migrations/0003_historicaldatasharingconsent_history_change_reason.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('consent', '0002_migrate_to_new_data_sharing_consent'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='historicaldatasharingconsent',
+            name='history_change_reason',
+            field=models.CharField(max_length=100, null=True),
+        ),
+    ]

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.52.3"
+__version__ = "0.52.4"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/migrations/0033_add_history_change_reason_field.py
+++ b/enterprise/migrations/0033_add_history_change_reason_field.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('enterprise', '0032_reporting_model'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='historicalenrollmentnotificationemailtemplate',
+            name='history_change_reason',
+            field=models.CharField(max_length=100, null=True),
+        ),
+        migrations.AddField(
+            model_name='historicalenterprisecourseenrollment',
+            name='history_change_reason',
+            field=models.CharField(max_length=100, null=True),
+        ),
+        migrations.AddField(
+            model_name='historicalenterprisecustomer',
+            name='history_change_reason',
+            field=models.CharField(max_length=100, null=True),
+        ),
+        migrations.AddField(
+            model_name='historicalenterprisecustomercatalog',
+            name='history_change_reason',
+            field=models.CharField(max_length=100, null=True),
+        ),
+        migrations.AddField(
+            model_name='historicalenterprisecustomerentitlement',
+            name='history_change_reason',
+            field=models.CharField(max_length=100, null=True),
+        ),
+    ]

--- a/integrated_channels/sap_success_factors/migrations/0008_historicalsapsuccessfactorsenterprisecustomerconfiguration_history_change_reason.py
+++ b/integrated_channels/sap_success_factors/migrations/0008_historicalsapsuccessfactorsenterprisecustomerconfiguration_history_change_reason.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('sap_success_factors', '0007_remove_historicalsapsuccessfactorsenterprisecustomerconfiguration_history_change_reason'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='historicalsapsuccessfactorsenterprisecustomerconfiguration',
+            name='history_change_reason',
+            field=models.CharField(max_length=100, null=True),
+        ),
+    ]

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -23,7 +23,7 @@ django-extensions==1.5.9
 django-filter==1.0.4
 django-model-utils==2.3.1
 django-object-actions==0.10.0
-django-simple-history==1.6.3
+django-simple-history==1.9.0
 django-waffle==0.12.0
 django==1.8.18
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -18,7 +18,7 @@ django-extensions==1.5.9
 django-filter==1.0.4
 django-model-utils==2.3.1
 django-object-actions==0.10.0
-django-simple-history==1.6.3
+django-simple-history==1.9.0
 django-waffle==0.12.0
 django==1.8.18
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -30,7 +30,7 @@ django-extensions==1.5.9
 django-filter==1.0.4
 django-model-utils==2.3.1
 django-object-actions==0.10.0
-django-simple-history==1.6.3
+django-simple-history==1.9.0
 django-waffle==0.12.0
 django==1.8.18
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions

--- a/requirements/test-hawthorn.in
+++ b/requirements/test-hawthorn.in
@@ -14,7 +14,7 @@ edx-drf-extensions==1.2.3               # edX extensions to django rest framewor
 unicodecsv==0.14.1                      # Allows exporting CSV with unicode support (a drop-in replacement for built-in csv module)
 Pillow==3.4                             # Image manipulation module, required to use ImageField
 django-extensions==1.5.9                # Required to use TimeStampedModel
-django-simple-history==1.8.2            # History for Django models
+django-simple-history==1.9.0            # History for Django models
 edx-rest-api-client==1.7.1              # For accessing the Enrollment API (and possibly other edX APIs)
 django-config-models==0.1.8
 requests==2.9.1                         # Required for SAPSuccessFactorsAPIClient

--- a/requirements/test-hawthorn.txt
+++ b/requirements/test-hawthorn.txt
@@ -17,7 +17,7 @@ django-extensions==1.5.9
 django-filter==1.0.4
 django-model-utils==2.3.1
 django-object-actions==0.10.0
-django-simple-history==1.8.2
+django-simple-history==1.9.0
 django-waffle==0.12.0
 django==1.11.6
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions

--- a/requirements/test-master.in
+++ b/requirements/test-master.in
@@ -12,7 +12,7 @@ edx-drf-extensions==1.2.3               # edX extensions to django rest framewor
 unicodecsv==0.14.1                      # Allows exporting CSV with unicode support (a drop-in replacement for built-in csv module)
 Pillow==3.4                             # Image manipulation module, required to use ImageField
 django-extensions==1.5.9                # Required to use TimeStampedModel
-django-simple-history==1.6.3            # History for Django models
+django-simple-history==1.9.0            # History for Django models
 edx-rest-api-client==1.7.1              # For accessing the Enrollment API (and possibly other edX APIs)
 django-config-models==0.1.8
 requests==2.9.1                         # Required for SAPSuccessFactorsAPIClient

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -17,7 +17,7 @@ django-extensions==1.5.9
 django-filter==1.0.4
 django-model-utils==2.3.1
 django-object-actions==0.10.0
-django-simple-history==1.6.3
+django-simple-history==1.9.0
 django-waffle==0.12.0
 django==1.8.18
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -17,7 +17,7 @@ django-extensions==1.5.9
 django-filter==1.0.4
 django-model-utils==2.3.1
 django-object-actions==0.10.0
-django-simple-history==1.6.3
+django-simple-history==1.9.0
 django-waffle==0.12.0
 django==1.8.18
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions


### PR DESCRIPTION
Add migration which adds change_reason field to history tables.
Bump version to 0.52.4.

**Description:** We are currently attempting to upgrade edx-platform to Django 1.11. We've removed all usage of django-simple-history from edx-platform. However, edx-enterprise still uses the module, which needs to upgrade to version 1.9.0 in order to add Django 1.11 support. This PR performs the upgrade in edx-enterprise.

I'm unsure how these upgrades are usually performed in edx-enterprise, so this is my best guess. After this PR is approved and merged, we'd then upgrade edx-platform to use version 0.52.4 of edx-enterprise in a separate edx-platform PR.


**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)
