### PR TITLE
update EnterpriseCustomerCatalog model and admin

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,3 +18,4 @@ Matjaz Gregoric <matjaz@opencraft.com>
 George Babey <gbabey@edx.org>
 Adam Stankiewicz <astankiewicz@edx.org>
 Zia Fazal <zfazal@edx.org>
+Muhammad Ammar <mammar@gmail.com>

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,13 @@ Change Log
 Unreleased
 ----------
 
+[0.68.9] - 2018-05-31
+---------------------
+
+* Increased character limit from 20 to 255 for field title in EnterpriseCustomerCatalog model
+* Reorder list display for EnterpriseCustomerCatalogAdmin
+* Add sorting order for EnterpriseCustomerCatalogAdmin
+
 [0.68.8] - 2018-05-30
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.68.8"
+__version__ = "0.68.9"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/admin/__init__.py
+++ b/enterprise/admin/__init__.py
@@ -497,13 +497,15 @@ class EnterpriseCustomerCatalogAdmin(admin.ModelAdmin):
     Django admin model for EnterpriseCustomerCatalog.
     """
 
+    ordering = ('enterprise_customer__name', 'title')
+
     class Meta(object):
         model = EnterpriseCustomerCatalog
 
     list_display = (
         'uuid',
-        'title',
         'enterprise_customer',
+        'title',
     )
 
     search_fields = (

--- a/enterprise/migrations/0049_auto_20180531_0321.py
+++ b/enterprise/migrations/0049_auto_20180531_0321.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('enterprise', '0048_enterprisecustomeruser_active'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='enterprisecustomercatalog',
+            name='title',
+            field=models.CharField(default='All Content', max_length=255),
+        ),
+        migrations.AlterField(
+            model_name='historicalenterprisecustomercatalog',
+            name='title',
+            field=models.CharField(default='All Content', max_length=255),
+        ),
+    ]

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -1029,7 +1029,7 @@ class EnterpriseCustomerCatalog(TimeStampedModel):
     )
     title = models.CharField(
         default='All Content',
-        max_length=20,
+        max_length=255,
         blank=False,
         null=False
     )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1034,6 +1034,21 @@ class TestEnterpriseCustomerCatalog(unittest.TestCase):
         enterprise_customer_catalog = factories.EnterpriseCustomerCatalogFactory()
         assert enterprise_customer_catalog.get_course_and_course_run('fake-course-run-id') == (None, None)
 
+    def test_title_length(self):
+        """
+        Test `EnterpriseCustomerCatalog.title` field can take 255 characters.
+        """
+        faker = FakerFactory.create()
+        uuid = faker.uuid4()  # pylint: disable=no-member
+        title = faker.text(max_nb_chars=255)  # pylint: disable=no-member
+        enterprise_catalog = EnterpriseCustomerCatalog(
+            uuid=uuid,
+            enterprise_customer=factories.EnterpriseCustomerFactory(),
+            title=title
+        )
+        enterprise_catalog.save()
+        assert EnterpriseCustomerCatalog.objects.get(uuid=uuid).title == title
+
 
 @mark.django_db
 @ddt.ddt


### PR DESCRIPTION
ENT-897

**Description:** update EnterpriseCustomerCatalog model and admin 
* Increased character limit from 20 to 255 for field `title` in `EnterpriseCustomerCatalog` model 
* Reorder list display for `EnterpriseCustomerCatalogAdmin`
* Add sorting order for `EnterpriseCustomerCatalogAdmin`

**JIRA:** https://openedx.atlassian.net/browse/ENT-897

**Testing instructions:**

TBD

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

