### PR TITLE
SuccessFactors: Support customer-specific default locales

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.69.3] - 2018-06-20
+---------------------
+
+* Add and transmit customer specific locales so that SuccessFactors show course title and description.
+
 [0.69.2] - 2018-06-18
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.69.2"
+__version__ = "0.69.3"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/sap_success_factors/admin/__init__.py
+++ b/integrated_channels/sap_success_factors/admin/__init__.py
@@ -46,6 +46,7 @@ class SAPSuccessFactorsEnterpriseCustomerConfigurationAdmin(admin.ModelAdmin):
         'user_type',
         'has_access_token',
         'transmission_chunk_size',
+        'additional_locales',
     )
 
     list_display = (

--- a/integrated_channels/sap_success_factors/exporters/content_metadata.py
+++ b/integrated_channels/sap_success_factors/exporters/content_metadata.py
@@ -58,23 +58,33 @@ class SapSuccessFactorsContentMetadataExporter(ContentMetadataExporter):  # pyli
         """
         Return the title of the content item.
         """
-        return [{
-            'locale': 'English',
-            'value':  content_metadata_item.get('title', '')
-        }]
+        title_with_locales = []
+
+        for locale in self.enterprise_configuration.get_locales():
+            title_with_locales.append({
+                'locale': locale,
+                'value':  content_metadata_item.get('title', '')
+            })
+
+        return title_with_locales
 
     def transform_description(self, content_metadata_item):
         """
         Return the description of the content item.
         """
-        return [{
-            'locale': 'English',
-            'value': (
-                content_metadata_item.get('full_description') or
-                content_metadata_item.get('short_description') or
-                content_metadata_item.get('title', '')
-            )
-        }]
+        description_with_locales = []
+
+        for locale in self.enterprise_configuration.get_locales():
+            description_with_locales.append({
+                'locale': locale,
+                'value': (
+                    content_metadata_item.get('full_description') or
+                    content_metadata_item.get('short_description') or
+                    content_metadata_item.get('title', '')
+                )
+            })
+
+        return description_with_locales
 
     def transform_image(self, content_metadata_item):
         """
@@ -131,24 +141,34 @@ class SapSuccessFactorsContentMetadataExporter(ContentMetadataExporter):  # pyli
                     enrollment_closed=_('Enrollment Closed')
                 )
 
-        return [{
-            'locale': transform_language_code(content_metadata_item.get('content_language', '')),
-            'value':  title
-        }]
+        title_with_locales = []
+        content_metadata_language_code = transform_language_code(content_metadata_item.get('content_language', ''))
+        for locale in self.enterprise_configuration.get_locales(default_locale=content_metadata_language_code):
+            title_with_locales.append({
+                'locale': locale,
+                'value':  title
+            })
+
+        return title_with_locales
 
     def transform_courserun_description(self, content_metadata_item):
         """
         Return the description of the courserun content item.
         """
-        return [{
-            'locale': transform_language_code(content_metadata_item.get('content_language', '')),
-            'value': (
-                content_metadata_item['full_description'] or
-                content_metadata_item['short_description'] or
-                content_metadata_item['title'] or
-                ''
-            )
-        }]
+        description_with_locales = []
+        content_metadata_language_code = transform_language_code(content_metadata_item.get('content_language', ''))
+        for locale in self.enterprise_configuration.get_locales(default_locale=content_metadata_language_code):
+            description_with_locales.append({
+                'locale': locale,
+                'value': (
+                    content_metadata_item['full_description'] or
+                    content_metadata_item['short_description'] or
+                    content_metadata_item['title'] or
+                    ''
+                )
+            })
+
+        return description_with_locales
 
     def transform_courserun_schedule(self, content_metadata_item):
         """

--- a/integrated_channels/sap_success_factors/migrations/0016_sapsuccessfactorsenterprisecustomerconfiguration_additional_locales.py
+++ b/integrated_channels/sap_success_factors/migrations/0016_sapsuccessfactorsenterprisecustomerconfiguration_additional_locales.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('sap_success_factors', '0015_auto_20180510_1259'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='sapsuccessfactorsenterprisecustomerconfiguration',
+            name='additional_locales',
+            field=models.TextField(default='', help_text='A comma-separated list of additional locales.', verbose_name='Additional Locales', blank=True),
+        ),
+    ]

--- a/integrated_channels/sap_success_factors/models.py
+++ b/integrated_channels/sap_success_factors/models.py
@@ -96,6 +96,33 @@ class SAPSuccessFactorsEnterpriseCustomerConfiguration(EnterpriseCustomerPluginC
         verbose_name="SAP User Type",
         help_text=_("Type of SAP User (admin or user).")
     )
+    additional_locales = models.TextField(
+        blank=True,
+        default='',
+        verbose_name="Additional Locales",
+        help_text=_("A comma-separated list of additional locales.")
+    )
+
+    def get_locales(self, default_locale=None):
+        """
+        Get the list of all(default + additional) locales
+
+        Args:
+            default_locale (str): Value of the default locale
+
+        Returns:
+            list: available locales
+        """
+        locales = []
+
+        if default_locale is None:
+            locales.append('English')
+        else:
+            locales.append(default_locale)
+
+        return set(
+            locales + [locale for locale in self.additional_locales.split(",") if locale]
+        )
 
     class Meta:
         app_label = 'sap_success_factors'

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1432,6 +1432,22 @@ class TestSAPSuccessFactorsEnterpriseCustomerConfiguration(unittest.TestCase):
     def test_channel_code(self):
         assert self.config.channel_code() == 'SAP'
 
+    def test_locales_wo_additional_locales(self):
+        """
+        Verify that ``SAPSuccessFactorsEnterpriseCustomerConfiguration.get_locales`` works without additional_locales
+        """
+        assert self.config.additional_locales == ''
+        assert self.config.get_locales() == set(['English'])
+
+    def test_locales_w_additional_locales(self):
+        """
+        Verify that ``SAPSuccessFactorsEnterpriseCustomerConfiguration.get_locales`` works with additional_locales
+        """
+        self.config.additional_locales = 'Malay,Arabic,English United Kingdom'
+        self.config.save()
+
+        assert self.config.get_locales() == set(['English', 'Malay', 'Arabic', 'English United Kingdom'])
+
 
 @mark.django_db
 @ddt.ddt


### PR DESCRIPTION
ENT-1027

**Description:** 
Add and transmit customer specific locales so that SuccessFactors show course title and description.

**JIRA:** https://openedx.atlassian.net/browse/ENT-1027

**Testing instructions:**

1. Set the locale other than `English` for a `user` on SuccessFactors, for example, `Japanese`
2. Do not add `Japanese` in `Additional Locales` field for a `success factors enterprise customer configuration`.
3. Then transmit the data from enterprise customer admin interface.
4. Login with `admin` user on SuccessFactors and import the course and add it `user` assigned tasks.
5. Login with`user` on SuccessFactors, open the imported course and you should not see the course `title` and `description`
6. Now add `Japanese` in `Additional Locales` field.
7. Transmit the data again and now course `title` and `description` should be shown on SuccessFactors
