### PR TITLE
ENT-767 Check embargo restrictions when rendering enterprise landing pages.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.55.4] - 2017-12-06
+---------------------
+
+* Redirect to embargo restriction message page if user is blocked from accessing course.
+
 [0.55.3] - 2017-12-05
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.55.3"
+__version__ = "0.55.4"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api_client/lms.py
+++ b/enterprise/api_client/lms.py
@@ -27,6 +27,11 @@ except ImportError:
     CourseEnrollment = None
 
 try:
+    from openedx.core.djangoapps.embargo import api as embargo_api
+except ImportError:
+    embargo_api = None
+
+try:
     from openedx.core.lib.token_utils import JwtBuilder
 except ImportError:
     JwtBuilder = None
@@ -110,6 +115,27 @@ class JwtLmsApiClient(object):
                 self.connect()
             return func(self, *args, **kwargs)
         return inner
+
+
+class EmbargoApiClient(object):
+    """
+    Client interface for using the edx-platform embargo API.
+    """
+
+    @staticmethod
+    def redirect_if_blocked(course_run_ids, user=None, ip_address=None, url=None):
+        """
+        Return redirect to embargo error page if the given user is blocked.
+        """
+        for course_run_id in course_run_ids:
+            redirect_url = embargo_api.redirect_if_blocked(
+                CourseKey.from_string(course_run_id),
+                user=user,
+                ip_address=ip_address,
+                url=url
+            )
+            if redirect_url:
+                return redirect_url
 
 
 class EnrollmentApiClient(LmsApiClient):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,4 +10,4 @@ edx-opaque-keys==0.4.0
 pbr==3.1.1                # via stevedore
 pymongo==3.5.1            # via edx-opaque-keys
 six==1.11.0               # via edx-opaque-keys, stevedore
-stevedore==1.27.1         # via edx-opaque-keys
+stevedore==1.28.0         # via edx-opaque-keys

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -23,6 +23,7 @@ diff-cover==1.0.0
 distlib==0.2.6            # via caniusepython3
 django-config-models==0.1.8
 django-filter==1.0.4
+django-ipware==1.1.0
 django-model-utils==2.3.1
 django-object-actions==0.10.0
 django-simple-history==1.9.0
@@ -33,7 +34,7 @@ djangorestframework-oauth==1.1.0
 djangorestframework==3.6.3
 edx-django-oauth2-provider==1.1.4
 edx-drf-extensions==1.2.3
-edx-i18n-tools==0.4.1
+edx-i18n-tools==0.4.2
 edx-lint==0.5.4
 edx-opaque-keys==0.4.0
 edx-rest-api-client==1.7.1
@@ -57,7 +58,7 @@ packaging==16.8           # via caniusepython3
 path.py==10.5             # via edx-i18n-tools
 pbr==3.1.1                # via stevedore
 pillow==3.4
-pip-tools==1.10.2
+pip-tools==1.11.0
 pkginfo==1.4.1            # via twine
 pluggy==0.6.0             # via tox
 polib==1.1.0              # via edx-i18n-tools
@@ -83,7 +84,7 @@ singledispatch==3.4.0.3   # via astroid, pylint
 six==1.11.0               # via analytics-python, astroid, cryptography, diff-cover, edx-i18n-tools, edx-lint, edx-opaque-keys, packaging, pip-tools, pydocstyle, pylint, python-dateutil, singledispatch, stevedore, tox
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==1.2.1    # via pydocstyle
-stevedore==1.27.1         # via edx-opaque-keys
+stevedore==1.28.0         # via edx-opaque-keys
 testfixtures==5.3.1
 tox-battery==0.5
 tox==2.9.1

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -18,6 +18,7 @@ chardet==3.0.4            # via doc8
 cryptography==1.9
 django-config-models==0.1.8
 django-filter==1.0.4
+django-ipware==1.1.0
 django-model-utils==2.3.1
 django-object-actions==0.10.0
 django-simple-history==1.9.0
