### PR TITLE
ENT-794 Update create_enterprise_course_enrollments command.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.56.0] - 2017-12-13
+---------------------
+
+* Update create_enterprise_course_enrollment command.
+
 [0.55.7] - 2017-12-13
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.55.7"
+__version__ = "0.56.0"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/tests/test_enterprise/management/test_create_enterprise_course_enrollments.py
+++ b/tests/test_enterprise/management/test_create_enterprise_course_enrollments.py
@@ -6,19 +6,13 @@ from __future__ import absolute_import, unicode_literals
 
 import ddt
 import mock
-from faker import Factory as FakerFactory
 from pytest import mark
 
-from django.core.management import CommandError, call_command
+from django.core.management import call_command
 from django.test import TestCase
 
-from enterprise.management.commands.create_enterprise_course_enrollments import HttpClientError
-from test_utils.factories import (
-    EnterpriseCourseEnrollmentFactory,
-    EnterpriseCustomerFactory,
-    EnterpriseCustomerUserFactory,
-    UserFactory,
-)
+from enterprise.models import EnterpriseCourseEnrollment, EnterpriseCustomer
+from test_utils.factories import EnterpriseCustomerFactory, EnterpriseCustomerUserFactory, UserFactory
 
 
 @mark.django_db
@@ -30,6 +24,7 @@ class CreateEnterpriseCourseEnrollmentCommandTests(TestCase):
     command = 'create_enterprise_course_enrollments'
 
     def setUp(self):
+        self.course_run_id = 'course-v1:edX+DemoX+Demo_Course'
         self.user = UserFactory.create(is_staff=True, is_active=True)
         self.enterprise_customer = EnterpriseCustomerFactory(
             name='Starfleet Academy',
@@ -42,169 +37,94 @@ class CreateEnterpriseCourseEnrollmentCommandTests(TestCase):
         )
         super(CreateEnterpriseCourseEnrollmentCommandTests, self).setUp()
 
-    def test_command_without_required_parameters(self):
+    def mock_db_connection(self, connection_mock):
         """
-        Test that calling command without the required parameters, enterprise
-        UUID and course run ids raise exception.
+        Set up db connection mock.
         """
