### PR TITLE
ENT-742 Enrollment API

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.54.0] - 2017-11-28
+---------------------
+
+* Introduce the bulk enrollment/upgrade api endpoint for Enterprise Customers.
+
 [0.53.19] - 2017-11-28
 ----------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.53.19"
+__version__ = "0.54.0"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -17,6 +17,7 @@ from django.apps import apps
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.contrib.sites.models import Site
+from django.core import mail
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.core.files.storage import default_storage
 from django.core.urlresolvers import reverse
@@ -26,16 +27,23 @@ from django.template import Context, Template
 from django.utils.crypto import get_random_string
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.functional import lazy
+from django.utils.http import urlquote
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ugettext
 
 from model_utils.models import TimeStampedModel
 
 from enterprise import utils
-from enterprise.api_client.discovery import CourseCatalogApiServiceClient
-from enterprise.api_client.lms import EnrollmentApiClient, ThirdPartyAuthApiClient, enroll_user_in_course_locally
+from enterprise.api_client.discovery import CourseCatalogApiClient, CourseCatalogApiServiceClient
+from enterprise.api_client.lms import (
+    EnrollmentApiClient,
+    ThirdPartyAuthApiClient,
+    enroll_user_in_course_locally,
+    parse_lms_api_datetime,
+)
 from enterprise.constants import json_serialized_course_modes
-from enterprise.utils import get_configuration_value
+from enterprise.utils import CourseEnrollmentDowngradeError, get_configuration_value
 from enterprise.validators import validate_image_extension, validate_image_size
 from six.moves.urllib.parse import urljoin  # pylint: disable=import-error,ungrouped-imports
 
@@ -250,6 +258,83 @@ class EnterpriseCustomer(TimeStampedModel):
                 return True
 
         return False
+
+    def enroll_user_pending_registration(self, email, course_mode, *course_ids):
+        """
+        Create pending enrollments for the user in any number of courses, which will take effect on registration.
+
+        Args:
+            email: The email address for the pending link to be created
+            course_mode: The mode with which the eventual enrollment should be created
+            *course_ids: An iterable containing any number of course IDs to eventually enroll the user in.
+
+        Returns:
+            The PendingEnterpriseCustomerUser attached to the email address
+        """
+        pending_ecu, __ = PendingEnterpriseCustomerUser.objects.get_or_create(
+            enterprise_customer=self,
+            user_email=email
+        )
+        for course_id in course_ids:
+            PendingEnrollment.objects.update_or_create(
+                user=pending_ecu,
+                course_id=course_id,
+                defaults={
+                    'course_mode': course_mode
+                }
+            )
+        return pending_ecu
+
+    def notify_enrolled_learners(self, catalog_api_user, course_id, users):
+        """
+        Notify learners about a course in which they've been enrolled.
+
+        Args:
+            catalog_api_user: The user for calling the Catalog API
+            course_id: The specific course the learners were enrolled in
+            users: An iterable of the users or pending users who were enrolled
+        """
+        course_details = CourseCatalogApiClient(catalog_api_user, self.site).get_course_run(course_id)
+        if not course_details:
+            LOGGER.warning(
+                ugettext("Course details were not found for course key {} - Course Catalog API returned nothing. "
+                         "Proceeding with enrollment, but notifications won't be sent").format(course_id)
+            )
+            return
+        course_path = urlquote('/courses/{course_id}/course'.format(course_id=course_id))
+        lms_root_url = utils.get_configuration_value_for_site(self.site, 'LMS_ROOT_URL')
+        destination_url = '{site}/{login_or_register}?next={course_path}'.format(
+            site=lms_root_url,
+            login_or_register='{login_or_register}',  # We don't know the value at this time
+            course_path=course_path
+        )
+        course_name = course_details.get('title')
+
+        try:
+            course_start = parse_lms_api_datetime(course_details.get('start'))
+        except (TypeError, ValueError):
+            course_start = None
+            LOGGER.exception(
+                'None or empty value passed as course start date.\nCourse Details:\n{course_details}'.format(
+                    course_details=course_details,
+                )
+            )
+
+        with mail.get_connection() as email_conn:
+            for user in users:
+                login_or_register = 'register' if isinstance(user, PendingEnterpriseCustomerUser) else 'login'
+                destination_url = destination_url.format(login_or_register=login_or_register)
+                utils.send_email_notification_message(
+                    user=user,
+                    enrolled_in={
+                        'name': course_name,
+                        'url': destination_url,
+                        'type': 'course',
+                        'start': course_start,
+                    },
+                    enterprise_customer=self,
+                    email_connection=email_conn
+                )
 
 
 class EnterpriseCustomerUserManager(models.Manager):
