### PR TITLE
ENT-823 Add course detail endpoint to EnterpriseCustomerCatalog API.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.66.0] - 2018-03-05
+---------------------
+
+* Add EnterpriseCustomerCatalog course detail endpoint.
+
 [0.65.8] - 2018-02-23
 ---------------------
 

--- a/api-compact.yaml
+++ b/api-compact.yaml
@@ -166,6 +166,12 @@ course_run_id_parameter: &course_run_id_parameter
   required: true
   type: "string"
 
+course_key_parameter: &course_key_parameter
+  name: "course_key"
+  in: "path"
+  required: true
+  type: "string"
+
 program_uuid_parameter: &program_uuid_parameter
   name: "program_uuid"
   in: "path"
@@ -282,6 +288,17 @@ x-amazon-apigateway-integration-with-enterprise-customer-catalog-uuid-and-course
     integration.request.querystring.page: "method.request.querystring.page"
     integration.request.querystring.page_size: "method.request.querystring.page_size"
 
+x-amazon-apigateway-integration-with-enterprise-customer-catalog-uuid-and-course-key-parameters: &apigateway_integration_with_enterprise_customer_catalog_uuid_and_course_key_parameters
+  responses: *apigateway_responses
+  httpMethod: "GET"
+  type: "http"
+  requestParameters:
+    integration.request.header.Authorization: "method.request.header.Authorization"
+    integration.request.path.uuid: "method.request.path.uuid"
+    integration.request.path.course_run_id: "method.request.path.course_key"
+    integration.request.querystring.page: "method.request.querystring.page"
+    integration.request.querystring.page_size: "method.request.querystring.page_size"
+
 endpoints:
   v1:
 
@@ -375,6 +392,22 @@ endpoints:
           x-amazon-apigateway-integration:
             <<: *apigateway_integration_with_enterprise_customer_catalog_uuid_and_course_run_id_parameters
             uri: "https://${stageVariables.enterprise_host}/enterprise/api/v1/enterprise_catalogs/{uuid}/course_runs/{course_run_id}/"
+
+    # /v1/enterprise_catalogs/{uuid}/courses/{course_key}/
+    enterpriseCustomerCatalogCourseByKey:
+        get:
+          produces: *produces
+          parameters:
+            - *auth_header
+            - *uuid_parameter
+            - *course_key_parameter
+            - *page_qs_parameter
+            - *page_size_qs_parameter
+          operationId: "get_enterprise_customer_catalog_course_by_key"
+          responses: *responses
+          x-amazon-apigateway-integration:
+            <<: *apigateway_integration_with_enterprise_customer_catalog_uuid_and_course_key_parameters
+            uri: "https://${stageVariables.enterprise_host}/enterprise/api/v1/enterprise_catalogs/{uuid}/courses/{course_key}/"
 
     # /v1/enterprise_catalogs/{uuid}/programs/{program_uuid}/
     enterpriseCustomerCatalogProgramByUuid:

--- a/api.yaml
+++ b/api.yaml
@@ -97,6 +97,11 @@ auth_header:
   name: Authorization
   required: true
   type: string
+course_key_parameter: 
+  in: path
+  name: course_key
+  required: true
+  type: string
 course_run_id_parameter: 
   in: path
   name: course_run_id
@@ -404,6 +409,78 @@ endpoints:
               statusCode: "400"
           type: http
           uri: "https://${stageVariables.enterprise_host}/enterprise/api/v1/enterprise_catalogs/{uuid}/"
+    enterpriseCustomerCatalogCourseByKey: 
+      get: 
+        operationId: get_enterprise_customer_catalog_course_by_key
+        parameters: 
+          - 
+            in: header
+            name: Authorization
+            required: true
+            type: string
+          - 
+            in: path
+            name: uuid
+            required: true
+            type: string
+          - 
+            in: path
+            name: course_key
+            required: true
+            type: string
+          - 
+            in: query
+            name: page
+            required: false
+            type: number
+          - 
+            in: query
+            name: page_size
+            required: false
+            type: number
+        produces: 
+          - application/json
+          - application/csv
+        responses: 
+          200: 
+            description: OK
+          400: 
+            description: "Bad Request"
+          401: 
+            description: Unauthorized
+          403: 
+            description: Forbidden
+          404: 
+            description: "Not Found"
+          429: 
+            description: "Too Many Requests"
+          500: 
+            description: "Internal Server Error"
+        x-amazon-apigateway-integration: 
+          httpMethod: GET
+          requestParameters: 
+            integration.request.header.Authorization: method.request.header.Authorization
+            integration.request.path.course_run_id: method.request.path.course_key
+            integration.request.path.uuid: method.request.path.uuid
+            integration.request.querystring.page: method.request.querystring.page
+            integration.request.querystring.page_size: method.request.querystring.page_size
+          responses: 
+            200: 
+              statusCode: "200"
+            401: 
+              statusCode: "401"
+            403: 
+              statusCode: "403"
+            404: 
+              statusCode: "404"
+            429: 
+              statusCode: "429"
+            500: 
+              statusCode: "500"
+            default: 
+              statusCode: "400"
+          type: http
+          uri: "https://${stageVariables.enterprise_host}/enterprise/api/v1/enterprise_catalogs/{uuid}/courses/{course_key}/"
     enterpriseCustomerCatalogCourseRunByUuid: 
       get: 
         operationId: get_enterprise_customer_catalog_course_run_by_id