@@ -63,7 +64,7 @@ snowballstemmer==1.2.1    # via sphinx
 sphinx==1.6.5
 sphinxcontrib-napoleon==0.6.1
 sphinxcontrib-websupport==1.0.1  # via sphinx
-stevedore==1.27.1         # via doc8, edx-opaque-keys
+stevedore==1.28.0         # via doc8, edx-opaque-keys
 testfixtures==5.3.1
 typing==3.6.2             # via sphinx
 unicodecsv==0.14.1

--- a/requirements/js_test.txt
+++ b/requirements/js_test.txt
@@ -5,18 +5,19 @@
 #    pip-compile --output-file requirements/js_test.txt requirements/js_test.in
 #
 argparse==1.4.0           # via jasmine
-cheroot==5.10.0           # via cherrypy
-cherrypy==12.0.1          # via jasmine
+cheroot==6.0.0            # via cherrypy
+cherrypy==13.0.0          # via jasmine
 glob2==0.6                # via jasmine-core
 jaraco.classes==1.4.3     # via cherrypy
 jasmine-core==2.8.0       # via jasmine
 jasmine==2.8.0
 jinja2==2.10              # via jasmine
 markupsafe==1.0           # via jinja2
+more-itertools==4.0.1     # via cheroot
 ordereddict==1.1          # via jasmine-core
 portend==2.2              # via cherrypy
 pytz==2017.3              # via tempora
 pyyaml==3.10              # via jasmine
-selenium==3.7.0           # via jasmine
-six==1.11.0               # via cheroot, cherrypy, jaraco.classes, jasmine, tempora
+selenium==3.8.0           # via jasmine
+six==1.11.0               # via cheroot, cherrypy, jaraco.classes, jasmine, more-itertools, tempora
 tempora==1.9              # via portend

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -31,6 +31,7 @@ diff-cover==1.0.0
 distlib==0.2.6            # via caniusepython3
 django-config-models==0.1.8
 django-filter==1.0.4
+django-ipware==1.1.0
 django-model-utils==2.3.1
 django-object-actions==0.10.0
 django-simple-history==1.9.0
@@ -43,7 +44,7 @@ doc8==0.8.0
 docutils==0.14            # via doc8, readme-renderer, restructuredtext-lint, sphinx
 edx-django-oauth2-provider==1.1.4
 edx-drf-extensions==1.2.3
-edx-i18n-tools==0.4.1
+edx-i18n-tools==0.4.2
 edx-lint==0.5.4
 edx-opaque-keys==0.4.0
 edx-rest-api-client==1.7.1
@@ -75,7 +76,7 @@ packaging==16.8           # via caniusepython3
 path.py==10.5             # via edx-i18n-tools
 pbr==3.1.1                # via mock, stevedore
 pillow==3.4
-pip-tools==1.10.2
+pip-tools==1.11.0
 pkginfo==1.4.1            # via twine
 pluggy==0.6.0             # via pytest, tox
 pockets==0.5.1            # via sphinxcontrib-napoleon
@@ -112,7 +113,7 @@ snowballstemmer==1.2.1    # via pydocstyle, sphinx
 sphinx==1.6.5
 sphinxcontrib-napoleon==0.6.1
 sphinxcontrib-websupport==1.0.1  # via sphinx
-stevedore==1.27.1         # via doc8, edx-opaque-keys
+stevedore==1.28.0         # via doc8, edx-opaque-keys
 testfixtures==5.3.1
 text-unidecode==1.1       # via faker
 tox-battery==0.5

--- a/requirements/test-ficus.in
+++ b/requirements/test-ficus.in
@@ -28,3 +28,4 @@ jsonfield==2.0.2                        # Provides a Django model field which se
 flaky==3.3.0                            # Rerun flaky tests automatically if they fail, up to a limit
 analytics-python==1.1.0                 # Used for Segment analytics
 event-tracking==0.2.4                   # Tracks context-aware semi-structured system events
+django-ipware==1.1.0

