### PR TITLE
ENT-740: Add identity_provider to enterprise customer API  response.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.53.18] - 2017-11-28
+----------------------
+
+* Add Identity Provider's ID to enterprise customer API response.
+
 [0.53.17] - 2017-11-27
 ----------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.53.17"
+__version__ = "0.53.18"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -102,7 +102,7 @@ class EnterpriseCustomerSerializer(serializers.ModelSerializer):
         model = models.EnterpriseCustomer
         fields = (
             'uuid', 'name', 'catalog', 'active', 'site', 'enable_data_sharing_consent', 'enforce_data_sharing_consent',
-            'branding_configuration', 'enterprise_customer_entitlements',
+            'branding_configuration', 'enterprise_customer_entitlements', 'identity_provider',
             'enable_audit_enrollment'
         )
 

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -597,7 +597,7 @@ class TestEnterpriseAPIViews(APITest):
                 'catalog': 1, 'active': True, 'enable_data_sharing_consent': True,
                 'enforce_data_sharing_consent': 'at_enrollment',
                 'branding_configuration': None, 'enterprise_customer_entitlements': [],
-                'enable_audit_enrollment': False,
+                'enable_audit_enrollment': False, 'identity_provider': None,
                 'site': {
                     'domain': 'example.com', 'name': 'example.com'
                 },
@@ -624,7 +624,7 @@ class TestEnterpriseAPIViews(APITest):
                     'catalog': 1, 'active': True, 'enable_data_sharing_consent': True,
                     'enforce_data_sharing_consent': 'at_enrollment',
                     'branding_configuration': None, 'enterprise_customer_entitlements': [],
-                    'enable_audit_enrollment': False,
+                    'enable_audit_enrollment': False, 'identity_provider': None,
                     'site': {
                         'domain': 'example.com', 'name': 'example.com'
                     },
@@ -657,6 +657,32 @@ class TestEnterpriseAPIViews(APITest):
                 'course_id': 'course-v1:edX+DemoX+DemoCourse',
             }],
         ),
+        (
+            factories.EnterpriseCustomerIdentityProviderFactory,
+            ENTERPRISE_CUSTOMER_LIST_ENDPOINT,
+            itemgetter('uuid'),
+            [{
+                'provider_id': FAKE_UUIDS[0],
+                'enterprise_customer__uuid': FAKE_UUIDS[1],
+                'enterprise_customer__name': 'Test Enterprise Customer', 'enterprise_customer__catalog': 1,
+                'enterprise_customer__active': True, 'enterprise_customer__enable_data_sharing_consent': True,
+                'enterprise_customer__enforce_data_sharing_consent': 'at_enrollment',
+                'enterprise_customer__site__domain': 'example.com',
+                'enterprise_customer__site__name': 'example.com',
+
+            }],
+            [{
+                'uuid': FAKE_UUIDS[1], 'name': 'Test Enterprise Customer',
+                'catalog': 1, 'active': True, 'enable_data_sharing_consent': True,
+                'enforce_data_sharing_consent': 'at_enrollment',
+                'branding_configuration': None, 'enterprise_customer_entitlements': [],
+                'enable_audit_enrollment': False, 'identity_provider': FAKE_UUIDS[0],
+                'site': {
+                    'domain': 'example.com', 'name': 'example.com'
+                },
+            }],
+        ),
+
     )
     @ddt.unpack
     def test_api_views(self, factory, url, sorting_key, model_items, expected_json):


### PR DESCRIPTION
**Description:** This PR is related to https://github.com/edx/edx-platform/pull/16556 , We needed to access `identity_provider` from enterprise customer API response. This PR makes sure to provide `identity_provider` in the API response.

**JIRA:** [ENT-740](https://openedx.atlassian.net/browse/ENT-740)

**Installation instructions:** Simply install edx-enterprise using this branch
**Testing instructions:**

1. Open page enterprise customer details page (/enterprise/api/v1/enterprise-customer/<enterprise-customer-uuid>)
2. Make sure identity_provider field is present with appropriate value.

**Merge checklist:**

- [x] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [x] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [x] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [x] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [x] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [x] Translations are updated
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)
