### PR TITLE
asadiqbal08/ENT-849 enterprise catalog API in XML format.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.65.1] - 2018-02-02
+---------------------
+
+* Provide an option for enterprise to pull enterprise catalog API in XML format not just JSON.
+
 [0.65.0] - 2018-01-30
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.65.0"
+__version__ = "0.65.1"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/renderers.py
+++ b/enterprise/api/renderers.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+"""
+Renderer(s) for api response.
+"""
+from __future__ import absolute_import, unicode_literals
+
+from rest_framework.negotiation import DefaultContentNegotiation
+from rest_framework.settings import api_settings
+
+
+class IgnoreClientContentNegotiation(DefaultContentNegotiation):
+    """
+    Class for client content negotiation.
+    """
+
+    def select_renderer(self, request, renderers, format_suffix):  # pylint: disable=signature-differs
+        # Allow URL style format override.  eg. "?format=json or http://example.com/v1/organizations.xml/
+        render_format = format_suffix or request.query_params.get(api_settings.FORMAT_SUFFIX_KWARG)
+        if render_format:
+            return DefaultContentNegotiation.select_renderer(self, request, renderers, render_format)
+
+        # Select the first renderer in the `.renderer_classes` list.
+        return (renderers[0], renderers[0].media_type)

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -11,8 +11,10 @@ from rest_framework import filters, permissions, viewsets
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.decorators import detail_route
 from rest_framework.exceptions import NotFound
+from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 from rest_framework.status import HTTP_200_OK, HTTP_400_BAD_REQUEST
+from rest_framework_xml.renderers import XMLRenderer
 
 from django.conf import settings
 from django.http import Http404
@@ -21,6 +23,7 @@ from django.utils.decorators import method_decorator
 from enterprise import models
 from enterprise.api.filters import EnterpriseCustomerUserFilterBackend, UserFilterBackend
 from enterprise.api.pagination import get_paginated_response
+from enterprise.api.renderers import IgnoreClientContentNegotiation
 from enterprise.api.throttles import ServiceUserThrottle
 from enterprise.api.v1 import serializers
 from enterprise.api.v1.decorators import enterprise_customer_required, require_at_least_one_query_parameter
@@ -290,6 +293,7 @@ class EnterpriseCustomerCatalogViewSet(EnterpriseReadOnlyModelViewSet):
     """
     API Views for performing search through course discovery at the ``enterprise_catalogs`` API endpoint.
     """
+    content_negotiation_class = IgnoreClientContentNegotiation
     queryset = models.EnterpriseCustomerCatalog.objects.all()
 
     USER_ID_FILTER = 'enterprise_customer__enterprise_customer_users__user_id'
@@ -298,6 +302,7 @@ class EnterpriseCustomerCatalogViewSet(EnterpriseReadOnlyModelViewSet):
     )
     filter_fields = FIELDS
     ordering_fields = FIELDS
+    renderer_classes = (JSONRenderer, XMLRenderer,)
 
     def get_serializer_class(self):
         action = getattr(self, 'action', None)

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,3 +1,4 @@
 # Core requirements for using this application that are not provided by edx-platform
 
 django-object-actions==0.10.0           # Object actions in Django admin
+djangorestframework-xml==1.3.0

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -1998,3 +1998,14 @@ class TestEnterpriseAPIViews(APITest):
         response = self.load_json(response.content)
 
         self.assertListEqual(response, expected_response)
+
+    def test_enterprise_customer_catalogs_response_formats(self):
+        """
+        ``enterprise_catalogs``'s xml and json responses verification.
+        """
+        response_xml_1 = self.client.get('{}?format=xml'.format(ENTERPRISE_CATALOGS_LIST_ENDPOINT))
+        response_xml_2 = self.client.get('/enterprise/api/v1/enterprise_catalogs.xml')
+        response_json = self.client.get('{}?format=json'.format(ENTERPRISE_CATALOGS_LIST_ENDPOINT))
+        self.assertTrue(response_xml_1['content-type'] == 'application/xml; charset=utf-8')
+        self.assertTrue(response_xml_2['content-type'] == 'application/xml; charset=utf-8')
+        self.assertTrue(response_json['content-type'] == 'application/json')


### PR DESCRIPTION
**Description:** Provided option for enterprise to pull enterprise/catalog API in XML format (not just JSON)

**JIRA:** [ENT-849](https://openedx.atlassian.net/browse/ENT-849)

**Testing instructions:**

- Hit [enterprise catalog api](https://business.sandbox.edx.org/enterprise/api/v1/enterprise_catalogs/) on business sandbox.
- By default, JSON response would be returned. 
- To get an xml response, Add the suffix **.xml** at the end of URL --> e.g. https://business.sandbox.edx.org/enterprise/api/v1/enterprise_catalogs.xml . An xml response would be returned