### PR TITLE
ENT-718 Updated the call level to enrollment URLs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.52.9] - 2017-10-20
+---------------------
+
+* Update the call level to enrollment uls from EnterpriseCustomer to EnterpriseCustomerCatalog.
+
 [0.52.8] - 2017-10-20
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.52.8"
+__version__ = "0.52.9"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -215,9 +215,9 @@ class EnterpriseCustomerCatalogDetailSerializer(EnterpriseCustomerCatalogSeriali
                 )
             # Add the Enterprise enrollment URL to each content item returned from the discovery service.
             if content_type == 'courserun':
-                item['enrollment_url'] = enterprise_customer.get_course_run_enrollment_url(item['key'])
+                item['enrollment_url'] = instance.get_course_run_enrollment_url(item['key'])
             elif content_type == 'program':
-                item['enrollment_url'] = enterprise_customer.get_program_enrollment_url(item['uuid'])
+                item['enrollment_url'] = instance.get_program_enrollment_url(item['uuid'])
 
         # Build pagination URLs
         previous_url = None

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -73,7 +73,7 @@ def side_effect(url, query_parameters):
     """
     returns a url with updated query parameters.
     """
-    if 'utm_medium' in query_parameters:
+    if any(key in ['utm_medium', 'catalog'] for key in query_parameters):
         return url
 
     scheme, netloc, path, query_string, fragment = urlsplit(url)


### PR DESCRIPTION
### NOTE: I will update the versions after the reviews. 


**Description:** Update the call for level from EnterpriseCustomer to EnterpriseCustomerCatalogs

**JIRA:** [ENT-718](https://openedx.atlassian.net/browse/ENT-718)

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [ ] Translations are updated
- [x] PR author is listed in AUTHORS