--- a/requirements/test-ficus.txt
+++ b/requirements/test-ficus.txt
@@ -17,6 +17,7 @@ cryptography==1.5.3
 ddt==1.1.1
 django-config-models==0.1.5
 django-filter==0.11.0
+django-ipware==1.1.0
 django-model-utils==2.3.1
 django-object-actions==0.10.0
 django-simple-history==1.6.3
@@ -37,7 +38,7 @@ flaky==3.3.0
 freezegun==0.3.9
 funcsigs==1.0.2           # via mock, pytest
 idna==2.6                 # via cryptography
-ipaddress==1.0.18         # via faker
+ipaddress==1.0.18         # via cryptography, faker
 jsonfield==2.0.2
 kombu==3.0.37             # via celery
 mock==2.0.0
@@ -60,7 +61,7 @@ responses==0.8.1
 shortuuid==0.5.0          # via edx-django-oauth2-provider
 six==1.11.0               # via analytics-python, cryptography, edx-opaque-keys, faker, freezegun, mock, pytest, python-dateutil, responses, stevedore
 slumber==0.7.1            # via edx-rest-api-client
-stevedore==1.27.1         # via edx-opaque-keys
+stevedore==1.28.0         # via edx-opaque-keys
 testfixtures==5.3.1
 text-unidecode==1.1       # via faker
 unicodecsv==0.14.1

--- a/requirements/test-ginkgo.in
+++ b/requirements/test-ginkgo.in
@@ -29,3 +29,4 @@ jsonfield==2.0.2                        # Provides a Django model field which se
 flaky==3.3.0                            # Rerun flaky tests automatically if they fail, up to a limit
 analytics-python==1.1.0                 # Used for Segment analytics
 event-tracking==0.2.4                   # Tracks context-aware semi-structured system events
+django-ipware==1.1.0

--- a/requirements/test-ginkgo.txt
+++ b/requirements/test-ginkgo.txt
@@ -17,6 +17,7 @@ cryptography==1.5.3
 ddt==1.1.1
 django-config-models==0.1.5
 django-filter==0.11.0
+django-ipware==1.1.0
 django-model-utils==2.3.1
 django-object-actions==0.10.0
 django-simple-history==1.6.3
@@ -37,7 +38,7 @@ flaky==3.3.0
 freezegun==0.3.9
 funcsigs==1.0.2           # via mock, pytest
 idna==2.6                 # via cryptography
-ipaddress==1.0.18         # via faker
+ipaddress==1.0.18         # via cryptography, faker
 jsonfield==2.0.2
 kombu==3.0.37             # via celery
 mock==2.0.0
@@ -60,7 +61,7 @@ responses==0.8.1
 shortuuid==0.5.0          # via edx-django-oauth2-provider
 six==1.11.0               # via analytics-python, cryptography, edx-opaque-keys, faker, freezegun, mock, pytest, python-dateutil, responses, stevedore
 slumber==0.7.1            # via edx-rest-api-client
-stevedore==1.27.1         # via edx-opaque-keys
+stevedore==1.28.0         # via edx-opaque-keys
 testfixtures==5.3.1
 text-unidecode==1.1       # via faker
 unicodecsv==0.14.1

--- a/requirements/test-hawthorn.in
+++ b/requirements/test-hawthorn.in
@@ -25,3 +25,4 @@ jsonfield==2.0.2                        # Provides a Django model field which se
 flaky==3.3.0                            # Rerun flaky tests automatically if they fail, up to a limit
 analytics-python==1.1.0                 # Used for Segment analytics
 event-tracking==0.2.4                   # Tracks context-aware semi-structured system events
+django-ipware==1.1.0

--- a/requirements/test-hawthorn.txt
+++ b/requirements/test-hawthorn.txt
@@ -18,11 +18,12 @@ cryptography==1.9
 ddt==1.1.1
 django-config-models==0.1.8
 django-filter==1.0.4
+django-ipware==1.1.0
 django-model-utils==2.3.1
 django-object-actions==0.10.0
 django-simple-history==1.9.0
 django-waffle==0.12.0
