### PR TITLE
PLAT-1199 Replace PyCrypto with cryptography

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,3 +13,4 @@ Matt Drayer <mattdrayer@edx.org>
 Lucas Tadeu Teixeira <lucas@opencraft.com>
 Bill Filler <bfiller@edx.org>
 Matt Tuchfarber <mtuchfarber@edx.org>
+Jeremy Bowman <jbowman@edx.org>

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.53.15] - 2017-11-16
+----------------------
+
+* Use the cryptography package instead of the unmaintained pycrypto.
+
 [0.53.14] - 2017-11-14
 ----------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.53.14"
+__version__ = "0.53.15"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,14 +8,17 @@ amqp==1.4.9               # via kombu
 analytics-python==1.1.0
 anyjson==0.3.3            # via kombu
 argparse==1.4.0           # via caniusepython3
+asn1crypto==0.23.0        # via cryptography
 astroid==1.5.2            # via edx-lint, pylint, pylint-celery, pylint-plugin-utils
 backports.functools-lru-cache==1.4  # via astroid, caniusepython3, pylint
 billiard==3.3.0.23        # via celery
 caniusepython3==6.0.0
 celery==3.1.18
+cffi==1.11.2              # via cryptography
 click-log==0.1.8          # via edx-lint
 click==6.7                # via click-log, edx-lint, pip-tools
 configparser==3.5.0       # via pylint
+cryptography==1.9
 diff-cover==0.9.12
 distlib==0.2.6            # via caniusepython3
 django-config-models==0.1.8
@@ -34,12 +37,14 @@ edx-i18n-tools==0.4.1
 edx-lint==0.5.4
 edx-opaque-keys==0.4.0
 edx-rest-api-client==1.7.1
-enum34==1.1.6             # via astroid
+enum34==1.1.6             # via astroid, cryptography
 event-tracking==0.2.4
 first==2.0.1              # via pip-tools
 flaky==3.3.0
 futures==3.1.1            # via caniusepython3
+idna==2.6                 # via cryptography
 inflect==0.2.5            # via jinja2-pluralize
+ipaddress==1.0.18         # via cryptography
 isort==4.2.15
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.10              # via diff-cover, jinja2-pluralize
@@ -58,7 +63,7 @@ pluggy==0.5.2             # via tox
 polib==1.0.8              # via edx-i18n-tools
 py==1.4.34                # via tox
 pycodestyle==2.3.1
-pycrypto==2.6.1
+pycparser==2.18           # via cffi
 pydocstyle==2.1.1
 pygments==2.2.0           # via diff-cover
 pyjwt==1.5.3              # via djangorestframework-jwt, edx-rest-api-client
@@ -75,7 +80,7 @@ requests-toolbelt==0.8.0  # via twine
 requests==2.9.1
 shortuuid==0.5.0          # via edx-django-oauth2-provider
 singledispatch==3.4.0.3   # via astroid, pylint
-six==1.11.0               # via analytics-python, astroid, diff-cover, edx-i18n-tools, edx-lint, edx-opaque-keys, packaging, pip-tools, pydocstyle, pylint, python-dateutil, singledispatch, stevedore, tox
+six==1.11.0               # via analytics-python, astroid, cryptography, diff-cover, edx-i18n-tools, edx-lint, edx-opaque-keys, packaging, pip-tools, pydocstyle, pylint, python-dateutil, singledispatch, stevedore, tox
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==1.2.1    # via pydocstyle
 stevedore==1.27.1         # via edx-opaque-keys

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -8,11 +8,14 @@ alabaster==0.7.10         # via sphinx
 amqp==1.4.9               # via kombu
 analytics-python==1.1.0
 anyjson==0.3.3            # via kombu
+asn1crypto==0.23.0        # via cryptography
 babel==2.5.1              # via sphinx
 billiard==3.3.0.23        # via celery
 bleach==2.1.1             # via readme-renderer
 celery==3.1.18
+cffi==1.11.2              # via cryptography
 chardet==3.0.4            # via doc8
+cryptography==1.9
 django-config-models==0.1.8
 django-filter==1.0.4
 django-model-utils==2.3.1
@@ -30,10 +33,13 @@ edx-drf-extensions==1.2.3
 edx-opaque-keys==0.4.0
 edx-rest-api-client==1.7.1
 edx-sphinx-theme==1.3.0
+enum34==1.1.6             # via cryptography
 event-tracking==0.2.4
 flaky==3.3.0
 html5lib==1.0b10          # via bleach
