### PR TITLE
Applied appropriate content filtering to the EnterpriseCustomerCatalog detail endpoint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.53.9] - 2017-11-02
+---------------------
+
+* Apply appropriate content filtering to the EnterpriseCustomerCatalog detail endpoints.
+
 [0.53.8] - 2017-11-02
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.53.8"
+__version__ = "0.53.9"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -216,7 +216,7 @@ class EnterpriseCustomerCatalogDetailSerializer(EnterpriseCustomerCatalogSeriali
             # Add the Enterprise enrollment URL to each content item returned from the discovery service.
             if content_type == 'courserun':
                 item['enrollment_url'] = instance.get_course_run_enrollment_url(item['key'])
-            elif content_type == 'program':
+            if content_type == 'program':
                 item['enrollment_url'] = instance.get_program_enrollment_url(item['uuid'])
 
         # Build pagination URLs

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -675,7 +675,7 @@ def parse_datetime_handle_invalid(datetime_value):
     Return the parsed version of a datetime string. If the string is invalid, return None.
     """
     try:
-        return parse_datetime(datetime_value)
+        return parse_datetime(datetime_value).replace(tzinfo=pytz.UTC)
     except TypeError:
         return None
 

--- a/test_utils/fake_catalog_api.py
+++ b/test_utils/fake_catalog_api.py
@@ -89,7 +89,9 @@ FAKE_COURSE_RUN = {
     'mobile_available': False,
     'hidden': False,
     'reporting_type': 'mooc',
-    'eligible_for_financial_aid': True
+    'eligible_for_financial_aid': True,
+    'content_type': 'courserun',
+    'has_enrollable_seats': True
 }
 FAKE_COURSE_RUN2 = copy.deepcopy(FAKE_COURSE_RUN)
 FAKE_COURSE_RUN2['key'] = 'course-v1:edX+DemoX+Demo_Course2'
@@ -926,6 +928,7 @@ FAKE_SEARCH_ALL_COURSE_RESULT = {
     "weeks_to_complete": None,
     "published": True,
     "content_type": "courserun",
+    "has_enrollable_seats": True,
     "authoring_organization_uuids": [
         "12de950c-6fae-49f7-aaa9-778c2fbdae56"
     ],
@@ -974,7 +977,7 @@ FAKE_SEARCH_ALL_SHORT_COURSE_RESULT_LIST = [
     },
 ]
 
-FAKE_SEARCH_ALL_PROGRAM_RESULT = {
+FAKE_SEARCH_ALL_PROGRAM_RESULT_1 = {
     "title": "Program Title 1",
     "marketing_url": "professional-certificate/marketingslug1",
     "content_type": "program",
@@ -1011,7 +1014,49 @@ FAKE_SEARCH_ALL_PROGRAM_RESULT = {
     "subtitle": "Program Subtitle 1",
     "status": "active",
     "weeks_to_complete_max": None,
-    "aggregation_key": "program:" + FAKE_UUIDS[3]
+    "aggregation_key": "program:" + FAKE_UUIDS[3],
+    "is_program_eligible_for_one_click_purchase": True
+}
+
+FAKE_SEARCH_ALL_PROGRAM_RESULT_2 = {
+    "title": "Program Title 2",
+    "marketing_url": "professional-certificate/marketingslug2",
+    "content_type": "program",
+    "card_image_url": "http://wowslider.com/sliders/demo-10/data/images/dock.jpg",
+    "min_hours_effort_per_week": 5,
+    "authoring_organization_uuids": [
+        "12de950c-6fae-49f7-aaa9-778c2fbdae56"
+    ],
+    "hidden": False,
+    "authoring_organizations": [
+        {
+            "marketing_url": None,
+            "homepage_url": None,
+            "tags": [],
+            "certificate_logo_image_url": None,
+            "name": "",
+            "key": "edX",
+            "description": None,
+            "uuid": "12de950c-6fae-49f7-aaa9-778c2fbdae56",
+            "logo_image_url": None
+        }
+    ],
+    "staff_uuids": [],
+    "published": True,
+    "uuid": FAKE_UUIDS[2],
+    "max_hours_effort_per_week": 10,
+    "subject_uuids": [],
+    "weeks_to_complete_min": None,
+    "type": "Professional Certificate",
+    "language": [
+        "English"
+    ],
+    "partner": "edx",
+    "subtitle": "Program Subtitle 1",
+    "status": "active",
+    "weeks_to_complete_max": None,
+    "aggregation_key": "program:" + FAKE_UUIDS[3],
+    "is_program_eligible_for_one_click_purchase": True
 }
 
 FAKE_SEARCH_ALL_RESULTS = {
@@ -1021,18 +1066,60 @@ FAKE_SEARCH_ALL_RESULTS = {
     "results": [
         FAKE_SEARCH_ALL_COURSE_RESULT,
         FAKE_SEARCH_ALL_SHORT_COURSE_RESULT,
-        FAKE_SEARCH_ALL_PROGRAM_RESULT,
+        FAKE_SEARCH_ALL_PROGRAM_RESULT_1,
+    ]
+}
+
+FAKE_SEARCH_ALL_RESULTS_2 = {
+    "count": 2,
+    "next": None,
+    "previous": None,
+    "results": [
+        FAKE_SEARCH_ALL_COURSE_RESULT,
+        FAKE_SEARCH_ALL_PROGRAM_RESULT_1,
+    ]
+}
+
+FAKE_SEARCH_ALL_COURSE_RESULT_1 = copy.deepcopy(FAKE_SEARCH_ALL_COURSE_RESULT)
+FAKE_SEARCH_ALL_COURSE_RESULT_1['marketing_url'] = None
+FAKE_SEARCH_ALL_COURSE_RESULT_1['key'] = "course-v1:test+test+DemoX+Demo_Course"
+FAKE_SEARCH_ALL_RESULTS_3 = {
+    "count": 2,
+    "next": None,
+    "previous": None,
+    "results": [
+        FAKE_SEARCH_ALL_COURSE_RESULT_1,
+        FAKE_SEARCH_ALL_PROGRAM_RESULT_1,
     ]
 }
 
 FAKE_SEARCH_ALL_RESULTS_WITH_PAGINATION = {
-    "count": 3,
+    "count": 2,
     "next": "https://fake.server/api/v1/?page=1",
-    "previous": "https://fake.server/api/v1/?page=3",
+    "previous": "https://fake.server/api/v1/?page=2",
     "results": [
         FAKE_SEARCH_ALL_COURSE_RESULT,
+        FAKE_SEARCH_ALL_PROGRAM_RESULT_1,
+    ]
+}
+
+FAKE_SEARCH_ALL_COURSE_RESULT_2 = copy.deepcopy(FAKE_SEARCH_ALL_COURSE_RESULT)
+FAKE_SEARCH_ALL_COURSE_RESULT_2['has_enrollable_seats'] = False
+FAKE_SEARCH_ALL_COURSE_RESULT_2["key"] = "course-v1:test+DemoX+Demo_Course"
+FAKE_SEARCH_ALL_PROGRAM_RESULT_3 = copy.deepcopy(FAKE_SEARCH_ALL_PROGRAM_RESULT_2)
+FAKE_SEARCH_ALL_PROGRAM_RESULT_3['is_program_eligible_for_one_click_purchase'] = False
+FAKE_SEARCH_ALL_PROGRAM_RESULT_3['uuid'] = FAKE_UUIDS[1]
+
+FAKE_SEARCH_ALL_RESULTS_WITH_PAGINATION_1 = {
+    "count": 4,
+    "next": "https://fake.server/api/v1/?page=1",
+    "previous": "https://fake.server/api/v1/?page=4",
+    "results": [
+        FAKE_SEARCH_ALL_COURSE_RESULT_1,
+        FAKE_SEARCH_ALL_COURSE_RESULT_2,
         FAKE_SEARCH_ALL_SHORT_COURSE_RESULT,
-        FAKE_SEARCH_ALL_PROGRAM_RESULT,
+        FAKE_SEARCH_ALL_PROGRAM_RESULT_1,
+        FAKE_SEARCH_ALL_PROGRAM_RESULT_3,
     ]
 }
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,6 +5,7 @@ Tests for the `edx-enterprise` models module.
 
 from __future__ import absolute_import, unicode_literals, with_statement
 
+import copy
 import datetime
 import unittest
 from operator import itemgetter
@@ -244,6 +245,12 @@ class TestEnterpriseCustomer(unittest.TestCase):
 
         # Test when EnterpriseCustomerCatalogs do not contain the course run.
         mock_catalog_api.get_search_results.return_value = None
+        assert enterprise_customer.catalog_contains_course(fake_catalog_api.FAKE_COURSE_RUN['key']) is False
+
+        # Test when EnterpriseCustomerCatalogs do not contain the course run when not any enrollable seats.
+        fake_course_run = copy.deepcopy(fake_catalog_api.FAKE_COURSE_RUN)
+        fake_course_run['has_enrollable_seats'] = False
+        mock_catalog_api.get_search_results.return_value = [fake_course_run]
         assert enterprise_customer.catalog_contains_course(fake_catalog_api.FAKE_COURSE_RUN['key']) is False
 
 


### PR DESCRIPTION
**Description:** Applied appropriate content filtering for courseruns to the EnterpriseCustomerCatalog detail endpoint

**JIRA:** [ENT-687](https://openedx.atlassian.net/browse/ENT-687)

#### NOTE: Kindly ignore the failing tests at that point which are failing due to programs content ids.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