@@ -856,6 +933,30 @@ x-amazon-apigateway-integration-id-response:
     default: 
       statusCode: "400"
   type: http
+x-amazon-apigateway-integration-with-enterprise-customer-catalog-uuid-and-course-key-parameters: 
+  httpMethod: GET
+  requestParameters: 
+    integration.request.header.Authorization: method.request.header.Authorization
+    integration.request.path.course_run_id: method.request.path.course_key
+    integration.request.path.uuid: method.request.path.uuid
+    integration.request.querystring.page: method.request.querystring.page
+    integration.request.querystring.page_size: method.request.querystring.page_size
+  responses: 
+    200: 
+      statusCode: "200"
+    401: 
+      statusCode: "401"
+    403: 
+      statusCode: "403"
+    404: 
+      statusCode: "404"
+    429: 
+      statusCode: "429"
+    500: 
+      statusCode: "500"
+    default: 
+      statusCode: "400"
+  type: http
 x-amazon-apigateway-integration-with-enterprise-customer-catalog-uuid-and-course-run-id-parameters: 
   httpMethod: GET
   requestParameters: 
@@ -960,4 +1061,3 @@ x-amazon-apigateway-integration-with-id-and-querystring-parameters:
     default: 
       statusCode: "400"
   type: http
-

--- a/consent/models.py
+++ b/consent/models.py
@@ -17,7 +17,7 @@ from django.utils.translation import ugettext_lazy as _
 from model_utils.models import TimeStampedModel
 
 from enterprise.models import EnterpriseCustomer
-from enterprise.utils import get_course_id_from_course_run_id
+from enterprise.utils import parse_course_key
 
 
 class DataSharingConsentQuerySet(models.query.QuerySet):
@@ -52,7 +52,7 @@ class DataSharingConsentQuerySet(models.query.QuerySet):
                 except DataSharingConsent.DoesNotExist:
                     # A record for the course run didn't exist, so modify the query
                     # parameters to look for just a course record on the second pass.
-                    kwargs['course_id'] = get_course_id_from_course_run_id(course_run_key)
+                    kwargs['course_id'] = parse_course_key(course_run_key)
 
         try:
             return self.get(*args, **kwargs)

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.65.8"
+__version__ = "0.66.0"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -220,6 +220,8 @@ class EnterpriseCustomerCatalogDetailSerializer(EnterpriseCustomerCatalogSeriali
                     marketing_url, utils.get_enterprise_utm_context(enterprise_customer)
                 )
             # Add the Enterprise enrollment URL to each content item returned from the discovery service.
+            if content_type == 'course':
+                item['enrollment_url'] = instance.get_course_enrollment_url(item['key'])
             if content_type == 'courserun':
                 item['enrollment_url'] = instance.get_course_run_enrollment_url(item['key'])
             if content_type == 'program':
