### PR TITLE
ENT-694 Fix migration issue for enabled-course-modes field

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.52.10] - 2017-10-23
+----------------------
+
+* Fix migration issue for `enabled-course-modes` field of EnterpriseCustomerCatalog
+
 [0.52.9] - 2017-10-20
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.52.9"
+__version__ = "0.52.10"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/migrations/0034_auto_20171023_0727.py
+++ b/enterprise/migrations/0034_auto_20171023_0727.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import jsonfield.fields
+
+from django.db import migrations, models
+
+import enterprise.constants
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('enterprise', '0033_add_history_change_reason_field'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='enterprisecustomercatalog',
+            name='enabled_course_modes',
+            field=jsonfield.fields.JSONField(default=enterprise.constants.json_serialized_course_modes, help_text='Ordered list of enrollment modes which can be displayed to learners for course runs in this catalog.'),
+        ),
+        migrations.AlterField(
+            model_name='historicalenterprisecustomercatalog',
+            name='enabled_course_modes',
+            field=jsonfield.fields.JSONField(default=enterprise.constants.json_serialized_course_modes, help_text='Ordered list of enrollment modes which can be displayed to learners for course runs in this catalog.'),
+        ),
+    ]


### PR DESCRIPTION
@asadiqbal08 @saleem-latif 

**Description:** Fix migration issue for `enabled-course-modes` field of `EnterpriseCustomerCatalog` model.

**History:** When we introduce the `enabled-course-modes` field for `EnterpriseCustomerCatalog` model (https://github.com/edx/edx-enterprise/pull/211/files) we were having difficulty reading the existing records for `EnterpriseCustomerCatalog` model as we wanted to provide a default list of course modes instead of just an empty value. So after creating the migration we manually edited the migration and changed the default for the `jsonfield` from `enterprise.constants.json_serialized_course_modes` to 
`enterprise.constants.COURSE_MODE_SORT_ORDER` (https://github.com/edx/edx-enterprise/pull/223/files). This resolved our issue but this change created mismatch between south records and the `EnterpriseCustomerCatalog` django model for the default value of  `enabled-course-modes` field.

So now we have created a new migration to resolve this mismatch between south records and the `EnterpriseCustomerCatalog` django model. The `0030` migration will help us in saving the proper default for the existing records and the new `0034` migration will keep the south history intact.


**JIRA:** [ENT-694](https://openedx.atlassian.net/browse/ENT-694)

**Dependencies:** N/A

**Merge deadline:** N/A

**Installation instructions:**  Install `edx-enterprise` from this branch `zub/ENT-694-fix-migration-for-enabled-course-modes-field` in `edx-platform`.



**Testing instructions:**

1. Run migrations for enterprise upto 29.
```
./manage.py migrate enterprise 0029
```
2. Create records for table `EnterpriseCustomerCatalog` from django admin (`enabled-course-modes` field not available)
3. Run migrations for enterprise upto 34.
```
./manage.py migrate enterprise 0034
```
4. Now verify that existing records of  table `EnterpriseCustomerCatalog` have proper default value for `enabled-course-modes` field and you can edit the values and save them without any error.
```python
['verified', 'professional', 'no-id-professional', 'credit', 'audit', 'honor']
```
5. Verify that you can also create new records with default value for `enabled-course-modes` field without any error.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
