### PR TITLE
ENT-842 Include start date in all course runs title

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.61.5] - 2018-01-18
+---------------------
+
+* Include start date in all course runs title when pushing to Integrated Channels.
+
 [0.61.4] - 2018-01-12
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.61.4"
+__version__ = "0.61.5"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/integrated_channel/exporters/course_metadata.py
+++ b/integrated_channels/integrated_channel/exporters/course_metadata.py
@@ -113,8 +113,9 @@ class CourseExporter(Exporter):
         """
         title = course_run.get('title') or ''
         course_run_start = course_run.get('start')
-        if course_run_start and course_run.get('pacing_type') == 'instructor_paced':
+        if course_run_start:
             title += ' (Starts: {:%B %Y})'.format(
                 parse_lms_api_datetime(course_run_start)
             )
+
         return title


### PR DESCRIPTION
@asadiqbal08 @saleem-latif @georgebabey 
**Description:** Include start date in all course runs title when pushing to Integrated Channels.

**JIRA:** [ENT-842](https://openedx.atlassian.net/browse/ENT-842)

**Dependencies:** N/A

**Merge deadline:** 26-Jan-2018

**Installation instructions:** Install `edx-enterprise` from this branch `zub/ENT-842-include-start-date-in-course-runs-title` in `edx-platform`.

**Testing instructions:**

1. Add enterprises with catalogs
1. Add configurations for integrated channels for `Degreed` and `SAP Success Factors`
2. Run django management command `transmit_course_metadata` and verify that all course runs (including both `instructor-paced` and `self-paced`) have start date in their title with the format `edX Demonstration Course (Starts: February 2013)`

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
