### PR TITLE
[ENT-840] EnterpriseCustomer Fields formatting

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,18 @@ Change Log
 Unreleased
 ----------
 
+[0.61.6] - 2018-01-18
+---------------------
+
+* Group Name, Active, Site, and Logo together.
+* Rename "Provider id" form label to "Identity Provider"
+* Rename "Entitlement id" form label to "Seat Entitlement"
+* Rename "Coupon URL" form label to "Seat Entitlement URL"
+* Add a "View details" hyperlink next to identity provider drop-down.
+* Add a "Create a new catalog" link under the Catalog drop-down.
+* Add a "View details" hyperlink next to catalog field, if catalog is selected.
+* Add a "Create a new identity provider" link under the Identity Provider drop-down.
+
 [0.61.5] - 2018-01-18
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.61.5"
+__version__ = "0.61.6"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/admin/__init__.py
+++ b/enterprise/admin/__init__.py
@@ -90,7 +90,7 @@ class EnterpriseCustomerEntitlementInline(admin.StackedInline):
 
     readonly_fields = ('ecommerce_coupon_url',)
     ecommerce_coupon_url.allow_tags = True
-    ecommerce_coupon_url.short_description = 'Coupon URL'
+    ecommerce_coupon_url.short_description = 'Seat Entitlement URL'
 
 
 class EnterpriseCustomerCatalogInline(admin.TabularInline):
@@ -112,14 +112,14 @@ class EnterpriseCustomerAdmin(DjangoObjectActions, SimpleHistoryAdmin):
     """
     list_display = (
         'name',
-        'uuid',
         'site',
         'active',
         'has_logo',
         'enable_dsc',
         'has_identity_provider',
         'has_enterprise_catalog',
-        'has_ecommerce_coupons'
+        'has_ecommerce_coupons',
+        'uuid',
     )
 
     list_filter = ('active',)

--- a/enterprise/migrations/0037_auto_20180110_0450.py
+++ b/enterprise/migrations/0037_auto_20180110_0450.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('enterprise', '0036_sftp_reporting_support'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='enterprisecustomerentitlement',
+            name='entitlement_id',
+            field=models.PositiveIntegerField(help_text="Enterprise customer's entitlement id for relationship with e-commerce coupon.", unique=True, verbose_name='Seat Entitlement'),
+        ),
+        migrations.AlterField(
+            model_name='historicalenterprisecustomerentitlement',
+            name='entitlement_id',
+            field=models.PositiveIntegerField(help_text="Enterprise customer's entitlement id for relationship with e-commerce coupon.", verbose_name='Seat Entitlement', db_index=True),
+        ),
+    ]

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -845,7 +845,8 @@ class EnterpriseCustomerEntitlement(TimeStampedModel):
         blank=False,
         null=False,
         unique=True,
-        help_text=_("Enterprise customer's entitlement id for relationship with e-commerce coupon.")
+        help_text=_("Enterprise customer's entitlement id for relationship with e-commerce coupon."),
+        verbose_name=_('Seat Entitlement')
     )
     history = HistoricalRecords()
 

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -154,17 +154,19 @@ def get_catalog_admin_url(catalog_id):
     return get_catalog_admin_url_template().format(catalog_id=catalog_id)
 
 
-def get_catalog_admin_url_template():
+def get_catalog_admin_url_template(mode='change'):
     """
     Get template of catalog admin url.
 
     URL template will contain a placeholder '{catalog_id}' for catalog id.
+    Arguments:
+        mode e.g. change/add.
 
     Returns:
         A string containing template for catalog url.
 
     Example:
-        >>> get_catalog_admin_url_template()
+        >>> get_catalog_admin_url_template('change')
         "http://localhost:18381/admin/catalogs/catalog/{catalog_id}/change/"
 
     """
@@ -177,7 +179,10 @@ def get_catalog_admin_url_template():
         return ""
 
     # Return matched FQDN from catalog api url appended with catalog admin path
-    return match.group("fqdn").rstrip("/") + "/admin/catalogs/catalog/{catalog_id}/change/"
+    if mode == 'change':
+        return match.group("fqdn").rstrip("/") + "/admin/catalogs/catalog/{catalog_id}/change/"
+    elif mode == 'add':
+        return match.group("fqdn").rstrip("/") + "/admin/catalogs/catalog/add/"
 
 
 def build_notification_message(template_context, template_configuration=None):


### PR DESCRIPTION
**Description:** Django admin EnterpriseCustomer Fields formatting.

**JIRA:** [ENT-840](https://openedx.atlassian.net/browse/ENT-840)

**Testing instructions:**

1. Visit EnterpriseCustomer [admin page](https://business.sandbox.edx.org/admin/enterprise/enterprisecustomer/8087b663-78bd-421e-8117-74eb03d22741/) to see the changes listed in ticket.
**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS