### PR TITLE
Log additional context in learner data transmission exceptions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.55.2] - 2017-12-04
+---------------------
+
+* Include additional context for learner data transmission job exceptions.
+
 [0.55.1] - 2017-11-30
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.55.1"
+__version__ = "0.55.2"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/integrated_channel/transmitters/learner_data.py
+++ b/integrated_channels/integrated_channel/transmitters/learner_data.py
@@ -80,8 +80,22 @@ class LearnerTransmitter(Transmitter):
             except RequestException as request_exception:
                 code = 500
                 body = str(request_exception)
-                LOGGER.error('Failed to send completion status call for enterprise enrollment {} with payload {}'
-                             '\nError message: {}'.format(enterprise_enrollment_id, learner_data, body))
+                try:
+                    sys_msg = request_exception.response.content
+                except AttributeError:
+                    sys_msg = 'Not available'
+                LOGGER.error(
+                    (
+                        'Failed to send completion status call for enterprise enrollment %s'
+                        'with payload %s'
+                        '\nError message: %s'
+                        '\nSystem message: %s'
+                    ),
+                    enterprise_enrollment_id,
+                    learner_data,
+                    body,
+                    sys_msg
+                )
 
             learner_data.status = str(code)
             learner_data.error_message = body if code >= 400 else ''


### PR DESCRIPTION
**Description:** I recently observed an exception that was triggered during the learner data transmission job.  

```
Dec  1 06:55:17 ip-10-2-70-239 [service_variant=lms][integrated_channels.integrated_channel.transmitters.learner_data][env:prod-edx-edxapp] ERROR [ip-10-2-70-239  4428] [learner_data.py:84] - Failed to send completion status call for enterprise enrollment 4995 with payload <SapSuccessFactorsLearnerDataTransmissionAudit None for enterprise enrollment 4995, SAPSF user 417218, and course course-v1:ANUx+EBM02x+2T2017>
Error message: 403 Client Error: Forbidden for url: {customer url}
```
While troubleshooting OData callback permissioning issues  a while back we determined that it was possible to capture the actual system message returned by SuccessFactors, so I'm adding that capability here as well in order to try and gain some insight into what happened. 
