### PR TITLE
ENT-711: Remove SAP_USE_ENTERPRISE_ENROLLMENT_PAGE waffle switch.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.53.11] - 2017-11-06
+----------------------
+
+* Removing SAP_USE_ENTERPRISE_ENROLLMENT_PAGE switch via django waffle and use landing page URL instead of track slection page.
+
 [0.53.10] - 2017-11-02
 ----------------------
 
@@ -60,12 +65,12 @@ Unreleased
 * Remove unused dependency on django-extensions
 
 [0.53.1] - 2017-10-24
-----------------------
+---------------------
 
 * Fix alteration in querystring parameters for decorator "enterprise_login_required".
 
 [0.53.0] - 2017-10-24
-----------------------
+---------------------
 
 * Get rid of the `EnterpriseIntegratedChannel` model and any other related but unused code.
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.53.10"
+__version__ = "0.53.11"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/sap_success_factors/migrations/0009_sapsuccessfactors_remove_enterprise_enrollment_page_waffle_flag.py
+++ b/integrated_channels/sap_success_factors/migrations/0009_sapsuccessfactors_remove_enterprise_enrollment_page_waffle_flag.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+def create_switch(apps, schema_editor):
+    """Create and activate the SAP_USE_ENTERPRISE_ENROLLMENT_PAGE switch if it does not already exist."""
+    Switch = apps.get_model('waffle', 'Switch')
+    Switch.objects.get_or_create(name='SAP_USE_ENTERPRISE_ENROLLMENT_PAGE', defaults={'active': False})
+
+
+def delete_switch(apps, schema_editor):
+    """Delete the SAP_USE_ENTERPRISE_ENROLLMENT_PAGE switch."""
+    Switch = apps.get_model('waffle', 'Switch')
+    Switch.objects.filter(name='SAP_USE_ENTERPRISE_ENROLLMENT_PAGE').delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('sap_success_factors', '0008_historicalsapsuccessfactorsenterprisecustomerconfiguration_history_change_reason'),
+        ('waffle', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(delete_switch, reverse_code=create_switch),
+    ]

--- a/integrated_channels/sap_success_factors/utils.py
+++ b/integrated_channels/sap_success_factors/utils.py
@@ -10,7 +10,6 @@ import os
 from logging import getLogger
 
 from integrated_channels.integrated_channel.course_metadata import BaseCourseExporter
-from waffle import switch_is_active
 
 from django.apps import apps
 from django.utils import timezone
