### PR TITLE
ENT-806 Make sure root url has a fallback for proxy enrollment email links

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.56.3] - 2017-12-14
+---------------------
+
+* Make sure root url has a fallback for proxy enrollment email links.
+
 [0.56.2] - 2017-12-13
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.56.2"
+__version__ = "0.56.3"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/admin/views.py
+++ b/enterprise/admin/views.py
@@ -481,7 +481,11 @@ class EnterpriseCustomerManageLearnersView(View):
         program_branding = program_details.get('type')
         program_uuid = program_details.get('uuid')
 
-        lms_root_url = get_configuration_value_for_site(enterprise_customer.site, 'LMS_ROOT_URL')
+        lms_root_url = get_configuration_value_for_site(
+            enterprise_customer.site,
+            'LMS_ROOT_URL',
+            settings.LMS_ROOT_URL
+        )
         program_path = urlquote(
             '/dashboard/programs/{program_uuid}/?tpa_hint={tpa_hint}'.format(
                 program_uuid=program_uuid,

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -308,7 +308,11 @@ class EnterpriseCustomer(TimeStampedModel):
                 tpa_hint=self.identity_provider,
             )
         )
-        lms_root_url = utils.get_configuration_value_for_site(self.site, 'LMS_ROOT_URL')
+        lms_root_url = utils.get_configuration_value_for_site(
+            self.site,
+            'LMS_ROOT_URL',
+            settings.LMS_ROOT_URL
+        )
         destination_url = '{site}/{login_or_register}?next={course_path}'.format(
             site=lms_root_url,
             login_or_register='{login_or_register}',  # We don't know the value at this time


### PR DESCRIPTION
**Description:** We discovered that proxy enrollment emails sent from prod weren't getting the host name properly filled in because it was trying to read from site configuration. So now we're sending a sensible default.

**JIRA:** 

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
