### PR TITLE
ENT-779 Remove references to ProviderConfig.drop_existing_session.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.57.0] - 2017-12-21
+---------------------
+
+* Remove references to SSO IdP config drop_existing_session flag.
+
 [0.56.5] - 2017-12-20
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.56.5"
+__version__ = "0.57.0"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/decorators.py
+++ b/enterprise/decorators.py
@@ -195,14 +195,13 @@ def force_fresh_session(view):
             # The enterprise_login_required decorator promises to set the fresh login URL
             # parameter for this URL when it was the agent that initiated the login process;
             # if that parameter isn't set, we can safely assume that the session is "stale";
-            # that isn't necessarily an issue, though. Check to see if the enterprise customer's
-            # linked identity provider requires a fresh session; if so, redirect the user to
+            # that isn't necessarily an issue, though. Redirect the user to
             # log out and then come back here - the enterprise_login_required decorator will
             # then take effect prior to us arriving back here again.
             enterprise_customer = get_enterprise_customer_or_404(kwargs.get('enterprise_uuid'))
             provider_id = enterprise_customer.identity_provider or ''
             sso_provider = get_identity_provider(provider_id)
-            if sso_provider and sso_provider.drop_existing_session:
+            if sso_provider:
                 # Parse the current request full path, quote just the path portion,
                 # then reconstruct the full path string.
                 # The path and query portions should be the only non-empty strings here.

--- a/test_utils/mixins.py
+++ b/test_utils/mixins.py
@@ -6,6 +6,9 @@ from __future__ import absolute_import, unicode_literals
 
 from django.contrib import messages
 
+from enterprise.decorators import FRESH_LOGIN_PARAMETER
+from six.moves.urllib.parse import urlencode  # pylint: disable=import-error
+
 
 class MessagesMixin(object):
     """
@@ -76,3 +79,18 @@ class EmbargoAPIMixin(object):
         Set up the embargo API module mock.
         """
         api_mock.redirect_if_blocked.return_value = redirect_url
+
+
+class EnterpriseViewMixin(object):
+    """
+    Mixin for testing enterprise views.
+    """
+
+    def _append_fresh_login_param(self, url):
+        """
+        Append the FRESH_LOGIN_PARAMETER query parameter to the URL.
+        """
+        fresh_login_param = urlencode({FRESH_LOGIN_PARAMETER: 'yes'})
+        if '?' in url:
+            return url + '&' + fresh_login_param
+        return url + '?' + fresh_login_param

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -264,16 +264,14 @@ class TestEnterpriseDecorators(unittest.TestCase):
         # Assert that view function was called.
         assert view_function.called
 
-    @ddt.data(True, False)
     @mock.patch('enterprise.utils.Registry')
-    def test_force_fresh_session_param_not_received(self, drop_exisiting_session, mock_registry):
+    def test_force_fresh_session_param_not_received(self, mock_registry):
         """
         Test that the force_fresh_session decorator redirects authenticated
         users with the appropriate provider config depending on the IdPs configuration.
         """
         mock_registry.get.return_value.configure_mock(
             provider_id=self.provider_id,
-            drop_existing_session=drop_exisiting_session
         )
         view_function = mock_view_function()
         course_id = 'course-v1:edX+DemoX+Demo_Course'
@@ -291,13 +289,8 @@ class TestEnterpriseDecorators(unittest.TestCase):
             request, enterprise_uuid=self.customer.uuid, course_id=course_id
         )
 
-        if drop_exisiting_session:
-            # Assert that redirect status code 302 is returned when a logged in user comes in
-            # with an sso provider configured to drop existing sessions
-            assert response.status_code == 302
-            # Assert the redirect URL query string is intact.
-            redirect_url_query = parse_qs(urlparse(response.url).query)
-            assert urlparse(unquote(redirect_url_query['redirect_url'][0])).query == query
-        else:
-            # Assert that view function was called.
-            assert view_function.called
+        # Assert that redirect status code 302 is returned
+        assert response.status_code == 302
+        # Assert the redirect URL query string is intact.
+        redirect_url_query = parse_qs(urlparse(response.url).query)
+        assert urlparse(unquote(redirect_url_query['redirect_url'][0])).query == query

