### PR TITLE
[ENT-962] Update sessions whenever Enterprise Customer is created.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.67.6] - 2018-04-20
+---------------------
+
+* Update user session when they become an Enterprise learner.
+
 [0.67.5] - 2018-04-18
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.67.5"
+__version__ = "0.67.6"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -212,6 +212,12 @@ class EnterpriseCustomer(TimeStampedModel):
         """
         return self.enable_audit_enrollment and self.enable_audit_data_reporting
 
+    @property
+    def serialized(self):
+        """Return a serialized version of this customer."""
+        from enterprise.api.v1 import serializers
+        return serializers.EnterpriseCustomerSerializer(self).data
+
     def get_data_sharing_consent_text_overrides(self, published_only=True):
         """
         Return DataSharingConsentTextOverrides associated with this instance.
@@ -643,6 +649,10 @@ class EnterpriseCustomerUser(TimeStampedModel):
                     given_mode=mode,
                 )
             )
+
+    def update_session(self, request):
+        """Update the session of a request for this learner."""
+        request.session['enterprise_customer'] = self.enterprise_customer.serialized
 
 
 @python_2_unicode_compatible

--- a/enterprise/tpa_pipeline.py
+++ b/enterprise/tpa_pipeline.py
@@ -62,7 +62,8 @@ def handle_enterprise_logistration(backend, user, **kwargs):
         return
 
     # proceed with the creation of a link between the user and the enterprise customer, then exit.
-    EnterpriseCustomerUser.objects.update_or_create(
+    enterprise_customer_user, _ = EnterpriseCustomerUser.objects.update_or_create(
         enterprise_customer=enterprise_customer,
         user_id=user.id
     )
+    enterprise_customer_user.update_session(request)

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -494,6 +494,7 @@ class GrantDataSharingPermissions(View):
                     enterprise_customer=consent_record.enterprise_customer,
                     user_id=request.user.id
                 )
+                enterprise_customer_user.update_session(request)
                 __, created = EnterpriseCourseEnrollment.objects.get_or_create(
                     enterprise_customer_user=enterprise_customer_user,
                     course_id=course_id,
@@ -875,6 +876,7 @@ class CourseEnrollmentView(NonAtomicView):
             enterprise_customer=enterprise_customer,
             user_id=request.user.id
         )
+        enterprise_customer_user.update_session(request)
 
         data_sharing_consent = DataSharingConsent.objects.proxied_get(
             username=enterprise_customer_user.username,
@@ -1334,6 +1336,7 @@ class ProgramEnrollmentView(NonAtomicView):
                 enterprise_customer=enterprise_customer,
                 user_id=request.user.id
             )
+            enterprise_customer_user.update_session(request)
 
         program_details = self.get_program_details(request, program_uuid, enterprise_customer)
         if program_details['certificate_eligible_for_program']:
@@ -1470,6 +1473,7 @@ class RouterView(NonAtomicView):
                 enterprise_customer=enterprise_customer,
                 user_id=request.user.id
             )
+            enterprise_customer_user.update_session(request)
 
         # Directly enroll in audit mode if the request in question has full direct audit enrollment eligibility.
         resource_id = course_run_id or program_uuid

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-enterprise",
-  "version": "0.67.4",
+  "version": "0.67.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-enterprise",
-  "version": "0.67.4",
+  "version": "0.67.6",
   "license": "AGPL-3.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Description:** This PR will allow the request session to update with the latest Enterprise Customer for the user that just became an Enterprise user.

**JIRA:** https://openedx.atlassian.net/browse/ENT-962

**Dependencies:** https://github.com/edx/edx-platform/pull/17969

**Merge deadline:** ASAP.

**Testing instructions:**

See https://github.com/edx/edx-platform/pull/17969

However in addition, you'll want to see that your request session is updated when your user becomes linked to an Enterprise through some request.

1. Go to `/enterprise/{enterprise_uuid}/course/{course_run_key}/enroll/`.
2. After going through the process, your user should be linked and that data should be in the session. If the customer had `replace_sensitive_sso_username` on, this'll give you a new username on the top-right corner, for example, without needing to relog. Go to the dashboard to confirm.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)
