### PR TITLE
ENT-775 Add sftp configuration support for EnterpriseCustomerReportingConfig

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.60.0] - 2018-01-03
+---------------------
+
+* Add sftp configuration options for EnterpriseCustomerReportingConfiguration.
+
 [0.59.0] - 2017-12-28
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.59.0"
+__version__ = "0.60.0"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/admin/__init__.py
+++ b/enterprise/admin/__init__.py
@@ -16,7 +16,11 @@ from django_object_actions import DjangoObjectActions
 from simple_history.admin import SimpleHistoryAdmin  # likely a bug in import order checker
 
 from enterprise.admin.actions import export_as_csv_action, get_clear_catalog_id_action
-from enterprise.admin.forms import EnterpriseCustomerAdminForm, EnterpriseCustomerIdentityProviderAdminForm
+from enterprise.admin.forms import (
+    EnterpriseCustomerAdminForm,
+    EnterpriseCustomerIdentityProviderAdminForm,
+    EnterpriseCustomerReportingConfigAdminForm,
+)
 from enterprise.admin.utils import UrlNames
 from enterprise.admin.views import EnterpriseCustomerManageLearnersView, TemplatePreviewView
 from enterprise.api_client.lms import CourseApiClient, EnrollmentApiClient
@@ -497,36 +501,17 @@ class EnterpriseCustomerReportingConfigurationAdmin(admin.ModelAdmin):
     Django admin model for EnterpriseCustomerReportingConfiguration.
     """
 
-    fields = (
-        "enterprise_customer",
-        "active",
-        "email",
-        "frequency",
-        "day_of_month",
-        "day_of_week",
-        "hour_of_day",
-        "decrypted_password",
-    )
-
     list_display = (
         "enterprise_customer",
         "active",
-        "email",
+        "delivery_method",
         "frequency",
-    )
-
-    readonly_fields = (
-        "decrypted_password",
     )
 
     list_filter = ("active",)
     search_fields = ("enterprise_customer__name", "email")
 
+    form = EnterpriseCustomerReportingConfigAdminForm
+
     class Meta(object):
         model = EnterpriseCustomerReportingConfiguration
-
-    def decrypted_password(self, obj):
-        """
-        The decrypted password to be displayed to the admin.
-        """
-        return decrypt_string(obj.password, obj.initialization_vector)

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -412,7 +412,8 @@ class EnterpriseCustomerReportingConfigurationSerializer(serializers.ModelSerial
         model = models.EnterpriseCustomerReportingConfiguration
         fields = (
             'enterprise_customer', 'active', 'delivery_method', 'email', 'frequency', 'day_of_month', 'day_of_week',
-            'hour_of_day', 'initialization_vector', 'password'
+            'hour_of_day', 'initialization_vector', 'password', 'sftp_hostname', 'sftp_port', 'sftp_username',
+            'sftp_password', 'sftp_file_path',
         )
 
     enterprise_customer = EnterpriseCustomerSerializer()

--- a/enterprise/migrations/0036_sftp_reporting_support.py
+++ b/enterprise/migrations/0036_sftp_reporting_support.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('enterprise', '0035_auto_20171212_1129'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='enterprisecustomerreportingconfiguration',
+            name='sftp_file_path',
+            field=models.CharField(help_text='If the delivery method is sftp, the path on the host to deliver the report to.', max_length=256, null=True, verbose_name='SFTP file path', blank=True),
+        ),
+        migrations.AddField(
+            model_name='enterprisecustomerreportingconfiguration',
+            name='sftp_hostname',
+            field=models.CharField(help_text='If the delivery method is sftp, the host to deliver the report to.', max_length=256, null=True, verbose_name='SFTP Host name', blank=True),
+        ),
+        migrations.AddField(
+            model_name='enterprisecustomerreportingconfiguration',
+            name='sftp_password',
+            field=models.BinaryField(max_length=256, blank=True, help_text='If the delivery method is sftp, the password to use to securely access the host.', null=True, verbose_name='SFTP password'),
+        ),
+        migrations.AddField(
+            model_name='enterprisecustomerreportingconfiguration',
+            name='sftp_port',
+            field=models.PositiveIntegerField(default=22, help_text='If the delivery method is sftp, the port on the host to connect to.', null=True, verbose_name='SFTP Port', blank=True),
+        ),
+        migrations.AddField(
+            model_name='enterprisecustomerreportingconfiguration',
+            name='sftp_username',
+            field=models.CharField(help_text='If the delivery method is sftp, the username to use to securely access the host.', max_length=256, null=True, verbose_name='SFTP username', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='enterprisecustomerreportingconfiguration',
+            name='delivery_method',
+            field=models.CharField(default='email', help_text='The method in which the data should be sent.', max_length=20, verbose_name='Delivery Method', choices=[('email', 'email'), ('sftp', 'sftp')]),
+        ),
+        migrations.AlterField(
+            model_name='enterprisecustomerreportingconfiguration',
+            name='password',
+            field=models.BinaryField(verbose_name='Password for the protected zip file.', max_length=256),
+        ),
+    ]

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -1264,12 +1264,11 @@ class EnterpriseCustomerReportingConfiguration(TimeStampedModel):
     )
 
     DELIVERY_METHOD_EMAIL = 'email'
-    # We are adding this field preemptively as we plan to support FTP, but don't have the details yet.
-    DELIVERY_METHOD_FTP = 'ftp'
+    DELIVERY_METHOD_SFTP = 'sftp'
 
     DELIVERY_METHOD_CHOICES = (
         (DELIVERY_METHOD_EMAIL, DELIVERY_METHOD_EMAIL),
-        (DELIVERY_METHOD_FTP, DELIVERY_METHOD_FTP),
+        (DELIVERY_METHOD_SFTP, DELIVERY_METHOD_SFTP),
     )
 
     DAYS_OF_WEEK = (
@@ -1337,8 +1336,42 @@ class EnterpriseCustomerReportingConfiguration(TimeStampedModel):
         max_length=256,
         blank=False,
         null=False,
-        editable=False,
-        verbose_name=_("Password"),
+        verbose_name=_("Password for the protected zip file."),
+    )
+    sftp_hostname = models.CharField(
+        max_length=256,
+        blank=True,
+        null=True,
+        verbose_name=_("SFTP Host name"),
+        help_text=_("If the delivery method is sftp, the host to deliver the report to.")
+    )
+    sftp_port = models.PositiveIntegerField(
+        blank=True,
+        null=True,
+        verbose_name=_("SFTP Port"),
+        help_text=_("If the delivery method is sftp, the port on the host to connect to."),
+        default=22,
+    )
+    sftp_username = models.CharField(
+        max_length=256,
+        blank=True,
+        null=True,
+        verbose_name=_("SFTP username"),
+        help_text=_("If the delivery method is sftp, the username to use to securely access the host.")
+    )
+    sftp_password = models.BinaryField(
+        max_length=256,
+        blank=True,
+        null=True,
+        verbose_name=_("SFTP password"),
+        help_text=_("If the delivery method is sftp, the password to use to securely access the host.")
+    )
+    sftp_file_path = models.CharField(
+        max_length=256,
+        blank=True,
+        null=True,
+        verbose_name=_("SFTP file path"),
+        help_text=_("If the delivery method is sftp, the path on the host to deliver the report to.")
     )
 
     class Meta:
@@ -1360,15 +1393,30 @@ class EnterpriseCustomerReportingConfiguration(TimeStampedModel):
 
     def save(self, *args, **kwargs):  # pylint: disable=arguments-differ
         """
