### PR TITLE
[ENT-997] Admin Tooling Enhancement - Order by Enterprise Customer Name 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,10 +14,10 @@ Change Log
 Unreleased
 ----------
 
-[0.68.6] - 2018-05-22
+[0.68.7] - 2018-05-24
 ---------------------
 
-* Update DSC to show notification interstitial communicating to enterprise learner they are leaving company's site.
+* Admin tooling enterprise customer reporting configuration enhancement - Order by Enterprise Customer Name.
 
 [0.68.5] - 2018-05-17
 ---------------------

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.68.6"
+__version__ = "0.68.7"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/admin/__init__.py
+++ b/enterprise/admin/__init__.py
@@ -531,6 +531,7 @@ class EnterpriseCustomerReportingConfigurationAdmin(admin.ModelAdmin):
 
     list_filter = ("active",)
     search_fields = ("enterprise_customer__name", "email")
+    ordering = ('enterprise_customer__name',)
 
     form = EnterpriseCustomerReportingConfigAdminForm
 


### PR DESCRIPTION
**Description:** Admin Tooling Enhancement - Order by Enterprise Customer Name 

**JIRA:** [ENT-997](https://openedx.atlassian.net/browse/ENT-997)

**Testing instructions:**

1. Visit Django admin on [business Sandbox. ](https://business.sandbox.edx.org/admin/)
2. Jump to [enterprise customer reporting configuration](http://open.edx:8000/admin/enterprise/enterprisecustomerreportingconfiguration/) model
3. Detail view should be ordered by enterprise customer name instead of enterprise customer uuid
