### PR TITLE
[ENT-660] Assume that edx-enterprise is deployed in the LMS runtime

### DIFF
--- a/enterprise/api_client/discovery.py
+++ b/enterprise/api_client/discovery.py
@@ -25,17 +25,11 @@ from enterprise.utils import (
 
 try:
     from openedx.core.lib.token_utils import JwtBuilder
-except ImportError:
-    JwtBuilder = None
-
-try:
     from openedx.core.djangoapps.catalog.models import CatalogIntegration
-except ImportError:
-    CatalogIntegration = None
-
-try:
     from openedx.core.lib.edx_api_utils import get_edx_api_data
 except ImportError:
+    JwtBuilder = None
+    CatalogIntegration = None
     get_edx_api_data = None
 
 

--- a/enterprise/api_client/lms.py
+++ b/enterprise/api_client/lms.py
@@ -23,44 +23,17 @@ from enterprise.utils import NotConnectedToOpenEdX
 
 try:
     from student.models import CourseEnrollment
-except ImportError:
-    CourseEnrollment = None
-
-try:
     from openedx.core.djangoapps.embargo import api as embargo_api
-except ImportError:
-    embargo_api = None
-
-try:
     from openedx.core.lib.token_utils import JwtBuilder
 except ImportError:
+    CourseEnrollment = None
+    embargo_api = None
     JwtBuilder = None
 
 
 LOGGER = logging.getLogger(__name__)
 LMS_API_DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 LMS_API_DATETIME_FORMAT_WITHOUT_TIMEZONE = '%Y-%m-%dT%H:%M:%S'
-
-
-class LmsApiClient(object):
-    """
-    Object builds an API client to make calls to the edxapp LMS API.
-
-    Authenticates using settings.EDX_API_KEY.
-    """
-
-    API_BASE_URL = settings.LMS_INTERNAL_ROOT_URL + '/api/'
-    APPEND_SLASH = False
-
-    def __init__(self):
-        """
-        Create an LMS API client, authenticated with the API token from Django settings.
-        """
-        session = Session()
-        session.headers = {"X-Edx-Api-Key": settings.EDX_API_KEY}
-        self.client = EdxRestApiClient(
-            self.API_BASE_URL, append_slash=self.APPEND_SLASH, session=session
-        )
 
 
 class JwtLmsApiClient(object):
@@ -138,7 +111,7 @@ class EmbargoApiClient(object):
                 return redirect_url
 
 
-class EnrollmentApiClient(LmsApiClient):
+class EnrollmentApiClient(object):
     """
     Object builds an API client to make calls to the Enrollment API.
     """
@@ -299,7 +272,7 @@ class EnrollmentApiClient(LmsApiClient):
         return self.client.enrollment.get(user=username)
 
 
-class CourseApiClient(LmsApiClient):
+class CourseApiClient(object):
     """
     Object builds an API client to make calls to the Course API.
     """
@@ -324,7 +297,7 @@ class CourseApiClient(LmsApiClient):
             return None
 
 
-class ThirdPartyAuthApiClient(LmsApiClient):
+class ThirdPartyAuthApiClient(object):
     """
     Object builds an API client to make calls to the Third Party Auth API.
     """
@@ -381,17 +354,13 @@ class ThirdPartyAuthApiClient(LmsApiClient):
         return None
 
 
-class GradesApiClient(JwtLmsApiClient):
+class GradesApiClient(object):
     """
     Object builds an API client to make calls to the LMS Grades API.
 
     Note that this API client requires a JWT token, and so it keeps its token alive.
     """
 
-    API_BASE_URL = settings.LMS_INTERNAL_ROOT_URL + '/api/grades/v0/'
-    APPEND_SLASH = True
-
-    @JwtLmsApiClient.refresh_token
     def get_course_grade(self, course_id, username):
         """
         Retrieve the grade for the given username for the given course_id.
@@ -423,17 +392,13 @@ class GradesApiClient(JwtLmsApiClient):
         raise HttpNotFoundError('No grade record found for course={}, username={}'.format(course_id, username))
 
 
-class CertificatesApiClient(JwtLmsApiClient):
+class CertificatesApiClient(object):
     """
     Object builds an API client to make calls to the LMS Certificates API.
 
     Note that this API client requires a JWT token, and so it keeps its token alive.
     """
 
-    API_BASE_URL = settings.LMS_INTERNAL_ROOT_URL + '/api/certificates/v0/'
-    APPEND_SLASH = True
-
-    @JwtLmsApiClient.refresh_token
     def get_course_certificate(self, course_id, username):
         """
         Retrieve the certificate for the given username for the given course_id.

--- a/enterprise/tpa_pipeline.py
+++ b/enterprise/tpa_pipeline.py
@@ -7,12 +7,9 @@ from enterprise.models import EnterpriseCustomer, EnterpriseCustomerUser
 
 try:
     from social_core.pipeline.partial import partial
-except ImportError:
-    from enterprise.decorators import null_decorator as partial  # pylint:disable=ungrouped-imports
-
-try:
     from third_party_auth.provider import Registry
 except ImportError:
+    from enterprise.decorators import null_decorator as partial  # pylint:disable=ungrouped-imports
     Registry = None
 
 

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -36,18 +36,11 @@ from enterprise.constants import ALLOWED_TAGS, PROGRAM_TYPE_DESCRIPTION
 
 try:
     from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
-except ImportError:
-    configuration_helpers = None
-
-try:
     from lms.djangoapps.branding.api import get_url
-except ImportError:
-    get_url = None
-
-try:
-    # Try to import identity provider registry if third_party_auth is present
     from third_party_auth.provider import Registry
 except ImportError:
+    configuration_helpers = None
+    get_url = None
     Registry = None
 
 LOGGER = logging.getLogger(__name__)

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -54,12 +54,9 @@ from enterprise.utils import (
 
 try:
     from openedx.core.djangoapps.catalog.utils import get_localized_price_text
-except ImportError:
-    get_localized_price_text = None
-
-try:
     from openedx.core.djangoapps.programs.utils import ProgramDataExtender
 except ImportError:
+    get_localized_price_text = None
     ProgramDataExtender = None
 
 LOGGER = getLogger(__name__)


### PR DESCRIPTION
**Description:** This PR removes all LMS REST API implementations that could just as well be Enterprise DB calls. It replaces them with some useful interface that comes from the LMS instead. If no such interface exists, we can just directly make database calls. The idea is to assume we are sitting in the LMS runtime, but since we're still not officially a codebase embedded in it, we maintain a clear interface through the use of API clients (just not _REST_ ones).

**JIRA:** https://openedx.atlassian.net/browse/ENT-660

**Dependencies:** A corresponding PR in the LMS is also required to meet the above assumption across the two parties, although it is not necessarily a physical dependency to this PR, and vice versa. Will link it here anyway when that gets started.

**Merge deadline:** June 4th '18.

**Testing instructions:**

Since a lot of places are affected by this, it'll be necessary to test a lot of different Enterprise functionality.

Actual instructions TBD.