### PR TITLE
Update enterprise to use new bundled bootstrap libary

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.56.5] - 2017-12-20
+---------------------
+
+* Fix templates to use new bootstrap bundle library.
+
 [0.56.4] - 2017-12-19
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.56.4"
+__version__ = "0.56.5"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/templates/enterprise/base.html
+++ b/enterprise/templates/enterprise/base.html
@@ -44,7 +44,6 @@
     {% endblock %}
 
     {% block contents %}{% endblock %}
-    <script type="text/javascript" src="{% static 'common/js/vendor/popper.js' %}"></script>
-    <script type="text/javascript" src="{% static 'common/js/vendor/bootstrap.js' %}"></script>
+    <script type="text/javascript" src="{% static 'common/js/vendor/bootstrap.bundle.js' %}"></script>
   </body>
 </html>


### PR DESCRIPTION


**Description:** Bootstrap.js relies on popper.js. In order to fix some bundling issues, we've switched to using the combined bootstrap + popper file now. bootstrap.js and popper.js are no longer in the CDN which is causing 404s and some pages to fail.

**JIRA:** N/A

**Dependencies:** None

**Merge deadline:** Soon?

**Installation instructions:** N/A

**Testing instructions:**
1. Open any enterprise page on stage/prod and see 404s
2. Merge this fix
3. No longer see those 404s

**Merge checklist:**

- [x] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [x] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [x] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [x] Called `make static` for webpack bundling if any static content was updated.
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [x] Translations are updated
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** 

Hard to test the failures except or stage or prod as Doug said the old files are still working on sandboxes.
