### PR TITLE
[ENT-995] Fix the Direct-to-Audit enrollment issue in case of course.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.69.2] - 2018-06-18
+---------------------
+
+* Fix the Direct-to-Audit enrollment issue in case of course.
+
 [0.69.1] - 2018-06-07
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.69.1"
+__version__ = "0.69.2"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name


### PR DESCRIPTION
**Description:** 

The direct-to-audit enrollment feature does not appear to work for enrollment URLs containing a Course identifier. After doing some investigation, I came to know that, the following condition is returning False in case of course key instead of course_run_id. [eligible_for_direct_audit_enrollment](https://github.com/edx/edx-enterprise/blob/master/enterprise/views.py#L1386)

> request.path == self.COURSE_ENROLLMENT_VIEW_URL.format(enterprise_customer.uuid, course_run_id)

**JIRA:** [ENT-995](https://openedx.atlassian.net/browse/ENT-995)