--- a/tests/test_enterprise/views/test_handle_consent_enrollment.py
+++ b/tests/test_enterprise/views/test_handle_consent_enrollment.py
@@ -22,11 +22,12 @@ from test_utils.factories import (
     EnterpriseCustomerUserFactory,
     UserFactory,
 )
+from test_utils.mixins import EnterpriseViewMixin
 
 
 @mark.django_db
 @ddt.ddt
-class TestHandleConsentEnrollmentView(TestCase):
+class TestHandleConsentEnrollmentView(EnterpriseViewMixin, TestCase):
     """
     Test HandleConsentEnrollment.
     """
@@ -63,7 +64,7 @@ class TestHandleConsentEnrollmentView(TestCase):
         """
         Sets up the SSO Registry object
         """
-        registry_mock.get.return_value.configure_mock(provider_id=provider_id, drop_existing_session=False)
+        registry_mock.get.return_value.configure_mock(provider_id=provider_id)
 
     @mock.patch('enterprise.views.ProgramDataExtender')
     @mock.patch('enterprise.utils.Registry')
@@ -88,9 +89,11 @@ class TestHandleConsentEnrollmentView(TestCase):
         self._setup_registry_mock(registry_mock, provider_id)
         EnterpriseCustomerIdentityProviderFactory(provider_id=provider_id, enterprise_customer=enterprise_customer)
         self._login()
