### PR TITLE
ENT-846 Do not display credit mode on course enrollment page.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.62.0] - 2018-01-18
+---------------------
+
+* Exclude credit course mode option from course enrollment page.
+
 [0.61.6] - 2018-01-18
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.61.6"
+__version__ = "0.62.0"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api_client/lms.py
+++ b/enterprise/api_client/lms.py
@@ -18,7 +18,7 @@ from slumber.exceptions import HttpNotFoundError, SlumberBaseException
 from django.conf import settings
 from django.utils import timezone
 
-from enterprise.constants import COURSE_MODE_SORT_ORDER
+from enterprise.constants import COURSE_MODE_SORT_ORDER, EXCLUDED_COURSE_MODES
 from enterprise.utils import NotConnectedToOpenEdX
 
 try:
@@ -199,7 +199,7 @@ class EnrollmentApiClient(LmsApiClient):
         """
         details = self.get_course_details(course_id)
         modes = details.get('course_modes', [])
-        return self._sort_course_modes(modes)
+        return self._sort_course_modes([mode for mode in modes if mode['slug'] not in EXCLUDED_COURSE_MODES])
 
     def has_course_mode(self, course_run_id, mode):
         """

--- a/enterprise/constants.py
+++ b/enterprise/constants.py
@@ -29,7 +29,10 @@ CONFIRMATION_ALERT_PROMPT_WARNING = _(
 )
 
 # Course mode sorting based on slug
-COURSE_MODE_SORT_ORDER = ['verified', 'professional', 'no-id-professional', 'credit', 'audit', 'honor']
+COURSE_MODE_SORT_ORDER = ['verified', 'professional', 'no-id-professional', 'audit', 'honor']
+
+# Course modes that should not be displayed to users.
+EXCLUDED_COURSE_MODES = ['credit']
 
 
 PROGRAM_TYPE_DESCRIPTION = {

--- a/tests/test_enterprise/api_client/test_lms.py
+++ b/tests/test_enterprise/api_client/test_lms.py
@@ -147,6 +147,7 @@ def test_is_enrolled():
 
 @responses.activate
 @mock.patch('enterprise.api_client.lms.COURSE_MODE_SORT_ORDER', ['a', 'list', 'containing', 'most', 'of', 'the'])
+@mock.patch('enterprise.api_client.lms.EXCLUDED_COURSE_MODES', ['course'])
 def test_get_enrollment_course_modes():
     course_id = "course-v1:edX+DemoX+Demo_Course"
     response = {
@@ -162,7 +163,6 @@ def test_get_enrollment_course_modes():
         {'slug': 'a'},
         {'slug': 'list'},
         {'slug': 'containing'},
-        {'slug': 'course'},
         {'slug': 'modes'},
     ]
     responses.add(
@@ -206,6 +206,7 @@ def test_has_course_modes():
 
 @responses.activate
 @mock.patch('enterprise.api_client.lms.COURSE_MODE_SORT_ORDER', ['a', 'list', 'containing', 'most', 'of', 'the'])
+@mock.patch('enterprise.api_client.lms.EXCLUDED_COURSE_MODES', ['course'])
 def test_doesnt_have_course_modes():
     course_id = "course-v1:edX+DemoX+Demo_Course"
     response = {
@@ -226,7 +227,7 @@ def test_doesnt_have_course_modes():
         json=response
     )
     client = lms_api.EnrollmentApiClient()
-    actual_response = client.has_course_mode(course_id, 'nope')
+    actual_response = client.has_course_mode(course_id, 'course')
     assert actual_response is False
 
 


### PR DESCRIPTION
## Testing Instructions

1. Visit https://business.sandbox.edx.org/enterprise/2b5a2956-7746-4fc9-9587-bc887ba45973/course/course-v1:edX+DemoX+Demo_Course/enroll/?catalog=cff09318-1358-4703-a277-bc2596480ed5.
2. Create new account.
3. Verify the course enrollment page does not list a credit option.