@@ -288,10 +287,7 @@ def get_launch_url(enterprise_customer, course_id, enrollment_url=None):
         course_id (str): The string identifier of the course in question
         enrollment_url (str): Enterprise landing page url for the given course from enterprise courses API
     """
-    if switch_is_active('SAP_USE_ENTERPRISE_ENROLLMENT_PAGE'):
-        return enrollment_url or enterprise_customer.get_course_run_enrollment_url(course_id)
-
-    return get_course_track_selection_url(enterprise_customer, course_id)
+    return enrollment_url or enterprise_customer.get_course_run_enrollment_url(course_id)
 
 
 def get_course_track_selection_url(enterprise_customer, course_id):
@@ -372,7 +368,7 @@ def get_course_metadata_for_inactivation(course_id, enterprise_customer, provide
         'content': [
             {
                 'providerID': provider_id,
-                'launchURL': get_course_track_selection_url(enterprise_customer, course_id),
+                'launchURL': get_launch_url(enterprise_customer, course_id),
                 'contentTitle': 'Course Description',
                 'launchType': 3,
                 'contentID': course_id,

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -18,7 +18,6 @@ from integrated_channels.sap_success_factors.models import SAPSuccessFactorsEnte
 from pytest import mark, raises
 from requests.compat import urljoin
 from testfixtures import LogCapture
-from waffle.testutils import override_switch
 
 from django.conf import settings
 from django.core.management import call_command
@@ -90,7 +89,6 @@ class TestTransmitCoursewareDataManagementCommand(unittest.TestCase, EnterpriseM
         mock_data_task.delay.assert_called_once_with('C-3PO', 'SAP', 1)
 
     @responses.activate
-    @override_switch('SAP_USE_ENTERPRISE_ENROLLMENT_PAGE', active=True)
     @mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
     @mock.patch('integrated_channels.sap_success_factors.utils.reverse')
     @mock.patch('integrated_channels.sap_success_factors.transmitters.SAPSuccessFactorsAPIClient')
@@ -170,7 +168,6 @@ class TestTransmitCoursewareDataManagementCommand(unittest.TestCase, EnterpriseM
                 assert message in log_capture.records[index].getMessage()
 
     @responses.activate
-    @override_switch('SAP_USE_ENTERPRISE_ENROLLMENT_PAGE', active=True)
     @mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
     @mock.patch('integrated_channels.sap_success_factors.utils.reverse')
     @mock.patch('integrated_channels.sap_success_factors.transmitters.SAPSuccessFactorsAPIClient')

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -14,7 +14,6 @@ from integrated_channels.integrated_channel.course_metadata import BaseCourseExp
 from integrated_channels.sap_success_factors.models import SAPSuccessFactorsEnterpriseCustomerConfiguration
 from integrated_channels.sap_success_factors.utils import SapCourseExporter, get_launch_url
 from pytest import mark, raises
-from waffle.testutils import override_switch
 
 from django.core import mail
 from django.test import override_settings
@@ -1145,7 +1144,7 @@ class TestSAPSuccessFactorsUtils(unittest.TestCase):
         )
 
     @mock.patch('integrated_channels.integrated_channel.course_metadata.get_course_runs')
-    @mock.patch('integrated_channels.sap_success_factors.utils.get_course_track_selection_url')
+    @mock.patch('integrated_channels.sap_success_factors.utils.get_launch_url')
     @ddt.data(
         (
             # course runs
@@ -1372,7 +1371,6 @@ class TestSAPSuccessFactorsUtils(unittest.TestCase):
         filtered_course_modes = utils.filter_audit_course_modes(self.customer, course_modes)
         assert len(filtered_course_modes) == 5
 
-    @override_switch('SAP_USE_ENTERPRISE_ENROLLMENT_PAGE', active=True)
     def test_get_launch_url_flag_on(self):
         """
         Test `get_launch_url` helper method.
@@ -1385,23 +1383,3 @@ class TestSAPSuccessFactorsUtils(unittest.TestCase):
 
         launch_url = get_launch_url(enterprise_customer, course_id)
         assert_url(launch_url, expected_url)
-
-    @override_switch('SAP_USE_ENTERPRISE_ENROLLMENT_PAGE', active=False)
-    @mock.patch('integrated_channels.sap_success_factors.utils.reverse')
-    def test_get_launch_url_flag_off(
-            self,
-            reverse_mock):
-        """
-        Test `get_launch_url` helper method.
-        """
-        reverse_mock.return_value = '/course_modes/choose/course-v1:edX+DemoX+Demo_Course/'
-        course_id = 'course-v1:edX+DemoX+Demo_Course'
-        enterprise_uuid = '37432370-0a6e-4d95-90fe-77b4fe64de2d'
-        expected_url = 'https://example.com/course_modes/choose/course-v1:edX+DemoX+Demo_Course/'
-        enterprise_customer = EnterpriseCustomerFactory(
-            site=SiteFactory(domain='example.com'),
-            uuid=enterprise_uuid
-        )
-
-        launch_url = get_launch_url(enterprise_customer, course_id)
-        assert launch_url == expected_url


### PR DESCRIPTION
**Description:**

Originally the launch URLs we were publishing to SuccessFactors directed learners to the track selection page in LMS. Subsequently, we implemented the enterprise course enrollment landing page. In order to ease the rollout of the course enrollment landing page we created the `SAP_USE_ENTERPRISE_ENROLLMENT_PAGE` waffle switch and used it to toggle between publishing the track selection URL and the course enrollment landing page URL. The course enrollment landing page URL should now be the only URL we publish.

**Acceptance Criteria:**
1. Remove the `SAP_USE_ENTERPRISE_ENROLLMENT_PAGE` waffle switch from the codebase.
2. Ensure that we always publish the course enrollment landing page URL to SuccessFactors.
3. Create a data migration for removing the `SAP_USE_ENTERPRISE_ENROLLMENT_PAGE` waffle switch from the database.

**JIRA:** [ENT-711](https://openedx.atlassian.net/browse/ENT-711)

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)
