### PR TITLE
ENT-729/Authenticating directly using "tpa_hint" URL does not link learner to enterprise customer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,16 @@ Change Log
 Unreleased
 ----------
 
+[0.53.14] - 2017-11-14
+----------------------
+
+* Link learner to enterprise customer directly using "tpa_hint" URL parameter.
+
+[0.53.13] - 2017-11-14
+----------------------
+
+* Update DSC policy to match legal requirements.
+
 [0.53.12] - 2017-11-09
 ----------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.53.13"
+__version__ = "0.53.14"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/decorators.py
+++ b/enterprise/decorators.py
@@ -220,3 +220,13 @@ def force_fresh_session(view):
         return view(request, *args, **kwargs)
 
     return wrapper
+
+
+def null_decorator(func):
+    """
+    Use this decorator to stub out decorators for testing.
+
+    If we're unable to import social_core.pipeline.partial, which is the case in our CI platform,
+    we need to be able to wrap the function with something.
+    """
+    return func

--- a/enterprise/tpa_pipeline.py
+++ b/enterprise/tpa_pipeline.py
@@ -1,0 +1,68 @@
+"""
+Module provides elements to be used in third-party auth pipeline.
+"""
+from __future__ import absolute_import, unicode_literals
+
+from enterprise.models import EnterpriseCustomer, EnterpriseCustomerUser
+
+try:
+    from social_core.pipeline.partial import partial
+except ImportError:
+    from enterprise.decorators import null_decorator as partial  # pylint:disable=ungrouped-imports
+
+try:
+    from third_party_auth.provider import Registry
+except ImportError:
+    Registry = None
+
+
+def get_enterprise_customer_for_running_pipeline(request, pipeline):  # pylint: disable=invalid-name
+    """
+    Get the EnterpriseCustomer associated with a running pipeline.
+    """
+    sso_provider_id = request.GET.get('tpa_hint')
+    if pipeline:
+        sso_provider_id = Registry.get_from_pipeline(pipeline).provider_id
+    return get_enterprise_customer_for_sso(sso_provider_id)
+
+
+def get_enterprise_customer_for_sso(sso_provider_id):
+    """
+    Get the EnterpriseCustomer object tied to an identity provider.
+    """
+    try:
+        return EnterpriseCustomer.objects.get(  # pylint: disable=no-member
+            enterprise_customer_identity_provider__provider_id=sso_provider_id
+        )
+    except EnterpriseCustomer.DoesNotExist:
+        return None
+
+
+@partial
+def handle_enterprise_logistration(backend, user, **kwargs):
+    """
+    Perform the linking of user in the process of logging to the Enterprise Customer.
+
+    Args:
+        backend: The class handling the SSO interaction (SAML, OAuth, etc)
+        user: The user object in the process of being logged in with
+        **kwargs: Any remaining pipeline variables
+
+    """
+    request = backend.strategy.request
+    enterprise_customer = get_enterprise_customer_for_running_pipeline(
+        request,
+        {
+            'backend': backend.name,
+            'kwargs': kwargs
+        }
+    )
+    if enterprise_customer is None:
+        # This pipeline element is not being activated as a part of an Enterprise logistration
+        return
+
+    # proceed with the creation of a link between the user and the enterprise customer, then exit.
+    EnterpriseCustomerUser.objects.update_or_create(
+        enterprise_customer=enterprise_customer,
+        user_id=user.id
+    )

