### PR TITLE
Add quotes to fix Javascript syntax in Django template.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.56.4] - 2017-12-19
+---------------------
+
+* Fix syntax error in template-embedded Javascript.
+
 [0.56.3] - 2017-12-14
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.56.3"
+__version__ = "0.56.4"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/templates/enterprise/grant_data_sharing_permissions.html
+++ b/enterprise/templates/enterprise/grant_data_sharing_permissions.html
@@ -6,9 +6,9 @@
   <script type="text/javascript">
     var courseId;
     var programId;
-    var successUrl = {{ redirect_url|default:"null"|escapejs }};
-    var failureUrl = {{ failure_url|default:"null"|escapejs }};
-    var deferCreation = {{ defer_creation|yesno:"true,false" }};
+    var successUrl = '{{ redirect_url|default:"null"|escapejs }}';
+    var failureUrl = '{{ failure_url|default:"null"|escapejs }}';
+    var deferCreation = '{{ defer_creation|yesno:"true,false" }}';
     {% if course_specific and course_id %}
       courseId = "{{ course_id }}";
     {% endif %}


### PR DESCRIPTION
**Description:** For some reason, this worked in the past and now it stopped working. I'm just correcting the Javascript syntax and moving on.

**Testing instructions:**

1. Visit https://business.sandbox.edx.org/enterprise/2b5a2956-7746-4fc9-9587-bc887ba45973/course/course-v1:edX+DemoX+Demo_Course/enroll/.
2. Login as alterego/alterego.
3. Click continue on the course enrollment landing page.
4. Verify that you can reject consent on the DSC page.

