### PR TITLE
ENT-693 Enrollment api prototype

### DIFF
--- a/enterprise/api/urls.py
+++ b/enterprise/api/urls.py
@@ -6,8 +6,6 @@ from __future__ import absolute_import, unicode_literals
 
 from django.conf.urls import include, url
 
-from enterprise.api.v1.urls import router as api_v1_router
-
 urlpatterns = [
-    url(r'^v1/', include(api_v1_router.urls), name='api')
+    url(r'^v1/', include('enterprise.api.v1.urls'), name='api')
 ]

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -410,3 +410,34 @@ class EnterpriseCustomerReportingConfigurationSerializer(serializers.ModelSerial
         )
 
     enterprise_customer = EnterpriseCustomerSerializer()
+
+
+class EnterpriseCustomerEnrollUserInCourseRunSerializer(serializers.Serializer):
+    """Serializes enrollment information for a collection of students/emails.
+
+    This is mainly useful for implementing validation when performing bulk enrollment operations.
+    """
+    lms_user_id = serializers.CharField(required=False)
+    tpa_user_id = serializers.CharField(required=False)
+    user_email = serializers.EmailField(required=False)
+    enterprise_id = serializers.UUIDField(required=True)
+    course_run_id = serializers.CharField(required=True)
+    course_mode = serializers.ChoiceField(
+        choices=(
+            ('audit', 'audit'),
+            ('verified', 'verified'),
+            ('professional', 'professional')
+        ),
+        required=True
+    )
+    email_students = serializers.BooleanField(default=False, required=False)
+
+    def validate(self, data):
+        """
+        Validate that at least one of the user identifier fields has been passed in.
+        """
+        if not data.get('lms_user_id') and not data.get('tpa_user_id') and not data.get('user_email'):
+            raise serializers.ValidationError('At least one of the following fields must be specified: '
+                                              'lms_user_id, tpa_user_id, user_email')
+
+        return data

