### PR TITLE
Added signal and added enterprise related information in SailThru Variables

### DIFF
--- a/enterprise/signals.py
+++ b/enterprise/signals.py
@@ -8,6 +8,7 @@ from logging import getLogger
 
 from enterprise.decorators import disable_for_loaddata
 from enterprise.models import EnterpriseCourseEnrollment, EnterpriseCustomerUser, PendingEnterpriseCustomerUser
+from enterprise.utils import get_or_create_enterprise_learner
 
 logger = getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -46,9 +47,9 @@ def handle_user_post_save(sender, **kwargs):  # pylint: disable=unused-argument
         except EnterpriseCustomerUser.DoesNotExist:
             pass  # everything ok - current user is not linked to other ECs
 
-    enterprise_customer_user = EnterpriseCustomerUser.objects.create(
+    enterprise_customer_user, __ = get_or_create_enterprise_learner(
         enterprise_customer=pending_ecu.enterprise_customer,
-        user_id=user_instance.id
+        user=user_instance
     )
     for enrollment in pending_ecu.pendingenrollment_set.all():
         # EnterpriseCustomers may enroll users in courses before the users themselves

--- a/enterprise/tpa_pipeline.py
+++ b/enterprise/tpa_pipeline.py
@@ -4,6 +4,7 @@ Module provides elements to be used in third-party auth pipeline.
 from __future__ import absolute_import, unicode_literals
 
 from enterprise.models import EnterpriseCustomer, EnterpriseCustomerUser
+from enterprise.utils import REGISTER_ENTERPRISE_USER
 
 try:
     from social_core.pipeline.partial import partial
@@ -62,7 +63,10 @@ def handle_enterprise_logistration(backend, user, **kwargs):
         return
 
     # proceed with the creation of a link between the user and the enterprise customer, then exit.
-    EnterpriseCustomerUser.objects.update_or_create(
+    __, created = EnterpriseCustomerUser.objects.update_or_create(
         enterprise_customer=enterprise_customer,
         user_id=user.id
     )
+    if created:
+        # Announce the registration
+        REGISTER_ENTERPRISE_USER.send(sender=None, user=user)

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -26,6 +26,7 @@ from django.conf import settings
 from django.core import mail
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.urlresolvers import reverse
+from django.dispatch import Signal
 from django.http import Http404
 from django.template.loader import render_to_string
 from django.utils.dateparse import parse_datetime
@@ -49,6 +50,9 @@ except ImportError:
     Registry = None
 
 LOGGER = logging.getLogger(__name__)
+
+# Used to announce a enterprise learner registration
+REGISTER_ENTERPRISE_USER = Signal(providing_args=["user"])
 
 
 class NotConnectedToOpenEdX(Exception):
@@ -734,3 +738,19 @@ def decrypt_string(string, iv):   # pylint: disable=invalid-name
     cipher = Cipher(AES(key), CFB(iv), backend=default_backend())
     decryptor = cipher.decryptor()
     return decryptor.update(string) + decryptor.finalize()
+
+
+def get_or_create_enterprise_learner(enterprise_customer, user):
+    """
+    Retrieve or create the enterprise customer learner for the given parameters.
+    """
+    EnterpriseCustomerUser = apps.get_model('enterprise', 'EnterpriseCustomerUser')  # pylint: disable=invalid-name
+    enterprise_customer_user, created = EnterpriseCustomerUser.objects.get_or_create(
+        enterprise_customer=enterprise_customer,
+        user_id=user.id
+    )
+    if created:
+        # Announce registration
+        REGISTER_ENTERPRISE_USER.send(sender=None, user=user)
+
+    return enterprise_customer_user, created


### PR DESCRIPTION
@douglashall can you give some initial review on that changes ? 

RELATES TO [PR#16665 ](https://github.com/edx/edx-platform/pull/16665)

**Description:** 
- Introduced a signal what will be triggered when an enterprise learner is created into the model. 
- The corresponding receiver is defined in [PR#16665 ](https://github.com/edx/edx-platform/pull/16665) that will update the `is_enterprise_leaner` variable SailThru Var for that user. 

**JIRA:** [ENT-751](https://openedx.atlassian.net/browse/ENT-751)