### PR TITLE
Add from email address to enrollment notification template model

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,11 +14,15 @@ Change Log
 Unreleased
 ----------
 
+[0.55.6] - 2017-12-12
+---------------------
+
+* Check site configuration for from email address first
+
 [0.55.5] - 2017-12-11
 ---------------------
 
 * Added course start date to title string for instructor-led courses
-
 
 [0.55.4] - 2017-12-06
 ---------------------

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.55.5"
+__version__ = "0.55.6"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -304,10 +304,16 @@ def send_email_notification_message(user, enrolled_in, enterprise_customer, emai
 
     subject_line = get_notification_subject_line(enrolled_in['name'], enterprise_template_config)
 
+    from_email_address = get_configuration_value_for_site(
+        enterprise_customer.site,
+        'DEFAULT_FROM_EMAIL',
+        default=settings.DEFAULT_FROM_EMAIL
+    )
+
     return mail.send_mail(
         subject_line,
         plain_msg,
-        settings.DEFAULT_FROM_EMAIL,
+        from_email_address,
         [user_email],
         html_message=html_msg,
         connection=email_connection


### PR DESCRIPTION
**Description:** Adds from_email_address to the email notification template so we can customize the email per enterprise. Defaults to `settings.DEFAULT_FROM_EMAIL`. 

**JIRA:** https://openedx.atlassian.net/browse/WL-1373

**Dependencies:** None

**Merge deadline:** Soon?

**Installation instructions:** N/A

**Testing instructions:**

1. Migrate migrations
2. Add enterprise enrollment notification template http://localhost:18000/admin/enterprise/enrollmentnotificationemailtemplate/add/ 
3. Set from_email_address
4. Add a learner to a enterprise/course via "Manage Learners" http://localhost:18000/admin/enterprise/enterprisecustomer/<ENTERPRISE_UUID>/manage_learners
5. See new email address in email log

**Merge checklist:**

- [x] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [x] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [x] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [x] Called `make static` for webpack bundling if any static content was updated.
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