+idna==2.6                 # via cryptography
 imagesize==0.7.1          # via sphinx
+ipaddress==1.0.18         # via cryptography
 jinja2==2.10              # via sphinx
 jsonfield==2.0.2
 kombu==3.0.37             # via celery
@@ -41,7 +47,7 @@ markupsafe==1.0           # via jinja2
 pbr==3.1.1                # via stevedore
 pillow==3.4
 pockets==0.5.1            # via sphinxcontrib-napoleon
-pycrypto==2.6.1
+pycparser==2.18           # via cffi
 pygments==2.2.0           # via readme-renderer, sphinx
 pyjwt==1.5.3              # via djangorestframework-jwt, edx-rest-api-client
 pymongo==3.5.1            # via edx-opaque-keys, event-tracking
@@ -51,7 +57,7 @@ readme-renderer==17.2
 requests==2.9.1
 restructuredtext-lint==1.1.2  # via doc8
 shortuuid==0.5.0          # via edx-django-oauth2-provider
-six==1.11.0               # via analytics-python, bleach, doc8, edx-opaque-keys, edx-sphinx-theme, html5lib, pockets, python-dateutil, readme-renderer, sphinx, sphinxcontrib-napoleon, stevedore
+six==1.11.0               # via analytics-python, bleach, cryptography, doc8, edx-opaque-keys, edx-sphinx-theme, html5lib, pockets, python-dateutil, readme-renderer, sphinx, sphinxcontrib-napoleon, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==1.2.1    # via sphinx
 sphinx==1.6.5

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -9,6 +9,7 @@ amqp==1.4.9               # via kombu
 analytics-python==1.1.0
 anyjson==0.3.3            # via kombu
 argparse==1.4.0           # via caniusepython3
+asn1crypto==0.23.0        # via cryptography
 astroid==1.5.2            # via edx-lint, pylint, pylint-celery, pylint-plugin-utils
 babel==2.5.1              # via sphinx
 backports.functools-lru-cache==1.4  # via astroid, caniusepython3, pylint
@@ -16,12 +17,14 @@ billiard==3.3.0.23        # via celery
 bleach==2.1.1             # via readme-renderer
 caniusepython3==6.0.0
 celery==3.1.18
+cffi==1.11.2              # via cryptography
 chardet==3.0.4            # via doc8
 click-log==0.1.8          # via edx-lint
 click==6.7                # via click-log, edx-lint, pip-tools
 configparser==3.5.0       # via pylint
 cookies==2.2.1            # via responses
 coverage==4.4.2           # via pytest-cov
+cryptography==1.9
 ddt==1.1.1
 diff-cover==0.9.12
 distlib==0.2.6            # via caniusepython3
@@ -44,7 +47,7 @@ edx-lint==0.5.4
 edx-opaque-keys==0.4.0
 edx-rest-api-client==1.7.1
 edx-sphinx-theme==1.3.0
-enum34==1.1.6             # via astroid
+enum34==1.1.6             # via astroid, cryptography
 event-tracking==0.2.4
 factory-boy==2.9.2
 faker==0.8.6              # via factory-boy
@@ -54,9 +57,10 @@ freezegun==0.3.9
 funcsigs==1.0.2           # via mock
 futures==3.1.1            # via caniusepython3
 html5lib==1.0b10          # via bleach
+idna==2.6                 # via cryptography
 imagesize==0.7.1          # via sphinx
 inflect==0.2.5            # via jinja2-pluralize
-ipaddress==1.0.18         # via faker
+ipaddress==1.0.18         # via cryptography, faker
 isort==4.2.15
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.10              # via diff-cover, jinja2-pluralize, sphinx
@@ -77,7 +81,7 @@ pockets==0.5.1            # via sphinxcontrib-napoleon
 polib==1.0.8              # via edx-i18n-tools
 py==1.4.34                # via pytest, pytest-catchlog, tox
 pycodestyle==2.3.1
-pycrypto==2.6.1
+pycparser==2.18           # via cffi
 pydocstyle==2.1.1
 pygments==2.2.0           # via diff-cover, readme-renderer, sphinx
 pyjwt==1.5.3              # via djangorestframework-jwt, edx-rest-api-client
@@ -101,7 +105,7 @@ responses==0.8.1
 restructuredtext-lint==1.1.2  # via doc8
 shortuuid==0.5.0          # via edx-django-oauth2-provider
 singledispatch==3.4.0.3   # via astroid, pylint