-django==1.11.7
+django==1.11.8
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework-oauth==1.1.0
 djangorestframework==3.6.3
@@ -60,7 +61,7 @@ responses==0.8.1
 shortuuid==0.5.0          # via edx-django-oauth2-provider
 six==1.11.0               # via analytics-python, cryptography, edx-opaque-keys, faker, freezegun, mock, pytest, python-dateutil, responses, stevedore
 slumber==0.7.1            # via edx-rest-api-client
-stevedore==1.27.1         # via edx-opaque-keys
+stevedore==1.28.0         # via edx-opaque-keys
 testfixtures==5.3.1
 text-unidecode==1.1       # via faker
 unicodecsv==0.14.1

--- a/requirements/test-master.in
+++ b/requirements/test-master.in
@@ -23,3 +23,4 @@ jsonfield==2.0.2                        # Provides a Django model field which se
 flaky==3.3.0                            # Rerun flaky tests automatically if they fail, up to a limit
 analytics-python==1.1.0                 # Used for Segment analytics
 event-tracking==0.2.4                   # Tracks context-aware semi-structured system events
+django-ipware==1.1.0

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -18,6 +18,7 @@ cryptography==1.9
 ddt==1.1.1
 django-config-models==0.1.8
 django-filter==1.0.4
+django-ipware==1.1.0
 django-model-utils==2.3.1
 django-object-actions==0.10.0
 django-simple-history==1.9.0
@@ -60,7 +61,7 @@ responses==0.8.1
 shortuuid==0.5.0          # via edx-django-oauth2-provider
 six==1.11.0               # via analytics-python, cryptography, edx-opaque-keys, faker, freezegun, mock, pytest, python-dateutil, responses, stevedore
 slumber==0.7.1            # via edx-rest-api-client
-stevedore==1.27.1         # via edx-opaque-keys
+stevedore==1.28.0         # via edx-opaque-keys
 testfixtures==5.3.1
 text-unidecode==1.1       # via faker
 unicodecsv==0.14.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -18,6 +18,7 @@ cryptography==1.9
 ddt==1.1.1
 django-config-models==0.1.8
 django-filter==1.0.4
+django-ipware==1.1.0
 django-model-utils==2.3.1
 django-object-actions==0.10.0
 django-simple-history==1.9.0
@@ -60,7 +61,7 @@ responses==0.8.1
 shortuuid==0.5.0          # via edx-django-oauth2-provider
 six==1.11.0               # via analytics-python, cryptography, edx-opaque-keys, faker, freezegun, mock, pytest, python-dateutil, responses, stevedore
 slumber==0.7.1            # via edx-rest-api-client
-stevedore==1.27.1         # via edx-opaque-keys
+stevedore==1.28.0         # via edx-opaque-keys
 testfixtures==5.3.1
 text-unidecode==1.1       # via faker
 unicodecsv==0.14.1

--- a/test_utils/mixins.py
+++ b/test_utils/mixins.py
@@ -62,3 +62,17 @@ class ConsentMixin(object):
         """Assert consent is not required."""
         with self.assertRaises(Exception):
             self._assert_consent_required(response)
+
+
+class EmbargoAPIMixin(object):
+    """
+    Mixin for testing with a mocked embargo API.
+    """
+
+    EMBARGO_REDIRECT_URL = 'http://localhost:18000/embargo/blocked-message/enrollment/embargo/'
+
+    def _setup_embargo_api(self, api_mock, redirect_url=None):
+        """
+        Set up the embargo API module mock.
+        """
+        api_mock.redirect_if_blocked.return_value = redirect_url

--- a/tests/test_enterprise/views/test_course_enrollment_view.py
+++ b/tests/test_enterprise/views/test_course_enrollment_view.py
@@ -32,12 +32,12 @@ from test_utils.factories import (
     UserFactory,
 )
 from test_utils.fake_catalog_api import FAKE_COURSE, FAKE_COURSE_RUN, setup_course_catalog_api_client_mock
