### PR TITLE
Paginate linked learners on manage learners admin view - ENT-933

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.70.1] - 2018-06-27
+---------------------
+
+* Paginate linked learners list on manage learners Django admin view.
+
 [0.70.0] - 2018-06-26
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.70.0"
+__version__ = "0.70.1"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/admin/paginator.py
+++ b/enterprise/admin/paginator.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+"""
+Custom paginator to implement smart pagination.
+"""
+from __future__ import absolute_import, unicode_literals
+
+from django.core.paginator import Paginator
+
+
+class CustomPaginator(Paginator):
+    """
+    Adopted from django/core/paginator
+    so as to implement smart links pagination in custom views.
+    """
+    _page_range = []
+
+    @property
+    def page_range(self):
+        """
+        We have customized the getter so that it can return the value of the page_range property
+        instead of always calculating the result.
+        """
+        return self._page_range or list(range(1, self.num_pages + 1))
+
+    @page_range.setter
+    def page_range(self, value):
+        """
+        We have introduced a setter method here, so as to set value for page_range property.
+        This was not present in Paginator class.
+        """
+        self._page_range = value

--- a/enterprise/admin/utils.py
+++ b/enterprise/admin/utils.py
@@ -8,11 +8,17 @@ import unicodecsv
 
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
+from django.core.paginator import EmptyPage, PageNotAnInteger
 from django.core.validators import validate_email
 from django.utils.translation import ugettext as _
 
+from enterprise.admin.paginator import CustomPaginator
 from enterprise.api_client.lms import parse_lms_api_datetime
 from enterprise.models import EnterpriseCustomerUser
+
+DOT = '.'
+PAGES_ON_EACH_SIDE = 3
+PAGES_ON_ENDS = 2
 
 
 class ProgramStatuses(object):