@@ -350,6 +352,36 @@ class EnterpriseCatalogCoursesReadOnlySerializer(ResponsePaginationSerializer, E
     pass
 
 
+class CourseDetailSerializer(ImmutableStateSerializer):
+    """
+    Serializer for course data retrieved from the discovery service course detail API endpoint.
+
+    This serializer updates the course and course run data with the EnterpriseCustomer-specific enrollment page URL
+    for the given course and course runs.
+    """
+
+    def to_representation(self, instance):
+        """
+        Return the updated course data dictionary.
+
+        Arguments:
+            instance (dict): The course data.
+
+        Returns:
+            dict: The updated course data.
+        """
+        updated_course = copy.deepcopy(instance)
+        enterprise_customer_catalog = self.context['enterprise_customer_catalog']
+        updated_course['enrollment_url'] = enterprise_customer_catalog.get_course_enrollment_url(
+            updated_course['key']
+        )
+        for course_run in updated_course['course_runs']:
+            course_run['enrollment_url'] = enterprise_customer_catalog.get_course_run_enrollment_url(
+                course_run['key']
+            )
+        return updated_course
+
+
 class CourseRunDetailSerializer(ImmutableStateSerializer):
     """
     Serializer for course run data retrieved from the discovery service course_run detail API endpoint.
@@ -369,8 +401,8 @@ class CourseRunDetailSerializer(ImmutableStateSerializer):
             dict: The updated course run data.
         """
         updated_course_run = copy.deepcopy(instance)
-        enterprise_customer = self.context['enterprise_customer']
-        updated_course_run['enrollment_url'] = enterprise_customer.get_course_run_enrollment_url(
+        enterprise_customer_catalog = self.context['enterprise_customer_catalog']
+        updated_course_run['enrollment_url'] = enterprise_customer_catalog.get_course_run_enrollment_url(
             updated_course_run['key']
         )
         return updated_course_run
@@ -395,11 +427,16 @@ class ProgramDetailSerializer(ImmutableStateSerializer):
             dict: The updated program data.
         """
         updated_program = copy.deepcopy(instance)
-        enterprise_customer = self.context['enterprise_customer']
-        updated_program['enrollment_url'] = enterprise_customer.get_program_enrollment_url(updated_program['uuid'])
+        enterprise_customer_catalog = self.context['enterprise_customer_catalog']
+        updated_program['enrollment_url'] = enterprise_customer_catalog.get_program_enrollment_url(
+            updated_program['uuid']
+        )
         for course in updated_program['courses']:
+            course['enrollment_url'] = enterprise_customer_catalog.get_course_enrollment_url(course['key'])
             for course_run in course['course_runs']:
-                course_run['enrollment_url'] = enterprise_customer.get_course_run_enrollment_url(course_run['key'])
+                course_run['enrollment_url'] = enterprise_customer_catalog.get_course_run_enrollment_url(
+                    course_run['key']
+                )
         return updated_program
 
 

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -27,6 +27,7 @@ from enterprise.api.throttles import ServiceUserThrottle
 from enterprise.api.v1 import serializers
 from enterprise.api.v1.decorators import enterprise_customer_required, require_at_least_one_query_parameter
 from enterprise.api_client.discovery import CourseCatalogApiClient
+from enterprise.constants import COURSE_KEY_URL_PATTERN
 from six.moves.urllib.parse import quote_plus, unquote  # pylint: disable=import-error,ungrouped-imports
 
 LOGGER = getLogger(__name__)
@@ -119,8 +120,8 @@ class EnterpriseCustomerViewSet(EnterpriseReadWriteModelViewSet):
 
         contains_content_items = False
         for catalog in enterprise_customer.enterprise_customer_catalogs.all():
-            contains_course_runs = not course_run_ids or catalog.contains_content_items('key', course_run_ids)
-            contains_program_uuids = not program_uuids or catalog.contains_content_items('uuid', program_uuids)
+            contains_course_runs = not course_run_ids or catalog.contains_courses(course_run_ids)
+            contains_program_uuids = not program_uuids or catalog.contains_programs(program_uuids)
             if contains_course_runs and contains_program_uuids:
                 contains_content_items = True
                 break
@@ -326,14 +327,32 @@ class EnterpriseCustomerCatalogViewSet(EnterpriseReadOnlyModelViewSet):
 
         contains_content_items = True
         if course_run_ids:
-            contains_content_items = enterprise_customer_catalog.contains_content_items('key', course_run_ids)
+            contains_content_items = enterprise_customer_catalog.contains_courses(course_run_ids)
         if program_uuids:
-            contains_content_items = contains_content_items and enterprise_customer_catalog.contains_content_items(
-                'uuid',
-                program_uuids
+            contains_content_items = (
+                contains_content_items and
+                enterprise_customer_catalog.contains_programs(program_uuids)
             )
 
         return Response({'contains_content_items': contains_content_items})
+
+    @detail_route(url_path='courses/{}'.format(COURSE_KEY_URL_PATTERN))
+    def course_detail(self, request, pk, course_key):  # pylint: disable=invalid-name,unused-argument
+        """
+        Return the metadata for the specified course.
+
+        The course needs to be included in the specified EnterpriseCustomerCatalog
+        in order for metadata to be returned from this endpoint.
+        """
+        enterprise_customer_catalog = self.get_object()
+        course = enterprise_customer_catalog.get_course(course_key)
+        if not course:
+            raise Http404
+
+        context = self.get_serializer_context()
+        context['enterprise_customer_catalog'] = enterprise_customer_catalog
+        serializer = serializers.CourseDetailSerializer(course, context=context)
+        return Response(serializer.data)
 
     @detail_route(url_path='course_runs/{}'.format(settings.COURSE_ID_PATTERN))
     def course_run_detail(self, request, pk, course_id):  # pylint: disable=invalid-name,unused-argument
@@ -349,7 +368,7 @@ class EnterpriseCustomerCatalogViewSet(EnterpriseReadOnlyModelViewSet):
             raise Http404
 
         context = self.get_serializer_context()
-        context['enterprise_customer'] = enterprise_customer_catalog.enterprise_customer
+        context['enterprise_customer_catalog'] = enterprise_customer_catalog
         serializer = serializers.CourseRunDetailSerializer(course_run, context=context)
         return Response(serializer.data)
 
@@ -367,7 +386,7 @@ class EnterpriseCustomerCatalogViewSet(EnterpriseReadOnlyModelViewSet):
             raise Http404
 
         context = self.get_serializer_context()
-        context['enterprise_customer'] = enterprise_customer_catalog.enterprise_customer
+        context['enterprise_customer_catalog'] = enterprise_customer_catalog
         serializer = serializers.ProgramDetailSerializer(program, context=context)
         return Response(serializer.data)
 

--- a/enterprise/api_client/discovery.py
+++ b/enterprise/api_client/discovery.py
@@ -20,7 +20,7 @@ from enterprise.utils import (
     MultipleProgramMatchError,
     NotConnectedToOpenEdX,
     get_configuration_value_for_site,
-    get_course_id_from_course_run_id,
+    parse_course_key,
 )
 
 try:
@@ -207,7 +207,7 @@ class CourseCatalogApiClient(object):
             tuple: The course metadata and the course run metadata.
         """
         # Parse the course ID from the course run ID.
-        course_id = get_course_id_from_course_run_id(course_run_id)
+        course_id = parse_course_key(course_run_id)
         # Retrieve the course metadata from the catalog service.
         course = self.get_course_details(course_id)
 

--- a/enterprise/constants.py
+++ b/enterprise/constants.py
@@ -28,6 +28,8 @@ CONFIRMATION_ALERT_PROMPT_WARNING = _(
     '{enterprise_customer_name}.'
 )
 
+COURSE_KEY_URL_PATTERN = r'(?P<course_key>[^/+]+(/|\+)[^/+]+)'
+
 # Course mode sorting based on slug
 COURSE_MODE_SORT_ORDER = ['verified', 'professional', 'no-id-professional', 'audit', 'honor']
 

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -27,7 +27,7 @@ from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 from django.template import Context, Template
 from django.utils.encoding import force_bytes, force_text, python_2_unicode_compatible
-from django.utils.functional import lazy
+from django.utils.functional import cached_property, lazy
 from django.utils.http import urlquote
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
@@ -44,7 +44,7 @@ from enterprise.api_client.lms import (
     parse_lms_api_datetime,
 )
 from enterprise.constants import json_serialized_course_modes
-from enterprise.utils import CourseEnrollmentDowngradeError, get_configuration_value
+from enterprise.utils import CourseEnrollmentDowngradeError, get_configuration_value, parse_course_key
 from enterprise.validators import validate_image_extension, validate_image_size
 from six.moves.urllib.parse import urljoin  # pylint: disable=import-error,ungrouped-imports
 
@@ -204,6 +204,24 @@ class EnterpriseCustomer(TimeStampedModel):
         """
         return self.enable_audit_enrollment and self.enable_audit_data_reporting
 
+    def get_course_enrollment_url(self, course_key):
+        """
+        Return enterprise landing page url for the given course.
+
+        Arguments:
+            course_key (str): The course key for the course to be displayed.
+        Returns:
+            (str): Enterprise landing page url.
+        """
+        url = urljoin(
+            get_configuration_value('LMS_ROOT_URL', settings.LMS_ROOT_URL),
+            reverse(
+                'enterprise_course_enrollment_page',
+                kwargs={'enterprise_uuid': self.uuid, 'course_key': course_key}
+            )
+        )
+        return utils.update_query_parameters(url, utils.get_enterprise_utm_context(self))
+
     def get_course_run_enrollment_url(self, course_run_key):
         """
         Return enterprise landing page url for the given course.
@@ -216,7 +234,7 @@ class EnterpriseCustomer(TimeStampedModel):
         url = urljoin(
             get_configuration_value('LMS_ROOT_URL', settings.LMS_ROOT_URL),
             reverse(
-                'enterprise_course_enrollment_page',
+                'enterprise_course_run_enrollment_page',
                 kwargs={'enterprise_uuid': self.uuid, 'course_id': course_run_key}
             )
         )
@@ -256,7 +274,7 @@ class EnterpriseCustomer(TimeStampedModel):
                 return True
 
         for catalog in self.enterprise_customer_catalogs.all():
-            if catalog.contains_content_items('key', [course_run_id]):
+            if catalog.contains_courses([course_run_id]):
                 return True
 
         return False
@@ -1026,6 +1044,13 @@ class EnterpriseCustomerCatalog(TimeStampedModel):
         """
         return self.__str__()
 
+    @cached_property
+    def content_filter_ids(self):
+        """
+        Return the list of any content IDs specified in the catalog's content filter.
+        """
+        return set(self.content_filter.get('key', []) + self.content_filter.get('uuid', []))
+
     def get_paginated_content(self, query_parameters):
         """
         Return paginated discovery service search results.
@@ -1043,6 +1068,8 @@ class EnterpriseCustomerCatalog(TimeStampedModel):
         for content in search_results['results']:
             if content['content_type'] == 'courserun' and content['has_enrollable_seats']:
                 results.append(content)
+            elif content['content_type'] == 'course':
+                results.append(content)
             elif content['content_type'] == 'program' and content['is_program_eligible_for_one_click_purchase']:
                 results.append(content)
 
@@ -1055,38 +1082,65 @@ class EnterpriseCustomerCatalog(TimeStampedModel):
 
         return response
 
-    def contains_content_items(self, content_id_field_name, content_id_values):
+    def _filter_members(self, content_id_field_name, content_id_values):
         """
-        Return True if this catalog contains the items identified by `content_id_field_name` and `content_id_values`.
+        Filter the given list of content_id_values, returning only those that are members of the catalog.
+
+        A content ID is the unique identifier for a content metadata entity, e.g. course, course run, program.
 
         Arguments:
             content_id_field_name (str): The name of the field on the catalog content item
                                          that stores the item's unique identifier, e.g. "key", "uuid".
-            content_id_values (list): The unique identifiers of the catalog content items.
+            content_id_values (list): If provided, return only the content IDs that are members of this list
+                                      and members of the catalog.
 
         Returns:
-            bool: True if this catalog contains the given content items, else false.
+            list: The list of content IDs that are members of the catalog.
         """
-        # Check the content_filter defined for this catalog to see if the
-        # unique key is a part of the filter that defines this catalog.
-        content_ids_in_catalog = set(self.content_filter.get(content_id_field_name, []))
-        if not content_ids_in_catalog:
-            # Otherwise add the unique key values to the content_filter and query
-            # the discovery service for the existence of the content.
-            updated_content_filter = self.content_filter.copy()
-            updated_content_filter[content_id_field_name] = content_id_values
-            results = CourseCatalogApiServiceClient().get_search_results(updated_content_filter)
-            if results:
-                for content in results:
-                    if content['content_type'] == 'courserun' and content['has_enrollable_seats']:
-                        content_ids_in_catalog.add(content[content_id_field_name])
-                    elif content['content_type'] == 'program' and content['is_program_eligible_for_one_click_purchase']:
-                        content_ids_in_catalog.add(content[content_id_field_name])
+        updated_content_filter = self.content_filter.copy()
+        updated_content_filter[content_id_field_name] = content_id_values
+        results = CourseCatalogApiServiceClient().get_search_results(updated_content_filter) or []
+        return {x[content_id_field_name] for x in results}
 
-        # Diff the content IDs found in the catalog with the set of
-        # IDs which we are checking for existence.
-        intersection = set(content_id_values) & content_ids_in_catalog
-        return len(intersection) == len(content_id_values)
+    def contains_courses(self, content_ids):
+        """
+        Return true if this catalog contains the given courses.
+
+        The content_ids parameter should be a list containing course keys
+        and/or course run ids.
+        """
+        # Translate any provided course run IDs to course keys.
+        course_keys = {parse_course_key(k) for k in content_ids}
+
+        content_ids_in_catalog = self.content_filter_ids
+        if not content_ids_in_catalog:
+            content_ids_in_catalog = self._filter_members('key', course_keys)
+
+        return set(content_ids).issubset(content_ids_in_catalog) or course_keys.issubset(content_ids_in_catalog)
+
+    def contains_programs(self, program_uuids):
+        """
+        Return true if this catalog contains the given programs.
+        """
+        content_ids_in_catalog = self.content_filter_ids
+        if not content_ids_in_catalog:
+            content_ids_in_catalog = self._filter_members('uuid', program_uuids)
+
+        return set(program_uuids).issubset(content_ids_in_catalog)
+
+    def get_course(self, course_key):
+        """
+        Get all of the metadata for the given course.
+
+        Arguments:
+            course_key (str): The course key which identifies the course.
+
+        Return:
+            dict: The course metadata.
+        """
+        if not self.contains_courses([course_key]):
+            return None
+        return CourseCatalogApiServiceClient(self.enterprise_customer.site).get_course_details(course_key)
 
     def get_course_run(self, course_run_id):
         """
@@ -1098,8 +1152,9 @@ class EnterpriseCustomerCatalog(TimeStampedModel):
         Return:
             dict: The course run metadata.
         """
-        if not self.contains_content_items('key', [course_run_id]):
+        if not self.contains_courses([course_run_id]):
             return None
+
         return CourseCatalogApiServiceClient(self.enterprise_customer.site).get_course_run(course_run_id)
 
     def get_course_and_course_run(self, course_run_id):
@@ -1116,8 +1171,9 @@ class EnterpriseCustomerCatalog(TimeStampedModel):
             ImproperlyConfigured: Missing or invalid catalog integration.
 
         """
-        if not self.contains_content_items('key', [course_run_id]):
+        if not self.contains_courses([course_run_id]):
             return None, None
+
         return CourseCatalogApiServiceClient(self.enterprise_customer.site).get_course_and_course_run(course_run_id)
 
     def get_program(self, program_uuid):
@@ -1130,9 +1186,25 @@ class EnterpriseCustomerCatalog(TimeStampedModel):
         Return:
             dict: The program metadata.
         """
-        if not self.contains_content_items('uuid', [program_uuid]):
+        if not self.contains_programs([program_uuid]):
             return None
         return CourseCatalogApiServiceClient(self.enterprise_customer.site).get_program_by_uuid(program_uuid)
+
+    def get_course_enrollment_url(self, course_key):
+        """
+        Return enterprise course enrollment page url with the catalog information for the given course.
+
+        Arguments:
+            course_key (str): The course key for the course to be displayed.
+
+        Returns:
+            (str): Enterprise landing page url.
+        """
+        url = self.enterprise_customer.get_course_enrollment_url(course_key)
+        if self.publish_audit_enrollment_urls:
+            url = utils.update_query_parameters(url, {'audit': 'true'})
+
+        return utils.update_query_parameters(url, {'catalog': self.uuid})
 
     def get_course_run_enrollment_url(self, course_run_key):
         """

--- a/enterprise/urls.py
+++ b/enterprise/urls.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, unicode_literals
 from django.conf import settings
 from django.conf.urls import include, url
 
+from enterprise.constants import COURSE_KEY_URL_PATTERN
 from enterprise.views import GrantDataSharingPermissions, RouterView
 
 ENTERPRISE_ROUTER = RouterView.as_view()
@@ -25,9 +26,14 @@ urlpatterns = [
         name='enterprise_handle_consent_enrollment'
     ),
     url(
-        r'^enterprise/(?P<enterprise_uuid>[^/]+)/course/{}/enroll/$'.format(settings.COURSE_ID_PATTERN),
+        r'^enterprise/(?P<enterprise_uuid>[^/]+)/course/{}/enroll/$'.format(COURSE_KEY_URL_PATTERN),
         ENTERPRISE_ROUTER,
         name='enterprise_course_enrollment_page'
+    ),
+    url(
+        r'^enterprise/(?P<enterprise_uuid>[^/]+)/course/{}/enroll/$'.format(settings.COURSE_ID_PATTERN),
+        ENTERPRISE_ROUTER,
+        name='enterprise_course_run_enrollment_page'
     ),
     url(
         r'^enterprise/(?P<enterprise_uuid>[^/]+)/program/(?P<program_uuid>[^/]+)/enroll/$',

--- a/test_utils/fake_enterprise_api.py
+++ b/test_utils/fake_enterprise_api.py
@@ -75,7 +75,7 @@ class EnterpriseMockMixin(object):
             'enrollment_url': urljoin(
                 settings.LMS_ROOT_URL,
                 reverse(
-                    'enterprise_course_enrollment_page',
+                    'enterprise_course_run_enrollment_page',
                     args=[enterprise_uuid, course_run_key.to_deprecated_string()],
                 )
             ),

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -109,7 +109,7 @@ class TestEnterpriseDecorators(unittest.TestCase):
         """
         view_function = mock_view_function()
         enterprise_launch_url = reverse(
-            'enterprise_course_enrollment_page',
+            'enterprise_course_run_enrollment_page',
             args=[self.customer.uuid, 'course-v1:edX+DemoX+Demo_Course'],
         )
         request = self._prepare_request(enterprise_launch_url, UserFactory(is_active=True))
@@ -125,7 +125,7 @@ class TestEnterpriseDecorators(unittest.TestCase):
         view_function = mock_view_function()
         course_id = 'course-v1:edX+DemoX+Demo_Course'
         enterprise_launch_url = reverse(
-            'enterprise_course_enrollment_page',
+            'enterprise_course_run_enrollment_page',
             args=[self.customer.uuid, course_id],
         )
         request = self._prepare_request(enterprise_launch_url, AnonymousUser())
@@ -149,7 +149,7 @@ class TestEnterpriseDecorators(unittest.TestCase):
         view_function = mock_view_function()
         course_id = 'course-v1:edX+DemoX+Demo_Course'
         course_enrollment_url = reverse(
-            'enterprise_course_enrollment_page',
+            'enterprise_course_run_enrollment_page',
             args=[self.customer.uuid, course_id],
         )
         querystring = 'catalog=dummy-catalog-uuid'
@@ -188,7 +188,7 @@ class TestEnterpriseDecorators(unittest.TestCase):
         view_function = mock_view_function()
         course_id = 'course-v1:edX+DemoX+Demo_Course'
         enterprise_launch_url = reverse(
-            'enterprise_course_enrollment_page',
+            'enterprise_course_run_enrollment_page',
             args=[self.customer.uuid, course_id],
         )
         request = self._prepare_request(enterprise_launch_url, UserFactory(is_active=True))
@@ -209,7 +209,7 @@ class TestEnterpriseDecorators(unittest.TestCase):
         view_function = mock_view_function()
         course_id = 'course-v1:edX+DemoX+Demo_Course'
         enterprise_launch_url = reverse(
-            'enterprise_course_enrollment_page',
+            'enterprise_course_run_enrollment_page',
             args=[self.customer.uuid, course_id],
         )
         request = self._prepare_request(enterprise_launch_url, AnonymousUser())
@@ -231,7 +231,7 @@ class TestEnterpriseDecorators(unittest.TestCase):
         view_function = mock_view_function()
         course_id = 'course-v1:edX+DemoX+Demo_Course'
         enterprise_launch_url = reverse(
-            'enterprise_course_enrollment_page',
+            'enterprise_course_run_enrollment_page',
             args=[self.customer.uuid, course_id],
         )
         request = self._prepare_request(enterprise_launch_url, UserFactory(is_active=True))
@@ -251,7 +251,7 @@ class TestEnterpriseDecorators(unittest.TestCase):
         view_function = mock_view_function()
         course_id = 'course-v1:edX+DemoX+Demo_Course'
         enterprise_launch_url = reverse(
-            'enterprise_course_enrollment_page',
+            'enterprise_course_run_enrollment_page',
             args=[self.customer.uuid, course_id],
         )
         enterprise_launch_url += '?new_enterprise_login=yes'
@@ -276,7 +276,7 @@ class TestEnterpriseDecorators(unittest.TestCase):
         view_function = mock_view_function()
         course_id = 'course-v1:edX+DemoX+Demo_Course'
         url_path = reverse(
-            'enterprise_course_enrollment_page',
+            'enterprise_course_run_enrollment_page',
             args=[self.customer.uuid, course_id],
         )
         query = 'foo=bar'

--- a/tests/test_enterprise/views/test_course_enrollment_view.py
+++ b/tests/test_enterprise/views/test_course_enrollment_view.py
@@ -174,7 +174,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
         EnterpriseCustomerIdentityProviderFactory(provider_id=self.provider_id, enterprise_customer=enterprise_customer)
         enterprise_landing_page_url = self._append_fresh_login_param(
             reverse(
-                'enterprise_course_enrollment_page',
+                'enterprise_course_run_enrollment_page',
                 args=[enterprise_customer.uuid, self.demo_course_id],
             )
         )
@@ -292,7 +292,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
         EnterpriseCustomerIdentityProviderFactory(provider_id=self.provider_id, enterprise_customer=enterprise_customer)
 
         course_enrollment_url = reverse(
-            'enterprise_course_enrollment_page',
+            'enterprise_course_run_enrollment_page',
             args=[enterprise_customer.uuid, self.demo_course_id],
         )
         querystring_dict = QueryDict('', mutable=True)
@@ -367,7 +367,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
         EnterpriseCustomerIdentityProviderFactory(provider_id=self.provider_id, enterprise_customer=enterprise_customer)
 
         course_enrollment_url = reverse(
-            'enterprise_course_enrollment_page',
+            'enterprise_course_run_enrollment_page',
             args=[enterprise_customer.uuid, self.demo_course_id],
         )
         querystring_dict = QueryDict('', mutable=True)
@@ -460,7 +460,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
         EnterpriseCustomerIdentityProviderFactory(provider_id=self.provider_id, enterprise_customer=enterprise_customer)
 
         course_enrollment_url = reverse(
-            'enterprise_course_enrollment_page',
+            'enterprise_course_run_enrollment_page',
             args=[enterprise_customer.uuid, self.demo_course_id],
         )
         querystring_dict = QueryDict('', mutable=True)
@@ -538,7 +538,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
         )
         enterprise_landing_page_url = self._append_fresh_login_param(
             reverse(
-                'enterprise_course_enrollment_page',
+                'enterprise_course_run_enrollment_page',
                 args=[enterprise_customer.uuid, self.demo_course_id],
             )
         )
@@ -617,7 +617,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
         )
         enterprise_landing_page_url = self._append_fresh_login_param(
             reverse(
-                'enterprise_course_enrollment_page',
+                'enterprise_course_run_enrollment_page',
                 args=[enterprise_customer.uuid, self.demo_course_id],
             )
         )
