### PR TITLE
ENT-731 Preserve catalog querystring on declining DSC

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.53.4] - 2017-10-26
+---------------------
+
+* Preserve catalog querystring on declining DSC.
+
 [0.53.3] - 2017-10-26
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.53.2"
+__version__ = "0.53.4"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -789,7 +789,22 @@ class CourseEnrollmentView(NonAtomicView):
                 ),
                 query_string=urlencode({'course_mode': selected_course_mode_name})
             )
+
             failure_url = reverse('enterprise_course_enrollment_page', args=[enterprise_customer.uuid, course_id])
+            if request.META['QUERY_STRING']:
+                # Preserve all querystring parameters in the request to build
+                # failure url, so that learner views the same enterprise course
+                # enrollment page (after redirect) as for the first time.
+                # Since this is a POST view so use `request.META` to get
+                # querystring instead of `request.GET`.
+                # https://docs.djangoproject.com/en/1.11/ref/request-response/#django.http.HttpRequest.META
+                failure_url = '{course_enrollment_url}?{query_string}'.format(
+                    course_enrollment_url=reverse(
+                        'enterprise_course_enrollment_page', args=[enterprise_customer.uuid, course_id]
+                    ),
+                    query_string=request.META['QUERY_STRING']
+                )
+
             return redirect(
                 '{grant_data_sharing_url}?{params}'.format(
                     grant_data_sharing_url=reverse('grant_data_sharing_permissions'),


### PR DESCRIPTION
@saleem-latif @asadiqbal08 @douglashall 

**Description:** Preserve catalog querystring on declining DSC

**JIRA:** [ENT-731](https://openedx.atlassian.net/browse/ENT-731)

**Dependencies:** N/A

**Merge deadline:** Urgently required for Microsoft enterprise integration

**Installation instructions:** Install `edx-enterprise` from this branch `zub/ENT-731-preserve-querystring-dsc-decline-url` in `edx-platform`.

**Testing instructions:**

1. Create a SAML IDP for while enabling the setting "Drop existing session"
2. Create enterprise with the above IDP
3. Create a related catalog in model `EnterpriseCustomerCatalog`
4. Access the enterprise course enrollment url with the catalog query parameter (value should be the UUID of above created `EnterpriseCustomerCatalog` records) with url like:
```
http://zubair.localhost:8000/enterprise/72416e52-8c77-4860-9584-15e5b06220fb/course/course-v1:edX+DemoX+Demo_Course/enroll/?catalog=6eca3efb-f3a0-4c08-806f-c6e6b65d61cb
```
5. Select some course mode and click on `Continue` button.
6. On `DSC` page decline the consent.
7. After redirect, verify that the catalog querysting `catalog=6eca3efb-f3a0-4c08-806f-c6e6b65d61cb` is still in the url.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