-six==1.11.0               # via analytics-python, astroid, bleach, diff-cover, doc8, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, faker, freezegun, html5lib, mock, packaging, pip-tools, pockets, pydocstyle, pylint, python-dateutil, readme-renderer, responses, singledispatch, sphinx, sphinxcontrib-napoleon, stevedore, tox
+six==1.11.0               # via analytics-python, astroid, bleach, cryptography, diff-cover, doc8, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, faker, freezegun, html5lib, mock, packaging, pip-tools, pockets, pydocstyle, pylint, python-dateutil, readme-renderer, responses, singledispatch, sphinx, sphinxcontrib-napoleon, stevedore, tox
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==1.2.1    # via pydocstyle, sphinx
 sphinx==1.6.5

--- a/requirements/test-ficus.in
+++ b/requirements/test-ficus.in
@@ -8,6 +8,7 @@
 #   segment events in some enterprise flows.
 
 celery==3.1.18                          # Run task workers in other locations
+cryptography==1.5.3                     # For random password generation
 django==1.8.18                          # Application server
 djangorestframework==3.2.3              # REST API extensions for Django
 djangorestframework-oauth==1.1.0        # For enterprise REST API endpoint
@@ -27,4 +28,3 @@ jsonfield==2.0.2                        # Provides a Django model field which se
 flaky==3.3.0                            # Rerun flaky tests automatically if they fail, up to a limit
 analytics-python==1.1.0                 # Used for Segment analytics
 event-tracking==0.2.4                   # Tracks context-aware semi-structured system events
-pycrypto>=2.6

--- a/requirements/test-ficus.txt
+++ b/requirements/test-ficus.txt
@@ -9,8 +9,10 @@ analytics-python==1.1.0
 anyjson==0.3.3            # via kombu
 billiard==3.3.0.23        # via celery
 celery==3.1.18
+cffi==1.11.2              # via cryptography
 cookies==2.2.1            # via responses
 coverage==4.4.2           # via pytest-cov
+cryptography==1.5.3
 ddt==1.1.1
 django-config-models==0.1.5
 django-filter==0.11.0
@@ -26,12 +28,14 @@ edx-django-oauth2-provider==1.1.4
 edx-drf-extensions==1.2.2
 edx-opaque-keys==0.4.0
 edx-rest-api-client==1.6.0
+enum34==1.1.6             # via cryptography
 event-tracking==0.2.4
 factory-boy==2.9.2
 faker==0.8.6              # via factory-boy
 flaky==3.3.0
 freezegun==0.3.9
 funcsigs==1.0.2           # via mock
+idna==2.6                 # via cryptography
 ipaddress==1.0.18         # via faker
 jsonfield==2.0.2
 kombu==3.0.37             # via celery
@@ -39,7 +43,8 @@ mock==2.0.0
 pbr==3.1.1                # via mock, stevedore
 pillow==3.4
 py==1.4.34                # via pytest, pytest-catchlog
-pycrypto==2.6.1
+pyasn1==0.3.7             # via cryptography
+pycparser==2.18           # via cffi
 pyjwt==1.5.3              # via djangorestframework-jwt, edx-rest-api-client
 pymongo==3.5.1            # via edx-opaque-keys, event-tracking
 pytest-catchlog==1.2.2
@@ -51,7 +56,7 @@ pytz==2017.3              # via celery, event-tracking
 requests==2.9.1
 responses==0.8.1
 shortuuid==0.5.0          # via edx-django-oauth2-provider
-six==1.11.0               # via analytics-python, edx-opaque-keys, faker, freezegun, mock, python-dateutil, responses, stevedore
+six==1.11.0               # via analytics-python, cryptography, edx-opaque-keys, faker, freezegun, mock, python-dateutil, responses, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 stevedore==1.27.1         # via edx-opaque-keys
 testfixtures==5.3.0

--- a/requirements/test-ginkgo.in
+++ b/requirements/test-ginkgo.in
@@ -8,6 +8,7 @@
 #   segment events in some enterprise flows.
 
 celery==3.1.18                          # Run task workers in other locations
+cryptography==1.5.3                     # For random password generation
 django==1.8.18                          # Application server
 djangorestframework==3.2.3              # REST API extensions for Django
 djangorestframework-oauth==1.1.0        # For enterprise REST API endpoint