-from test_utils.mixins import MessagesMixin
+from test_utils.mixins import EmbargoAPIMixin, MessagesMixin
 
 
 @mark.django_db
 @ddt.ddt
-class TestCourseEnrollmentView(MessagesMixin, TestCase):
+class TestCourseEnrollmentView(EmbargoAPIMixin, MessagesMixin, TestCase):
     """
     Test CourseEnrollmentView.
     """
@@ -144,6 +144,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
             assert response.context[key] == value  # pylint: disable=no-member
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
+    @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.EnrollmentApiClient')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
@@ -154,11 +155,13 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
             ecommerce_api_client_mock,
             enrollment_api_client_mock,
             course_catalog_client_mock,
+            embargo_api_mock,
             *args
     ):  # pylint: disable=unused-argument
         setup_course_catalog_api_client_mock(course_catalog_client_mock)
         self._setup_ecommerce_client(ecommerce_api_client_mock, 100)
         self._setup_enrollment_client(enrollment_api_client_mock)
+        self._setup_embargo_api(embargo_api_mock)
         enterprise_customer = EnterpriseCustomerFactory(
             name='Starfleet Academy',
             enable_data_sharing_consent=True,
@@ -195,6 +198,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
         self._check_expected_enrollment_page(response, expected_context)
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
+    @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.EnrollmentApiClient')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
@@ -216,6 +220,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
             ecommerce_api_client_mock,
             enrollment_api_client_mock,
             catalog_api_client_views_mock,
+            embargo_api_mock,
             *args
     ):  # pylint: disable=unused-argument
         """
@@ -229,6 +234,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
         setup_course_catalog_api_client_mock(catalog_api_client_views_mock)
         self._setup_ecommerce_client(ecommerce_api_client_mock, 100)
         self._setup_enrollment_client(enrollment_api_client_mock)
+        self._setup_embargo_api(embargo_api_mock)
         enterprise_customer = EnterpriseCustomerFactory(
             name='Starfleet Academy',
             enable_data_sharing_consent=True,
@@ -318,6 +324,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
         self._check_expected_enrollment_page(response, expected_context)
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
+    @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.EnrollmentApiClient')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
@@ -328,6 +335,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
             ecommerce_api_client_mock,
             enrollment_api_client_mock,
             catalog_api_client_views_mock,
+            embargo_api_mock,
             *args
     ):  # pylint: disable=unused-argument
         """
@@ -341,6 +349,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
         setup_course_catalog_api_client_mock(catalog_api_client_views_mock)
         self._setup_ecommerce_client(ecommerce_api_client_mock, 100)
         self._setup_enrollment_client(enrollment_api_client_mock)
+        self._setup_embargo_api(embargo_api_mock)
         enterprise_customer = EnterpriseCustomerFactory(
             name='Starfleet Academy',
             enable_data_sharing_consent=True,
@@ -382,6 +391,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
         self._check_expected_enrollment_page(response, expected_context)
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
+    @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.EnrollmentApiClient')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
@@ -394,6 +404,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
             ecommerce_api_client_mock,
             enrollment_api_client_mock,
             catalog_api_client_views_mock,
+            embargo_api_mock,
             *args
     ):  # pylint: disable=unused-argument
         """
@@ -408,6 +419,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
         setup_course_catalog_api_client_mock(catalog_api_client_views_mock)
         self._setup_ecommerce_client(ecommerce_api_client_mock, 100)
         self._setup_enrollment_client(enrollment_api_client_mock)
+        self._setup_embargo_api(embargo_api_mock)
         enterprise_customer = EnterpriseCustomerFactory(
             name='Starfleet Academy',
             enable_data_sharing_consent=True,
@@ -469,6 +481,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
         self._check_expected_enrollment_page(response, expected_context)
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
+    @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.EnrollmentApiClient')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
@@ -481,6 +494,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
             ecommerce_api_client_mock,
             enrollment_api_client_mock,
             course_catalog_client_mock,
+            embargo_api_mock,
             *args
     ):  # pylint: disable=unused-argument
         """
