### PR TITLE
PLAT-1780 Remove dependency on django-extensions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.53.2] - 2017-10-24
+---------------------
+
+* Remove unused dependency on django-extensions
+
 [0.53.1] - 2017-10-24
 ----------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.53.1"
+__version__ = "0.53.2"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -19,7 +19,6 @@ configparser==3.5.0       # via pylint
 diff-cover==0.9.12
 distlib==0.2.5            # via caniusepython3
 django-config-models==0.1.8
-django-extensions==1.5.9
 django-filter==1.0.4
 django-model-utils==2.3.1
 django-object-actions==0.10.0
@@ -76,7 +75,7 @@ requests-toolbelt==0.8.0  # via twine
 requests==2.9.1
 shortuuid==0.5.0          # via edx-django-oauth2-provider
 singledispatch==3.4.0.3   # via astroid, pylint
-six==1.11.0               # via analytics-python, astroid, diff-cover, django-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, packaging, pip-tools, pydocstyle, pylint, python-dateutil, singledispatch, stevedore, tox
+six==1.11.0               # via analytics-python, astroid, diff-cover, edx-i18n-tools, edx-lint, edx-opaque-keys, packaging, pip-tools, pydocstyle, pylint, python-dateutil, singledispatch, stevedore, tox
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==1.2.1    # via pydocstyle
 stevedore==1.27.1         # via edx-opaque-keys

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -14,7 +14,6 @@ bleach==2.1.1             # via readme-renderer
 celery==3.1.18
 chardet==3.0.4            # via doc8
 django-config-models==0.1.8
-django-extensions==1.5.9
 django-filter==1.0.4
 django-model-utils==2.3.1
 django-object-actions==0.10.0
@@ -52,7 +51,7 @@ readme-renderer==17.2
 requests==2.9.1
 restructuredtext-lint==1.1.1  # via doc8
 shortuuid==0.5.0          # via edx-django-oauth2-provider
-six==1.11.0               # via analytics-python, bleach, django-extensions, doc8, edx-opaque-keys, edx-sphinx-theme, html5lib, pockets, python-dateutil, readme-renderer, sphinx, sphinxcontrib-napoleon, stevedore
+six==1.11.0               # via analytics-python, bleach, doc8, edx-opaque-keys, edx-sphinx-theme, html5lib, pockets, python-dateutil, readme-renderer, sphinx, sphinxcontrib-napoleon, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==1.2.1    # via sphinx
 sphinx==1.6.5

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -26,7 +26,6 @@ ddt==1.1.1
 diff-cover==0.9.12
 distlib==0.2.5            # via caniusepython3
 django-config-models==0.1.8
-django-extensions==1.5.9
 django-filter==1.0.4
 django-model-utils==2.3.1
 django-object-actions==0.10.0
@@ -102,7 +101,7 @@ responses==0.8.1
 restructuredtext-lint==1.1.1  # via doc8
 shortuuid==0.5.0          # via edx-django-oauth2-provider
 singledispatch==3.4.0.3   # via astroid, pylint
-six==1.11.0               # via analytics-python, astroid, bleach, diff-cover, django-extensions, doc8, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, faker, freezegun, html5lib, mock, packaging, pip-tools, pockets, pydocstyle, pylint, python-dateutil, readme-renderer, responses, singledispatch, sphinx, sphinxcontrib-napoleon, stevedore, tox
+six==1.11.0               # via analytics-python, astroid, bleach, diff-cover, doc8, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, faker, freezegun, html5lib, mock, packaging, pip-tools, pockets, pydocstyle, pylint, python-dateutil, readme-renderer, responses, singledispatch, sphinx, sphinxcontrib-napoleon, stevedore, tox
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==1.2.1    # via pydocstyle, sphinx
 sphinx==1.6.5

--- a/requirements/test-ficus.in
+++ b/requirements/test-ficus.in
@@ -17,7 +17,6 @@ edx-django-oauth2-provider==1.1.4       # edx Django OAuth2 provider
 edx-drf-extensions==1.2.2               # edX extensions to django rest framework
 unicodecsv==0.14.1                      # Allows exporting CSV with unicode support (a drop-in replacement for built-in csv module)
 Pillow==3.4                             # Image manipulation module, required to use ImageField
