### PR TITLE
[ENT-958]Update enrollment api authorization to check group permissions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ----------
 
+[0.68.3] - 2018-05-11
+---------------------
+
+* Update enrollment api authorization to check group permissions.
 
 [0.68.2] - 2018-05-10
 ---------------------

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.68.2"
+__version__ = "0.68.3"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/v1/permissions.py
+++ b/enterprise/api/v1/permissions.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+
+""" Custom API permissions. """
+
+from __future__ import absolute_import, unicode_literals
+
+from rest_framework import permissions
+
+
+class IsAdminUserOrInGroup(permissions.IsAdminUser):
+    """
+    Find the requesting user is either staff or belong to specific group.
+    It will return a 403 forbidden response with a message if the user is not authorized to access the view.
+    """
+    ALLOWED_API_GROUPS = []  # pylint: disable=invalid-name
+    message = u'User is not allowed to access the view.'
+
+    def has_permission(self, request, view):
+        """
+        Returns True if the requesting user is either 'staff' or belong to specific group, False otherwise.
+        """
+        return super(IsAdminUserOrInGroup, self).has_permission(request, view) or request.user.groups.filter(
+            name__in=self.ALLOWED_API_GROUPS
+        ).exists()
+
+
+class HasEnterpriseEnrollmentAPIAccess(IsAdminUserOrInGroup):
+    """
+    Find the requesting user is either staff or belong to enterprise_enrollment_api_access group.
+    It will return a 403 forbidden response with a message if the user is not authorized to access the view.
+    """
+    def __init__(self):
+        """ Initialize the class with a API_ALLOWED_GROUPS """
+        self.ALLOWED_API_GROUPS = [u'enterprise_enrollment_api_access', ]  # pylint: disable=invalid-name

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -27,6 +27,7 @@ from enterprise.api.pagination import get_paginated_response
 from enterprise.api.throttles import ServiceUserThrottle
 from enterprise.api.v1 import serializers
 from enterprise.api.v1.decorators import enterprise_customer_required, require_at_least_one_query_parameter
+from enterprise.api.v1.permissions import HasEnterpriseEnrollmentAPIAccess
 from enterprise.api_client.discovery import CourseCatalogApiClient
 from enterprise.constants import COURSE_KEY_URL_PATTERN
 
@@ -171,8 +172,12 @@ class EnterpriseCustomerViewSet(EnterpriseReadWriteModelViewSet):
         serializer.update_enterprise_courses(enterprise_customer, catalog_id=enterprise_customer.catalog)
         return get_paginated_response(serializer.data, request)
 
-    @detail_route(methods=['post'])
-    def course_enrollments(self, request, pk):  # pylint: disable=invalid-name,unused-argument
+    @detail_route(methods=['post'], permission_classes=[
+        permissions.IsAuthenticated,
+        HasEnterpriseEnrollmentAPIAccess,
+    ])
+    # pylint: disable=invalid-name,unused-argument
+    def course_enrollments(self, request, pk):
         """
         Creates a course enrollment for an EnterpriseCustomerUser.
         """

--- a/test_utils/factories.py
+++ b/test_utils/factories.py
@@ -10,7 +10,7 @@ from uuid import UUID
 import factory
 from faker import Factory as FakerFactory
 
-from django.contrib.auth.models import User
+from django.contrib.auth.models import Group, User
 from django.contrib.sites.models import Site
 from django.utils import timezone
 
@@ -120,6 +120,20 @@ class PendingEnterpriseCustomerUserFactory(factory.django.DjangoModelFactory):
 
     enterprise_customer = factory.SubFactory(EnterpriseCustomerFactory)
     user_email = factory.LazyAttribute(lambda x: FAKER.email())
+
+
+class GroupFactory(factory.DjangoModelFactory):
+    """
+    Group factory.
+
+    Creates an instance of Group with minimal boilerplate.
+    """
+
+    class Meta(object):
+        model = Group
+        django_get_or_create = ('name', )
+
+    name = factory.Sequence(u'group{0}'.format)
 
 
 class UserFactory(factory.DjangoModelFactory):