@@ -489,6 +503,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
         setup_course_catalog_api_client_mock(course_catalog_client_mock)
         self._setup_ecommerce_client(ecommerce_api_client_mock, 100)
         self._setup_enrollment_client(enrollment_api_client_mock)
+        self._setup_embargo_api(embargo_api_mock)
         enterprise_customer = EnterpriseCustomerFactory(
             name='Starfleet Academy',
             enable_data_sharing_consent=True,
@@ -540,6 +555,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
             )
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
+    @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.EnrollmentApiClient')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
@@ -552,6 +568,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
             ecommerce_api_client_mock,
             enrollment_api_client_mock,
             course_catalog_client_mock,
+            embargo_api_mock,
             *args
     ):  # pylint: disable=unused-argument
         """
@@ -562,6 +579,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
         })
         self._setup_ecommerce_client(ecommerce_api_client_mock, 100)
         self._setup_enrollment_client(enrollment_api_client_mock)
+        self._setup_embargo_api(embargo_api_mock)
         enterprise_customer = EnterpriseCustomerFactory(
             name='Starfleet Academy',
             enable_data_sharing_consent=True,
@@ -608,6 +626,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
             )
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
+    @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.EnrollmentApiClient')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
@@ -618,6 +637,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
             ecommerce_api_client_mock,
             enrollment_api_client_mock,
             course_catalog_client_mock,
+            embargo_api_mock,
             *args
     ):  # pylint: disable=unused-argument
         """
@@ -628,6 +648,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
         })
         self._setup_ecommerce_client(ecommerce_api_client_mock)
         self._setup_enrollment_client(enrollment_api_client_mock)
+        self._setup_embargo_api(embargo_api_mock)
         enterprise_customer = EnterpriseCustomerFactory(
             name='Starfleet Academy',
             enable_data_sharing_consent=True,
@@ -648,6 +669,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
         self._check_expected_enrollment_page(response, expected_context)
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
+    @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.EnrollmentApiClient')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
@@ -658,6 +680,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
             ecommerce_api_client_mock,
             enrollment_api_client_mock,
             course_catalog_client_mock,
+            embargo_api_mock,
             *args
     ):  # pylint: disable=unused-argument
         setup_course_catalog_api_client_mock(
@@ -667,6 +690,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
         )
         self._setup_ecommerce_client(ecommerce_api_client_mock, 30.1)
         self._setup_enrollment_client(enrollment_api_client_mock)
+        self._setup_embargo_api(embargo_api_mock)
         enterprise_customer = EnterpriseCustomerFactory(
             name='Starfleet Academy',
             enable_data_sharing_consent=True,
@@ -706,6 +730,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
         self._check_expected_enrollment_page(response, expected_context)
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
+    @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.EnrollmentApiClient')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
@@ -716,6 +741,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
             ecommerce_api_client_mock,
             enrollment_api_client_mock,
             course_catalog_client_mock,
+            embargo_api_mock,
             *args
     ):  # pylint: disable=unused-argument
         setup_course_catalog_api_client_mock(
@@ -725,6 +751,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
         )
         self._setup_ecommerce_client(ecommerce_api_client_mock, 30.1)
         self._setup_enrollment_client(enrollment_api_client_mock)
+        self._setup_embargo_api(embargo_api_mock)
         enterprise_customer = EnterpriseCustomerFactory(
             name='Starfleet Academy',
             enable_data_sharing_consent=True,
@@ -765,6 +792,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
         self._check_expected_enrollment_page(response, expected_context)
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
+    @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.EnrollmentApiClient')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
@@ -775,11 +803,13 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
             ecommerce_api_client_mock,
             enrollment_api_client_mock,
             course_catalog_client_mock,
+            embargo_api_mock,
             *args
     ):  # pylint: disable=unused-argument
         setup_course_catalog_api_client_mock(course_catalog_client_mock)
         self._setup_ecommerce_client(ecommerce_api_client_mock)
         self._setup_enrollment_client(enrollment_api_client_mock)