@@ -675,7 +675,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
         EnterpriseCustomerIdentityProviderFactory(provider_id=provider_id, enterprise_customer=enterprise_customer)
         enterprise_landing_page_url = self._append_fresh_login_param(
             reverse(
-                'enterprise_course_enrollment_page',
+                'enterprise_course_run_enrollment_page',
                 args=[enterprise_customer.uuid, self.demo_course_id],
             )
         )
@@ -717,7 +717,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
         EnterpriseCustomerIdentityProviderFactory(provider_id=self.provider_id, enterprise_customer=enterprise_customer)
         enterprise_landing_page_url = self._append_fresh_login_param(
             reverse(
-                'enterprise_course_enrollment_page',
+                'enterprise_course_run_enrollment_page',
                 args=[enterprise_customer.uuid, self.demo_course_id],
             )
         )
@@ -780,7 +780,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
         EnterpriseCustomerIdentityProviderFactory(provider_id=self.provider_id, enterprise_customer=enterprise_customer)
         enterprise_landing_page_url = self._append_fresh_login_param(
             reverse(
-                'enterprise_course_enrollment_page',
+                'enterprise_course_run_enrollment_page',
                 args=[enterprise_customer.uuid, self.demo_course_id],
             )
         )
@@ -841,7 +841,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
         EnterpriseCustomerIdentityProviderFactory(provider_id=self.provider_id, enterprise_customer=enterprise_customer)
         enterprise_landing_page_url = self._append_fresh_login_param(
             reverse(
-                'enterprise_course_enrollment_page',
+                'enterprise_course_run_enrollment_page',
                 args=[enterprise_customer.uuid, self.demo_course_id],
             )
         )
