### PR TITLE
ENT-850 Update course title on the basis of enrollment start and end dates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.65.8] - 2018-02-23
+---------------------
+
+* Add "Enrollment Closed" in course title if the course is no longer open for enrollment.
+
 [0.65.7] - 2018-02-14
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.65.7"
+__version__ = "0.65.8"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/integrated_channel/exporters/course_metadata.py
+++ b/integrated_channels/integrated_channel/exporters/course_metadata.py
@@ -18,6 +18,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from enterprise.api_client.enterprise import EnterpriseApiClient
 from enterprise.api_client.lms import parse_lms_api_datetime
+from enterprise.utils import is_course_run_enrollable
 
 LOGGER = getLogger(__name__)
 
@@ -135,6 +136,13 @@ class CourseExporter(Exporter):
         """
         Check if a course run is available for enrollment.
         """
-        return course_run['availability'] in [
+        is_course_archived = course_run['availability'] not in [
             self.AVAILABILITY_CURRENT, self.AVAILABILITY_STARTING_SOON, self.AVAILABILITY_UPCOMING
         ]
+        if is_course_archived:
+            # course is archived so not available for enrollment
+            return False
+
+        # now check if the course run is enrollable on the basis of enrollment
+        # start and end date
+        return is_course_run_enrollable(course_run)

--- a/tests/test_integrated_channels/test_sap_success_factors/test_exporters/test_course_metadata.py
+++ b/tests/test_integrated_channels/test_sap_success_factors/test_exporters/test_course_metadata.py
@@ -104,16 +104,36 @@ class TestSapSuccessFactorsCourseExporter(unittest.TestCase, EnterpriseMockMixin
     @ddt.data(
         {
             'start': '2013-02-05T05:00:00Z',
+            'enrollment_start': None,
+            'enrollment_end': None,
             'pacing_type': 'instructor_paced',
             'availability': CourseExporter.AVAILABILITY_ARCHIVED,
             'title': 'edX Demonstration Course'
         },
         {
             'start': '2013-02-05T05:00:00Z',
+            'enrollment_start': None,
+            'enrollment_end': None,
             'availability': CourseExporter.AVAILABILITY_ARCHIVED,
             'pacing_type': 'self_paced',
             'title': 'edX Demonstration Course'
-        }
+        },
+        {
+            'start': '2013-02-05T05:00:00Z',
+            'enrollment_start': None,
+            'enrollment_end': '2012-02-05T05:00:00Z',
+            'pacing_type': 'instructor_paced',
+            'availability': CourseExporter.AVAILABILITY_CURRENT,
+            'title': 'edX Demonstration Course'
+        },
+        {
+            'start': '2013-02-05T05:00:00Z',
+            'enrollment_start': '2014-02-05T05:00:00Z',
+            'enrollment_end': '2015-02-05T05:00:00Z',
+            'pacing_type': 'instructor_paced',
+            'availability': CourseExporter.AVAILABILITY_UPCOMING,
+            'title': 'edX Demonstration Course'
+        },
     )
     @responses.activate
     def test_transform_title_includes_enrollment_closed(self, course_run):


### PR DESCRIPTION
@asadiqbal08 @saleem-latif @georgebabey 
**Description:** Indicate when a course is no longer open for enrollment by adding the message `Enrollment Closed` in the title along with the start date with the format `edX Demonstration Course (February 2013 - Enrollment Closed)`.

* The enrollment is considered closed when a course is Archived
* Course run `enrollment_end` is less than now if `enrollment_end` is set 
* Current date for course run is not between `enrollment_start` and `enrollment_end` date if both `enrollment_start` and `enrollment_end` are set 

**JIRA:** [ENT-850](https://openedx.atlassian.net/browse/ENT-850)

**Related PR:** https://github.com/edx/edx-enterprise/pull/283

**Dependencies:** N/A

**Merge deadline:** 23 Mar, 2018

**Installation instructions:**  Install `edx-enterprise` from this branch `zub/ENT-850-enrollment-closed-message-in-course-title-update` in `edx-platform`.

**Testing instructions:**

1. Add an enterprise with catalogs
2. Add configurations for integrated channels for `Degreed` and `SAP Success Factors`
    * Addcourse run A in above catalog with [availability `Current`](https://github.com/edx/course-discovery/blob/master/course_discovery/apps/course_metadata/models.py#L724-L736) 
    * Add course run B in above catalog with [availability `Starting Soon`](https://github.com/edx/course-discovery/blob/master/course_discovery/apps/course_metadata/models.py#L724-L736) 
    * Add course run C in above catalog with [availability `Upcoming`](https://github.com/edx/course-discovery/blob/master/course_discovery/apps/course_metadata/models.py#L724-L736)
    * Add course run D in above catalog with [availability `Archived`](https://github.com/edx/course-discovery/blob/master/course_discovery/apps/course_metadata/models.py#L724-L736)
    * Add course run E in above catalog with availability `Current` but with `enrollment_end` date in past
    * Add course run F in above catalog with availability `Current` but with both `enrollment_start` and `enrollment_end` date in past
4. Run django management command `transmit_course_metadata` and verify that course runs A, B and C have start date in their title with the format `edX Demonstration Course (Starts: February 2013)` but course D with availability `Archived`, course E and course F have start date in its title with the format `edX Demonstration Course (February 2013 - Enrollment Closed)`

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
