### PR TITLE
ENT-763 Show pricing in local currency

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.61.4] - 2018-01-12
+---------------------
+
+* Add localized currency to enterprise landing page.
+
 [0.61.3] - 2018-01-11
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.61.3"
+__version__ = "0.61.4"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -5,10 +5,10 @@ User-facing views for the Enterprise app.
 from __future__ import absolute_import, unicode_literals
 
 import re
-import waffle
 from logging import getLogger
 from uuid import UUID
 
+import waffle
 from consent.helpers import get_data_sharing_consent
 from consent.models import DataSharingConsent
 from dateutil.parser import parse
@@ -107,15 +107,16 @@ def get_global_context(request):
 
 def get_price_text(price, request):
     """
-    Returns the localized converted price as string (ex. '$150 USD')
+    Return the localized converted price as string (ex. '$150 USD').
 
     If the local_currency switch is enabled and the users location has been determined this will convert the
     given price based on conversion rate from the Catalog service and return a localized string
     """
     if waffle.switch_is_active('local_currency') and get_localized_price_text:
-       return get_localized_price_text(price, request)
-    else:
-        return format_price(price)
+        return get_localized_price_text(price, request)
+
+    return format_price(price)
+
 
 class NonAtomicView(View):
     """


### PR DESCRIPTION
When the waffle switch for localized currency is enabled, this will update the display price on the enterprise landing page so it displays in the users local currency based on their ip address

https://openedx.atlassian.net/browse/ENT-763

**Testing instructions:**

1. Using a new session (log out of any existing lms session) utilize a VPN to access a course through one of the LMS channels (ie. SuccessFactors) from another country (ie. Canada)
2. Verify the landing page has the price updated in the users local currency.
3. Turn off waffle switch and verify the currency is in USD
4. Turn on waffle switch and disable the VPN, verify the currency shows in USD.


Requires https://github.com/edx/edx-platform/pull/17153