### PR TITLE
ENT-833 Support sending data reports to multiple emails

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ----------
 
+[0.65.7] - 2018-02-14
+---------------------
+
+* Support multiple emails in EnterpriseCustomerReportingConfiguration.
+* Only require email(s) in EnterpriseCustomerReportingConfiguration if the selected delivery method is email.
+
 [0.65.6] - 2018-02-13
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.65.6"
+__version__ = "0.65.7"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -417,6 +417,9 @@ class EnterpriseCustomerReportingConfigurationSerializer(serializers.ModelSerial
         )
 
     enterprise_customer = EnterpriseCustomerSerializer()
+    email = serializers.ListField(
+        child=serializers.EmailField()
+    )
 
 
 # pylint: disable=abstract-method

--- a/enterprise/migrations/0041_auto_20180212_1507.py
+++ b/enterprise/migrations/0041_auto_20180212_1507.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import multi_email_field.fields
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('enterprise', '0040_auto_20180129_1428'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='enterprisecustomerreportingconfiguration',
+            name='email',
+            field=multi_email_field.fields.MultiEmailField(help_text='The email(s), one per line, where the report should be sent.', verbose_name='Email', blank=True),
+        ),
+    ]

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -12,6 +12,7 @@ from uuid import uuid4
 import six
 from fernet_fields import EncryptedCharField
 from jsonfield.fields import JSONField
+from multi_email_field.fields import MultiEmailField
 from simple_history.models import HistoricalRecords
 
 from django.apps import apps
@@ -1295,7 +1296,11 @@ class EnterpriseCustomerReportingConfiguration(TimeStampedModel):
         verbose_name=_("Delivery Method"),
         help_text=_("The method in which the data should be sent.")
     )
