### PR TITLE
ENT-738 Added publish_audit_enrollment_url flag

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.56.1] - 2017-12-13
+---------------------
+
+* Add publish_audit_enrollment_url flag to EnterpriseCustomerCatalog.
+
 [0.56.0] - 2017-12-13
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.56.0"
+__version__ = "0.56.1"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/migrations/0035_auto_20171212_1129.py
+++ b/enterprise/migrations/0035_auto_20171212_1129.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('enterprise', '0034_auto_20171023_0727'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='enterprisecustomercatalog',
+            name='publish_audit_enrollment_urls',
+            field=models.BooleanField(default=False, help_text='Specifies whether courses should be published with direct-to-audit enrollment URLs.'),
+        ),
+        migrations.AddField(
+            model_name='historicalenterprisecustomercatalog',
+            name='publish_audit_enrollment_urls',
+            field=models.BooleanField(default=False, help_text='Specifies whether courses should be published with direct-to-audit enrollment URLs.'),
+        ),
+    ]

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -987,6 +987,12 @@ class EnterpriseCustomerCatalog(TimeStampedModel):
         help_text=_('Ordered list of enrollment modes which can be displayed to learners for course runs in'
                     ' this catalog.'),
     )
+    publish_audit_enrollment_urls = models.BooleanField(
+        default=False,
+        help_text=_(
+            "Specifies whether courses should be published with direct-to-audit enrollment URLs."
+        )
+    )
 
     history = HistoricalRecords()
 
@@ -1132,6 +1138,9 @@ class EnterpriseCustomerCatalog(TimeStampedModel):
             (str): Enterprise landing page url.
         """
         url = self.enterprise_customer.get_course_run_enrollment_url(course_run_key)
+        if self.publish_audit_enrollment_urls:
+            url = utils.update_query_parameters(url, {'audit': 'true'})
+
         return utils.update_query_parameters(url, {'catalog': self.uuid})
 
     def get_program_enrollment_url(self, program_uuid):
@@ -1145,6 +1154,9 @@ class EnterpriseCustomerCatalog(TimeStampedModel):
             (str): Enterprise program landing page url.
         """
         url = self.enterprise_customer.get_program_enrollment_url(program_uuid)
+        if self.publish_audit_enrollment_urls:
+            url = utils.update_query_parameters(url, {'audit': 'true'})
+
         return utils.update_query_parameters(url, {'catalog': self.uuid})
 
 

--- a/test_utils/__init__.py
+++ b/test_utils/__init__.py
@@ -167,7 +167,7 @@ def assert_url(first, second):
 
 def assert_url_contains_query_parameters(url, query_params):
     """
-    Asserts that a url string contains the given query parameters
+    Assert that a url string contains the given query parameters.
 
     Args:
         url: Full url string to check

--- a/test_utils/__init__.py
+++ b/test_utils/__init__.py
@@ -19,8 +19,7 @@ import mock
 import six
 from pytest import mark
 from rest_framework.test import APITestCase, APIClient
-from six.moves.urllib.parse import parse_qs, urljoin, urlsplit  # pylint: disable=import-error,ungrouped-imports
-
+from six.moves.urllib.parse import parse_qs, urlparse, urljoin, urlsplit  # pylint: disable=import-error,ungrouped-imports
 from django.shortcuts import render
 
 from test_utils import factories
@@ -160,6 +159,17 @@ def assert_url(first, second):
 
     assert first == second
 
+def assert_url_contains_query_parameters(url, query_params):
+    """
+    Asserts that a url string contains the given query parameters
+    :param url: Full url string to check
+    :param query_params: Dict of query string key/value pairs
+    :raises: Assertion error if the params do not exist in the given url
+    """
+    query_string = urlparse(url).query
+    query_string_dict = parse_qs(query_string)
+    for key, value in six.iteritems(query_params):
+        assert key in query_string_dict and value in query_string_dict.get(key)
 
 @mark.django_db
 class APITest(APITestCase):

--- a/test_utils/__init__.py
+++ b/test_utils/__init__.py
@@ -19,7 +19,12 @@ import mock
 import six
 from pytest import mark
 from rest_framework.test import APITestCase, APIClient
-from six.moves.urllib.parse import parse_qs, urlparse, urljoin, urlsplit  # pylint: disable=import-error,ungrouped-imports
+from six.moves.urllib.parse import (  # pylint: disable=import-error,ungrouped-imports
+    parse_qs,
+    urlparse,
+    urljoin,
+    urlsplit
+)
 from django.shortcuts import render
 
 from test_utils import factories
@@ -159,17 +164,24 @@ def assert_url(first, second):
 
     assert first == second
 
+
 def assert_url_contains_query_parameters(url, query_params):
     """
     Asserts that a url string contains the given query parameters
-    :param url: Full url string to check
-    :param query_params: Dict of query string key/value pairs
-    :raises: Assertion error if the params do not exist in the given url
+
+    Args:
+        url: Full url string to check
+        query_params: Dict of query string key/value pairs
+
+    Raises:
+        Assertion error if the params do not exist in the given url
+
     """
     query_string = urlparse(url).query
     query_string_dict = parse_qs(query_string)
     for key, value in six.iteritems(query_params):
         assert key in query_string_dict and value in query_string_dict.get(key)
+
 
 @mark.django_db
 class APITest(APITestCase):


### PR DESCRIPTION
If publish_audit_enrollment_url flag is True on EnterpriseCustomerCatalog
courses will be published with the direct-to-audit querystring url (?audit=true)

https://openedx.atlassian.net/browse/ENT-738

**Testing instructions:**

1. In django-admin, update an EnterpriseCustomerCatalog to set the publish_audit_enrollment_url flag
2. Run the transmit_course_metadata admin job
3. From the LMS set up to use the catalog from step 1, verify that when a user clicks through a course they are taken directly to the course (based on direct-to-audit work done in https://openedx.atlassian.net/browse/ENT-738)

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