--- a/enterprise/api/v1/urls.py
+++ b/enterprise/api/v1/urls.py
@@ -4,6 +4,8 @@ URL definitions for enterprise api version 1 endpoint.
 """
 from __future__ import absolute_import, unicode_literals
 
+from django.conf.urls import include, url
+
 from rest_framework.routers import DefaultRouter
 
 from enterprise.api.v1 import views
@@ -29,3 +31,12 @@ router.register(
     views.EnterpriseCustomerReportingConfigurationViewSet,
     'enterprise-customer-reporting',
 )
+
+urlpatterns = [
+    url(
+        r'^enroll_user_in_course',
+        views.EnterpriseCustomerEnrollUserInCourseRunView.as_view(),
+        name='enroll-user-in-course'
+    ),
+    url(r'^', include(router.urls)),
+]

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -12,18 +12,23 @@ from rest_framework.authentication import SessionAuthentication
 from rest_framework.decorators import detail_route
 from rest_framework.exceptions import NotFound
 from rest_framework.response import Response
+from rest_framework.status import HTTP_200_OK, HTTP_400_BAD_REQUEST, HTTP_401_UNAUTHORIZED
+from rest_framework.views import APIView
 
 from django.conf import settings
+from django.contrib.auth.models import User
 from django.http import Http404
 from django.utils.decorators import method_decorator
 
 from enterprise import models
+from enterprise.admin.views import EnterpriseCustomerManageLearnersView
 from enterprise.api.filters import EnterpriseCustomerUserFilterBackend, UserFilterBackend
 from enterprise.api.pagination import get_paginated_response
 from enterprise.api.throttles import ServiceUserThrottle
 from enterprise.api.v1 import serializers
 from enterprise.api.v1.decorators import enterprise_customer_required, require_at_least_one_query_parameter
 from enterprise.api_client.discovery import CourseCatalogApiClient
+from enterprise.api_client.lms import ThirdPartyAuthApiClient
 from six.moves.urllib.parse import quote_plus, unquote  # pylint: disable=import-error,ungrouped-imports
 
 LOGGER = getLogger(__name__)
@@ -438,3 +443,136 @@ class EnterpriseCustomerReportingConfigurationViewSet(EnterpriseReadOnlyModelVie
     )
     filter_fields = FIELDS
     ordering_fields = FIELDS
+
+
+class EnterpriseCustomerEnrollUserInCourseRunView(APIView):
+    """
+
+    """
+
+    queryset = models.EnterpriseCustomer.active_customers.all()
+    serializer_class = serializers.EnterpriseCustomerEnrollUserInCourseRunSerializer
+    authentication_classes = (JwtAuthentication, BearerAuthentication, SessionAuthentication,)
+    filter_backends = (filters.OrderingFilter, filters.DjangoFilterBackend, EnterpriseCustomerUserFilterBackend)
+    permission_classes = (permissions.IsAuthenticated,)
+    throttle_classes = (ServiceUserThrottle,)
+
+    def get(self, request):
+        return Response(status=HTTP_200_OK)
+
+    def post(self, request, format=None):
+        """
+
+        """
+        serializer = serializers.EnterpriseCustomerEnrollUserInCourseRunSerializer(data=request.data)
+        if serializer.is_valid():
+            # Verify that the user is staff or associated with the specified enteprise
+            enterprise_id = serializer.data.get('enterprise_id')
+            try:
+                enterprise_customer = models.EnterpriseCustomer.objects.get(uuid=enterprise_id)
+            except models.EnterpriseCustomer.DoesNotExist:
+                return Response(
+                    data={
+                        'detail': 'The  given enterprise {enterprise} does not exist.'.format(
+                            enterprise=enterprise_id
+                        )
+                    },
+                    status=HTTP_400_BAD_REQUEST
+                )
+
+            if not request.user.is_staff:
+                try:
+                    models.EnterpriseCustomerUser.objects.get(
+                        user_id=request.user.id,
+                        enterprise_customer=enterprise_customer
+                    )
+                except models.EnterpriseCustomerUser.DoesNotExist:
+                    return Response(
+                        data={
+                            'detail': 'The request user {user} does not have access '
+                            'to the given enterprise {enterprise}.'.format(
+                                user=request.user.username,
+                                enterprise=enterprise_customer.name
+                            )
+                        },
+                        status=HTTP_401_UNAUTHORIZED
+                    )
+
+            lms_user_id = serializer.data.get('lms_user_id')
+            tpa_user_id = serializer.data.get('tpa_user_id')
+            user_email = serializer.data.get('user_email')
+            course_run_id = serializer.data.get('course_run_id')
+            course_mode = serializer.data.get('course_mode')
+            email_students = serializer.data.get('email_students')
+
+            enterprise_customer_user = None
+            pending_enterprise_user = None
+            errors = []
+            if lms_user_id:
+                try:
+                    # Ensure the given user is associated with the enterprise.
+                    enterprise_customer_user = models.EnterpriseCustomerUser.objects.get(
+                        user_id=lms_user_id,
+                        enterprise_customer=enterprise_customer
+                    )
+                except models.EnterpriseCustomerUser.DoesNotExist:
+                    errors.append('Unable to find user {user} associated with enterprise {enterprise}'.format(
+                        user=lms_user_id,
+                        enterprise=enterprise_customer.name
+                    ))
+
+            if tpa_user_id and not enterprise_customer_user:
+                try:
+                    tpa_client = ThirdPartyAuthApiClient()
+                    username = tpa_client.get_username_from_remote_id(
+                        enterprise_customer.identity_provider, tpa_user_id
+                    )
+                    user = User.objects.get(username=username)
+                    enterprise_customer_user = models.EnterpriseCustomerUser.objects.get(
+                        user_id=user.id,
+                        enterprise_customer=enterprise_customer
+                    )
+                except models.EnterpriseCustomerUser.DoesNotExist:
+                    errors.append('Unable to find user {user} associated with enterprise {enterprise}'.format(
+                        user=lms_user_id,
+                        enterprise=enterprise_customer.name
+                    ))
+
+            if user_email and not enterprise_customer_user:
+                try:
+                    user = User.objects.get(email=user_email)
+                    enterprise_customer_user = models.EnterpriseCustomerUser.objects.get(
+                        user_id=user.id,
+                        enterprise_customer=enterprise_customer
+                    )
+                except User.DoesNotExist, models.EnterpriseCustomerUser.DoesNotExist:
+                    pending_enterprise_user = EnterpriseCustomerManageLearnersView.enroll_user_pending_registration(
+                        enterprise_customer,
+                        user_email,
+                        course_mode,
+                        course_run_id
+                    )
+
+            if enterprise_customer_user:
+                enterprise_customer_user.enroll(course_run_id, course_mode)
+            elif pending_enterprise_user:
+                enterprise_customer_user = pending_enterprise_user
+            else:
+                return Response(
+                    {
+                        'detail': errors
+                    },
+                    status=HTTP_400_BAD_REQUEST
+                )
+
+            if email_students:
+                EnterpriseCustomerManageLearnersView.notify_enrolled_learners(
+                    enterprise_customer,
+                    request,
+                    course_run_id,
+                    [enterprise_customer_user]
+                )
+
+            return Response({'detail': 'success'}, status=HTTP_200_OK)
+        else:
+            return Response(serializer.errors, status=HTTP_400_BAD_REQUEST)

--- a/enterprise/api_client/lms.py
+++ b/enterprise/api_client/lms.py
@@ -328,6 +328,29 @@ class ThirdPartyAuthApiClient(LmsApiClient):
                 return row.get('remote_id')
         return None
 
+    def get_username_from_remote_id(self, identity_provider, remote_id):
+        """
+        Retrieve the remote identifier for the given username.
+
+        Args:
+        * ``identity_provider`` (str): identifier slug for the third-party authentication service used during SSO.
+        * ``remote_id`` (str): The remote id identifying the user for which to retrieve the usernamename.
+
+        Returns:
+            string or None: the username of the given user.  None if not found.
+        """
+        try:
+            returned = self.client.providers(identity_provider).users.get(remote_id=remote_id)
+            results = returned.get('results', [])
+        except HttpNotFoundError:
+            LOGGER.error('username not found for third party provider=%s, remote_id=%s', identity_provider, remote_id)
+            results = []
+
+        for row in results:
+            if row.get('remote_id') == remote_id:
+                return row.get('username')
+        return None
+
 
 class GradesApiClient(JwtLmsApiClient):
     """