@@ -216,3 +222,55 @@ def split_usernames_and_emails(email_field):
     provide a list of email addresses or usernames if it is.
     """
     return [name.strip() for name in email_field.split(',')]
+
+
+# pylint: disable=range-builtin-not-iterating
+def paginated_list(object_list, page, page_size=25):
+    """
+    Returns paginated list.
+
+    Arguments:
+        object_list (QuerySet): A list of records to be paginated.
+        page (int): Current page number.
+        page_size (int): Number of records displayed in each paginated set.
+        show_all (bool): Whether to show all records.
+
+    Adopted from django/contrib/admin/templatetags/admin_list.py
+    https://github.com/django/django/blob/1.11.1/django/contrib/admin/templatetags/admin_list.py#L50
+    """
+    paginator = CustomPaginator(object_list, page_size)
+    try:
+        object_list = paginator.page(page)
+    except PageNotAnInteger:
+        object_list = paginator.page(1)
+    except EmptyPage:
+        object_list = paginator.page(paginator.num_pages)
+
+    page_range = []
+    page_num = object_list.number
+
+    # If there are 10 or fewer pages, display links to every page.
+    # Otherwise, do some fancy
+    if paginator.num_pages <= 10:
+        page_range = range(paginator.num_pages)
+    else:
+        # Insert "smart" pagination links, so that there are always ON_ENDS
+        # links at either end of the list of pages, and there are always
+        # ON_EACH_SIDE links at either end of the "current page" link.
+        if page_num > (PAGES_ON_EACH_SIDE + PAGES_ON_ENDS + 1):
+            page_range.extend(range(1, PAGES_ON_ENDS + 1))
+            page_range.append(DOT)
+            page_range.extend(range(page_num - PAGES_ON_EACH_SIDE, page_num + 1))
+        else:
+            page_range.extend(range(1, page_num + 1))
+        if page_num < (paginator.num_pages - PAGES_ON_EACH_SIDE - PAGES_ON_ENDS):
+            page_range.extend(range(page_num + 1, page_num + PAGES_ON_EACH_SIDE + 1))
+            page_range.append(DOT)
+            page_range.extend(range(paginator.num_pages + 1 - PAGES_ON_ENDS, paginator.num_pages + 1))
+        else:
+            page_range.extend(range(page_num + 1, paginator.num_pages + 1))
+
+        # Override page range to implement custom smart links.
+        object_list.paginator.page_range = page_range
+
+    return object_list

--- a/enterprise/constants.py
+++ b/enterprise/constants.py
@@ -44,6 +44,8 @@ COURSE_MODE_SORT_ORDER = ['verified', 'professional', 'no-id-professional', 'aud
 # Course modes that should not be displayed to users.
 EXCLUDED_COURSE_MODES = ['credit']
 
+# Number of records to display in each paginated set.
+PAGE_SIZE = 25
 
 PROGRAM_TYPE_DESCRIPTION = {
     'MicroMasters Certificate': _(

--- a/enterprise/templates/enterprise/admin/manage_learners.html
+++ b/enterprise/templates/enterprise/admin/manage_learners.html
@@ -86,8 +86,6 @@ global Javascript variables that can be used in any of the loaded packages.
                  id="searchbar"
                  placeholder="{% trans 'Search email address or username' %}">
           <input type="submit" value="Search">
-          <!-- TODO: Remove this message when paging is added to this list. -->
-          <label>You must enter a search keyword to list linked learners.</label>
         </div>
       </form>
     </div>
@@ -120,7 +118,20 @@ global Javascript variables that can be used in any of the loaded packages.
       {% endfor %}
       </tbody>
     </table>
-
+    {% if learners.has_other_pages %}
+      <p class="paginator">
+        {% for page_number in learners.paginator.page_range %}
+          {% if page_number == '.' %}
+          ...
+          {% elif learners.number == page_number %}
+          <span class="this-page">{{ page_number }}</span>
+          {% else %}
+          <a href="?page={{ page_number }}">{{ page_number }}</a>
+          {% endif %}
+        {% endfor %}
+        {{ learners.paginator.count }} learner{{ learners.paginator.count|pluralize}}
+      </p>
+    {% endif %}
     <h1>Pending linked learners</h1>
     <table class="learners-table pending-linked-learners">
       <thead>

--- a/tests/test_admin/test_view.py
+++ b/tests/test_admin/test_view.py
@@ -2,9 +2,10 @@
 """
 Tests for the `edx-enterprise` admin forms module.
 """
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, division, unicode_literals
 
 import json
+from math import ceil
 
 import ddt
 import mock
@@ -26,6 +27,7 @@ from enterprise.admin import (
 )
 from enterprise.admin.forms import ManageLearnersForm, TransmitEnterpriseCoursesForm
 from enterprise.admin.utils import ValidationMessages, get_course_runs_from_program
+from enterprise.constants import PAGE_SIZE
 from enterprise.django_compatibility import reverse
 from enterprise.models import (
     EnrollmentNotificationEmailTemplate,
@@ -218,6 +220,31 @@ class TestEnterpriseCustomerManageLearnersViewGet(BaseTestEnterpriseCustomerMana
     Tests for EnterpriseCustomerManageLearnersView GET endpoint.
     """
 