--- a/tests/test_tpa_pipeline.py
+++ b/tests/test_tpa_pipeline.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for the `edx-enterprise` tpa-pipeline module.
+"""
+from __future__ import absolute_import, unicode_literals
+
+import unittest
+
+import ddt
+import mock
+from pytest import mark
+
+from django.contrib.messages.storage import fallback
+from django.contrib.sessions.backends import cache
+from django.test import RequestFactory
+
+from enterprise.models import EnterpriseCustomerUser
+from enterprise.tpa_pipeline import get_enterprise_customer_for_running_pipeline, handle_enterprise_logistration
+from test_utils.factories import EnterpriseCustomerFactory, EnterpriseCustomerIdentityProviderFactory, UserFactory
+
+
+@ddt.ddt
+@mark.django_db
+class TestTpaPipeline(unittest.TestCase):
+    """
+    Test functions in the tpa_pipeline module.
+    """
+
+    def setUp(self):
+        ecidp = EnterpriseCustomerIdentityProviderFactory(provider_id='provider_slug')
+        self.customer = ecidp.enterprise_customer
+        self.user = UserFactory(is_active=True)
+        self.request_factory = RequestFactory()
+        self.request = self.request_factory.get('/')
+        self.request.session = cache.SessionStore()
+        super(TestTpaPipeline, self).setUp()
+
+    def get_mocked_sso_backend(self):
+        """
+        Get a mocked request backend with mocked strategy.
+        """
+        # Monkey-patch storage for messaging;   pylint: disable=protected-access
+        self.request._messages = fallback.FallbackStorage(self.request)
+
+        strategy_mock = mock.MagicMock(request=self.request)
+        backend = mock.MagicMock(
+            name=None,
+            strategy=strategy_mock,
+        )
+        return backend
+
+    @ddt.data(False, True)
+    def test_handle_enterprise_logistration_user_linking(
+            self,
+            user_is_active,
+    ):
+        """
+        Test that we create an EnterpriseCustomerUser, then return.
+        """
+        backend = self.get_mocked_sso_backend()
+        self.user = UserFactory(is_active=user_is_active)
+        with mock.patch('enterprise.tpa_pipeline.get_enterprise_customer_for_running_pipeline') as fake_get_ec:
+            enterprise_customer = EnterpriseCustomerFactory(
+                enable_data_sharing_consent=False
+            )
+            fake_get_ec.return_value = enterprise_customer
+            assert handle_enterprise_logistration(backend, self.user) is None
+            assert EnterpriseCustomerUser.objects.filter(
+                enterprise_customer=enterprise_customer,
+                user_id=self.user.id
+            ).count() == 1
+
+    def test_handle_enterprise_logistration_not_user_linking(self):
+        """
+        Test if there is not any enterprise customer then EnterpriseCustomerUser would not be associated with it.
+        """
+        backend = self.get_mocked_sso_backend()
+        self.user = UserFactory()
+        with mock.patch('enterprise.tpa_pipeline.get_enterprise_customer_for_running_pipeline') as fake_get_ec:
+            enterprise_customer = EnterpriseCustomerFactory(
+                enable_data_sharing_consent=False
+            )
+            fake_get_ec.return_value = None
+            assert handle_enterprise_logistration(backend, self.user) is None
+            assert EnterpriseCustomerUser.objects.filter(
+                enterprise_customer=enterprise_customer,
+                user_id=self.user.id
+            ).count() == 0
+
+    def test_get_ec_for_pipeline(self):
+        """
+        Test that we get the correct results for a given running pipeline.
+        """
+        with mock.patch('enterprise.tpa_pipeline.Registry') as fake_registry:
+            provider = mock.MagicMock(provider_id='provider_slug')
+            fake_registry.get_from_pipeline.return_value = provider
+            assert get_enterprise_customer_for_running_pipeline(self.request, 'pipeline') == self.customer
+
+            # pipeline is None
+            assert get_enterprise_customer_for_running_pipeline(self.request, None) is None
+
+            # provider_id is None
+            provider = mock.MagicMock(provider_id=None)
+            fake_registry.get_from_pipeline.return_value = provider
+            assert get_enterprise_customer_for_running_pipeline(self.request, 'pipeline') is None


### PR DESCRIPTION
@douglashall @zubair-arbi Can you please look around the change set. 
I will create a corresponding PR in edx-platform.

#### NOTE: As testshib is not working, It was difficult to test it locally. I did the changes as per my best understanding in code.

**Description:** Authenticating directly using "tpa_hint" URL does not link learner to enterprise customer

**JIRA:** [ENT-729](https://openedx.atlassian.net/browse/ENT-729)

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