@@ -28,4 +29,3 @@ jsonfield==2.0.2                        # Provides a Django model field which se
 flaky==3.3.0                            # Rerun flaky tests automatically if they fail, up to a limit
 analytics-python==1.1.0                 # Used for Segment analytics
 event-tracking==0.2.4                   # Tracks context-aware semi-structured system events
-pycrypto>=2.6

--- a/requirements/test-ginkgo.txt
+++ b/requirements/test-ginkgo.txt
@@ -9,8 +9,10 @@ analytics-python==1.1.0
 anyjson==0.3.3            # via kombu
 billiard==3.3.0.23        # via celery
 celery==3.1.18
+cffi==1.11.2              # via cryptography
 cookies==2.2.1            # via responses
 coverage==4.4.2           # via pytest-cov
+cryptography==1.5.3
 ddt==1.1.1
 django-config-models==0.1.5
 django-filter==0.11.0
@@ -26,12 +28,14 @@ edx-django-oauth2-provider==1.1.4
 edx-drf-extensions==1.2.2
 edx-opaque-keys==0.4.0
 edx-rest-api-client==1.7.1
+enum34==1.1.6             # via cryptography
 event-tracking==0.2.4
 factory-boy==2.9.2
 faker==0.8.6              # via factory-boy
 flaky==3.3.0
 freezegun==0.3.9
 funcsigs==1.0.2           # via mock
+idna==2.6                 # via cryptography
 ipaddress==1.0.18         # via faker
 jsonfield==2.0.2
 kombu==3.0.37             # via celery
@@ -39,7 +43,8 @@ mock==2.0.0
 pbr==3.1.1                # via mock, stevedore
 pillow==3.4
 py==1.4.34                # via pytest, pytest-catchlog
-pycrypto==2.6.1
+pyasn1==0.3.7             # via cryptography
+pycparser==2.18           # via cffi
 pyjwt==1.5.3              # via djangorestframework-jwt, edx-rest-api-client
 pymongo==3.5.1            # via edx-opaque-keys, event-tracking
 pytest-catchlog==1.2.2
@@ -51,7 +56,7 @@ pytz==2017.3              # via celery, event-tracking
 requests==2.9.1
 responses==0.8.1
 shortuuid==0.5.0          # via edx-django-oauth2-provider
-six==1.11.0               # via analytics-python, edx-opaque-keys, faker, freezegun, mock, python-dateutil, responses, stevedore
+six==1.11.0               # via analytics-python, cryptography, edx-opaque-keys, faker, freezegun, mock, python-dateutil, responses, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 stevedore==1.27.1         # via edx-opaque-keys
 testfixtures==5.3.0

--- a/requirements/test-hawthorn.in
+++ b/requirements/test-hawthorn.in
@@ -4,6 +4,7 @@
 # kept up-to-date to ensure compatibility.
 
 celery==3.1.18                          # Run task workers in other locations
+cryptography==1.9                       # For random password generation
 django>=1.11,<2.0                       # Application server
 djangorestframework==3.6.3              # REST API extensions for Django
 djangorestframework-oauth==1.1.0        # For enterprise REST API endpoint
@@ -24,4 +25,3 @@ jsonfield==2.0.2                        # Provides a Django model field which se
 flaky==3.3.0                            # Rerun flaky tests automatically if they fail, up to a limit
 analytics-python==1.1.0                 # Used for Segment analytics
 event-tracking==0.2.4                   # Tracks context-aware semi-structured system events
-pycrypto>=2.6

--- a/requirements/test-hawthorn.txt
+++ b/requirements/test-hawthorn.txt
@@ -7,10 +7,13 @@
 amqp==1.4.9               # via kombu
 analytics-python==1.1.0
 anyjson==0.3.3            # via kombu
+asn1crypto==0.23.0        # via cryptography
 billiard==3.3.0.23        # via celery
 celery==3.1.18
+cffi==1.11.2              # via cryptography
 cookies==2.2.1            # via responses
 coverage==4.4.2           # via pytest-cov
+cryptography==1.9
 ddt==1.1.1
 django-config-models==0.1.8
 django-filter==1.0.4
@@ -26,20 +29,22 @@ edx-django-oauth2-provider==1.1.4
 edx-drf-extensions==1.2.3
 edx-opaque-keys==0.4.0
 edx-rest-api-client==1.7.1