-django-extensions==1.5.9                # Required to use TimeStampedModel
 django-simple-history==1.6.3            # History for Django models
 edx-rest-api-client==1.6.0              # For accessing the Enrollment API (and possibly other edX APIs)
 django-config-models==0.1.5

--- a/requirements/test-ficus.txt
+++ b/requirements/test-ficus.txt
@@ -13,7 +13,6 @@ cookies==2.2.1            # via responses
 coverage==4.4.1           # via pytest-cov
 ddt==1.1.1
 django-config-models==0.1.5
-django-extensions==1.5.9
 django-filter==0.11.0
 django-model-utils==2.3.1
 django-object-actions==0.10.0
@@ -52,7 +51,7 @@ pytz==2017.2              # via celery, event-tracking
 requests==2.9.1
 responses==0.8.1
 shortuuid==0.5.0          # via edx-django-oauth2-provider
-six==1.11.0               # via analytics-python, django-extensions, edx-opaque-keys, faker, freezegun, mock, python-dateutil, responses, stevedore
+six==1.11.0               # via analytics-python, edx-opaque-keys, faker, freezegun, mock, python-dateutil, responses, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 stevedore==1.27.1         # via edx-opaque-keys
 testfixtures==5.2.0

--- a/requirements/test-ginkgo.in
+++ b/requirements/test-ginkgo.in
@@ -17,7 +17,6 @@ edx-django-oauth2-provider==1.1.4       # edx Django OAuth2 provider
 edx-drf-extensions==1.2.2               # edX extensions to django rest framework
 unicodecsv==0.14.1                      # Allows exporting CSV with unicode support (a drop-in replacement for built-in csv module)
 Pillow==3.4                             # Image manipulation module, required to use ImageField
-django-extensions==1.5.9                # Required to use TimeStampedModel
 django-simple-history==1.6.3            # History for Django models
 edx-rest-api-client==1.7.1              # For accessing the Enrollment API (and possibly other edX APIs)
 django-config-models==0.1.5

--- a/requirements/test-ginkgo.txt
+++ b/requirements/test-ginkgo.txt
@@ -13,7 +13,6 @@ cookies==2.2.1            # via responses
 coverage==4.4.1           # via pytest-cov
 ddt==1.1.1
 django-config-models==0.1.5
-django-extensions==1.5.9
 django-filter==0.11.0
 django-model-utils==2.3.1
 django-object-actions==0.10.0
@@ -52,7 +51,7 @@ pytz==2017.2              # via celery, event-tracking
 requests==2.9.1
 responses==0.8.1
 shortuuid==0.5.0          # via edx-django-oauth2-provider
-six==1.11.0               # via analytics-python, django-extensions, edx-opaque-keys, faker, freezegun, mock, python-dateutil, responses, stevedore
+six==1.11.0               # via analytics-python, edx-opaque-keys, faker, freezegun, mock, python-dateutil, responses, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 stevedore==1.27.1         # via edx-opaque-keys
 testfixtures==5.2.0

--- a/requirements/test-hawthorn.in
+++ b/requirements/test-hawthorn.in
@@ -13,7 +13,6 @@ edx-django-oauth2-provider==1.1.4       # edx Django OAuth2 provider
 edx-drf-extensions==1.2.3               # edX extensions to django rest framework
 unicodecsv==0.14.1                      # Allows exporting CSV with unicode support (a drop-in replacement for built-in csv module)
 Pillow==3.4                             # Image manipulation module, required to use ImageField
-django-extensions==1.5.9                # Required to use TimeStampedModel
 django-simple-history==1.9.0            # History for Django models
 edx-rest-api-client==1.7.1              # For accessing the Enrollment API (and possibly other edX APIs)
 django-config-models==0.1.8

--- a/requirements/test-hawthorn.txt
+++ b/requirements/test-hawthorn.txt
@@ -13,7 +13,6 @@ cookies==2.2.1            # via responses
 coverage==4.4.1           # via pytest-cov
 ddt==1.1.1
 django-config-models==0.1.8