-        handle_consent_enrollment_url = reverse(
-            'enterprise_handle_consent_enrollment',
-            args=[enterprise_customer.uuid, course_id],
+        handle_consent_enrollment_url = self._append_fresh_login_param(
+            reverse(
+                'enterprise_handle_consent_enrollment',
+                args=[enterprise_customer.uuid, course_id],
+            )
         )
         response = self.client.get(handle_consent_enrollment_url)
         redirect_url = LMS_DASHBOARD_URL
@@ -124,11 +127,13 @@ class TestHandleConsentEnrollmentView(TestCase):
         self._setup_registry_mock(registry_mock, provider_id)
         EnterpriseCustomerIdentityProviderFactory(provider_id=provider_id, enterprise_customer=enterprise_customer)
         self._login()
-        handle_consent_enrollment_url = '{consent_enrollment_url}?{params}'.format(
-            consent_enrollment_url=reverse(
-                'enterprise_handle_consent_enrollment', args=[enterprise_customer.uuid, course_id]
-            ),
-            params=urlencode({'course_mode': 'professional'})
+        handle_consent_enrollment_url = self._append_fresh_login_param(
+            '{consent_enrollment_url}?{params}'.format(
+                consent_enrollment_url=reverse(
+                    'enterprise_handle_consent_enrollment', args=[enterprise_customer.uuid, course_id]
+                ),
+                params=urlencode({'course_mode': 'professional'})
+            )
         )
         response = self.client.get(handle_consent_enrollment_url)
         assert response.status_code == 404
@@ -168,11 +173,13 @@ class TestHandleConsentEnrollmentView(TestCase):
         mocked_enterprise_customer_user = get_ec_user_mock.return_value
         mocked_enterprise_customer_user.return_value = enterprise_customer_user
         self._login()
-        handle_consent_enrollment_url = '{consent_enrollment_url}?{params}'.format(
-            consent_enrollment_url=reverse(
-                'enterprise_handle_consent_enrollment', args=[enterprise_customer.uuid, course_id]
-            ),
-            params=urlencode({'course_mode': 'some-invalid-course-mode'})
+        handle_consent_enrollment_url = self._append_fresh_login_param(
+            '{consent_enrollment_url}?{params}'.format(
+                consent_enrollment_url=reverse(
+                    'enterprise_handle_consent_enrollment', args=[enterprise_customer.uuid, course_id]
+                ),
+                params=urlencode({'course_mode': 'some-invalid-course-mode'})
+            )
         )
         response = self.client.get(handle_consent_enrollment_url)
         redirect_url = LMS_DASHBOARD_URL
@@ -211,11 +218,13 @@ class TestHandleConsentEnrollmentView(TestCase):
         enrollment_client = enrollment_api_client_mock.return_value
         enrollment_client.get_course_modes.return_value = self.dummy_demo_course_modes
         self._login()
-        handle_consent_enrollment_url = '{consent_enrollment_url}?{params}'.format(
-            consent_enrollment_url=reverse(
-                'enterprise_handle_consent_enrollment', args=[enterprise_customer.uuid, course_id]
-            ),
-            params=urlencode({'course_mode': 'audit'})
+        handle_consent_enrollment_url = self._append_fresh_login_param(
+            '{consent_enrollment_url}?{params}'.format(
+                consent_enrollment_url=reverse(
+                    'enterprise_handle_consent_enrollment', args=[enterprise_customer.uuid, course_id]
+                ),
+                params=urlencode({'course_mode': 'audit'})
+            )
         )
         response = self.client.get(handle_consent_enrollment_url)
         redirect_url = LMS_COURSEWARE_URL.format(course_id=course_id)
@@ -267,11 +276,13 @@ class TestHandleConsentEnrollmentView(TestCase):
         enrollment_client = enrollment_api_client_mock.return_value
         enrollment_client.get_course_modes.return_value = self.dummy_demo_course_modes
         self._login()
-        handle_consent_enrollment_url = '{consent_enrollment_url}?{params}'.format(
-            consent_enrollment_url=reverse(
-                'enterprise_handle_consent_enrollment', args=[enterprise_customer.uuid, course_id]
-            ),
-            params=urlencode({'course_mode': 'professional'})
+        handle_consent_enrollment_url = self._append_fresh_login_param(
+            '{consent_enrollment_url}?{params}'.format(
+                consent_enrollment_url=reverse(
+                    'enterprise_handle_consent_enrollment', args=[enterprise_customer.uuid, course_id]
+                ),
+                params=urlencode({'course_mode': 'professional'})
+            )
         )
         response = self.client.get(handle_consent_enrollment_url)
         redirect_url = LMS_START_PREMIUM_COURSE_FLOW_URL.format(course_id=course_id)

--- a/tests/test_enterprise/views/test_program_enrollment_view.py
+++ b/tests/test_enterprise/views/test_program_enrollment_view.py
@@ -111,7 +111,7 @@ class TestProgramEnrollmentView(EmbargoAPIMixin, MessagesMixin, TestCase):
         """
         Sets up the SSO Registry object.
         """
-        registry_mock.get.return_value.configure_mock(provider_id=provider_id, drop_existing_session=False)
+        registry_mock.get.return_value.configure_mock(provider_id=provider_id)
 
     def _setup_get_data_sharing_consent(self, client_mock, required):
         """


### PR DESCRIPTION
Forcing a fresh edX session should not be optional when users are
accessing the enrollment landing pages. This removes the option.

**Related PRs**
https://github.com/edx/edx-platform/pull/16987 which I will update with the edx-enterprise version bump once this PR merges.

**Testing Instructions**
1. Clear your browser cookies.
2. Login to https://business.sandbox.edx.org with known user credentials.
3. Open new browser tab and visit https://business.sandbox.edx.org/enterprise/2b5a2956-7746-4fc9-9587-bc887ba45973/course/course-v1:edX+DemoX+Demo_Course/enroll/.
4. Login via Testshib.
5. Verify you are taken to either the registration or login page.
6. Refresh the first browser tab and verify that you are taken to the login page.