### PR TITLE
ENT-784 Added check for active companies when getting channels

### DIFF
--- a/integrated_channels/integrated_channel/management/commands/__init__.py
+++ b/integrated_channels/integrated_channel/management/commands/__init__.py
@@ -53,7 +53,7 @@ class IntegratedChannelCommandMixin(object):
 
     def get_integrated_channels(self, options, **filter_kwargs):
         """
-        Generates a list of active integrated channels, filtered from the given options.
+        Generates a list of active integrated channels for active customers, filtered from the given options.
 
         Raises errors when invalid options are encountered.
 
@@ -68,7 +68,7 @@ class IntegratedChannelCommandMixin(object):
 
         channel_classes = self.get_channel_classes(options.get('channel'))
         for channel_class in channel_classes:
-            integrated_channels = channel_class.objects.filter(active=True)
+            integrated_channels = channel_class.objects.filter(active=True, enterprise_customer__active=True)
 
             if filter_kwargs:
                 integrated_channels = integrated_channels.filter(**filter_kwargs)

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -381,6 +381,28 @@ class TestTransmitCourseMetadataManagementCommand(unittest.TestCase, EnterpriseM
             # Because there are no EnterpriseCustomers with a catalog, the process will end early.
             assert not log_capture.records
 
+    @responses.activate
+    def test_transmit_course_metadata_task_inactive_customer(self):
+        """
+        Test the data transmission task with a channel for an inactive customer
+        """
+        integrated_channel_enterprise = self.enterprise_customer
+        integrated_channel_enterprise.active = False
+        integrated_channel_enterprise.save()
+
+        uuid = str(self.enterprise_customer.uuid)
+        course_run_ids = ['course-v1:edX+DemoX+Demo_Course_1', 'course-v1:edX+DemoX+Demo_Course_2']
+        self.mock_ent_courses_api_with_pagination(
+            enterprise_uuid=uuid,
+            course_run_ids=course_run_ids[:1]
+        )
+
+        with LogCapture(level=logging.INFO) as log_capture:
+            call_command('transmit_course_metadata', '--catalog_user', self.user.username)
+
+            # Because there are no active customers, the process will end early.
+            assert not log_capture.records
+
 
 COURSE_ID = 'course-v1:edX+DemoX+DemoCourse'
 


### PR DESCRIPTION
Do not execute channel jobs for inactive enterprise customer profiles	

https://openedx.atlassian.net/browse/ENT-784

**Testing instructions:**

1. In django admin, disable an enterprise customer
2. Run the transmit_course_metadata_task
3. Verify in the logs this message no longer is displayed for the customer `Processing course runs for integrated channel using configuration: [<XXXXXXEnterpriseCustomerConfiguration for COMPANY>]`

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)