@@ -913,7 +913,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
         EnterpriseCustomerIdentityProviderFactory(provider_id=self.provider_id, enterprise_customer=enterprise_customer)
         course_enrollment_page_url = self._append_fresh_login_param(
             reverse(
-                'enterprise_course_enrollment_page',
+                'enterprise_course_run_enrollment_page',
                 args=[enterprise_customer.uuid, course_id],
             )
         )
@@ -960,7 +960,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
         EnterpriseCustomerIdentityProviderFactory(provider_id=self.provider_id, enterprise_customer=enterprise_customer)
         course_enrollment_page_url = self._append_fresh_login_param(
             reverse(
-                'enterprise_course_enrollment_page',
+                'enterprise_course_run_enrollment_page',
                 args=[enterprise_customer.uuid, self.demo_course_id],
             )
         )
@@ -1007,7 +1007,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
         EnterpriseCustomerIdentityProviderFactory(provider_id=self.provider_id, enterprise_customer=enterprise_customer)
         course_enrollment_page_url = self._append_fresh_login_param(
             reverse(
-                'enterprise_course_enrollment_page',
+                'enterprise_course_run_enrollment_page',
                 args=[enterprise_customer.uuid, self.demo_course_id],
             )
         )
@@ -1054,7 +1054,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
         self._login()
         course_enrollment_page_url = self._append_fresh_login_param(
             reverse(
-                'enterprise_course_enrollment_page',
+                'enterprise_course_run_enrollment_page',
                 args=[enterprise_customer.uuid, self.demo_course_id],
             )
         )