-django-extensions==1.5.9
 django-filter==1.0.4
 django-model-utils==2.3.1
 django-object-actions==0.10.0
@@ -52,7 +51,7 @@ pytz==2017.2              # via celery, django, event-tracking
 requests==2.9.1
 responses==0.8.1
 shortuuid==0.5.0          # via edx-django-oauth2-provider
-six==1.11.0               # via analytics-python, django-extensions, edx-opaque-keys, faker, freezegun, mock, python-dateutil, responses, stevedore
+six==1.11.0               # via analytics-python, edx-opaque-keys, faker, freezegun, mock, python-dateutil, responses, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 stevedore==1.27.1         # via edx-opaque-keys
 testfixtures==5.2.0

--- a/requirements/test-master.in
+++ b/requirements/test-master.in
@@ -11,7 +11,6 @@ edx-django-oauth2-provider==1.1.4       # edx Django OAuth2 provider
 edx-drf-extensions==1.2.3               # edX extensions to django rest framework
 unicodecsv==0.14.1                      # Allows exporting CSV with unicode support (a drop-in replacement for built-in csv module)
 Pillow==3.4                             # Image manipulation module, required to use ImageField
-django-extensions==1.5.9                # Required to use TimeStampedModel
 django-simple-history==1.9.0            # History for Django models
 edx-rest-api-client==1.7.1              # For accessing the Enrollment API (and possibly other edX APIs)
 django-config-models==0.1.8

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -13,7 +13,6 @@ cookies==2.2.1            # via responses
 coverage==4.4.1           # via pytest-cov
 ddt==1.1.1
 django-config-models==0.1.8
-django-extensions==1.5.9
 django-filter==1.0.4
 django-model-utils==2.3.1
 django-object-actions==0.10.0
@@ -52,7 +51,7 @@ pytz==2017.2              # via celery, event-tracking
 requests==2.9.1
 responses==0.8.1
 shortuuid==0.5.0          # via edx-django-oauth2-provider
-six==1.11.0               # via analytics-python, django-extensions, edx-opaque-keys, faker, freezegun, mock, python-dateutil, responses, stevedore
+six==1.11.0               # via analytics-python, edx-opaque-keys, faker, freezegun, mock, python-dateutil, responses, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 stevedore==1.27.1         # via edx-opaque-keys
 testfixtures==5.2.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -13,7 +13,6 @@ cookies==2.2.1            # via responses
 coverage==4.4.1           # via pytest-cov
 ddt==1.1.1
 django-config-models==0.1.8
-django-extensions==1.5.9
 django-filter==1.0.4
 django-model-utils==2.3.1
 django-object-actions==0.10.0
@@ -52,7 +51,7 @@ pytz==2017.2              # via celery, event-tracking
 requests==2.9.1
 responses==0.8.1
 shortuuid==0.5.0          # via edx-django-oauth2-provider
-six==1.11.0               # via analytics-python, django-extensions, edx-opaque-keys, faker, freezegun, mock, python-dateutil, responses, stevedore
+six==1.11.0               # via analytics-python, edx-opaque-keys, faker, freezegun, mock, python-dateutil, responses, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 stevedore==1.27.1         # via edx-opaque-keys
 testfixtures==5.2.0


### PR DESCRIPTION
**Description:** Removes the dependency on django-extensions, which doesn't seem to actually be used.  Trying to upgrade it in edx-platform to a version which fully supports Django 1.11 is causing errors in seemingly unrelated edx-enterprise migrations, so I'm attempting removal instead.

**JIRA:** [PLAT-1780](https://openedx.atlassian.net/browse/PLAT-1780)

**Dependencies:** None

**Merge deadline:** None

**Installation instructions:** None

**Testing instructions:**

1. Verify that automated tests pass

**Merge checklist:**

- [x] Check that the versions of the requirements in the `test-master.in` file match edx-platform.
- [x] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [x] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** It looks like this dependency was never actually used; it may have been added in confusion because of `TimeStampedModel`, which exists in both django-extensions and django-model-utils, but only code from the latter is used here.  If there's another legitimate reason for keeping the dependency, please let me know.  This shouldn't require a new version of edx-enterprise, since the only changes are in requirements files for testing and local development.