+enum34==1.1.6             # via cryptography
 event-tracking==0.2.4
 factory-boy==2.9.2
 faker==0.8.6              # via factory-boy
 flaky==3.3.0
 freezegun==0.3.9
 funcsigs==1.0.2           # via mock
-ipaddress==1.0.18         # via faker
+idna==2.6                 # via cryptography
+ipaddress==1.0.18         # via cryptography, faker
 jsonfield==2.0.2
 kombu==3.0.37             # via celery
 mock==2.0.0
 pbr==3.1.1                # via mock, stevedore
 pillow==3.4
 py==1.4.34                # via pytest, pytest-catchlog
-pycrypto==2.6.1
+pycparser==2.18           # via cffi
 pyjwt==1.5.3              # via djangorestframework-jwt, edx-rest-api-client
 pymongo==3.5.1            # via edx-opaque-keys, event-tracking
 pytest-catchlog==1.2.2
@@ -51,7 +56,7 @@ pytz==2017.3              # via celery, django, event-tracking
 requests==2.9.1
 responses==0.8.1
 shortuuid==0.5.0          # via edx-django-oauth2-provider
-six==1.11.0               # via analytics-python, edx-opaque-keys, faker, freezegun, mock, python-dateutil, responses, stevedore
+six==1.11.0               # via analytics-python, cryptography, edx-opaque-keys, faker, freezegun, mock, python-dateutil, responses, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 stevedore==1.27.1         # via edx-opaque-keys
 testfixtures==5.3.0

--- a/requirements/test-master.in
+++ b/requirements/test-master.in
@@ -2,6 +2,7 @@
 # - In edx-platform, DRF is a custom version; we do not use the extra features.
 
 celery==3.1.18                          # Run task workers in other locations
+cryptography==1.9                       # For random password generation
 django==1.8.18                          # Application server
 djangorestframework==3.6.3              # REST API extensions for Django
 djangorestframework-oauth==1.1.0        # For enterprise REST API endpoint
@@ -22,4 +23,3 @@ jsonfield==2.0.2                        # Provides a Django model field which se
 flaky==3.3.0                            # Rerun flaky tests automatically if they fail, up to a limit
 analytics-python==1.1.0                 # Used for Segment analytics
 event-tracking==0.2.4                   # Tracks context-aware semi-structured system events
-pycrypto>=2.6

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -7,10 +7,13 @@
 amqp==1.4.9               # via kombu
 analytics-python==1.1.0
 anyjson==0.3.3            # via kombu
+asn1crypto==0.23.0        # via cryptography
 billiard==3.3.0.23        # via celery
 celery==3.1.18
+cffi==1.11.2              # via cryptography
 cookies==2.2.1            # via responses
 coverage==4.4.2           # via pytest-cov
+cryptography==1.9
 ddt==1.1.1
 django-config-models==0.1.8
 django-filter==1.0.4
@@ -26,20 +29,22 @@ edx-django-oauth2-provider==1.1.4
 edx-drf-extensions==1.2.3
 edx-opaque-keys==0.4.0
 edx-rest-api-client==1.7.1
+enum34==1.1.6             # via cryptography
 event-tracking==0.2.4
 factory-boy==2.9.2
 faker==0.8.6              # via factory-boy
 flaky==3.3.0
 freezegun==0.3.9
 funcsigs==1.0.2           # via mock
-ipaddress==1.0.18         # via faker
+idna==2.6                 # via cryptography
+ipaddress==1.0.18         # via cryptography, faker
 jsonfield==2.0.2
 kombu==3.0.37             # via celery
 mock==2.0.0
 pbr==3.1.1                # via mock, stevedore
 pillow==3.4
 py==1.4.34                # via pytest, pytest-catchlog
-pycrypto==2.6.1
+pycparser==2.18           # via cffi
 pyjwt==1.5.3              # via djangorestframework-jwt, edx-rest-api-client
 pymongo==3.5.1            # via edx-opaque-keys, event-tracking
 pytest-catchlog==1.2.2
@@ -51,7 +56,7 @@ pytz==2017.3              # via celery, event-tracking
 requests==2.9.1
 responses==0.8.1
 shortuuid==0.5.0          # via edx-django-oauth2-provider
-six==1.11.0               # via analytics-python, edx-opaque-keys, faker, freezegun, mock, python-dateutil, responses, stevedore
+six==1.11.0               # via analytics-python, cryptography, edx-opaque-keys, faker, freezegun, mock, python-dateutil, responses, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 stevedore==1.27.1         # via edx-opaque-keys
 testfixtures==5.3.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,10 +7,13 @@
 amqp==1.4.9               # via kombu
 analytics-python==1.1.0
 anyjson==0.3.3            # via kombu