@@ -1087,7 +1087,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
         self._setup_enrollment_client(enrollment_api_client_mock)
         self._login()
         course_enrollment_page_url = reverse(
-            'enterprise_course_enrollment_page',
+            'enterprise_course_run_enrollment_page',
             args=['some-fake-enterprise-customer-uuid', self.demo_course_id],
         )
         response = self.client.get(course_enrollment_page_url)
@@ -1115,7 +1115,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
         EnterpriseCustomerIdentityProviderFactory(provider_id=self.provider_id, enterprise_customer=enterprise_customer)
         enterprise_landing_page_url = self._append_fresh_login_param(
             reverse(
-                'enterprise_course_enrollment_page',
+                'enterprise_course_run_enrollment_page',
                 args=[enterprise_customer.uuid, course_id],
             )
         )
@@ -1178,7 +1178,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
         )
         enterprise_landing_page_url = self._append_fresh_login_param(
             reverse(
-                'enterprise_course_enrollment_page',
+                'enterprise_course_run_enrollment_page',
                 args=[enterprise_customer.uuid, course_id],
             )
         )
@@ -1239,7 +1239,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
         self._login()
         course_enrollment_page_url = self._append_fresh_login_param(
             reverse(
-                'enterprise_course_enrollment_page',
+                'enterprise_course_run_enrollment_page',
                 args=[enterprise_customer.uuid, course_id],
             )
         )
