### PR TITLE
Add EnterpriseCustomerCatalog inline admin to EnterpriseCustomer admin.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.53.7] - 2017-10-30
+---------------------
+
+* Added inline admin form to EnterpriseCustomer admin for EnterpriseCustomerCatalog.
+
 [0.53.6] - 2017-10-30
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.53.6"
+__version__ = "0.53.7"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/admin/__init__.py
+++ b/enterprise/admin/__init__.py
@@ -89,6 +89,18 @@ class EnterpriseCustomerEntitlementInline(admin.StackedInline):
     ecommerce_coupon_url.short_description = 'Coupon URL'
 
 
+class EnterpriseCustomerCatalogInline(admin.TabularInline):
+    """
+    Django admin model for EnterpriseCustomerCatalog.
+    The admin interface has the ability to edit models on the same page as a parent model. These are called inlines.
+    https://docs.djangoproject.com/en/1.8/ref/contrib/admin/#django.contrib.admin.StackedInline
+    """
+
+    model = EnterpriseCustomerCatalog
+    extra = 0
+    can_delete = False
+
+
 @admin.register(EnterpriseCustomer)
 class EnterpriseCustomerAdmin(DjangoObjectActions, SimpleHistoryAdmin):
     """
@@ -111,7 +123,8 @@ class EnterpriseCustomerAdmin(DjangoObjectActions, SimpleHistoryAdmin):
     inlines = [
         EnterpriseCustomerBrandingConfigurationInline,
         EnterpriseCustomerIdentityProviderInline,
-        EnterpriseCustomerEntitlementInline
+        EnterpriseCustomerEntitlementInline,
+        EnterpriseCustomerCatalogInline,
     ]
 
     EXPORT_AS_CSV_FIELDS = ["name", "active", "site", "uuid", "identity_provider", "catalog"]


### PR DESCRIPTION
**Description:** This adds an inline admin form to the EnterpriseCustomer admin for creating/updating EnterpriseCustomerCatalog models.

**Testing instructions:**

1. Visit https://business.sandbox.edx.org/admin/enterprise/enterprisecustomer/2b5a2956-7746-4fc9-9587-bc887ba45973/.
2. Verify the "Enterprise Customer Catalogs" section is visible.
