### PR TITLE
ENT-717 Show generic info message on enterprise course enrollment page

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.53.8] - 2017-11-02
+---------------------
+
+* Show generic info message on enterprise course enrollment page.
+
 [0.53.7] - 2017-10-30
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.53.7"
+__version__ = "0.53.8"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/templates/enterprise/_enterprise_customer_sidebar.html
+++ b/enterprise/templates/enterprise/_enterprise_customer_sidebar.html
@@ -1,0 +1,9 @@
+{% if enterprise_customer.branding_configuration %}
+    <img class="enterprise-logo" src="{{ enterprise_customer.branding_configuration.logo.url }}" alt="{{ enterprise_customer.name }}"/>
+{% endif %}
+<p class="partnered-text">
+    {{ welcome_text }}
+</p>
+<p class="partnered-text">
+    {% autoescape off %}{{ enterprise_welcome_text }}{% endautoescape %}
+</p>

--- a/enterprise/templates/enterprise/enterprise_course_enrollment_error_page.html
+++ b/enterprise/templates/enterprise/enterprise_course_enrollment_error_page.html
@@ -1,0 +1,18 @@
+{% extends 'enterprise/base.html' %}
+
+{% load staticfiles enterprise %}
+
+{% block contents %}
+  <div class="enterprise-container">
+    <div class="row">
+      <div class="col-3">
+        {% include "enterprise/_enterprise_customer_sidebar.html" %}
+      </div>
+
+      <div class="col-7 border-left">
+        {# Display success, error, warning or info messages #}
+        {% alert_messages messages %}
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/enterprise/templates/enterprise/enterprise_course_enrollment_page.html
+++ b/enterprise/templates/enterprise/enterprise_course_enrollment_page.html
@@ -10,11 +10,7 @@
   <div class="enterprise-container">
     <div class="row">
       <div class="col-3">
-        <img class="enterprise-logo" src="{{ enterprise_customer.branding_configuration.logo.url }}" alt="{{ enterprise_customer.name }}"/>
-        <p class="partnered-text">{{ welcome_text }}</p>
-        <p class="partnered-text">
-          {% autoescape off %}{{ enterprise_welcome_text }}{% endautoescape %}
-        </p>
+        {% include "enterprise/_enterprise_customer_sidebar.html" %}
       </div>
       <div class="col-7 border-left">
 

--- a/enterprise/templates/enterprise/grant_data_sharing_permissions.html
+++ b/enterprise/templates/enterprise/grant_data_sharing_permissions.html
@@ -24,13 +24,7 @@
   <div class="enterprise-container">
       <div class="row">
           <div class="col-3">
-              {% if enterprise_customer.branding_configuration %}
-                 <img class="enterprise-logo" src="{{ enterprise_customer.branding_configuration.logo.url }}" alt="{{ enterprise_customer.name }}"/>
-              {% endif %}
-              <p class="partnered-text">{{ welcome_text }}</p>
-              <p class="partnered-text">
-                {{ enterprise_welcome_text|safe }}
-              </p>
+              {% include "enterprise/_enterprise_customer_sidebar.html" %}
           </div>
           <div class="col-7 border-left">
               <main>


### PR DESCRIPTION
@asadiqbal08 @saleem-latif 

**Description:** Show generic info message on enterprise course enrollment page in case there was an error getting course or course run information.

**JIRA:** [ENT-717](https://openedx.atlassian.net/browse/ENT-717)

**Dependencies:** N/A

**Merge deadline:** 3 November, 2017 

**Installation instructions:** Install `edx-enterprise` from this branch `zub/ENT-717-course-enrollment-show-generic-messages-for-error` in `edx-platform`.


**Testing instructions:**

1. Create a SAML IDP for while enabling the setting "Drop existing session"
2. Create enterprise with the above IDP
3. Create a related catalog in model `EnterpriseCustomerCatalog`
4. Access the enterprise course enrollment url with the catalog query parameter (value should be the UUID of above created `EnterpriseCustomerCatalog` records) with url like:
http://zubair.localhost:8000/enterprise/72416e52-8c77-4860-9584-15e5b06220fb/course/course-v1:edX+DemoX+Demo_Course/enroll/?catalog=6eca3efb-f3a0-4c08-806f-c6e6b65d61cb
and verify that page renders without any error.

5. Now try to access same page with invalid course id:
http://zubair.localhost:8000/enterprise/72416e52-8c77-4860-9584-15e5b06220fb/course/course-v1:edX+DemoX+Invalid_Course/enroll/?catalog=6eca3efb-f3a0-4c08-806f-c6e6b65d61cb

6. Verify that now learner sees a generic info message `"Something happened.
This course is not available. Please start over and select a different course."` without any course information on the page.
<img width="841" alt="screen shot 2017-10-30 at 12 41 07 pm" src="https://user-images.githubusercontent.com/5072991/32159901-2b71c544-bd71-11e7-8977-59bb6cfe7f85.png">


**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