-        Override of model save method to dynamically generate the password field and perform additional validation.
+        Override of model save method to handle encryption logic for password fields.
         """
+        # These will only get passed in from the Django Admin Form for this model.
+        decrypted_password = getattr(self, 'decrypted_password', None)
+        decrypted_sftp_password = getattr(self, 'decrypted_sftp_password', None)
         if not self.pk:
             self.initialization_vector = utils.generate_aes_initialization_vector()
+            decrypted_password = decrypted_password or get_random_string(length=32)
+
+        if decrypted_password:
             self.password = utils.encrypt_string(
-                get_random_string(length=32),
+                decrypted_password,
                 self.initialization_vector
             )
+
+        if decrypted_sftp_password:
+            self.sftp_password = utils.encrypt_string(
+                decrypted_sftp_password,
+                self.initialization_vector
+            )
+
+        if decrypted_password or decrypted_sftp_password:
             self.full_clean()
+
         super(EnterpriseCustomerReportingConfiguration, self).save(*args, **kwargs)
 
     def clean(self):
@@ -1388,3 +1436,17 @@ class EnterpriseCustomerReportingConfiguration(TimeStampedModel):
             self.day_of_week = None
         else:
             raise ValidationError(_('Frequency must be set to either daily, weekly, or monthly.'))
+
+        if self.delivery_method == self.DELIVERY_METHOD_SFTP:
+            validation_errors = {}
+            if not self.sftp_hostname:
+                validation_errors['sftp_hostname'] = _('SFTP Hostname must be set if the delivery method is sftp')
+
+            if not self.sftp_username:
+                validation_errors['sftp_username'] = _('SFTP username must be set if the delivery method is sftp')
+
+            if not self.sftp_file_path:
+                validation_errors['sftp_file_path'] = _('SFTP File Path must be set if the delivery method is sftp')
+
+            if validation_errors:
+                raise ValidationError(validation_errors)


### PR DESCRIPTION
**Description:** This PR adds the ability to configure the EnterpriseCustomerReportingConfig for SFTP. It finally utilizes the delivery method field, which now has sftp in addition to email. It also adds 5 new fields for sftp: hostname, port, username, password, and file path. These fields are required when sftp is selected as the delivery method. The sftp password field is stored encrypted in the database, just as the existing password field is.

Additionally, this PR now enables editing of the existing password field as well as the sftp password. After migrations are run, the existing decrypted password display will be replaced by a text box that displays the decrypted password, and making changes to the password in the text box will be updated on save just as any other field.

Finally, the new fields have been added to the serializer so that they get returned in the api endpoint for the object.

**JIRA:** https://openedx.atlassian.net/browse/ENT-775

**Dependencies:** https://github.com/edx/edx-enterprise-data/pull/15 depends on this. 

**Merge deadline:** 

**Installation instructions:** After installing, be sure to run migrations!

**Testing instructions:**

Verify that existing configurations have their data in tact. Please note that on the business sandbox, something about the passwords for earlier configurations got corrupted due to either the secret or initialization vectors changing, so they may display as blank. They can be edited and new changes will work as expected, and we shouldn't run into this issue in production.

Verify that if you select sftp as the delivery method, you must enter the other sftp fields, excluding password (blank passwords are technically valid, plus this one was more complicated with the encryption logic) and port (has a default value of 22, so it is always set). Verify that the existing validation has remained the same.

Verify that if you hit the api endpoint for reporting configs (https://business.sandbox.edx.org/enterprise/api/v1/enterprise_customer_reporting) that the new sftp fields come through.

Verify that both the password and sftp_password field display in plain text in the configuration but are saved encrypted in the database.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
