### PR TITLE
ENT-799 Add save_enterprise_customer_users command.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.58.0] - 2017-12-22
+---------------------
+
+* Add save_enterprise_customer_users command.
+
 [0.57.0] - 2017-12-21
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.57.0"
+__version__ = "0.58.0"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/management/commands/save_enterprise_customer_users.py
+++ b/enterprise/management/commands/save_enterprise_customer_users.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+"""
+Django management command for saving EnterpriseCustomerUser models.
+"""
+from __future__ import absolute_import, unicode_literals
+
+import logging
+
+from django.core.management import BaseCommand
+
+from enterprise.models import EnterpriseCustomerUser
+
+LOGGER = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    Calls save() on EnterpriseCustomerUser models.
+
+    This is useful for triggering save-related signals causing the
+    associated signal receiver functions to fire.
+    """
+    help = 'Save existing EnterpriseCustomerUser models.'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '-e',
+            '--enterprise_customer_uuid',
+            action='store',
+            dest='enterprise_customer_uuid',
+            default=None,
+            help='Run this command for only the given EnterpriseCustomer UUID.'
+        )
+
+    def handle(self, *args, **options):
+        enterprise_customer_filter = {}
+        enterprise_customer_uuid = options.get('enterprise_customer_uuid')
+        if enterprise_customer_uuid:
+            enterprise_customer_filter['enterprise_customer'] = enterprise_customer_uuid
+
+        count = 0
+        for enterprise_customer_user in EnterpriseCustomerUser.objects.filter(**enterprise_customer_filter):
+            enterprise_customer_user.save()
+            count += 1
+
+        LOGGER.info('%s EnterpriseCustomerUser models saved.', count)

--- a/tests/test_enterprise/management/test_save_enterprise_customer_users.py
+++ b/tests/test_enterprise/management/test_save_enterprise_customer_users.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for the djagno management command `save_enterprise_customer_users`.
+"""
+from __future__ import absolute_import, unicode_literals
+
+import mock
+from pytest import mark
+
+from django.core.management import call_command
+from django.db.models.signals import post_save
+from django.test import TestCase
+
+from enterprise.models import EnterpriseCustomerUser
+from test_utils.factories import EnterpriseCustomerFactory, EnterpriseCustomerUserFactory, UserFactory
+
+
+@mark.django_db
+class SaveEnterpriseCustomerUsersCommandTests(TestCase):
+    """
+    Test command `save_enterprise_customer_users`.
+    """
+    command = 'save_enterprise_customer_users'
+
+    def setUp(self):
+        self.user_1 = UserFactory.create(is_active=True)
+        self.enterprise_customer_1 = EnterpriseCustomerFactory(
+            name='Test EnterpriseCustomer 1',
+            enable_data_sharing_consent=True,
+            enforce_data_sharing_consent='at_enrollment',
+        )
+        self.enterprise_customer_user_1 = EnterpriseCustomerUserFactory(
+            user_id=self.user_1.id,
+            enterprise_customer=self.enterprise_customer_1
+        )
+        self.user_2 = UserFactory.create(is_active=True)
+        self.enterprise_customer_2 = EnterpriseCustomerFactory(
+            name='Test EnterpriseCustomer 2',
+            enable_data_sharing_consent=True,
+            enforce_data_sharing_consent='at_enrollment',
+        )
+        self.enterprise_customer_user_2 = EnterpriseCustomerUserFactory(
+            user_id=self.user_2.id,
+            enterprise_customer=self.enterprise_customer_2
+        )
+        super(SaveEnterpriseCustomerUsersCommandTests, self).setUp()
+
+    @mock.patch('enterprise.management.commands.save_enterprise_customer_users.LOGGER')
+    def test_enterprise_customer_user_saved(self, logger_mock):
+        """
+        Test that the command creates missing EnterpriseCourseEnrollment records.
+        """
+        post_save_handler = mock.MagicMock()
+        post_save.connect(post_save_handler, sender=EnterpriseCustomerUser)
+
+        call_command(self.command)
+
+        logger_mock.info.assert_called_with('%s EnterpriseCustomerUser models saved.', 2)
+        post_save_handler.assert_called()
+
+    @mock.patch('enterprise.management.commands.save_enterprise_customer_users.LOGGER')
+    def test_enterprise_customer_user_saved_with_option(self, logger_mock):
+        """
+        Test that the command creates missing EnterpriseCourseEnrollment records.
+        """
+        call_command(self.command, enterprise_customer_uuid=self.enterprise_customer_1.uuid)
+
+        logger_mock.info.assert_called_with('%s EnterpriseCustomerUser models saved.', 1)


### PR DESCRIPTION
We need to be able to back-populate enterprise data on
SailThru users. The easiest way to do this is to run
through all EnterpriseCustomerUsers and save them which
will cause a signal receiver in LMS to fire off tasks
for updating the SailThru user via the SailThru API.

**Testing instructions:**

1. Shell into business.sandbox.edx.org.
2. $ edxapp
3. $ python manage.py lms save_enterprise_customer_users --settings=aws