@@ -1295,7 +1295,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
         self._login()
         course_enrollment_page_url = self._append_fresh_login_param(
             reverse(
-                'enterprise_course_enrollment_page',
+                'enterprise_course_run_enrollment_page',
                 args=[enterprise_customer_uuid, course_id],
             )
         )
@@ -1309,7 +1309,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
         )
         expected_failure_url = '{course_enrollment_url}?{query_string}'.format(
             course_enrollment_url=reverse(
-                'enterprise_course_enrollment_page', args=[enterprise_customer.uuid, course_id]
+                'enterprise_course_run_enrollment_page', args=[enterprise_customer.uuid, course_id]
             ),
             query_string=urlencode({FRESH_LOGIN_PARAMETER: 'yes'}),
         )
@@ -1382,7 +1382,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
         course_enrollment_page_url = self._append_fresh_login_param(
             '{course_enrollment_url}?{query_string}'.format(
                 course_enrollment_url=reverse(
-                    'enterprise_course_enrollment_page', args=[enterprise_customer_uuid, course_id]
+                    'enterprise_course_run_enrollment_page', args=[enterprise_customer_uuid, course_id]
                 ),
                 query_string=urlencode({'catalog_uuid': enterprise_customer_catalog.uuid})
             )
@@ -1396,7 +1396,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
         )
         expected_failure_url = '{course_enrollment_url}?{query_string}'.format(
             course_enrollment_url=reverse(
-                'enterprise_course_enrollment_page', args=[enterprise_customer.uuid, course_id]
+                'enterprise_course_run_enrollment_page', args=[enterprise_customer.uuid, course_id]
             ),
             query_string=urlencode(OrderedDict([
                 ('catalog_uuid', enterprise_customer_catalog.uuid),
@@ -1445,7 +1445,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
         EnterpriseCustomerIdentityProviderFactory(provider_id=self.provider_id, enterprise_customer=enterprise_customer)
         course_enrollment_page_url = self._append_fresh_login_param(
             reverse(
-                'enterprise_course_enrollment_page',
+                'enterprise_course_run_enrollment_page',
                 args=[enterprise_customer.uuid, self.demo_course_id],
             )
         )
@@ -1511,7 +1511,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
         self._login()
         course_enrollment_page_url = self._append_fresh_login_param(
             reverse(
-                'enterprise_course_enrollment_page',
+                'enterprise_course_run_enrollment_page',
                 args=[enterprise_customer.uuid, course_id],
             )
         )
@@ -1563,7 +1563,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
         EnterpriseCustomerIdentityProviderFactory(provider_id=self.provider_id, enterprise_customer=enterprise_customer)
         enterprise_landing_page_url = self._append_fresh_login_param(
             reverse(
-                'enterprise_course_enrollment_page',
+                'enterprise_course_run_enrollment_page',
                 args=[enterprise_customer.uuid, self.demo_course_id],
             )
         )
@@ -1632,7 +1632,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
             enforce_data_sharing_consent='at_enrollment',
         )
         enterprise_landing_page_url = reverse(
-            'enterprise_course_enrollment_page',
+            'enterprise_course_run_enrollment_page',
             args=[enterprise_customer.uuid, self.demo_course_id],
         )
 
@@ -1678,7 +1678,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
 
         enterprise_landing_page_url = self._append_fresh_login_param(
             reverse(
-                'enterprise_course_enrollment_page',
+                'enterprise_course_run_enrollment_page',
                 args=[enterprise_customer.uuid, self.demo_course_id],
             )
         )


### PR DESCRIPTION
This will enable us to define EnterpriseCustomerCatalogs with a `"content_type": "course"` content filter and provide a way for direct integrators to pull the full details for each course in the catalog (including course run data).

I have a [WIP branch](https://github.com/edx/edx-enterprise/pull/293) which refactors the `integrated_channels` codebase to allow it to manage content metadata for more than just course runs (which is what it is limited to currently). I'd like to get these changes merged as I continue to work on that refactoring.

## Testing Instructions ##
1. Visit https://business.sandbox.edx.org/enterprise/api/v1/enterprise_catalogs/f8f13d0b-58a1-4708-b1be-6accc88acfb1/. This is the detail endpoint for an EnterpriseCustomerCatalog which uses the `"content_type": "course"` content filter.
2. Grab a course key for one of the courses and attempt to hit the courses detail endpoint. For example, https://business.sandbox.edx.org/enterprise/api/v1/enterprise_catalogs/f8f13d0b-58a1-4708-b1be-6accc88acfb1/courses/edX+DemoX/.