@@ -478,9 +563,14 @@ class EnterpriseCustomerUser(TimeStampedModel):
         """
         enrollment_api_client = EnrollmentApiClient()
         # Check to see if the user's already enrolled and we have an enterprise course enrollment to track it.
-        enrolled_in_course = enrollment_api_client.is_enrolled(self.username, course_run_id)
-        if not enrolled_in_course:
-            # Directly enroll into the audit track.
+        course_enrollment = enrollment_api_client.get_course_enrollment(self.username, course_run_id) or {}
+        enrolled_in_course = course_enrollment and course_enrollment.get('is_active', False)
+
+        audit_modes = getattr(settings, 'ENTERPRISE_COURSE_ENROLLMENT_AUDIT_MODES', ['audit', 'honor'])
+        paid_modes = ['verified', 'professional']
+        is_upgrading = mode in paid_modes and course_enrollment.get('mode') in audit_modes
+        if not enrolled_in_course or is_upgrading:
+            # Directly enroll into the specified track.
             enrollment_api_client.enroll_user_in_course(self.username, course_run_id, mode)
             utils.track_event(self.user_id, 'edx.bi.user.enterprise.enrollment.course', {
                 'category': 'enterprise',
@@ -488,11 +578,22 @@ class EnterpriseCustomerUser(TimeStampedModel):
                 'enterprise_customer_uuid': str(self.enterprise_customer.uuid),
                 'enterprise_customer_name': self.enterprise_customer.name,
                 'mode': mode,
+                'is_upgrading': is_upgrading,
             })
-        EnterpriseCourseEnrollment.objects.get_or_create(
-            enterprise_customer_user=self,
-            course_id=course_run_id
-        )
+            EnterpriseCourseEnrollment.objects.get_or_create(
+                enterprise_customer_user=self,
+                course_id=course_run_id
+            )
+        elif enrolled_in_course and course_enrollment.get('mode') in paid_modes and mode in audit_modes:
+            # This enrollment is attempting to "downgrade" the user from a paid track they are already in.
+            raise CourseEnrollmentDowngradeError(
+                'The user is already enrolled in the course {course_run_id} in {current_mode} mode '
+                'and cannot be enrolled in {given_mode} mode'.format(
+                    course_run_id=course_run_id,
+                    current_mode=course_enrollment.get('mode'),
+                    given_mode=mode,
+                )
+            )
 
 
 @python_2_unicode_compatible

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -91,6 +91,12 @@ class MultipleProgramMatchError(CourseCatalogApiError):
         self.programs_matched = programs_matched
 
 
+class CourseEnrollmentDowngradeError(Exception):
+    """
+    Exception to raise when an enrollment attempts to enroll the user in an unpaid mode when they are in a paid mode.
+    """
+
+
 def get_identity_provider(provider_id):
     """
     Get Identity Provider with given id.

--- a/tests/test_admin/test_view.py
+++ b/tests/test_admin/test_view.py
@@ -482,7 +482,7 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
         })
         return response
 
-    @mock.patch("enterprise.admin.views.CourseCatalogApiClient")
+    @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.admin.views.EnrollmentApiClient")
     @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
     def test_post_enroll_user(self, forms_client, views_client, course_catalog_client):
@@ -581,7 +581,7 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
             num_messages = len(mail.outbox)
             assert num_messages == enrollment_count
 
-    @mock.patch("enterprise.admin.views.CourseCatalogApiClient")
+    @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.admin.views.EnrollmentApiClient")
     @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
     def test_post_multi_enroll_user(self, forms_client, views_client, course_catalog_client):