### PR DESCRIPTION
### **Description:** 
Introduces a new endpoint for enrolling a single user in a single course run for a given enterprise.

**Endpoint:** /enterprise/api/v1/enroll_user_in_course

**POST params:**
*At least one of lms_user_id, tpa_user_id, or user_email must be specified.
lms_user_id = The django user model id. 
tpa_user_id = The third party auth SSO user id.
user_email = The user email.
enterprise_id = The enterprise customer uuid. Required.
course_run_id = The course run id. Required.
course_mode = The mode for enrollment (audit, verified, professional). Required.
email_students = Whether or not to send a notification email to the learner about this enrollment. Defaults to False.

**Behavior:**
After validating the input, the EntepriseCustomer is fetched, and the request user is validated to either be a staff user or linked as an EnterpriseCustomerUser.
Then, using the lms_user_id, if specified, an EnterpriseCustomerUser is fetched with that user id and enterprise customer, if it exists.
If the tpa user id was specified and we were unable to fetch an enterprise customer user from the lms_user_id, we call the ThirdPartyAuth api to fetch the username associated with the tpa user id, look up the user, and then look up the EnterpriseCustomerUser, if it exists.
If the first two parameters were not given or did not find an EntepriseCustomerUser, we use the email to look up a user and then an enterprise customer user. If it doesn't exist, we create a pending user and pending enrollment.
If we did find an EnterpriseCustomerUser object, we call the enroll method on the model to complete the enrollment. 
If email_students is true, we send an email notification to the user regarding their enrollment. This email should be the same as the one sent when users are proxy enrolled from the django admin screen.

When the users login to LMS, they will see the new course in their dashboard, and when they try to access it, if data sharing consent is enabled, they will be prompted for consent before they can see the content.

**Implementation notes:**
This is a rough prototype. It takes advantage of some of the existing proxy enrollment code, and is not implemented as a view set since there is no one underlying model that it is linked to. I'll be writing up my recommendations for an implementation with the same logic.

**JIRA:** https://openedx.atlassian.net/browse/ENT-693

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** This shouldn't merge.

**Installation instructions:** 

**Testing instructions:**


**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
