### PR TITLE
ENT-916 Temporarily disable linked learners list on manage learners Django admin page for performance reasons.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.66.1] - 2018-03-23
+---------------------
+
+* Temporarily disable linked learners list on manage learners Django admin view until paging can be added.
+
 [0.66.0] - 2018-03-05
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.66.0"
+__version__ = "0.66.1"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/admin/views.py
+++ b/enterprise/admin/views.py
@@ -248,9 +248,12 @@ class EnterpriseCustomerManageLearnersView(View):
             customer_uuid (str): A unique identifier to filter down to only users linked to a
             particular EnterpriseCustomer.
         """
-        learners = EnterpriseCustomerUser.objects.filter(enterprise_customer__uuid=customer_uuid)
-
+        # TODO: Add paging so the admin view does not time out.
+        # For now, we will allow search, but will return an empty list
+        # if no search keyword is provided.
+        learners = []
         if search_keyword is not None:
+            learners = EnterpriseCustomerUser.objects.filter(enterprise_customer__uuid=customer_uuid)
             user_ids = learners.values_list('user_id', flat=True)
             matching_users = User.objects.filter(
                 Q(pk__in=user_ids),

--- a/enterprise/templates/enterprise/admin/manage_learners.html
+++ b/enterprise/templates/enterprise/admin/manage_learners.html
@@ -86,6 +86,8 @@ global Javascript variables that can be used in any of the loaded packages.
                  id="searchbar"
                  placeholder="{% trans 'Search email address or username' %}">
           <input type="submit" value="Search">
+          <!-- TODO: Remove this message when paging is added to this list. -->
+          <label>You must enter a search keyword to list linked learners.</label>
         </div>
       </form>
     </div>

--- a/tests/test_admin/test_view.py
+++ b/tests/test_admin/test_view.py
@@ -245,30 +245,28 @@ class TestEnterpriseCustomerManageLearnersViewGet(BaseTestEnterpriseCustomerMana
     def test_get_existing_links_only(self):
         self._login()
 
-        users = [
-            EnterpriseCustomerUserFactory(enterprise_customer=self.enterprise_customer),
-            EnterpriseCustomerUserFactory(enterprise_customer=self.enterprise_customer),
-            EnterpriseCustomerUserFactory(enterprise_customer=self.enterprise_customer),
-        ]
+        EnterpriseCustomerUserFactory(enterprise_customer=self.enterprise_customer)
+        EnterpriseCustomerUserFactory(enterprise_customer=self.enterprise_customer)
+        EnterpriseCustomerUserFactory(enterprise_customer=self.enterprise_customer)
 
         response = self.client.get(self.view_url)
-        self._test_get_response(response, users, [])
+        # Test existing linked learners are not returned by default (until paging is added).
+        self._test_get_response(response, [], [])
 
     def test_get_existing_and_pending_links(self):
         self._login()
 
-        linked_learners = [
-            EnterpriseCustomerUserFactory(enterprise_customer=self.enterprise_customer),
-            EnterpriseCustomerUserFactory(enterprise_customer=self.enterprise_customer),
-            EnterpriseCustomerUserFactory(enterprise_customer=self.enterprise_customer),
-        ]
+        EnterpriseCustomerUserFactory(enterprise_customer=self.enterprise_customer)
+        EnterpriseCustomerUserFactory(enterprise_customer=self.enterprise_customer)
+        EnterpriseCustomerUserFactory(enterprise_customer=self.enterprise_customer)
         pending_linked_learners = [
             PendingEnterpriseCustomerUserFactory(enterprise_customer=self.enterprise_customer),
             PendingEnterpriseCustomerUserFactory(enterprise_customer=self.enterprise_customer),
         ]
 
         response = self.client.get(self.view_url)
-        self._test_get_response(response, linked_learners, pending_linked_learners)
+        # Test existing linked learners are not returned by default (until paging is added).
+        self._test_get_response(response, [], pending_linked_learners)
 
     def test_get_with_search_param(self):
         self._login()


### PR DESCRIPTION
**Sandox**
https://business.sandbox.edx.org/admin/enterprise/enterprisecustomer/2b5a2956-7746-4fc9-9587-bc887ba45973/manage_learners