### PR TITLE
Do not change EnterpriseCustomerReportingConfiguration.password on update.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.53.19] - 2017-11-28
+----------------------
+
+* Do not change EnterpriseCustomerReportingConfiguration.password on update.
+
 [0.53.18] - 2017-11-28
 ----------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.53.18"
+__version__ = "0.53.19"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -1240,12 +1240,13 @@ class EnterpriseCustomerReportingConfiguration(TimeStampedModel):
         """
         Override of model save method to dynamically generate the password field and perform additional validation.
         """
-        self.initialization_vector = utils.generate_aes_initialization_vector()
-        self.password = utils.encrypt_string(
-            get_random_string(length=32),
-            self.initialization_vector
-        )
-        self.full_clean()
+        if not self.pk:
+            self.initialization_vector = utils.generate_aes_initialization_vector()
+            self.password = utils.encrypt_string(
+                get_random_string(length=32),
+                self.initialization_vector
+            )
+            self.full_clean()
         super(EnterpriseCustomerReportingConfiguration, self).save(*args, **kwargs)
 
     def clean(self):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1517,3 +1517,7 @@ class TestEnterpriseCustomerReportingConfiguration(unittest.TestCase):
         config.save()
         assert EnterpriseCustomerReportingConfiguration.objects.count() == 1
         assert EnterpriseCustomerReportingConfiguration.objects.first().password
+
+        # Test that an update does not change the password.
+        config.save()
+        assert config.password == bytes(EnterpriseCustomerReportingConfiguration.objects.first().password)


### PR DESCRIPTION
We do not want to generate a new password every time someone saves
an EnterpriseCustomerReportingConfiguration model.
