### PR TITLE
ENT-965: Added order_by on queries inside view set to resolve Pagination warning.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.67.8] - 2018-05-04
+---------------------
+
+* Added ordering to resolve warnings of probable invalid pagination data.
+
 [0.67.7] - 2018-04-23
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.67.7"
+__version__ = "0.67.8"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/migrations/0043_auto_20180507_0138.py
+++ b/enterprise/migrations/0043_auto_20180507_0138.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('enterprise', '0042_replace_sensitive_sso_username'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='enrollmentnotificationemailtemplate',
+            options={'ordering': ['created']},
+        ),
+        migrations.AlterModelOptions(
+            name='enterprisecourseenrollment',
+            options={'ordering': ['created']},
+        ),
+        migrations.AlterModelOptions(
+            name='enterprisecustomer',
+            options={'verbose_name': 'Enterprise Customer', 'verbose_name_plural': 'Enterprise Customers', 'ordering': ['created']},
+        ),
+        migrations.AlterModelOptions(
+            name='enterprisecustomerbrandingconfiguration',
+            options={'verbose_name': 'Branding Configuration', 'verbose_name_plural': 'Branding Configurations', 'ordering': ['created']},
+        ),
+        migrations.AlterModelOptions(
+            name='enterprisecustomercatalog',
+            options={'verbose_name': 'Enterprise Customer Catalog', 'verbose_name_plural': 'Enterprise Customer Catalogs', 'ordering': ['created']},
+        ),
+        migrations.AlterModelOptions(
+            name='enterprisecustomerentitlement',
+            options={'verbose_name': 'Enterprise Customer Entitlement', 'verbose_name_plural': 'Enterprise Customer Entitlements', 'ordering': ['created']},
+        ),
+        migrations.AlterModelOptions(
+            name='enterprisecustomeridentityprovider',
+            options={'ordering': ['created']},
+        ),
+        migrations.AlterModelOptions(
+            name='enterprisecustomerreportingconfiguration',
+            options={'ordering': ['created']},
+        ),
+        migrations.AlterModelOptions(
+            name='enterprisecustomeruser',
+            options={'verbose_name': 'Enterprise Customer Learner', 'verbose_name_plural': 'Enterprise Customer Learners', 'ordering': ['created']},
+        ),
+        migrations.AlterModelOptions(
+            name='pendingenrollment',
+            options={'ordering': ['created']},
+        ),
+        migrations.AlterModelOptions(
+            name='pendingenterprisecustomeruser',
+            options={'ordering': ['created']},
+        ),
+    ]

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -94,6 +94,7 @@ class EnterpriseCustomer(TimeStampedModel):
         app_label = 'enterprise'
         verbose_name = _("Enterprise Customer")
         verbose_name_plural = _("Enterprise Customers")
+        ordering = ['created']
 
     objects = models.Manager()
     active_customers = EnterpriseCustomerManager()
@@ -487,6 +488,7 @@ class EnterpriseCustomerUser(TimeStampedModel):
         verbose_name = _("Enterprise Customer Learner")
         verbose_name_plural = _("Enterprise Customer Learners")
         unique_together = (("enterprise_customer", "user_id"),)
+        ordering = ['created']
 
     @property
     def user(self):
@@ -671,6 +673,7 @@ class PendingEnterpriseCustomerUser(TimeStampedModel):
 
     class Meta(object):
         app_label = 'enterprise'
+        ordering = ['created']
 
     def __str__(self):
         """
@@ -716,6 +719,7 @@ class PendingEnrollment(TimeStampedModel):
     class Meta(object):
         app_label = 'enterprise'
         unique_together = (("user", "course_id"),)
+        ordering = ['created']
 
     def complete_enrollment(self):
         """
@@ -790,6 +794,7 @@ class EnterpriseCustomerBrandingConfiguration(TimeStampedModel):
         app_label = 'enterprise'
         verbose_name = _("Branding Configuration")
         verbose_name_plural = _("Branding Configurations")
+        ordering = ['created']
 
     def save(self, *args, **kwargs):  # pylint: disable=arguments-differ
         """Save the enterprise customer branding config."""
@@ -849,6 +854,7 @@ class EnterpriseCustomerIdentityProvider(TimeStampedModel):
 
     class Meta(object):
         app_label = 'enterprise'
+        ordering = ['created']
 
     def __str__(self):
         """
@@ -887,6 +893,7 @@ class EnterpriseCustomerEntitlement(TimeStampedModel):
         app_label = 'enterprise'
         verbose_name = _("Enterprise Customer Entitlement")
         verbose_name_plural = _("Enterprise Customer Entitlements")
+        ordering = ['created']
 
     enterprise_customer = models.ForeignKey(EnterpriseCustomer, related_name="enterprise_customer_entitlements")
     entitlement_id = models.PositiveIntegerField(
@@ -928,6 +935,7 @@ class EnterpriseCourseEnrollment(TimeStampedModel):
     class Meta(object):
         unique_together = (('enterprise_customer_user', 'course_id',),)
         app_label = 'enterprise'
+        ordering = ['created']
 
     enterprise_customer_user = models.ForeignKey(
         EnterpriseCustomerUser,
@@ -1054,6 +1062,7 @@ class EnterpriseCustomerCatalog(TimeStampedModel):
         verbose_name = _("Enterprise Customer Catalog")
         verbose_name_plural = _("Enterprise Customer Catalogs")
         app_label = 'enterprise'
+        ordering = ['created']
 
     def __str__(self):
         """
@@ -1276,6 +1285,7 @@ class EnrollmentNotificationEmailTemplate(TimeStampedModel):
 
     class Meta(object):
         app_label = 'enterprise'
+        ordering = ['created']
 
     BODY_HELP_TEXT = mark_safe_lazy(_(
         'Fill in a standard Django template that, when rendered, produces the email you want '
@@ -1477,6 +1487,7 @@ class EnterpriseCustomerReportingConfiguration(TimeStampedModel):
 
     class Meta:
         app_label = 'enterprise'
+        ordering = ['created']
 
     @property
     def encrypted_password(self):


### PR DESCRIPTION
**Description:** 
Since updating to Django 1.11 we are getting a number of warnings in the log:

UnorderedObjectListWarning: Pagination may yield inconsistent results with an unordered object_list: `<class 'enterprise.models.EnterpriseCustomerUser'>` QuerySet

This PR fixes this by adding ordering to our ViewSets that don't include it already.

**JIRA:** [ENT-965](https://openedx.atlassian.net/browse/ENT-965)

**Installation instructions:**
Simply Install edx-enterprise with this branch.

**Testing instructions:**

1. Open all the enterprise API endpoints one by one, API endpoints are listed below
   - https://business.sandbox.edx.org/enterprise/api/v1/enterprise_catalogs/
   - https://business.sandbox.edx.org/enterprise/api/v1/enterprise-course-enrollment/
   - https://business.sandbox.edx.org/enterprise/api/v1/enterprise-customer/
   - https://business.sandbox.edx.org/enterprise/api/v1/enterprise-learner/
   - https://business.sandbox.edx.org/enterprise/api/v1/enterprise-customer-branding/
   - https://business.sandbox.edx.org/enterprise/api/v1/enterprise-customer-entitlement/
   - https://business.sandbox.edx.org/enterprise/api/v1/enterprise_customer_reporting/ 
2. Make sure `UnorderedObjectListWarning` does not appear in the logs.

**Merge checklist:**

- [x] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [x] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [x] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [x] Called `make static` for webpack bundling if any static content was updated.
- [x] All reviewers approved
- [ ] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [x] Translations are updated
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)