@@ -590,7 +590,7 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
         """
         self._post_multi_enroll(forms_client, views_client, course_catalog_client, True)
 
-    @mock.patch("enterprise.admin.views.CourseCatalogApiClient")
+    @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.admin.views.EnrollmentApiClient")
     @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
     def test_post_multi_enroll_pending_user(self, forms_client, views_client, course_catalog_client):
@@ -599,7 +599,7 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
         """
         self._post_multi_enroll(forms_client, views_client, course_catalog_client, False)
 
-    @mock.patch("enterprise.admin.views.CourseCatalogApiClient")
+    @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.admin.views.EnrollmentApiClient")
     @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
     def test_post_enroll_no_course_detail(self, forms_client, views_client, course_catalog_client):
@@ -632,7 +632,7 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
         num_messages = len(mail.outbox)
         assert num_messages == 0
 
-    @mock.patch("enterprise.admin.views.CourseCatalogApiClient")
+    @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.admin.views.EnrollmentApiClient")
     @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
     def test_post_enroll_with_missing_course_start_date(self, forms_client, views_client, course_catalog_client):
@@ -676,7 +676,7 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
         assert num_messages == 1
 
     @mock.patch("enterprise.utils.reverse")
-    @mock.patch("enterprise.admin.views.CourseCatalogApiClient")
+    @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.admin.views.EnrollmentApiClient")
     @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
     def test_post_enrollment_error(self, forms_client, views_client, course_catalog_client, reverse_mock):
@@ -702,7 +702,7 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
 
     @mock.patch('enterprise.admin.views.logging.error')
     @mock.patch("enterprise.utils.reverse")
-    @mock.patch("enterprise.admin.views.CourseCatalogApiClient")
+    @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.admin.views.EnrollmentApiClient")
     @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
     def test_post_enrollment_error_bad_error_string(
@@ -737,7 +737,7 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
             (messages.ERROR, "The following learners could not be enrolled in {}: {}".format(course_id, user.email)),
         ]))
 
-    @mock.patch("enterprise.admin.views.CourseCatalogApiClient")
+    @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.admin.views.EnrollmentApiClient")
     @mock.patch("enterprise.admin.forms.CourseCatalogApiClient")
     def test_post_enroll_user_into_program(
@@ -767,7 +767,7 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
         num_messages = len(mail.outbox)
         assert num_messages == 1
 
-    @mock.patch("enterprise.admin.views.CourseCatalogApiClient")
+    @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.admin.forms.CourseCatalogApiClient")
     def test_post_enroll_pending_user_into_program(self, catalog_client, views_catalog_client):
         views_catalog_instance = views_catalog_client.return_value
@@ -785,7 +785,7 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
         assert PendingEnrollment.objects.count() == len(expected_courses)
         assert PendingEnterpriseCustomerUser.objects.count() == 1
 
-    @mock.patch("enterprise.admin.views.CourseCatalogApiClient")
+    @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.admin.views.EnrollmentApiClient")
     @mock.patch("enterprise.admin.forms.CourseCatalogApiClient")
     def test_post_enroll_user_into_program_error(
@@ -1016,7 +1016,7 @@ class TestEnterpriseCustomerManageLearnersViewPostBulkUpload(BaseTestEnterpriseC
             (messages.SUCCESS, "2 new learners were added to {}.".format(self.enterprise_customer.name)),
         ]))
 
-    @mock.patch("enterprise.admin.views.CourseCatalogApiClient")
+    @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.admin.views.EnrollmentApiClient")
     @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
     def test_post_link_and_enroll(self, forms_client, views_client, course_catalog_client):