+asn1crypto==0.23.0        # via cryptography
 billiard==3.3.0.23        # via celery
 celery==3.1.18
+cffi==1.11.2              # via cryptography
 cookies==2.2.1            # via responses
 coverage==4.4.2           # via pytest-cov
+cryptography==1.9
 ddt==1.1.1
 django-config-models==0.1.8
 django-filter==1.0.4
@@ -26,20 +29,22 @@ edx-django-oauth2-provider==1.1.4
 edx-drf-extensions==1.2.3
 edx-opaque-keys==0.4.0
 edx-rest-api-client==1.7.1
+enum34==1.1.6             # via cryptography
 event-tracking==0.2.4
 factory-boy==2.9.2
 faker==0.8.6              # via factory-boy
 flaky==3.3.0
 freezegun==0.3.9
 funcsigs==1.0.2           # via mock
-ipaddress==1.0.18         # via faker
+idna==2.6                 # via cryptography
+ipaddress==1.0.18         # via cryptography, faker
 jsonfield==2.0.2
 kombu==3.0.37             # via celery
 mock==2.0.0
 pbr==3.1.1                # via mock, stevedore
 pillow==3.4
 py==1.4.34                # via pytest, pytest-catchlog
-pycrypto==2.6.1
+pycparser==2.18           # via cffi
 pyjwt==1.5.3              # via djangorestframework-jwt, edx-rest-api-client
 pymongo==3.5.1            # via edx-opaque-keys, event-tracking
 pytest-catchlog==1.2.2
@@ -51,7 +56,7 @@ pytz==2017.3              # via celery, event-tracking
 requests==2.9.1
 responses==0.8.1
 shortuuid==0.5.0          # via edx-django-oauth2-provider
-six==1.11.0               # via analytics-python, edx-opaque-keys, faker, freezegun, mock, python-dateutil, responses, stevedore
+six==1.11.0               # via analytics-python, cryptography, edx-opaque-keys, faker, freezegun, mock, python-dateutil, responses, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 stevedore==1.27.1         # via edx-opaque-keys
 testfixtures==5.3.0

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1077,12 +1077,12 @@ class TestEnterpriseUtils(unittest.TestCase):
         """
         assert utils.is_course_run_enrollable(course_run) == expected_enrollment_eligibility
 
-    @override_settings(ENTERPRISE_REPORTING_SECRET='abcdefgh12345678')
+    @override_settings(ENTERPRISE_REPORTING_SECRET=b'abcdefgh12345678')
     def test_encrypt_and_decrypt_string(self):
         """
         Test the encrypt_string and decrypt_string functions.
         """
-        test_string = 'test_string'
+        test_string = b'test_string'
         iv = utils.generate_aes_initialization_vector()   # pylint: disable=invalid-name
         encrypted_string = utils.encrypt_string(test_string, iv)
         assert test_string == utils.decrypt_string(encrypted_string, iv)


### PR DESCRIPTION
**Description:** Switch from `PyCrypto` (which hasn't been maintained in years) to the `cryptography` package, which provides equivalent functionality and has been used in edx-platform since at least Ficus.

**JIRA:** [PLAT-1199](https://openedx.atlassian.net/browse/PLAT-1199)

**Dependencies:** None

**Merge deadline:** None

**Installation instructions:** None

**Testing instructions:**

1. A newly generated `EnterpriseCustomerReportingConfiguration` should still get an encrypted random password
2. The correct decrypted password should still be shown in Django admin

**Merge checklist:**

- [x] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [x] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [x] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [x] All reviewers approved
- [ ] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [ ] Translations are updated
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:**

* I'm a little fuzzy on the exact testing instructions, but the features above are the only ones where the change should affect this package.  There are unit tests covering this.
* The requirements file changes look significant because `cryptography` has a few dependencies, but we already install these in edx-platform anyway (and don't pin most of them yet, I'll be fixing that soon).
* This isn't quite a standard operation recommended by `cryptography` (hence the "hazmat" imports), but it has to work this way to keep compatibility with already saved encrypted passwords.
* `cryptography` [recommends using `os.urandom`](https://cryptography.io/en/latest/random-numbers/) on Python versions below 3.6, hence the switch away from a custom random number generator in this PR.