-    email = models.EmailField(blank=False, null=False, verbose_name=_("Email"))
+    email = MultiEmailField(
+        blank=True,
+        verbose_name=_("Email"),
+        help_text=_("The email(s), one per line, where the report should be sent.")
+    )
     frequency = models.CharField(
         max_length=20,
         choices=FREQUENCY_CHOICES,
@@ -1432,6 +1437,10 @@ class EnterpriseCustomerReportingConfiguration(TimeStampedModel):
             validation_errors[NON_FIELD_ERRORS] = _('Frequency must be set to either daily, weekly, or monthly.')
 
         if self.delivery_method == self.DELIVERY_METHOD_EMAIL:
+            if not self.email:
+                validation_errors['email'] = _(
+                    'Email(s) must be set if the delivery method is email.'
+                )
             if not self.decrypted_password:
                 validation_errors['decrypted_password'] = _(
                     'Decrypted password must be set if the delivery method is email.'

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,3 +2,4 @@
 
 django-object-actions==0.10.0           # Object actions in Django admin
 djangorestframework-xml==1.3.0
+django-multi-email-field==0.5.1         # Multi email input field in Django admin

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -10,7 +10,7 @@ anyjson==0.3.3            # via kombu
 argparse==1.4.0           # via caniusepython3
 asn1crypto==0.24.0        # via cryptography
 astroid==1.5.2            # via edx-lint, pylint, pylint-celery, pylint-plugin-utils
-backports.functools-lru-cache==1.4  # via astroid, caniusepython3, pylint
+backports.functools-lru-cache==1.5  # via astroid, caniusepython3, pylint
 billiard==3.3.0.23        # via celery
 caniusepython3==6.0.0
 celery==3.1.18
@@ -19,6 +19,7 @@ click-log==0.1.8          # via edx-lint
 click==6.7                # via click-log, edx-lint, pip-tools
 configparser==3.5.0       # via pydocstyle, pylint
 cryptography==1.9
+defusedxml==0.5.0         # via djangorestframework-xml
 diff-cover==1.0.2
 distlib==0.2.6            # via caniusepython3
 django-config-models==0.1.8
@@ -26,12 +27,14 @@ django-fernet-fields==0.5
 django-filter==1.0.4
 django-ipware==1.1.0
 django-model-utils==2.3.1
+django-multi-email-field==0.5.1
 django-object-actions==0.10.0
 django-simple-history==1.9.0
 django-waffle==0.12.0
 django==1.8.18
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework-oauth==1.1.0
+djangorestframework-xml==1.3.0
 djangorestframework==3.6.3
 edx-django-oauth2-provider==1.1.4
 edx-drf-extensions==1.2.3
@@ -56,7 +59,7 @@ lazy-object-proxy==1.3.1  # via astroid
 markupsafe==1.0           # via jinja2
 mccabe==0.6.1             # via pylint
 packaging==16.8           # via caniusepython3
-path.py==10.5             # via edx-i18n-tools
+path.py==11.0             # via edx-i18n-tools
 pbr==3.1.1                # via stevedore
 pillow==3.4
 pip-tools==1.11.0
@@ -76,7 +79,7 @@ pylint==1.7.1             # via edx-lint, pylint-celery, pylint-django, pylint-p
 pymongo==3.6.0            # via edx-opaque-keys, event-tracking
 pyparsing==2.2.0          # via packaging
 python-dateutil==2.6.1    # via analytics-python, edx-drf-extensions
-pytz==2017.3              # via celery, event-tracking
+pytz==2018.3              # via celery, event-tracking
 pyyaml==3.12              # via edx-i18n-tools
 requests-toolbelt==0.8.0  # via twine
 requests==2.9.1
@@ -86,7 +89,7 @@ six==1.11.0               # via analytics-python, astroid, cryptography, diff-co
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==1.2.1    # via pydocstyle
 stevedore==1.28.0         # via edx-opaque-keys
-testfixtures==5.3.1
+testfixtures==5.4.0
 tox-battery==0.5
 tox==2.9.1
 tqdm==4.19.5              # via twine

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -16,17 +16,20 @@ celery==3.1.18
 cffi==1.11.4              # via cryptography
 chardet==3.0.4            # via doc8
 cryptography==1.9
+defusedxml==0.5.0         # via djangorestframework-xml
 django-config-models==0.1.8
 django-fernet-fields==0.5
 django-filter==1.0.4
 django-ipware==1.1.0
 django-model-utils==2.3.1
+django-multi-email-field==0.5.1
 django-object-actions==0.10.0
 django-simple-history==1.9.0
 django-waffle==0.12.0
 django==1.8.18
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework-oauth==1.1.0
+djangorestframework-xml==1.3.0
 djangorestframework==3.6.3
 doc8==0.8.0
 docutils==0.14            # via doc8, readme-renderer, restructuredtext-lint, sphinx
@@ -46,6 +49,7 @@ jinja2==2.10              # via sphinx
 jsonfield==2.0.2
 kombu==3.0.37             # via celery
 markupsafe==1.0           # via jinja2
+packaging==16.8           # via sphinx
 pbr==3.1.1                # via stevedore
 pillow==3.4
 pockets==0.5.1            # via sphinxcontrib-napoleon
@@ -53,20 +57,21 @@ pycparser==2.18           # via cffi
 pygments==2.2.0           # via readme-renderer, sphinx
 pyjwt==1.5.3              # via djangorestframework-jwt, edx-rest-api-client
 pymongo==3.6.0            # via edx-opaque-keys, event-tracking
+pyparsing==2.2.0          # via packaging
 python-dateutil==2.6.1    # via analytics-python, edx-drf-extensions
-pytz==2017.3              # via babel, celery, event-tracking
+pytz==2018.3              # via babel, celery, event-tracking
 readme-renderer==17.2
 requests==2.9.1
 restructuredtext-lint==1.1.2  # via doc8
 shortuuid==0.5.0          # via edx-django-oauth2-provider
-six==1.11.0               # via analytics-python, bleach, cryptography, doc8, edx-opaque-keys, edx-sphinx-theme, html5lib, pockets, python-dateutil, readme-renderer, sphinx, sphinxcontrib-napoleon, stevedore
+six==1.11.0               # via analytics-python, bleach, cryptography, doc8, edx-opaque-keys, edx-sphinx-theme, html5lib, packaging, pockets, python-dateutil, readme-renderer, sphinx, sphinxcontrib-napoleon, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==1.2.1    # via sphinx
-sphinx==1.6.6
+sphinx==1.7.0
 sphinxcontrib-napoleon==0.6.1
 sphinxcontrib-websupport==1.0.1  # via sphinx
 stevedore==1.28.0         # via doc8, edx-opaque-keys
-testfixtures==5.3.1
+testfixtures==5.4.0
 typing==3.6.4             # via sphinx
 unicodecsv==0.14.1
 webencodings==0.5.1       # via html5lib

--- a/requirements/js_test.in
+++ b/requirements/js_test.in
@@ -1,3 +1,3 @@
 # Requirements for Jasmine javascript testing framework
 
-jasmine
+jasmine==2.9.0

--- a/requirements/js_test.txt
+++ b/requirements/js_test.txt
@@ -4,9 +4,8 @@
 #
 #    pip-compile --output-file requirements/js_test.txt requirements/js_test.in
 #
-argparse==1.4.0           # via jasmine
 cheroot==6.0.0            # via cherrypy
-cherrypy==13.1.0          # via jasmine
+cherrypy==14.0.0          # via jasmine
 glob2==0.6                # via jasmine-core
 jasmine-core==2.9.1       # via jasmine
 jasmine==2.9.0
@@ -15,8 +14,8 @@ markupsafe==1.0           # via jinja2
 more-itertools==4.1.0     # via cheroot
 ordereddict==1.1          # via jasmine-core
 portend==2.2              # via cherrypy
-pytz==2017.3              # via tempora
+pytz==2018.3              # via tempora
 pyyaml==3.10              # via jasmine
-selenium==3.6.0           # via jasmine
-six==1.11.0               # via cheroot, cherrypy, jasmine, more-itertools, tempora
+selenium==3.9.0           # via jasmine
+six==1.11.0               # via cheroot, cherrypy, more-itertools, tempora
 tempora==1.10             # via portend

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -13,7 +13,7 @@ asn1crypto==0.24.0        # via cryptography
 astroid==1.5.2            # via edx-lint, pylint, pylint-celery, pylint-plugin-utils
 attrs==17.4.0             # via pytest
 babel==2.5.3              # via sphinx
-backports.functools-lru-cache==1.4  # via astroid, caniusepython3, pylint
+backports.functools-lru-cache==1.5  # via astroid, caniusepython3, pylint
 billiard==3.3.0.23        # via celery
 bleach==2.1.2             # via readme-renderer
 caniusepython3==6.0.0
@@ -24,9 +24,10 @@ click-log==0.1.8          # via edx-lint
 click==6.7                # via click-log, edx-lint, pip-tools
 configparser==3.5.0       # via pydocstyle, pylint
 cookies==2.2.1            # via responses
-coverage==4.4.2           # via pytest-cov
+coverage==4.5.1           # via pytest-cov
 cryptography==1.9
 ddt==1.1.1
+defusedxml==0.5.0         # via djangorestframework-xml
 diff-cover==1.0.2
 distlib==0.2.6            # via caniusepython3
 django-config-models==0.1.8
@@ -34,12 +35,14 @@ django-fernet-fields==0.5
 django-filter==1.0.4
 django-ipware==1.1.0
 django-model-utils==2.3.1
+django-multi-email-field==0.5.1
 django-object-actions==0.10.0
 django-simple-history==1.9.0
 django-waffle==0.12.0
 django==1.8.18
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework-oauth==1.1.0
+djangorestframework-xml==1.3.0
 djangorestframework==3.6.3
 doc8==0.8.0
 docutils==0.14            # via doc8, readme-renderer, restructuredtext-lint, sphinx
@@ -52,7 +55,7 @@ edx-rest-api-client==1.7.1
 edx-sphinx-theme==1.3.0
 enum34==1.1.6             # via astroid, cryptography
 event-tracking==0.2.4
-factory-boy==2.9.2
+factory-boy==2.10.0
 faker==0.8.10             # via factory-boy
 first==2.0.1              # via pip-tools
 flaky==3.3.0
@@ -73,8 +76,8 @@ lazy-object-proxy==1.3.1  # via astroid
 markupsafe==1.0           # via jinja2
 mccabe==0.6.1             # via pylint
 mock==2.0.0
-packaging==16.8           # via caniusepython3
-path.py==10.5             # via edx-i18n-tools
+packaging==16.8           # via caniusepython3, sphinx
+path.py==11.0             # via edx-i18n-tools
 pbr==3.1.1                # via mock, stevedore
 pillow==3.4
 pip-tools==1.11.0
@@ -97,9 +100,9 @@ pyparsing==2.2.0          # via packaging
 pytest-catchlog==1.2.2
 pytest-cov==2.5.1
 pytest-django==3.1.2
-pytest==3.3.2             # via pytest-catchlog, pytest-cov, pytest-django
+pytest==3.4.0             # via pytest-catchlog, pytest-cov, pytest-django
 python-dateutil==2.6.1    # via analytics-python, edx-drf-extensions, faker, freezegun
-pytz==2017.3              # via babel, celery, event-tracking
+pytz==2018.3              # via babel, celery, event-tracking
 pyyaml==3.12              # via edx-i18n-tools
 readme-renderer==17.2
 requests-toolbelt==0.8.0  # via twine
@@ -111,11 +114,11 @@ singledispatch==3.4.0.3   # via astroid, pylint
 six==1.11.0               # via analytics-python, astroid, bleach, cryptography, diff-cover, doc8, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, faker, freezegun, html5lib, mock, packaging, pip-tools, pockets, pydocstyle, pylint, pytest, python-dateutil, readme-renderer, responses, singledispatch, sphinx, sphinxcontrib-napoleon, stevedore, tox
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==1.2.1    # via pydocstyle, sphinx
-sphinx==1.6.6
+sphinx==1.7.0
 sphinxcontrib-napoleon==0.6.1
 sphinxcontrib-websupport==1.0.1  # via sphinx
 stevedore==1.28.0         # via doc8, edx-opaque-keys
-testfixtures==5.3.1
+testfixtures==5.4.0
 text-unidecode==1.1       # via faker
 tox-battery==0.5
 tox==2.9.1

--- a/requirements/test-ficus.txt
+++ b/requirements/test-ficus.txt
@@ -12,20 +12,23 @@ billiard==3.3.0.23        # via celery
 celery==3.1.18
 cffi==1.11.4              # via cryptography
 cookies==2.2.1            # via responses
-coverage==4.4.2           # via pytest-cov
+coverage==4.5.1           # via pytest-cov
 cryptography==1.5.3
 ddt==1.1.1
+defusedxml==0.5.0         # via djangorestframework-xml
 django-config-models==0.1.5
 django-fernet-fields==0.5
 django-filter==0.11.0
 django-ipware==1.1.0
 django-model-utils==2.3.1
+django-multi-email-field==0.5.1
 django-object-actions==0.10.0
 django-simple-history==1.6.3
 django-waffle==0.12.0
 django==1.8.18
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework-oauth==1.1.0
+djangorestframework-xml==1.3.0
 djangorestframework==3.2.3
 edx-django-oauth2-provider==1.1.4
 edx-drf-extensions==1.2.2
@@ -33,7 +36,7 @@ edx-opaque-keys==0.4.0
 edx-rest-api-client==1.6.0
 enum34==1.1.6             # via cryptography
 event-tracking==0.2.4
-factory-boy==2.9.2
+factory-boy==2.10.0
 faker==0.8.10             # via factory-boy
 flaky==3.3.0
 freezegun==0.3.9
@@ -54,15 +57,15 @@ pymongo==3.6.0            # via edx-opaque-keys, event-tracking
 pytest-catchlog==1.2.2
 pytest-cov==2.5.1
 pytest-django==3.1.2
-pytest==3.3.2             # via pytest-catchlog, pytest-cov, pytest-django
+pytest==3.4.0             # via pytest-catchlog, pytest-cov, pytest-django
 python-dateutil==2.6.1    # via analytics-python, edx-drf-extensions, faker, freezegun
-pytz==2017.3              # via celery, event-tracking
+pytz==2018.3              # via celery, event-tracking
 requests==2.9.1
 responses==0.8.1
 shortuuid==0.5.0          # via edx-django-oauth2-provider
 six==1.11.0               # via analytics-python, cryptography, edx-opaque-keys, faker, freezegun, mock, pytest, python-dateutil, responses, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 stevedore==1.28.0         # via edx-opaque-keys
-testfixtures==5.3.1
+testfixtures==5.4.0
 text-unidecode==1.1       # via faker
 unicodecsv==0.14.1

--- a/requirements/test-ginkgo.txt
+++ b/requirements/test-ginkgo.txt
@@ -12,20 +12,23 @@ billiard==3.3.0.23        # via celery
 celery==3.1.18
 cffi==1.11.4              # via cryptography
 cookies==2.2.1            # via responses
-coverage==4.4.2           # via pytest-cov
+coverage==4.5.1           # via pytest-cov
 cryptography==1.5.3
 ddt==1.1.1
+defusedxml==0.5.0         # via djangorestframework-xml
 django-config-models==0.1.5
 django-fernet-fields==0.5
 django-filter==0.11.0
 django-ipware==1.1.0
 django-model-utils==2.3.1
+django-multi-email-field==0.5.1
 django-object-actions==0.10.0
 django-simple-history==1.6.3
 django-waffle==0.12.0
 django==1.8.18
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework-oauth==1.1.0
+djangorestframework-xml==1.3.0
 djangorestframework==3.2.3
 edx-django-oauth2-provider==1.1.4
 edx-drf-extensions==1.2.2
@@ -33,7 +36,7 @@ edx-opaque-keys==0.4.0
 edx-rest-api-client==1.7.1
 enum34==1.1.6             # via cryptography
 event-tracking==0.2.4
-factory-boy==2.9.2
+factory-boy==2.10.0
 faker==0.8.10             # via factory-boy
 flaky==3.3.0
 freezegun==0.3.9
@@ -54,15 +57,15 @@ pymongo==3.6.0            # via edx-opaque-keys, event-tracking
 pytest-catchlog==1.2.2
 pytest-cov==2.5.1
 pytest-django==3.1.2
-pytest==3.3.2             # via pytest-catchlog, pytest-cov, pytest-django
+pytest==3.4.0             # via pytest-catchlog, pytest-cov, pytest-django
 python-dateutil==2.6.1    # via analytics-python, edx-drf-extensions, faker, freezegun
-pytz==2017.3              # via celery, event-tracking
+pytz==2018.3              # via celery, event-tracking
 requests==2.9.1
 responses==0.8.1
 shortuuid==0.5.0          # via edx-django-oauth2-provider
 six==1.11.0               # via analytics-python, cryptography, edx-opaque-keys, faker, freezegun, mock, pytest, python-dateutil, responses, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 stevedore==1.28.0         # via edx-opaque-keys
-testfixtures==5.3.1
+testfixtures==5.4.0
 text-unidecode==1.1       # via faker
 unicodecsv==0.14.1

--- a/requirements/test-hawthorn.txt
+++ b/requirements/test-hawthorn.txt
@@ -13,20 +13,23 @@ billiard==3.3.0.23        # via celery
 celery==3.1.18
 cffi==1.11.4              # via cryptography
 cookies==2.2.1            # via responses
-coverage==4.4.2           # via pytest-cov
+coverage==4.5.1           # via pytest-cov
 cryptography==1.9
 ddt==1.1.1
+defusedxml==0.5.0         # via djangorestframework-xml
 django-config-models==0.1.8
 django-fernet-fields==0.5
 django-filter==1.0.4
 django-ipware==1.1.0
 django-model-utils==2.3.1
+django-multi-email-field==0.5.1
 django-object-actions==0.10.0
 django-simple-history==1.9.0
 django-waffle==0.12.0
-django==1.11.9
+django==1.11.10
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework-oauth==1.1.0
+djangorestframework-xml==1.3.0
 djangorestframework==3.6.3
 edx-django-oauth2-provider==1.1.4
 edx-drf-extensions==1.2.3
@@ -34,7 +37,7 @@ edx-opaque-keys==0.4.0
 edx-rest-api-client==1.7.1
 enum34==1.1.6             # via cryptography
 event-tracking==0.2.4
-factory-boy==2.9.2
+factory-boy==2.10.0
 faker==0.8.10             # via factory-boy
 flaky==3.3.0
 freezegun==0.3.9
@@ -54,15 +57,15 @@ pymongo==3.6.0            # via edx-opaque-keys, event-tracking
 pytest-catchlog==1.2.2
 pytest-cov==2.5.1
 pytest-django==3.1.2
-pytest==3.3.2             # via pytest-catchlog, pytest-cov, pytest-django
+pytest==3.4.0             # via pytest-catchlog, pytest-cov, pytest-django
 python-dateutil==2.6.1    # via analytics-python, edx-drf-extensions, faker, freezegun
-pytz==2017.3              # via celery, django, event-tracking
+pytz==2018.3              # via celery, django, event-tracking
 requests==2.9.1
 responses==0.8.1
 shortuuid==0.5.0          # via edx-django-oauth2-provider
 six==1.11.0               # via analytics-python, cryptography, edx-opaque-keys, faker, freezegun, mock, pytest, python-dateutil, responses, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 stevedore==1.28.0         # via edx-opaque-keys
-testfixtures==5.3.1
+testfixtures==5.4.0
 text-unidecode==1.1       # via faker
 unicodecsv==0.14.1

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -13,20 +13,23 @@ billiard==3.3.0.23        # via celery
 celery==3.1.18
 cffi==1.11.4              # via cryptography
 cookies==2.2.1            # via responses
-coverage==4.4.2           # via pytest-cov
+coverage==4.5.1           # via pytest-cov
 cryptography==1.9
 ddt==1.1.1
+defusedxml==0.5.0         # via djangorestframework-xml
 django-config-models==0.1.8
 django-fernet-fields==0.5
 django-filter==1.0.4
 django-ipware==1.1.0
 django-model-utils==2.3.1
+django-multi-email-field==0.5.1
 django-object-actions==0.10.0
 django-simple-history==1.9.0
 django-waffle==0.12.0
 django==1.8.18
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework-oauth==1.1.0
+djangorestframework-xml==1.3.0
 djangorestframework==3.6.3
 edx-django-oauth2-provider==1.1.4
 edx-drf-extensions==1.2.3
@@ -34,7 +37,7 @@ edx-opaque-keys==0.4.0
 edx-rest-api-client==1.7.1
 enum34==1.1.6             # via cryptography
 event-tracking==0.2.4
-factory-boy==2.9.2
+factory-boy==2.10.0
 faker==0.8.10             # via factory-boy
 flaky==3.3.0
 freezegun==0.3.9
@@ -54,15 +57,15 @@ pymongo==3.6.0            # via edx-opaque-keys, event-tracking
 pytest-catchlog==1.2.2
 pytest-cov==2.5.1
 pytest-django==3.1.2
-pytest==3.3.2             # via pytest-catchlog, pytest-cov, pytest-django
+pytest==3.4.0             # via pytest-catchlog, pytest-cov, pytest-django
 python-dateutil==2.6.1    # via analytics-python, edx-drf-extensions, faker, freezegun
-pytz==2017.3              # via celery, event-tracking
+pytz==2018.3              # via celery, event-tracking
 requests==2.9.1
 responses==0.8.1
 shortuuid==0.5.0          # via edx-django-oauth2-provider
 six==1.11.0               # via analytics-python, cryptography, edx-opaque-keys, faker, freezegun, mock, pytest, python-dateutil, responses, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 stevedore==1.28.0         # via edx-opaque-keys
-testfixtures==5.3.1
+testfixtures==5.4.0
 text-unidecode==1.1       # via faker
 unicodecsv==0.14.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -13,20 +13,23 @@ billiard==3.3.0.23        # via celery
 celery==3.1.18
 cffi==1.11.4              # via cryptography
 cookies==2.2.1            # via responses
-coverage==4.4.2           # via pytest-cov
+coverage==4.5.1           # via pytest-cov
 cryptography==1.9
 ddt==1.1.1
+defusedxml==0.5.0         # via djangorestframework-xml
 django-config-models==0.1.8
 django-fernet-fields==0.5
 django-filter==1.0.4
 django-ipware==1.1.0
 django-model-utils==2.3.1
+django-multi-email-field==0.5.1
 django-object-actions==0.10.0
 django-simple-history==1.9.0
 django-waffle==0.12.0
 django==1.8.18
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework-oauth==1.1.0
+djangorestframework-xml==1.3.0
 djangorestframework==3.6.3
 edx-django-oauth2-provider==1.1.4
 edx-drf-extensions==1.2.3
@@ -34,7 +37,7 @@ edx-opaque-keys==0.4.0
 edx-rest-api-client==1.7.1
 enum34==1.1.6             # via cryptography
 event-tracking==0.2.4
-factory-boy==2.9.2
+factory-boy==2.10.0
 faker==0.8.10             # via factory-boy
 flaky==3.3.0
 freezegun==0.3.9
@@ -54,15 +57,15 @@ pymongo==3.6.0            # via edx-opaque-keys, event-tracking
 pytest-catchlog==1.2.2
 pytest-cov==2.5.1
 pytest-django==3.1.2
-pytest==3.3.2             # via pytest-catchlog, pytest-cov, pytest-django
+pytest==3.4.0             # via pytest-catchlog, pytest-cov, pytest-django
 python-dateutil==2.6.1    # via analytics-python, edx-drf-extensions, faker, freezegun
-pytz==2017.3              # via celery, event-tracking
+pytz==2018.3              # via celery, event-tracking
 requests==2.9.1
 responses==0.8.1
 shortuuid==0.5.0          # via edx-django-oauth2-provider
 six==1.11.0               # via analytics-python, cryptography, edx-opaque-keys, faker, freezegun, mock, pytest, python-dateutil, responses, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 stevedore==1.28.0         # via edx-opaque-keys
-testfixtures==5.3.1
+testfixtures==5.4.0
 text-unidecode==1.1       # via faker
 unicodecsv==0.14.1

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -6,8 +6,8 @@
 #
 certifi==2018.1.18        # via requests
 chardet==3.0.4            # via requests
-codecov==2.0.14
-coverage==4.4.2           # via codecov
+codecov==2.0.15
+coverage==4.5.1           # via codecov
 idna==2.6                 # via requests
 pluggy==0.6.0             # via tox
 py==1.5.2                 # via tox

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -762,7 +762,7 @@ class TestEnterpriseAPIViews(APITest):
         factory = factories.EnterpriseCustomerReportingConfigFactory
         model_item = {
             'enterprise_customer__uuid': FAKE_UUIDS[0],
-            'email': 'test@test.com',
+            'email': 'test@test.com\nfoo@test.com',
             'decrypted_password': 'test_password',
             'decrypted_sftp_password': 'test_password',
         }
@@ -773,7 +773,7 @@ class TestEnterpriseAPIViews(APITest):
             'active': True,
             'delivery_method': 'email',
             'frequency': 'monthly',
-            'email': 'test@test.com',
+            'email': ['test@test.com', 'foo@test.com'],
             'day_of_month': 1,
             'day_of_week': None,
             'hour_of_day': 1,


### PR DESCRIPTION
**Description:** Introduces a new field in the reporting configuration admin page to support multiple email input. Also included is a change to the verification such that an email is required only when the delivery method is set to "email." [Related PR](https://github.com/edx/edx-enterprise-data/pull/21) for `edx-enterprise-data`.

**JIRA:** [ENT-833](https://openedx.atlassian.net/browse/ENT-833)

**Testing instructions:**

1. Open the Enterprise Django admin, and navigate to the reporting configurations.
2. Verify that it's possible to add/save multiple emails (one per line).
3. Ensure that an email is required only when "email" is selected as the delivery method.
4. Verify that the email field returned by the [`enterprise_customer_reporting` API endpoint](https://business.sandbox.edx.org/enterprise/api/v1/enterprise_customer_reporting) is a list.