@@ -1063,7 +1063,7 @@ class TestEnterpriseCustomerManageLearnersViewPostBulkUpload(BaseTestEnterpriseC
         num_messages = len(mail.outbox)
         assert num_messages == 2
 
-    @mock.patch("enterprise.admin.views.CourseCatalogApiClient")
+    @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.admin.views.EnrollmentApiClient")
     @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
     def test_post_link_and_enroll_no_course_details(self, forms_client, views_client, course_catalog_client):
@@ -1107,7 +1107,7 @@ class TestEnterpriseCustomerManageLearnersViewPostBulkUpload(BaseTestEnterpriseC
         num_messages = len(mail.outbox)
         assert num_messages == 0
 
-    @mock.patch("enterprise.admin.views.CourseCatalogApiClient")
+    @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.admin.views.EnrollmentApiClient")
     @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
     @mock.patch("enterprise.admin.forms.CourseCatalogApiClient")
@@ -1159,7 +1159,7 @@ class TestEnterpriseCustomerManageLearnersViewPostBulkUpload(BaseTestEnterpriseC
         num_messages = len(mail.outbox)
         assert num_messages == 0
 
-    @mock.patch("enterprise.admin.views.CourseCatalogApiClient")
+    @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.admin.views.EnrollmentApiClient")
     @mock.patch("enterprise.admin.forms.CourseCatalogApiClient")
     def test_post_link_and_enroll_into_program(self, catalog_client, views_client, views_catalog_client):

--- a/tests/test_enterprise/api_client/test_lms.py
+++ b/tests/test_enterprise/api_client/test_lms.py
@@ -427,6 +427,74 @@ def test_get_remote_id():
     assert actual_response == "LukeIamYrFather"
 
 
+@responses.activate
+def test_get_username_from_remote_id_not_found():
+    remote_id = "Darth"
+    provider_id = "DeathStar"
+    responses.add(
+        responses.GET,
+        _url("third_party_auth", "providers/{provider}/users?remote_id={user}".format(
+            provider=provider_id, user=remote_id
+        )),
+        match_querystring=True,
+        status=404
+    )
+    client = lms_api.ThirdPartyAuthApiClient()
+    actual_response = client.get_username_from_remote_id(provider_id, remote_id)
+    assert actual_response is None
+
+
+@responses.activate
+def test_get_username_from_remote_id_no_results():
+    remote_id = "Darth"
+    provider_id = "DeathStar"
+    expected_response = {
+        "page": 1,
+        "page_size": 200,
+        "count": 2,
+        "results": [
+            {"username": "Obi-Wan", "remote_id": "Kenobi"},
+            {"username": "Hans", "remote_id": "Solo"},
+        ]
+    }
+    responses.add(
+        responses.GET,
+        _url("third_party_auth", "providers/{provider}/users?remote_id={user}".format(
+            provider=provider_id, user=remote_id
+        )),
+        match_querystring=True,
+        json=expected_response,
+    )
+    client = lms_api.ThirdPartyAuthApiClient()
+    actual_response = client.get_username_from_remote_id(provider_id, remote_id)
+    assert actual_response is None
+
+
+@responses.activate
+def test_get_username_from_remote_id():
+    remote_id = "LukeIamYrFather"
+    provider_id = "DeathStar"
+    expected_response = {
+        "page": 1,
+        "page_size": 200,
+        "count": 1,
+        "results": [
+            {"username": "Darth", "remote_id": "LukeIamYrFather"}
+        ]
+    }
+    responses.add(
+        responses.GET,
+        _url("third_party_auth", "providers/{provider}/users?remote_id={user}".format(
+            provider=provider_id, user=remote_id
+        )),
+        match_querystring=True,
+        json=expected_response,
+    )
+    client = lms_api.ThirdPartyAuthApiClient()
+    actual_response = client.get_username_from_remote_id(provider_id, remote_id)
+    assert actual_response == "Darth"
+
+
 def test_jwt_lms_api_client_locally_raises():
     with raises(NotConnectedToOpenEdX):
         client = lms_api.JwtLmsApiClient('user-goes-here')


### PR DESCRIPTION
**Description:** 
Introduces a new endpoint for enrolling a single user in a single course run for a given enterprise.

See https://github.com/edx/edx-enterprise/pull/237 for the initial prototype this is based on.

**JIRA:** https://openedx.atlassian.net/browse/ENT-742

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** 

**Installation instructions:** 

**Testing instructions:**
The endpoint can be accessed using POST calls only at: {base_url}/enterprise/api/v1/enterprise-customer/{enterprise_uuid}/course_enrollments
Only users that have create access to Enterprise Customer models can hit this endpoint. This is temporary until the Authorization story is handled.

The fields to be sent in the POST data are as follows:
lms_user_id - the edX user id
tpa_user_id - the IdP user id
user_email - the user's email address
course_run_id - the course run ID to enroll the user in
course_mode - the course mode to enroll the user in (audit, verified, professional)
email_students - whether or not to email the students to notify them of the enrollment. defaults to false

The endpoint accepts a list of payloads with the above params. So for an individual enrollment call, an example payload would be:
[{
	"course_run_id":"course-v1:edX+DemoX+Demo_Course",
	"course_mode":"verified",
	"user_email":"bexline+enapitest4@edx.org",
	"email_students": true
}]

Multiple would be sent like so:
[
  {
	"course_run_id":"course-v1:edX+DemoX+Demo_Course",
	"course_mode":"verified",
	"user_email":"bexline+enapitest4@edx.org",
	"email_students": true
  },
  {
	"course_run_id":"course-v1:edX+DemoX+Demo_Course",
	"course_mode":"audit",
	"tpa_user_id":"abcdefg"
  }
]

The corresponding response will return an array with dictionaries mapping to each item in the original request. Successful responses will appear as {'detail': 'success'}, and unsuccessful responses will have a message indicating what the failure was for that payload.

Testing basic field validation - course_run_id and course_mode are always required, and at least one of lms_user_id, tpa_user_id, and user_email must be sent. The course_run_id must be part of the Enterprise Customer's Catalog. Making calls that do not meet these requirements should return responses that detail what is missing from the request data.

Note that for calls with multiple payloads, validation is processed serially. If one fails, all other payloads after it in the sequence will not be processed and return an empty value in the response.

Testing user identifier field validation - because the user identifier fields require at least one be specified, and multiple user identifier fields can be sent in one request, ie sending both lms_user_id and tpa_user_id together, there is some additional complexity in the validation. If more than one is specified, the field which results in a successful lookup of an EnterpriseCustomerUser is used, with preference given to lms_user_id, then tpa_user_id, then user_email. If user_email is given and no user is associated with it, and the other fields are not given or are also not associated with a user, a Pending Enterprise User and Pending Enrollment will be created. This fall back does not exist for the other two fields - if they are specified, no user can be found, and user_email is not specified, then the request will return an error indicating this.

Additionally, if the user is enrolled in a paid mode (verified or professional) and the request is attempting to enroll in audit, there will be a message specific to that and no change to enrollment will be performed. This will not impact later payloads if there are multiple sent. The reverse of this is allowed and will affect the enrollment, meaning a user already enrolled in audit or honor can be upgraded to verified/professional through this endpoint. Enrollment calls that attempt to enroll the user in their same mode will behave as if successful.

Testing enrolled user experience - this should behave as it does for users enrolled through the django admin interface. When they log in, they will see the course on their dashboard. If data sharing consent is enabled, they will be prompted for consent when they try to access the course for the first time. For pending users, this will happen after they register with the email they were enrolled with.

Testing email_students flag - if this is set to True, it will behave as the django admin interface and send an email using the same template to new or existing users about their enrollment.

Example Calls and their expected behaviors:
using a user that does not have add EnterpriseCustomer model access - Should give a message about insufficient permission.
no parameters - Should give a message about course_run_id and course_mode being required.
call with course_mode and course_run_id only - Should give a message about specifying one of the user identifier fields.
call with course_mode, course_run_id, and lms_user_id and/or tpa_user_id without an existing user - Should give a message indicating that no user could be found and user_email not being present.
call with course_mode, course_run_id, and user_email without an existing user - Should return a successful response, with a corresponding new PendingEnterpriseCustomerUser and PendingEnrollment created.
call with course_mode, course_run_id, and lms_user_id/tpa_user_id/user_mail with an existing user - Should return a successful response, and a new EnterpriseCourseEnrollment with the corresponding user and course should be created.

Remaining items:
*Links from the email do not trigger SSO for the Enterprise Customer. Depends on work from https://openedx.atlassian.net/browse/ENT-729. Once that is completed, we can change the url sent in emails to learners to include a tpa_hint. This might land separately from this PR depending on timing.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
