### PR TITLE
ENT-726 Fix alteration in querystring parameters for enterprise login decorator

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.53.1] - 2017-10-24
+----------------------
+
+* Fix alteration in querystring parameters for decorator "enterprise_login_required".
+
 [0.53.0] - 2017-10-24
 ----------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.53.0"
+__version__ = "0.53.1"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/decorators.py
+++ b/enterprise/decorators.py
@@ -141,7 +141,7 @@ def enterprise_login_required(view):
             })
             next_url = '{current_path}?{query_string}'.format(
                 current_path=quote(parsed_current_url.path),
-                query_string=urlencode(parsed_query_string)
+                query_string=urlencode(parsed_query_string, doseq=True)
             )
             return redirect(
                 '{login_url}?{params}'.format(


### PR DESCRIPTION
@asadiqbal08 @saleem-latif @douglashall 

**Description:** Fix alteration in querystring parameters for decorator "enterprise_login_required" when learner is redirected from `SSO`.

**JIRA:** [ENT-726](https://openedx.atlassian.net/browse/ENT-726)

**Dependencies:** N/A

**Merge deadline:** End of sprint `V`.

**Installation instructions:** Install `edx-enterprise` from this branch `zub/ENT-726-fix-enterprise-login-querysting-alteration` in `edx-platform`.

**Testing instructions:**

1. Create a SAML IDP for while enabling the setting "Drop existing session"
2. Create enterprise with the above IDP
3. Create a related catalog in model `EnterpriseCustomerCatalog`
4. Access the enterprise course enrollment url with the catalog query parameter (value should be the UUID of above created `EnterpriseCustomerCatalog` records) with url like:
```
http://zubair.localhost:8000/enterprise/72416e52-8c77-4860-9584-15e5b06220fb/course/course-v1:edX+DemoX+Demo_Course/enroll/?catalog=6eca3efb-f3a0-4c08-806f-c6e6b65d61cb
```
5. Now verify that you can view the course enrollment page after redirecting from SSO (valid credentials). Note that the value for `catalog` query parameter in the url is string instead of a list.


**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [x] All reviewers approved
- [ ] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