+    def _verify_pagination(
+            self,
+            page_object,
+            total_result,
+            page_number=1,
+            page_start=0,
+            page_end=PAGE_SIZE,
+            page_size=PAGE_SIZE
+    ):
+        """
+        Verifies pagination.
+        """
+        # Verify current page details
+        assert page_object.number == page_number
+        assert list(page_object.object_list) == total_result[page_start:page_end]
+
+        # Verify pagination details
+        assert page_object.paginator.count == len(total_result)
+        assert page_object.paginator.per_page == page_size
+
+        # if no record is set, pagination will have 1 empty page i.e showing Page 1 of 1.
+        result_pages = int(ceil(len(total_result) / float(page_size))) if total_result else 1
+        assert page_object.paginator.num_pages == result_pages
+        assert list(page_object.paginator.object_list) == total_result
+
     def _test_get_response(self, response, linked_learners, pending_linked_learners):
         """
         Test view GET response for common parts.
@@ -228,6 +255,7 @@ class TestEnterpriseCustomerManageLearnersViewGet(BaseTestEnterpriseCustomerMana
         assert list(response.context[self.context_parameters.PENDING_LEARNERS]) == pending_linked_learners
         assert response.context[self.context_parameters.ENTERPRISE_CUSTOMER] == self.enterprise_customer
         assert not response.context[self.context_parameters.MANAGE_LEARNERS_FORM].is_bound
+        self._verify_pagination(response.context[self.context_parameters.LEARNERS], linked_learners)
 
     def test_get_not_logged_in(self):
         assert settings.SESSION_COOKIE_NAME not in self.client.cookies  # precondition check - no session cookie
@@ -245,28 +273,46 @@ class TestEnterpriseCustomerManageLearnersViewGet(BaseTestEnterpriseCustomerMana
     def test_get_existing_links_only(self):
         self._login()
 
-        EnterpriseCustomerUserFactory(enterprise_customer=self.enterprise_customer)
-        EnterpriseCustomerUserFactory(enterprise_customer=self.enterprise_customer)
-        EnterpriseCustomerUserFactory(enterprise_customer=self.enterprise_customer)
-
+        linked_learners = [
+            EnterpriseCustomerUserFactory(
+                enterprise_customer=self.enterprise_customer,
+                user_id=UserFactory().id,
+            ),
+            EnterpriseCustomerUserFactory(
+                enterprise_customer=self.enterprise_customer,
+                user_id=UserFactory().id,
+            ),
+            EnterpriseCustomerUserFactory(
+                enterprise_customer=self.enterprise_customer,
+                user_id=UserFactory().id,
+            ),
+        ]
         response = self.client.get(self.view_url)
-        # Test existing linked learners are not returned by default (until paging is added).
-        self._test_get_response(response, [], [])
+        self._test_get_response(response, linked_learners, [])
 
     def test_get_existing_and_pending_links(self):
         self._login()
 
-        EnterpriseCustomerUserFactory(enterprise_customer=self.enterprise_customer)
-        EnterpriseCustomerUserFactory(enterprise_customer=self.enterprise_customer)
-        EnterpriseCustomerUserFactory(enterprise_customer=self.enterprise_customer)
+        linked_learners = [
+            EnterpriseCustomerUserFactory(
+                enterprise_customer=self.enterprise_customer,
+                user_id=UserFactory().id,
+            ),
+            EnterpriseCustomerUserFactory(
+                enterprise_customer=self.enterprise_customer,
+                user_id=UserFactory().id,
+            ),
+            EnterpriseCustomerUserFactory(
+                enterprise_customer=self.enterprise_customer,
+                user_id=UserFactory().id,
+            ),
+        ]
         pending_linked_learners = [
             PendingEnterpriseCustomerUserFactory(enterprise_customer=self.enterprise_customer),
             PendingEnterpriseCustomerUserFactory(enterprise_customer=self.enterprise_customer),
         ]
-
         response = self.client.get(self.view_url)
-        # Test existing linked learners are not returned by default (until paging is added).
-        self._test_get_response(response, [], pending_linked_learners)
+        self._test_get_response(response, linked_learners, pending_linked_learners)
 
     def test_get_with_search_param(self):
         self._login()
@@ -316,6 +362,44 @@ class TestEnterpriseCustomerManageLearnersViewGet(BaseTestEnterpriseCustomerMana
 
         response = self.client.get(self.view_url + '?q=longstringthatdoesnthappen')
         self._test_get_response(response, [], [])
+
+    @ddt.data(
+        (1, 1, 0, 25, 50),
+        (6, 6, 125, 150, 300),
+        (7, 7, 150, 175, 300),
+        #  Invalid page values
+        ('invalid-page-value', 1, 0, 25, 50),
+        (100, 2, 25, 50, 50),
+        (-1, 2, 25, 50, 50)
+    )
+    @ddt.unpack
+    def test_get_pagination(self, current_page_number, expected_page_number, page_start, page_end, total_records):
+        """
+        Test pagination for linked learners list works expectedly.
+        """
+        self._login()
+        linked_learners = []
+        for i in range(0, total_records):
+            learner = EnterpriseCustomerUserFactory(
+                enterprise_customer=self.enterprise_customer,
+                user_id=UserFactory(
+                    username='user{user_index}'.format(user_index=i),
+                    id=i + 10,  # Just to make sure we don't get IntegrityError.
+                ).id
+            )
+            linked_learners.append(learner)
+
+        # Verify we get the paginated result for correct page.
+        response = self.client.get('{view_url}?page={page_number}'.format(
+            view_url=self.view_url, page_number=current_page_number
+        ))
+        self._verify_pagination(
+            response.context[self.context_parameters.LEARNERS],
+            linked_learners,
+            page_number=expected_page_number,
+            page_start=page_start,
+            page_end=page_end
+        )
 
 
 @ddt.ddt


### PR DESCRIPTION
**Description:** The purpose of this PR is to add pagination support to linked learners list on manage learners admin view.

**Testing instructions:**

1. Open Enterprise customer detail view.
2. Click manage learners
3. Expect linked learners list to be paginated.


**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
