### PR TITLE
ENT-817 Ad hoc script for creating enterprise users/enrollments

### DIFF
--- a/scripts/create_enterprise_users_enrollments.py
+++ b/scripts/create_enterprise_users_enrollments.py
@@ -1,0 +1,89 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+"""
+Creates Enterprise User and Enrollment records for a given Enterprise and enrollment data file.
+"""
+
+from __future__ import absolute_import, unicode_literals
+
+import logging
+
+import argparse
+import csv
+import sys
+import os
+import time
+
+from edx_rest_api_client.client import EdxRestApiClient
+from edx_rest_api_client.exceptions import HttpClientError
+
+logging.basicConfig(level=logging.INFO)
+LOGGER = logging.getLogger(__name__)
+
+API_BASE_URL = 'https://courses.edx.org/' + 'enterprise/api/v1/'
+CREATE_USER_PATH = 'enterprise-learner'
+CREATE_ENROLLMENT_PATH = 'enterprise-course-enrollment'
+
+
+def create_enterprise_enrollment(client, username, course_id):
+    try:
+        LOGGER.info('Creating enterprise enrollment for user {}, course {}'.format(username, course_id))
+        endpoint = getattr(client, CREATE_ENROLLMENT_PATH)
+        endpoint.post({'username': username, 'course_id': course_id})
+    except HttpClientError:
+        LOGGER.error('Hit the rate limit, try again later!')
+    except Exception:
+        LOGGER.exception('Failed to create enterprise enrollment for user {}, course {}'.format(username, course_id))
+
+
+def create_enterprise_user(client, username, enterprise_customer):
+    try:
+        LOGGER.info('Creating enterprise user {} for enterprise {}'.format(username, enterprise_customer))
+        endpoint = getattr(client, CREATE_USER_PATH)
+        endpoint.post({'username': username, 'enterprise_customer': enterprise_customer})
+    except HttpClientError:
+        LOGGER.error('Hit the rate limit, try again later!')
+    except Exception:
+        LOGGER.exception('Failed to create enterprise user {} for enterprise {}'.format(username, enterprise_customer))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-e', '--enterprise-customer', required=True, type=str,
+                        help="EnterpriseCustomer UUID.")
+    parser.add_argument('-f', '--enrollment-file', required=True, type=str,
+                        help="Enrollment Data CSV Filename.")
+    parser.add_argument('-a', '--access-token', required=True, type=str,
+                        help="JWT Access Token for making calls to the Enterprise API")
+    args = parser.parse_args()
+
+    if not os.path.exists(args.enrollment_file):
+        LOGGER.error('Unable to locate given enrollment file name: {}'.format(args.enrollment_file))
+
+    existing_users = {}
+    client = EdxRestApiClient(
+        API_BASE_URL, append_slash=True, jwt=args.access_token,
+    )
+
+    with open(args.enrollment_file, 'r') as csv_file:
+        csv_reader = csv.reader(csv_file, delimiter=str(u','))
+        call_count = 0
+        for row in csv_reader:
+            if call_count < 58:
+                username = row[0]
+                course_id = row[1]
+
+                if username not in existing_users:
+                    create_enterprise_user(client, username, args.enterprise_customer)
+                    existing_users[username] = 1
+                    call_count += 1
+
+                create_enterprise_enrollment(client, username, course_id)
+                call_count += 1
+            else:
+                LOGGER.info('Sleeping for a minute to avoid rate limits')
+                time.sleep(60)
+                call_count = 0
+
+
+    sys.exit(0)


### PR DESCRIPTION
**Description:**I don't intend to have this merged unless we think it's useful. The script takes an enterprise id, a csv of usernames and courses, and an access token for a staff user, and hits the production LMS enterprise api to create enrollments and users for that enterprise.

**JIRA:** https://openedx.atlassian.net/browse/ENT-817

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

python scripts/create_enterprise_users_enrollments.py --enterprise-customer=<enterprise_uuid> --enrollment-file='<path_to_file>' --access-token='<prod_jwt>'

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
