### PR TITLE
[ENT-744] Track enterprise course enrollment events.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.55.1] - 2017-11-30
+---------------------
+
+* Track enterprise course enrollment events.
+
 [0.55.0] - 2017-11-29
 ---------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,6 +18,7 @@ Contents:
    development
    testing
    internationalization
+   segment_events
    modules
    changelog
 

--- a/docs/segment_events.rst
+++ b/docs/segment_events.rst
@@ -1,0 +1,67 @@
+Segment events
+==============
+
+``Edx-enterprise`` emits several Segment events.
+
+edx.bi.user.enterprise.onboarding
+---------------------------------
+
+Emitted when a new ``EnterpriseCourseEnrollment`` record gets created.
+
+The event contains these properties:
+
+- **pathway**: A string identifying the mechanism through which the ``EntepriseCourseEnrollment`` was created. See below
+  for possible values.
+- **course_run_id**: EdX course ID associated with the enrollment.
+- **url_path**: The url path the user was visiting when the enterprise course enrollment got created. Can be null when
+  the enrollment is created outside of a learner's request (for example admin or REST API enrollments).
+
+The possible values of the **pathway** property are:
+
+- **admin-enrollment**: Enrollment was created by an admin via the "Manage Learners" tool.
+- **pending-admin-enrollment**: Enrollment was created from a pending enrollment record previously set up by an admin
+  via the "Manage Learners" tool.
+- **rest-api-enrollment**: Enrollment was created via the REST API.
+- **data-consent-page-enrollment**: Enrollment was created when learner submitted the form on the data sharing consent
+  page.
+- **course-landing-page-enrollment**: Enrollment was created when learner enrolled via the course landing page.
+- **direct-audit-enrollment**: Enrollment was created via the direct audit enrollment mechanism.
+
+edx.bi.user.enterprise.enrollment.course
+----------------------------------------
+
+Emitted when the enterprise app enrolls a user into a course.
+
+The event contains these properties:
+
+- **label**: EdX course ID associated with the enrollment.
+- **enterprise_customer_uuid**: UUID of the ``EnterpriseCustomer`` associated with the enrollment.
+- **enterprise_customer_name**: Name of the ``EnterpriseCustomer`` associated with the enrollment.
+- **mode**: The mode of the enrollment (audit, verified, etc.).
+
+edx.bi.user.consent_form.shown
+------------------------------
+
+Emitted when the learner is presented with the data sharing consent page.
+
+The event contains these properties:
+
+- **deferCreation**: True when creation of course enrollment is deferred.
+- **successUrl**: URL to redirect the user to if consent is provided.
+- **failureUrl**: URL to redirect the user to in case consent is not provided.
+- **courseId**: EdX course ID of the associated course.
+- **programId**: ID of the associated program.
+
+edx.bi.user.consent_form.accepted
+---------------------------------
+
+Emitted after the learner grants data sharing consent.
+
+The event contains the same properties as the `edx.bi.user.consent_form.shown`_ event.
+
+edx.bi.user.consent_form.denied
+-------------------------------
+
+Emitted after the learner denies data sharing consent.
+
+The event contains the same properties as the `edx.bi.user.consent_form.shown`_ event.

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.55.0"
+__version__ = "0.55.1"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/admin/views.py
+++ b/enterprise/admin/views.py
@@ -42,7 +42,7 @@ from enterprise.models import (
     EnterpriseCustomerUser,
     PendingEnterpriseCustomerUser,
 )
-from enterprise.utils import get_configuration_value_for_site, send_email_notification_message
+from enterprise.utils import get_configuration_value_for_site, send_email_notification_message, track_enrollment
 
 
 class TemplatePreviewView(View):
@@ -346,10 +346,12 @@ class EnterpriseCustomerManageLearnersView(View):
                     dict(user=user.username, message=error_message)
                 )
             else:
-                EnterpriseCourseEnrollment.objects.get_or_create(
+                __, created = EnterpriseCourseEnrollment.objects.get_or_create(
                     enterprise_customer_user=enterprise_customer_user,
                     course_id=course_id
                 )
+                if created:
+                    track_enrollment('admin-enrollment', user.id, course_id)
         return succeeded
 
     @classmethod

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -17,6 +17,7 @@ from django.utils.translation import ugettext_lazy as _
 from enterprise import models, utils
 from enterprise.api.v1.mixins import EnterpriseCourseContextSerializerMixin
 from enterprise.api_client.lms import ThirdPartyAuthApiClient
+from enterprise.utils import track_enrollment
 
 
 class ImmutableStateSerializer(serializers.Serializer):
@@ -165,10 +166,12 @@ class EnterpriseCourseEnrollmentWriteSerializer(serializers.ModelSerializer):
         """
         course_id = self.validated_data['course_id']
 
-        models.EnterpriseCourseEnrollment.objects.get_or_create(
+        __, created = models.EnterpriseCourseEnrollment.objects.get_or_create(
             enterprise_customer_user=self.enterprise_customer_user,
             course_id=course_id,
         )
+        if created:
+            track_enrollment('rest-api-enrollment', self.enterprise_customer_user.user_id, course_id)
 
 
 class EnterpriseCustomerCatalogSerializer(serializers.ModelSerializer):

--- a/enterprise/management/commands/create_enterprise_course_enrollments.py
+++ b/enterprise/management/commands/create_enterprise_course_enrollments.py
@@ -118,7 +118,6 @@ class Command(BaseCommand):
                     enterprise_customer_user=enterprise_learner,
                     course_id=course_id,
                 )
-
                 if created:
                     ent_course_enrollments_count += 1
 

--- a/enterprise/signals.py
+++ b/enterprise/signals.py
@@ -8,6 +8,7 @@ from logging import getLogger
 
 from enterprise.decorators import disable_for_loaddata
 from enterprise.models import EnterpriseCourseEnrollment, EnterpriseCustomerUser, PendingEnterpriseCustomerUser
+from enterprise.utils import track_enrollment
 
 logger = getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -55,8 +56,9 @@ def handle_user_post_save(sender, **kwargs):  # pylint: disable=unused-argument
         # actually exist in the system; in such a case, the enrollment for each such
         # course is finalized when the user registers with the OpenEdX platform.
         enrollment.complete_enrollment()
-        EnterpriseCourseEnrollment.objects.get_or_create(
+        EnterpriseCourseEnrollment.objects.create(
             enterprise_customer_user=enterprise_customer_user,
-            course_id=enrollment.course_id
+            course_id=enrollment.course_id,
         )
+        track_enrollment('pending-admin-enrollment', user_instance.id, enrollment.course_id)
     pending_ecu.delete()

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -664,6 +664,17 @@ def track_event(user_id, event_name, properties):
         })
 
 
+def track_enrollment(pathway, user_id, course_run_id, url_path=None):
+    """
+    Emit a track event for enterprise course enrollment.
+    """
+    track_event(user_id, 'edx.bi.user.enterprise.onboarding', {
+        'pathway': pathway,
+        'url_path': url_path,
+        'course_run_id': course_run_id,
+    })
+
+
 def parse_datetime_handle_invalid(datetime_value):
     """
     Return the parsed version of a datetime string. If the string is invalid, return None.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-enterprise",
-  "version": "0.55.0",
+  "version": "0.55.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-enterprise",
-  "version": "0.55.0",
+  "version": "0.55.1",
   "license": "AGPL-3.0",
   "repository": {
     "type": "git",

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -17,7 +17,7 @@ celery==3.1.18
 cffi==1.11.2              # via cryptography
 click-log==0.1.8          # via edx-lint
 click==6.7                # via click-log, edx-lint, pip-tools
-configparser==3.5.0       # via pylint
+configparser==3.5.0       # via pydocstyle, pylint
 cryptography==1.9
 diff-cover==1.0.0
 distlib==0.2.6            # via caniusepython3

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -22,7 +22,7 @@ cffi==1.11.2              # via cryptography
 chardet==3.0.4            # via doc8
 click-log==0.1.8          # via edx-lint
 click==6.7                # via click-log, edx-lint, pip-tools
-configparser==3.5.0       # via pylint
+configparser==3.5.0       # via pydocstyle, pylint
 cookies==2.2.1            # via responses
 coverage==4.4.2           # via pytest-cov
 cryptography==1.9

--- a/tests/test_enterprise/test_signals.py
+++ b/tests/test_enterprise/test_signals.py
@@ -92,8 +92,9 @@ class TestUserPostSaveSignalHandler(unittest.TestCase):
             enterprise_customer=pending_link.enterprise_customer, user_id=user.id
         ).count() == 1
 
+    @mock.patch('enterprise.signals.track_enrollment')
     @mock.patch('enterprise.api_client.lms.CourseEnrollment')
-    def test_handle_user_post_save_with_pending_course_enrollment(self, mock_course_enrollment):
+    def test_handle_user_post_save_with_pending_course_enrollment(self, mock_course_enrollment, mock_track_enrollment):
         mock_course_enrollment.enroll.return_value = None
         email = "fake_email@edx.org"
         user = UserFactory(id=1, email=email)
@@ -118,6 +119,7 @@ class TestUserPostSaveSignalHandler(unittest.TestCase):
         mock_course_enrollment.enroll.assert_called_once_with(
             user, CourseKey.from_string(course_id), mode='audit', check_access=True
         )
+        mock_track_enrollment.assert_called_once_with('pending-admin-enrollment', user.id, course_id)
 
     def test_handle_user_post_save_modified_user_already_linked(self):
         email = "jackie.chan@hollywood.com"

--- a/tests/test_enterprise/views/test_handle_consent_enrollment.py
+++ b/tests/test_enterprise/views/test_handle_consent_enrollment.py
@@ -179,12 +179,14 @@ class TestHandleConsentEnrollmentView(TestCase):
         self.assertRedirects(response, redirect_url, fetch_redirect_response=False)
 
     @mock.patch('enterprise.views.ProgramDataExtender')
+    @mock.patch('enterprise.views.track_enrollment')
     @mock.patch('enterprise.views.EnrollmentApiClient')
     @mock.patch('enterprise.utils.Registry')
     def test_handle_consent_enrollment_with_audit_course_mode(
             self,
             registry_mock,
             enrollment_api_client_mock,
+            track_enrollment_mock,
             *args
     ):  # pylint: disable=unused-argument
         """
@@ -225,13 +227,22 @@ class TestHandleConsentEnrollmentView(TestCase):
             course_id=course_id
         ).exists())
 
+        track_enrollment_mock.assert_called_once_with(
+            'course-landing-page-enrollment',
+            enterprise_customer_user.user_id,
+            course_id,
+            handle_consent_enrollment_url,
+        )
+
     @mock.patch('enterprise.views.ProgramDataExtender')
+    @mock.patch('enterprise.views.track_enrollment')
     @mock.patch('enterprise.views.EnrollmentApiClient')
     @mock.patch('enterprise.utils.Registry')
     def test_handle_consent_enrollment_with_professional_course_mode(
             self,
             registry_mock,
             enrollment_api_client_mock,
+            track_enrollment_mock,
             *args
     ):  # pylint: disable=unused-argument
         """
@@ -271,3 +282,10 @@ class TestHandleConsentEnrollmentView(TestCase):
             enterprise_customer_user__user_id=enterprise_customer_user.user_id,
             course_id=course_id
         ).exists())