-        expected_command_log_message = 'Please provide the enterprise UUID and comma-delimited list of course run IDs.'
-        with self.assertRaisesMessage(CommandError, expected_command_log_message):
-            call_command(self.command, commit=False)
-
-    def test_command_for_invalid_enterprise_cutomer(self):
-        """
-        Test that calling command with invalid enterprise UUID raise exception.
-        """
-        faker = FakerFactory.create()
-        invalid_enterprise_uuid = faker.uuid4()  # pylint: disable=no-member
-        courses = 'course-v1:edX+DemoX+Demo_Course'
-        expected_command_log_message = 'No enterprise customer found for UUID: {uuid}'.format(
-            uuid=invalid_enterprise_uuid
+        description = mock.MagicMock()
+        description.__iter__.return_value = (('user_id',), ('enterprise_customer_uuid',), ('course_run_id',))
+        fetchall = mock.MagicMock()
+        fetchall.__iter__.return_value = [(self.user.id, self.enterprise_customer.uuid, self.course_run_id)]
+        connection_mock.cursor.return_value = mock.MagicMock(
+            __enter__=mock.MagicMock(
+                return_value=mock.MagicMock(
+                    description=description,
+                    fetchall=mock.MagicMock(
+                        side_effect=lambda: fetchall
+                    )
+                )
+            )
         )
-        with self.assertRaisesMessage(CommandError, expected_command_log_message):
-            call_command(self.command, enterprise_uuid=invalid_enterprise_uuid, courses=courses, commit=False)
 
-    @mock.patch('enterprise.management.commands.create_enterprise_course_enrollments.CourseApiClient')
+    @mock.patch.object(EnterpriseCustomer, 'catalog_contains_course', mock.Mock(side_effect=lambda x: True))
     @mock.patch('enterprise.management.commands.create_enterprise_course_enrollments.LOGGER')
-    def test_command_for_non_existing_course(self, logger_mock, course_api_client_mock):
+    @mock.patch('enterprise.management.commands.create_enterprise_course_enrollments.connection')
+    @ddt.data(True, False)
+    def test_enrollments_created(self, filter_by_enterprise_customer, connection_mock, logger_mock):
         """
-        Test that the command skips enrollments for the course which doesn't
-        exist.
+        Test that the command creates missing EnterpriseCourseEnrollment records.
         """
-        non_existing_course_id = 'course-v1:Non+Existing+Course'
-        course_api_client = course_api_client_mock.return_value
-        course_api_client.get_course_details.side_effect = HttpClientError
-        call_command(
-            self.command,
-            enterprise_uuid=self.enterprise_customer.uuid,
-            courses=non_existing_course_id,
-            commit=False,
-        )
+        self.mock_db_connection(connection_mock)
+        kwargs = {}
+        if filter_by_enterprise_customer:
+            kwargs['enterprise_customer_uuid'] = self.enterprise_customer.uuid
 
-        expected_course_api_log_message = 'Failed to retrieve course details from LMS API for {course}'.format(
-            course=non_existing_course_id
-        )
-        expected_command_log_message = 'Course {course} not found, skipping.'.format(course=non_existing_course_id)
-        logger_mock.error.assert_called_with(expected_course_api_log_message)
-        logger_mock.warning.assert_called_with(expected_command_log_message)
+        call_command(self.command, **kwargs)
 
-    @mock.patch('enterprise.management.commands.create_enterprise_course_enrollments.CourseApiClient')
-    @mock.patch('enterprise.management.commands.create_enterprise_course_enrollments.EnrollmentApiClient')
-    @mock.patch('enterprise.management.commands.create_enterprise_course_enrollments.LOGGER')
-    def test_command_for_missing_enterprise_course_enrollment(
-            self, logger_mock,
-            enrollment_api_client_mock,
-            course_api_client_mock
-    ):
-        """
-        Test that the command adds missing enterprise course enrollment records
-        against the provided enterprise courses for the enterprise learners
-        which are enrolled but don't have enterprise course enrollment record.
-        """
-        course_id = 'course-v1:edX+DemoX+Demo_Course'
-        course_api_client = course_api_client_mock.return_value
-        course_api_client.get_course_details.return_value = {
-            'name': 'edX Demo Course',
-        }
-        enrollment_api_client = enrollment_api_client_mock.return_value
-        enrollment_api_client.get_course_enrollment.return_value = {
-            'user': 'john_doe',
-            'is_active': True,
-        }
-        call_command(
-            self.command,
-            enterprise_uuid=self.enterprise_customer.uuid,
-            courses=course_id,
-            commit=False,
-        )
-
-        expected_enrolled_users_count = 1
-        expected_ent_cour_enroll_count = 1
-        expected_command_log_message = 'Created {created} missing EnterpriseCourseEnrollments ' \
-                                       'for {enrolled} enterprise learners enrolled in {course}.'.format(
-                                           created=expected_ent_cour_enroll_count,
-                                           enrolled=expected_enrolled_users_count,
-                                           course=course_id,
-                                       )
-        logger_mock.info.assert_called_with(expected_command_log_message)
-
-    @mock.patch('enterprise.management.commands.create_enterprise_course_enrollments.CourseApiClient')
-    @mock.patch('enterprise.management.commands.create_enterprise_course_enrollments.EnrollmentApiClient')
-    @mock.patch('enterprise.management.commands.create_enterprise_course_enrollments.LOGGER')
-    def test_command_for_un_enrolled_learners(
-            self, logger_mock,
-            enrollment_api_client_mock,
-            course_api_client_mock
-    ):
-        """
-        Test that the command don't add enterprise course enrollment records
-        for the enterprise learners which are not enrolled in the provided
-        enterprise courses.
-        """
-        course_id = 'course-v1:edX+DemoX+Demo_Course'
-        course_api_client = course_api_client_mock.return_value
-        course_api_client.get_course_details.return_value = {
-            'name': 'edX Demo Course',
-        }
-        enrollment_api_client = enrollment_api_client_mock.return_value
-        enrollment_api_client.get_course_enrollment.return_value = None
-        call_command(
-            self.command,
-            enterprise_uuid=self.enterprise_customer.uuid,
-            courses=course_id,
-            commit=False,
-        )
-
-        expected_enrolled_users_count = 0
-        expected_ent_cour_enroll_count = 0
-        expected_command_log_message = 'Created {created} missing EnterpriseCourseEnrollments ' \
-                                       'for {enrolled} enterprise learners enrolled in {course}.'.format(
-                                           created=expected_ent_cour_enroll_count,
-                                           enrolled=expected_enrolled_users_count,
-                                           course=course_id,
-                                       )
-        logger_mock.info.assert_called_with(expected_command_log_message)
-
-    @mock.patch('enterprise.management.commands.create_enterprise_course_enrollments.CourseApiClient')
-    @mock.patch('enterprise.management.commands.create_enterprise_course_enrollments.EnrollmentApiClient')
-    @mock.patch('enterprise.management.commands.create_enterprise_course_enrollments.LOGGER')
-    def test_command_for_learners_with_existing_enterprise_course_enrollment(
-            self, logger_mock,
-            enrollment_api_client_mock,
-            course_api_client_mock
-    ):
-        """
-        Test that the command don't add enterprise course enrollment records
-        for the enterprise learners which have existing enterprise course
-        enrollment against the provided enterprise courses.
-        """
-        course_id = 'course-v1:edX+DemoX+Demo_Course'
-        course_api_client = course_api_client_mock.return_value
-        course_api_client.get_course_details.return_value = {
-            'name': 'edX Demo Course',
-        }
-        enrollment_api_client = enrollment_api_client_mock.return_value
-        enrollment_api_client.get_course_enrollment.return_value = {
-            'user': 'john_doe',
-            'is_active': True,
-        }
-        EnterpriseCourseEnrollmentFactory(
-            course_id=course_id,
+        count = EnterpriseCourseEnrollment.objects.filter(
             enterprise_customer_user=self.enterprise_customer_user,
-        )
-        call_command(
-            self.command,
-            enterprise_uuid=self.enterprise_customer.uuid,
-            courses=course_id,
-            commit=False,
+            course_id=self.course_run_id
+        ).count()
+
+        assert count == 1
+        logger_mock.info.assert_called_with('Created %s missing EnterpriseCourseEnrollments.', 1)
+
+    @mock.patch.object(EnterpriseCustomer, 'catalog_contains_course', mock.Mock(side_effect=lambda x: False))
+    @mock.patch('enterprise.management.commands.create_enterprise_course_enrollments.LOGGER')
+    @mock.patch('enterprise.management.commands.create_enterprise_course_enrollments.connection')
+    def test_course_not_in_catalog(self, connection_mock, logger_mock):
+        """
+        Test that the command does not create missing EnterpriseCourseEnrollment records when
+        the enrolled course is not in the catalog.
+        """
+        self.mock_db_connection(connection_mock)
+
+        call_command(self.command)
+
+        count = EnterpriseCourseEnrollment.objects.filter(
+            enterprise_customer_user=self.enterprise_customer_user,
+            course_id=self.course_run_id
+        ).count()
+
+        assert count == 0
+        logger_mock.info.assert_called_with('Created %s missing EnterpriseCourseEnrollments.', 0)
+
+    @mock.patch.object(EnterpriseCustomer, 'catalog_contains_course', mock.Mock(side_effect=lambda x: True))
+    @mock.patch('enterprise.management.commands.create_enterprise_course_enrollments.LOGGER')
+    @mock.patch('enterprise.management.commands.create_enterprise_course_enrollments.connection')
+    def test_existing_enterprise_course_enrollment(self, connection_mock, logger_mock):
+        """
+        Test that the command does not create missing EnterpriseCourseEnrollment records when
+        the enrolled course is not in the catalog.
+        """
+        self.mock_db_connection(connection_mock)
+        EnterpriseCourseEnrollment.objects.create(
+            enterprise_customer_user=self.enterprise_customer_user,
+            course_id=self.course_run_id
         )
 
-        expected_enrolled_users_count = 1
-        expected_ent_cour_enroll_count = 0
-        expected_command_log_message = 'Created {created} missing EnterpriseCourseEnrollments ' \
-                                       'for {enrolled} enterprise learners enrolled in {course}.'.format(
-                                           created=expected_ent_cour_enroll_count,
-                                           enrolled=expected_enrolled_users_count,
-                                           course=course_id,
-                                       )
-        logger_mock.info.assert_called_with(expected_command_log_message)
+        call_command(self.command)
+
+        count = EnterpriseCourseEnrollment.objects.filter(
+            enterprise_customer_user=self.enterprise_customer_user,
+            course_id=self.course_run_id
+        ).count()
+
+        assert count == 1
+        logger_mock.warning.assert_called_with(
+            'EnterpriseCourseEnrollment exists: EnterpriseCustomer [%s] - User [%s] - CourseRun [%s]',
+            self.enterprise_customer.uuid,
+            self.user.id,
+            self.course_run_id
+        )
+        logger_mock.info.assert_called_with('Created %s missing EnterpriseCourseEnrollments.', 0)


### PR DESCRIPTION
This updates the create_enterprise_course_enrollment command to
allow us to identify missing EnterpriseCourseEnrollment records
and create them.

**Testing Instructions**
1. $ ssh [username]@business.sandbox.edx.org
2. $ edxapp
3. $ python manage.py lms create_enterprise_course_enrollments --settings=aws