+        self._setup_embargo_api(embargo_api_mock)
         enterprise_customer = EnterpriseCustomerFactory(
             name='Starfleet Academy',
             enable_data_sharing_consent=True,
@@ -827,6 +857,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
         self._check_expected_enrollment_page(response, expected_context)
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
+    @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.EnrollmentApiClient')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
@@ -837,6 +868,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
             ecommerce_api_client_mock,
             enrollment_api_client_mock,
             course_catalog_client_mock,
+            embargo_api_mock,
             *args
     ):  # pylint: disable=unused-argument
         """
@@ -854,6 +886,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
             enforce_data_sharing_consent='at_enrollment',
         )
         self._setup_registry_mock(registry_mock, self.provider_id)
+        self._setup_embargo_api(embargo_api_mock)
         EnterpriseCustomerIdentityProviderFactory(provider_id=self.provider_id, enterprise_customer=enterprise_customer)
         course_enrollment_page_url = reverse(
             'enterprise_course_enrollment_page',
@@ -871,6 +904,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
             assert response.context[key] == value  # pylint: disable=no-member
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
+    @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.EnrollmentApiClient')
     @mock.patch('enterprise.utils.Registry')
@@ -879,6 +913,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
             registry_mock,
             enrollment_api_client_mock,
             catalog_api_client_mock,
+            embargo_api_mock,
             *args
     ):  # pylint: disable=unused-argument
         """
@@ -889,6 +924,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
         course_client.get_course_and_course_run.return_value = (None, None)
         enrollment_client = enrollment_api_client_mock.return_value
         enrollment_client.get_course_modes.return_value = {}
+        self._setup_embargo_api(embargo_api_mock)
         self._login()
         enterprise_customer = EnterpriseCustomerFactory(
             name='Starfleet Academy',
@@ -913,6 +949,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
         self._assert_django_test_client_messages(response, expected_log_messages)
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
+    @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.EnrollmentApiClient')
     @mock.patch('enterprise.utils.Registry')
@@ -921,6 +958,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
             registry_mock,
             enrollment_api_client_mock,
             catalog_api_client_mock,
+            embargo_api_mock,
             *args
     ):  # pylint: disable=unused-argument
         """
@@ -931,6 +969,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
         course_client.get_course_and_course_run.side_effect = ImproperlyConfigured
         enrollment_client = enrollment_api_client_mock.return_value
         enrollment_client.get_course_modes.return_value = {}
+        self._setup_embargo_api(embargo_api_mock)
         self._login()
         enterprise_customer = EnterpriseCustomerFactory(
             name='Starfleet Academy',
@@ -955,6 +994,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
         self._assert_django_test_client_messages(response, expected_log_messages)
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
+    @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.EnrollmentApiClient')
     @mock.patch('enterprise.utils.Registry')
@@ -963,6 +1003,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
             registry_mock,
             enrollment_api_client_mock,
             catalog_api_client_mock,
+            embargo_api_mock,
             *args
     ):  # pylint: disable=unused-argument
         """
@@ -972,6 +1013,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
         setup_course_catalog_api_client_mock(catalog_api_client_mock)
         enrollment_client = enrollment_api_client_mock.return_value
         enrollment_client.get_course_modes.return_value = {}