+
+        track_enrollment_mock.assert_called_once_with(
+            'course-landing-page-enrollment',
+            enterprise_customer_user.user_id,
+            course_id,
+            handle_consent_enrollment_url,
+        )

--- a/tests/test_enterprise/views/test_router_view.py
+++ b/tests/test_enterprise/views/test_router_view.py
@@ -160,9 +160,10 @@ class TestRouterView(TestCase):
         router_view_mock.get(self.request, **self.kwargs)
         router_view_mock.redirect.assert_called_once()
 
+    @mock.patch('enterprise.views.track_enrollment')
     @mock.patch('enterprise.models.EnrollmentApiClient')
     @mock.patch('enterprise.views.RouterView', new_callable=views.RouterView)
-    def test_get_direct_audit_enrollment(self, router_view_mock, enrollment_api_client_mock):
+    def test_get_direct_audit_enrollment(self, router_view_mock, enrollment_api_client_mock, track_enrollment_mock):
         """
         ``get`` redirects to the LMS courseware when the request is fully eligible for direct audit enrollment.
         """
@@ -170,6 +171,12 @@ class TestRouterView(TestCase):
         router_view_mock.eligible_for_direct_audit_enrollment = mock.MagicMock(return_value=True)
         response = router_view_mock.get(self.request, **self.kwargs)
         enrollment_api_client_mock.return_value.enroll_user_in_course.assert_called_once()
+        track_enrollment_mock.assert_called_once_with(
+            'direct-audit-enrollment',
+            self.request.user.id,
+            self.course_run_id,
+            self.request.get_full_path(),
+        )
         self.assertRedirects(
             response,
             'http://lms.example.com/courses/{}/courseware'.format(self.course_run_id),

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -998,6 +998,22 @@ class TestEnterpriseUtils(unittest.TestCase):
         utils.track_event('user_id', 'event_name', 'properties')
         analytics_mock.track.assert_not_called()
 
+    @mock.patch('enterprise.utils.track_event')
+    def test_track_enrollment(self, track_event_mock):
+        """
+        ``track_enrollment`` invokes ``track_event`` with custom properties.
+        """
+        pathway = 'some-pathway'
+        user_id = 123123
+        course_run_id = 'course-v1:Some+edX+Course'
+        url_path = '/some/url/path'
+        utils.track_enrollment(pathway, user_id, course_run_id, url_path)
+        track_event_mock.assert_called_once_with(user_id, 'edx.bi.user.enterprise.onboarding', {
+            'pathway': pathway,
+            'url_path': url_path,
+            'course_run_id': course_run_id,
+        })
+
     @ddt.data(
         ("2014-10-13T13:11:03Z", utils.parse_datetime("2014-10-13T13:11:03Z")),
         (None, None)


### PR DESCRIPTION
**Description:** This patch adds `track_event` calls to all call sites where `EnterpriseCourseEnrollment` instances get created.

**JIRA:** [ENT-744](https://openedx.atlassian.net/browse/ENT-744)

**Dependencies:** None

**Testing instructions:**

1. Install this patch & run the migration.
2. Create some enterprise course enrollments (direct from admin, pending from admin, course landing page...).
4. Verify tracking events are emitted whenever course enrollment objects get created. One way to do that is to temporarily patch the `enterprise.utils.track_event` method to log its calls.

**Merge checklist:**

- [x] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [x] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [x] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [x] Called `make static` for webpack bundling if any static content was updated.
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [x] Translations are updated
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** 

There are many different flows and it is hard to capture all of them without threading a lot of parameters through multiple systems edx-enterprise, edx-platform, ecommerce. For example an enrollment may start on the course landing page, go via ecommerce and finally be created on the data sharing consent page.


