### PR TITLE
[ENT-947] Enterprise Django admin tool not loading correctly

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.67.2] - 2018-04-05
+---------------------
+
+* Fix the enterprise manage learner django admin tool is loading correctly for chrome users.
+
 [0.67.1] - 2018-04-04
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.67.1"
+__version__ = "0.67.2"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/admin/views.py
+++ b/enterprise/admin/views.py
@@ -17,6 +17,7 @@ from django.contrib.auth.models import User
 from django.core import mail
 from django.core.exceptions import ValidationError
 from django.core.management import call_command
+from django.core.urlresolvers import reverse
 from django.db.models import Q
 from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
@@ -27,6 +28,7 @@ from django.views.generic import View
 
 from enterprise.admin.forms import ManageLearnersForm, TransmitEnterpriseCoursesForm
 from enterprise.admin.utils import (
+    UrlNames,
     ValidationMessages,
     email_or_username__to__email,
     get_course_runs_from_program,
@@ -839,7 +841,11 @@ class EnterpriseCustomerManageLearnersView(View):
                 )
 
             # Redirect to GET if everything went smooth.
-            return HttpResponseRedirect("")
+            manage_learners_url = reverse("admin:" + UrlNames.MANAGE_LEARNERS, args=(customer_uuid,))
+            search_keyword = self.get_search_keyword(request)
+            if search_keyword:
+                manage_learners_url = manage_learners_url + "?q=" + search_keyword
+            return HttpResponseRedirect(manage_learners_url)
 
         # if something went wrong - display bound form on the page
         context = self._build_context(request, customer_uuid)

--- a/tests/test_admin/test_view.py
+++ b/tests/test_admin/test_view.py
@@ -447,6 +447,25 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
         assert EnterpriseCustomerUser.objects.count() == 1
         assert PendingEnterpriseCustomerUser.objects.count() == 1
 
+    def test_post_redirected_successfully(self):
+        """
+        Test post call to enroll user redirected successfully.
+        """
+        self._login()
+
+        email = FAKER.email()  # pylint: disable=no-member
+
+        user = UserFactory(email=email, id=2)
+        EnterpriseCustomerUserFactory(user_id=user.id)
+        response = self.client.post(
+            self.view_url + "?q=bob",
+            data={
+                ManageLearnersForm.Fields.EMAIL_OR_USERNAME: email + ', john@smith.com'
+            }
+        )
+        self.assertRedirects(response, self.view_url + "?q=bob")
+        self.assertEqual(response.status_code, 302)
+
     def test_post_existing_pending_record(self):
         # precondition checks:
         self._login()


### PR DESCRIPTION
@georgebabey @brittneyexline FYI. 

**Description:** Enterprise Django admin tool not loading correctly in manage learner form.

**JIRA:** [ENT-947](https://openedx.atlassian.net/browse/ENT-947)

**Testing instructions:**

1. Login to django admin tool on business sandbox. 
2. Visit manage learner tool under enterprise customer view e.g. [example](https://business.sandbox.edx.org/admin/enterprise/enterprisecustomer/905a19f5-a9a7-406f-8c24-d5f04eecef1e/manage_learners)
3. Add data in Link Learners form.
4. Press submit. Page should be rendered properly on both Chrome and Firefox