--- a/tests/test_enterprise/api/test_permissions.py
+++ b/tests/test_enterprise/api/test_permissions.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for the Enterprise API permissions.
+"""
+
+from __future__ import absolute_import, unicode_literals
+
+from rest_framework.parsers import JSONParser
+from rest_framework.request import Request
+from rest_framework.test import APIRequestFactory, APITestCase, force_authenticate
+
+from enterprise.api.v1.permissions import HasEnterpriseEnrollmentAPIAccess
+from test_utils.factories import GroupFactory, UserFactory
+
+
+class PermissionsTestMixin(object):
+    """
+    Permission Test Mixin.
+    """
+    def get_request(self, user=None, data=None):
+        """
+        :return Request object
+        """
+        request = APIRequestFactory().post('/', data)
+
+        if user:
+            force_authenticate(request, user=user)
+
+        return Request(request, parsers=(JSONParser(),))
+
+
+class TestEnterpriseAPIPermissions(PermissionsTestMixin, APITestCase):
+    """
+    Tests for Enterprise API permissions.
+    """
+
+    permissions_class = HasEnterpriseEnrollmentAPIAccess()
+
+    def setUp(self):
+        """
+        Setup the test cases.
+        """
+        super(TestEnterpriseAPIPermissions, self).setUp()
+        self.user = UserFactory(email='test@example.com', password='test', is_staff=True)
+        self.group = GroupFactory(name='enterprise_enrollment_api_access')
+
+    def test_is_staff_or_user_in_group_permissions(self):
+        self.group.user_set.add(self.user)
+        request = self.get_request(user=self.user)
+        self.assertTrue(self.permissions_class.has_permission(request, None))
+
+    def test_not_staff_and_not_in_group_permissions(self):
+        user = UserFactory(email='test@example.com', password='test', is_staff=False)
+        request = self.get_request(user=user)
+        self.assertFalse(self.permissions_class.has_permission(request, None))
+
+    def test_staff_but_not_in_group_permissions(self):
+        user = UserFactory(email='test@example.com', password='test', is_staff=True)
+        request = self.get_request(user=user)
+        self.assertTrue(self.permissions_class.has_permission(request, None))
+
+    def test_not_staff_but_in_group_permissions(self):
+        user = UserFactory(email='test@example.com', password='test', is_staff=False)
+        self.group.user_set.add(user)
+        request = self.get_request(user=user)
+        self.assertTrue(self.permissions_class.has_permission(request, None))

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -11,6 +11,7 @@ import ddt
 import mock
 from pytest import mark
 from rest_framework.reverse import reverse
+from rest_framework.test import APIClient
 from six.moves.urllib.parse import (  # pylint: disable=import-error,ungrouped-imports
     parse_qs,
     urlencode,
@@ -1615,10 +1616,16 @@ class TestEnterpriseAPIViews(APITest):
             name="test_enterprise"
         )
 
-        expected_result = {'detail': 'You do not have permission to perform this action.'}
+        # creating a non staff user so verify the insufficient permission conditions.
+        user = factories.UserFactory(username='test_user', is_active=True, is_staff=False)
+        user.set_password('test_password')  # pylint: disable=no-member
+        user.save()  # pylint: disable=no-member
+        client = APIClient()
+        client.login(username='test_user', password='test_password')
+        expected_result = {u'detail': u'User is not allowed to access the view.'}
 
         # Make the call!
-        response = self.client.post(
+        response = client.post(
             settings.TEST_SERVER + ENTERPRISE_CUSTOMER_COURSE_ENROLLMENTS_ENDPOINT,
             data=json.dumps([{}]),
             content_type='application/json',


### PR DESCRIPTION
**Description:** Update enrollment api authorization to check group permissions

**JIRA:** [ENT-958](https://openedx.atlassian.net/browse/ENT-958)

Testing Instructions: 

1. Go to admin portal on [sandbox ](http://business.sandbox.edx.org/admin/) and add a new group with name **enterprise_enrollment_api_access**.
2. Hit the [course_enrollments](https://business.sandbox.edx.org/enterprise/api/v1/enterprise-customer/0a35930c-168c-4955-886c-db99eb699007/course_enrollments/) API endpoint via using Postman tool or the normal flow. 
3. Try to execute the following test cases. 
    - If a user is not staff or not belong to 'enterprise_enrollment_api_access' group then permission denied should be raised with a message u"User is not allowed to access the view."
    - A staff user or a user belong to 'enterprise_enrollment_api_access' group should be allowed to access the api endpoint.

