### PR TITLE
ENT-737 Fix error for empty course start date

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.53.6] - 2017-10-30
+---------------------
+
+* Fix error for empty course start date on DSC page.
+
 [0.53.5] - 2017-10-26
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.53.5"
+__version__ = "0.53.6"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -5,7 +5,6 @@ User-facing views for the Enterprise app.
 from __future__ import absolute_import, unicode_literals
 
 import re
-from calendar import month_name
 from logging import getLogger
 from uuid import UUID
 
@@ -281,16 +280,15 @@ class GrantDataSharingPermissions(View):
                 raise Http404
 
             course_run_details = catalog_api_client.get_course_run(course_id)
-            course_start = parse(course_run_details['start'])
+            course_start_date = ''
+            if course_run_details['start']:
+                course_start_date = parse(course_run_details['start']).strftime('%B %d, %Y')
+
             context_data.update({
                 'course_id': course_id,
                 'course_specific': True,
                 'course_title': course_run_details['title'],
-                'course_start_date': '{month} {day}, {year}'.format(
-                    month=month_name[course_start.month],
-                    day=course_start.day,
-                    year=course_start.year,
-                ),
+                'course_start_date': course_start_date,
             })
         else:
             context_data.update({

--- a/tests/test_enterprise/views/test_grant_data_sharing_permissions.py
+++ b/tests/test_enterprise/views/test_grant_data_sharing_permissions.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, unicode_literals
 
 import ddt
 import mock
+from dateutil.parser import parse
 from pytest import mark
 
 from django.conf import settings
@@ -85,15 +86,19 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
     @mock.patch('enterprise.models.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.CourseApiClient')
     @ddt.data(
-        (False, True),
-        (False, False),
-        (True, False),
+        (False, True, None),
+        (False, False, None),
+        (True, False, None),
+        (False, True, '2013-02-05T05:00:00Z'),
+        (False, False, '2013-02-05T05:00:00Z'),
+        (True, False, '2013-02-05T05:00:00Z'),
     )
     @ddt.unpack
     def test_get_course_specific_consent(
             self,
             defer_creation,
             existing_course_enrollment,
+            course_start_date,
             course_api_client_mock,
             course_catalog_api_client_model_mock,
             course_catalog_api_client_view_mock,
@@ -102,8 +107,8 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
         course_id = 'course-v1:edX+DemoX+Demo_Course'
         course_catalog_api_client_model_mock.return_value.course_in_catalog.return_value = True
         course_run_details = {
-            "start": "2013-02-05T05:00:00Z",
-            "title": "Demo Course"
+            'start': course_start_date,
+            'title': 'Demo Course'
         }
         course_catalog_api_client_view_mock.return_value.get_course_run.return_value = course_run_details
 
@@ -144,14 +149,17 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
             'In order to start this course and use your discount, <b>you must</b> consent to share your '
             'course data with Starfleet Academy.'
         )
+        expected_course_start_date = ''
+        if course_start_date:
+            expected_course_start_date = parse(course_run_details['start']).strftime('%B %d, %Y')
 
         for key, value in {
-                "platform_name": "Test platform",
-                "platform_description": "Test description",
-                "tagline": "High-quality online learning opportunities from the world's best universities",
-                "header_logo_alt_text": "Test platform home page",
-                "consent_request_prompt": expected_prompt,
-                "requested_permissions_header": (
+                'platform_name': 'Test platform',
+                'platform_description': 'Test description',
+                'tagline': "High-quality online learning opportunities from the world's best universities",
+                'header_logo_alt_text': 'Test platform home page',
+                'consent_request_prompt': expected_prompt,
+                'requested_permissions_header': (
                     'Per the <a href="#consent-policy-dropdown-bar" '
                     'class="policy-dropdown-link background-input failure-link" id="policy-dropdown-link">'
                     'Data Sharing Policy</a>, <b>Starfleet Academy</b> would like to know about:'
@@ -165,14 +173,15 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
                     'with Starfleet Academy, I may not withdraw my permission but I may elect to unenroll '
                     'from any courses that are sponsored by Starfleet Academy.'
                 ),
-                "course_id": "course-v1:edX+DemoX+Demo_Course",
-                "redirect_url": "https://google.com",
-                "course_specific": True,
-                "defer_creation": defer_creation,
-                "welcome_text": "Welcome to Test platform.",
+                'course_id': 'course-v1:edX+DemoX+Demo_Course',
+                'redirect_url': 'https://google.com',
+                'course_specific': True,
+                'defer_creation': defer_creation,
+                'welcome_text': 'Welcome to Test platform.',
                 'sharable_items_note_header': 'Please note',
                 'LMS_SEGMENT_KEY': settings.LMS_SEGMENT_KEY,
                 'LMS_ROOT_URL': 'http://localhost:8000',
+                'course_start_date': expected_course_start_date,
         }.items():
             assert response.context[key] == value  # pylint:disable=no-member
 


### PR DESCRIPTION
@asadiqbal08 @saleem-latif @douglashall

**Description:** Fix error for empty course start date

**JIRA:** [ENT-737](https://openedx.atlassian.net/browse/ENT-737)

**Dependencies:** N/A

**Related PR:** https://github.com/edx/edx-enterprise/pull/216/

**Merge deadline:** ASAP

**Installation instructions:** Install `edx-enterprise` from this branch `zub/ENT-737-fix-error-for-course-start-date-not-set` in `edx-platform`.

**Testing instructions:**

1. Create a SAML IDP for while enabling the setting "Drop existing session"
2. Create enterprise with the above IDP
3. Create a related catalog in model `EnterpriseCustomerCatalog`
4. Add a course in the catalog which don't have any start data (null value in discovery API response for the catalog).
5. Access the enterprise course enrollment url with the catalog query parameter (value should be the UUID of above created `EnterpriseCustomerCatalog` records) with url like:
http://zubair.localhost:8000/enterprise/72416e52-8c77-4860-9584-15e5b06220fb/course/course-v1:edX+DemoX+Demo_Course/enroll/?catalog=6eca3efb-f3a0-4c08-806f-c6e6b65d61cb
6. Select a course mode and click on `Continue` button.
7. Verify that DSC page renders without any error.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
