### PR TITLE
Decrease SAPSF chunk size from 1000 to 500

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.65.3] - 2018-02-06
+---------------------
+
+* Decreased SuccessFactors course metadata chunk size from 1000 to 500, per SAP's recommendation.
+
 [0.65.2] - 2018-02-05
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.65.2"
+__version__ = "0.65.3"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/sap_success_factors/exporters/course_metadata.py
+++ b/integrated_channels/sap_success_factors/exporters/course_metadata.py
@@ -27,7 +27,7 @@ class SapSuccessFactorsCourseExporter(CourseExporter):  # pylint: disable=abstra
     Class to provide data transforms for SAP SuccessFactors course metadata export task.
     """
 
-    CHUNK_PAGE_LENGTH = 1000
+    CHUNK_PAGE_LENGTH = 500
     STATUS_ACTIVE = 'ACTIVE'
     STATUS_INACTIVE = 'INACTIVE'
 


### PR DESCRIPTION
Per SAP technical support, while the SuccessFactors Learning API does support payloads up to 1000 records per request, this is too much data for most tenants to handle in a single request.  SAPSF recommends sending no more than 500 records per request.