+        self._setup_embargo_api(embargo_api_mock)
 
         enterprise_customer = EnterpriseCustomerFactory(
             name='Starfleet Academy',
@@ -1063,6 +1105,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
         for fragment in expected_fragments:
             assert fragment in response.url
 
+    @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.EnrollmentApiClient')
     @mock.patch('enterprise.utils.Registry')
@@ -1071,6 +1114,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
             registry_mock,
             enrollment_api_client_mock,
             catalog_api_client_mock,
+            embargo_api_mock,
             *args
     ):  # pylint: disable=unused-argument
         """
@@ -1082,6 +1126,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
         enrollment_client = enrollment_api_client_mock.return_value
         enrollment_client.get_course_modes.return_value = self.dummy_demo_course_modes
         enrollment_client.get_course_enrollment.return_value = {"course_details": {"course_id": course_id}}
+        self._setup_embargo_api(embargo_api_mock)
         self._login()
         enterprise_customer = EnterpriseCustomerFactory(
             name='Starfleet Academy',
@@ -1432,6 +1477,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
         )
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
+    @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.EnrollmentApiClient')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
@@ -1442,6 +1488,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
             ecommerce_api_client_mock,
             enrollment_api_client_mock,
             course_catalog_client_mock,
+            embargo_api_mock,
             *args
     ):  # pylint: disable=unused-argument
         # Set up Ecommerce API client that returns an error
@@ -1450,6 +1497,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
         attrs = {method_name + '.side_effect': HttpClientError()}
         broken_price_details_mock.configure_mock(**attrs)
         ecommerce_api_client_mock.return_value = broken_price_details_mock
+        self._setup_embargo_api(embargo_api_mock)
 
         # Set up course catalog API client
         setup_course_catalog_api_client_mock(course_catalog_client_mock)
@@ -1495,6 +1543,7 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
         self._check_expected_enrollment_page(response, expected_context)
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
+    @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.EnrollmentApiClient')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
@@ -1503,8 +1552,10 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
             ecommerce_api_client_mock,
             enrollment_api_client_mock,
             course_catalog_client_mock,
+            embargo_api_mock,
             *args
     ):  # pylint: disable=unused-argument
+        self._setup_embargo_api(embargo_api_mock)
 
         # Set up course catalog API client
         setup_course_catalog_api_client_mock(course_catalog_client_mock)
@@ -1557,3 +1608,34 @@ class TestCourseEnrollmentView(MessagesMixin, TestCase):
         self._login()
         response = self.client.get(enterprise_landing_page_url)
         self._check_expected_enrollment_page(response, expected_context)
+
+    @mock.patch('enterprise.api_client.lms.embargo_api')
+    @mock.patch('enterprise.utils.Registry')
+    def test_embargo_restriction(
+            self,
+            registry_mock,
+            embargo_api_mock,
+            *args
+    ):  # pylint: disable=unused-argument
+        self._setup_embargo_api(embargo_api_mock, redirect_url=self.EMBARGO_REDIRECT_URL)
+        enterprise_customer = EnterpriseCustomerFactory(
+            name='Starfleet Academy',
+            enable_data_sharing_consent=True,
+            enforce_data_sharing_consent='at_enrollment',
+        )
+        self._setup_registry_mock(registry_mock, self.provider_id)
+        EnterpriseCustomerIdentityProviderFactory(provider_id=self.provider_id, enterprise_customer=enterprise_customer)
+
+        enterprise_landing_page_url = reverse(
+            'enterprise_course_enrollment_page',
+            args=[enterprise_customer.uuid, self.demo_course_id],
+        )
+
+        self._login()
+        response = self.client.get(enterprise_landing_page_url)
+        assert response.status_code == 302
+        self.assertRedirects(
+            response,
+            self.EMBARGO_REDIRECT_URL,
+            fetch_redirect_response=False
+        )


### PR DESCRIPTION
Redirect the user to the embargo restriction page if their access
to the given course run/program is restricted.

**JIRA:** https://openedx.atlassian.net/browse/ENT-767

**Testing Instructions:**
1. Visit https://business.sandbox.edx.org/enterprise/2b5a2956-7746-4fc9-9587-bc887ba45973/course/course-v1:edX+DemoX+Demo_Course/enroll/?catalog=cff09318-1358-4703-a277-bc2596480ed5&utm_medium=enterprise&utm_source=pied-piper.
2. Register a new account. Choose "Canada" as your country.
3. Verify that the Embargo restriction message page is displayed.

![screen shot 2017-12-05 at 12 43 27 pm](https://user-images.githubusercontent.com/224634/33621789-f4f0774e-d9b9-11e7-9644-779bcf11e526.png)
