### PR TITLE
ENT-1006 Fixing requirements snafoo

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.69.6] - 2018-06-25
+---------------------
+
+* Update requirements to fix pip install issues and to keep in line with edx-platform.
+
 [0.69.5] - 2018-06-25
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.69.5"
+__version__ = "0.69.6"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,16 +12,17 @@ asn1crypto==0.24.0        # via cryptography
 astroid==1.5.2            # via edx-lint, pylint, pylint-celery, pylint-plugin-utils
 backports.functools-lru-cache==1.5  # via astroid, caniusepython3, pylint
 billiard==3.3.0.23        # via celery
-caniusepython3==6.0.0
+bleach==1.4
+caniusepython3==7.0.0
 celery==3.1.18
 cffi==1.11.5              # via cryptography
 click-log==0.1.8          # via edx-lint
 click==6.7                # via click-log, edx-lint, pip-tools
-configparser==3.5.0       # via pydocstyle, pylint
+configparser==3.5.0       # via pylint
 cryptography==1.9
 defusedxml==0.5.0         # via djangorestframework-xml
-diff-cover==1.0.2
-distlib==0.2.6            # via caniusepython3
+diff-cover==0.9.8
+distlib==0.2.7            # via caniusepython3
 django-config-models==0.1.8
 django-fernet-fields==0.5
 django-filter==1.0.4
@@ -38,7 +39,7 @@ djangorestframework-xml==1.3.0
 djangorestframework==3.6.3
 edx-django-oauth2-provider==1.1.4
 edx-drf-extensions==1.2.3
-edx-i18n-tools==0.4.3
+edx-i18n-tools==0.4.6
 edx-lint==0.5.5
 edx-opaque-keys==0.4.0
 edx-rest-api-client==1.7.1
@@ -47,54 +48,56 @@ event-tracking==0.2.4
 first==2.0.1              # via pip-tools
 flaky==3.3.0
 futures==3.1.1
-idna==2.6                 # via cryptography
-inflect==0.2.5            # via jinja2-pluralize
-ipaddress==1.0.19         # via cryptography
+html5lib==0.999
+idna==2.7                 # via cryptography
+inflect==0.3.1            # via jinja2-pluralize
+ipaddress==1.0.22         # via cryptography
 isort==4.3.4
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.10              # via diff-cover, jinja2-pluralize
+jsondiff==1.1.1
 jsonfield==2.0.2
 kombu==3.0.37             # via celery
 lazy-object-proxy==1.3.1  # via astroid
 markupsafe==1.0           # via jinja2
 mccabe==0.6.1             # via pylint
 packaging==17.1           # via caniusepython3
-path.py==11.0             # via edx-i18n-tools
-pbr==3.1.1                # via stevedore
+path.py==8.2.1
+pbr==4.0.4                # via stevedore
 pillow==3.4
-pip-tools==1.11.0
+pip-tools==2.0.2
 pkginfo==1.4.2            # via twine
 pluggy==0.6.0             # via tox
 polib==1.1.0              # via edx-i18n-tools
 py==1.5.3                 # via tox
-pycodestyle==2.3.1
+pycodestyle==2.4.0
 pycparser==2.18           # via cffi
 pydocstyle==2.1.1
 pygments==2.2.0           # via diff-cover
-pyjwt==1.6.1              # via djangorestframework-jwt, edx-rest-api-client
+pyjwt==1.6.4              # via djangorestframework-jwt, edx-rest-api-client
 pylint-celery==0.3        # via edx-lint
 pylint-django==0.7.2      # via edx-lint
 pylint-plugin-utils==0.2.6  # via pylint-celery, pylint-django
 pylint==1.7.1             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.6.1            # via edx-opaque-keys, event-tracking
 pyparsing==2.2.0          # via packaging
-python-dateutil==2.7.0    # via analytics-python, edx-drf-extensions
-pytz==2018.3              # via celery, event-tracking
+python-dateutil==2.4.0
+pytz==2016.10
 pyyaml==3.12              # via edx-i18n-tools
 requests-toolbelt==0.8.0  # via twine
 requests==2.9.1
 shortuuid==0.5.0          # via edx-django-oauth2-provider
 singledispatch==3.4.0.3   # via astroid, pylint
-six==1.11.0               # via analytics-python, astroid, cryptography, diff-cover, edx-i18n-tools, edx-lint, edx-opaque-keys, packaging, pip-tools, pydocstyle, pylint, python-dateutil, singledispatch, stevedore, tox
+six==1.11.0               # via analytics-python, astroid, bleach, cryptography, diff-cover, edx-i18n-tools, edx-lint, edx-opaque-keys, html5lib, packaging, pip-tools, pydocstyle, pylint, python-dateutil, singledispatch, stevedore, tox
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==1.2.1    # via pydocstyle
 stevedore==1.28.0         # via edx-opaque-keys
-testfixtures==5.4.0
+testfixtures==6.2.0
 tox-battery==0.5
-tox==2.9.1
-tqdm==4.19.8              # via twine
+tox==3.0.0
+tqdm==4.23.4              # via twine
 twine==1.11.0
 unicodecsv==0.14.1
-virtualenv==15.2.0        # via tox
-wheel==0.30.0
+virtualenv==16.0.0        # via tox
+wheel==0.31.1
 wrapt==1.10.11            # via astroid

--- a/requirements/doc.in
+++ b/requirements/doc.in
@@ -2,6 +2,7 @@
 
 doc8                      # reStructuredText style checker
 edx_sphinx_theme          # edX theme for Sphinx output
-readme_renderer           # Validates README.rst for usage on PyPI
+readme_renderer==0.7.0    # Validates README.rst for usage on PyPI
 Sphinx                    # Documentation builder
 sphinxcontrib-napoleon    # Google Style docstring support for sphinx
+docutils==0.12

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -4,20 +4,20 @@
 #
 #    pip-compile --output-file requirements/doc.txt requirements/base.in requirements/test-master.in requirements/doc.in
 #
-alabaster==0.7.10         # via sphinx
+alabaster==0.7.11         # via sphinx
 amqp==1.4.9               # via kombu
 analytics-python==1.1.0
 anyjson==0.3.3            # via kombu
 asn1crypto==0.24.0        # via cryptography
-babel==2.5.3              # via sphinx
+babel==2.6.0              # via sphinx
 billiard==3.3.0.23        # via celery
-bleach==2.1.3             # via readme-renderer
+bleach==1.4
 celery==3.1.18
 cffi==1.11.5              # via cryptography
 chardet==3.0.4            # via doc8
-commonmark==0.7.5         # via readme-renderer
 cryptography==1.9
 defusedxml==0.5.0         # via djangorestframework-xml
+diff-cover==0.9.8
 django-config-models==0.1.8
 django-fernet-fields==0.5
 django-filter==1.0.4
@@ -33,7 +33,7 @@ djangorestframework-oauth==1.1.0
 djangorestframework-xml==1.3.0
 djangorestframework==3.6.3
 doc8==0.8.0
-docutils==0.14            # via doc8, readme-renderer, restructuredtext-lint, sphinx
+docutils==0.12
 edx-django-oauth2-provider==1.1.4
 edx-drf-extensions==1.2.3
 edx-opaque-keys==0.4.0
@@ -42,38 +42,40 @@ edx-sphinx-theme==1.3.0
 enum34==1.1.6             # via cryptography
 event-tracking==0.2.4
 flaky==3.3.0
-future==0.16.0            # via commonmark
-html5lib==1.0.1           # via bleach
-idna==2.6                 # via cryptography
+html5lib==0.999
+idna==2.7                 # via cryptography
 imagesize==1.0.0          # via sphinx
-ipaddress==1.0.19         # via cryptography
-jinja2==2.10              # via sphinx
+inflect==0.3.1            # via jinja2-pluralize
+ipaddress==1.0.22         # via cryptography
+jinja2-pluralize==0.3.0   # via diff-cover
+jinja2==2.10              # via diff-cover, jinja2-pluralize, sphinx
+jsondiff==1.1.1
 jsonfield==2.0.2
 kombu==3.0.37             # via celery
 markupsafe==1.0           # via jinja2
 packaging==17.1           # via sphinx
-pbr==3.1.1                # via stevedore
+path.py==8.2.1
+pbr==4.0.4                # via stevedore
 pillow==3.4
 pockets==0.6.2            # via sphinxcontrib-napoleon
 pycparser==2.18           # via cffi
-pygments==2.2.0           # via readme-renderer, sphinx
-pyjwt==1.6.1              # via djangorestframework-jwt, edx-rest-api-client
+pygments==2.2.0           # via diff-cover, readme-renderer, sphinx
+pyjwt==1.6.4              # via djangorestframework-jwt, edx-rest-api-client
 pymongo==3.6.1            # via edx-opaque-keys, event-tracking
 pyparsing==2.2.0          # via packaging
-python-dateutil==2.7.0    # via analytics-python, edx-drf-extensions
-pytz==2018.3              # via babel, celery, event-tracking
-readme-renderer==17.4
+python-dateutil==2.4.0
+pytz==2016.10
+readme_renderer==0.7.0
 requests==2.9.1
 restructuredtext-lint==1.1.3  # via doc8
 shortuuid==0.5.0          # via edx-django-oauth2-provider
-six==1.11.0               # via analytics-python, bleach, cryptography, doc8, edx-opaque-keys, edx-sphinx-theme, html5lib, packaging, pockets, python-dateutil, readme-renderer, sphinx, sphinxcontrib-napoleon, stevedore
+six==1.11.0               # via analytics-python, bleach, cryptography, diff-cover, doc8, edx-opaque-keys, edx-sphinx-theme, html5lib, packaging, pockets, python-dateutil, readme-renderer, sphinx, sphinxcontrib-napoleon, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==1.2.1    # via sphinx
-sphinx==1.7.2
+sphinx==1.7.5
 sphinxcontrib-napoleon==0.6.1
-sphinxcontrib-websupport==1.0.1  # via sphinx
+sphinxcontrib-websupport==1.1.0  # via sphinx
 stevedore==1.28.0         # via doc8, edx-opaque-keys
-testfixtures==5.4.0
+testfixtures==6.2.0
 typing==3.6.4             # via sphinx
 unicodecsv==0.14.1
-webencodings==0.5.1       # via html5lib

--- a/requirements/js_test.txt
+++ b/requirements/js_test.txt
@@ -5,17 +5,18 @@
 #    pip-compile --output-file requirements/js_test.txt requirements/js_test.in
 #
 argparse==1.4.0           # via jasmine
-cheroot==6.0.0            # via cherrypy
-cherrypy==14.0.0          # via jasmine
+backports.functools-lru-cache==1.5  # via cheroot
+cheroot==6.3.2            # via cherrypy
+cherrypy==16.0.2          # via jasmine
 glob2==0.6                # via jasmine-core
 jasmine-core==2.99.1      # via jasmine
 jasmine==2.9.0
 jinja2==2.10              # via jasmine
 markupsafe==1.0           # via jinja2
-more-itertools==4.1.0     # via cheroot
+more-itertools==4.2.0     # via cheroot
 ordereddict==1.1          # via jasmine-core
-portend==2.2              # via cherrypy
-pytz==2018.3              # via tempora
+portend==2.3              # via cherrypy
+pytz==2018.4              # via tempora
 pyyaml==3.10              # via jasmine
 selenium==3.6.0           # via jasmine
 six==1.11.0               # via cheroot, cherrypy, jasmine, more-itertools, tempora

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,33 +4,33 @@
 #
 #    pip-compile --output-file requirements/quality.txt requirements/base.in requirements/test-master.in requirements/dev.in requirements/quality.in requirements/doc.in requirements/test.in
 #
-alabaster==0.7.10         # via sphinx
+alabaster==0.7.11         # via sphinx
 amqp==1.4.9               # via kombu
 analytics-python==1.1.0
 anyjson==0.3.3            # via kombu
 argparse==1.4.0           # via caniusepython3
 asn1crypto==0.24.0        # via cryptography
 astroid==1.5.2            # via edx-lint, pylint, pylint-celery, pylint-plugin-utils
-attrs==17.4.0             # via pytest
-babel==2.5.3              # via sphinx
+atomicwrites==1.1.5       # via pytest
+attrs==18.1.0             # via pytest
+babel==2.6.0              # via sphinx
 backports.functools-lru-cache==1.5  # via astroid, caniusepython3, pylint
 billiard==3.3.0.23        # via celery
-bleach==2.1.3             # via readme-renderer
-caniusepython3==6.0.0
+bleach==1.4
+caniusepython3==7.0.0
 celery==3.1.18
 cffi==1.11.5              # via cryptography
 chardet==3.0.4            # via doc8
 click-log==0.1.8          # via edx-lint
 click==6.7                # via click-log, edx-lint, pip-tools
-commonmark==0.7.5         # via readme-renderer
-configparser==3.5.0       # via pydocstyle, pylint
+configparser==3.5.0       # via pylint
 cookies==2.2.1            # via responses
 coverage==4.5.1           # via pytest-cov
 cryptography==1.9
-ddt==1.1.2
+ddt==1.1.3
 defusedxml==0.5.0         # via djangorestframework-xml
-diff-cover==1.0.2
-distlib==0.2.6            # via caniusepython3
+diff-cover==0.9.8
+distlib==0.2.7            # via caniusepython3
 django-config-models==0.1.8
 django-fernet-fields==0.5
 django-filter==1.0.4
@@ -46,53 +46,54 @@ djangorestframework-oauth==1.1.0
 djangorestframework-xml==1.3.0
 djangorestframework==3.6.3
 doc8==0.8.0
-docutils==0.14            # via doc8, readme-renderer, restructuredtext-lint, sphinx
+docutils==0.12
 edx-django-oauth2-provider==1.1.4
 edx-drf-extensions==1.2.3
-edx-i18n-tools==0.4.3
+edx-i18n-tools==0.4.6
 edx-lint==0.5.5
 edx-opaque-keys==0.4.0
 edx-rest-api-client==1.7.1
 edx-sphinx-theme==1.3.0
 enum34==1.1.6             # via astroid, cryptography
 event-tracking==0.2.4
-factory-boy==2.10.0
-faker==0.8.12             # via factory-boy
+factory-boy==2.11.1
+faker==0.8.16             # via factory-boy
 first==2.0.1              # via pip-tools
 flaky==3.3.0
 freezegun==0.3.10
 funcsigs==1.0.2           # via mock, pytest
-future==0.16.0            # via commonmark
 futures==3.1.1
-html5lib==1.0.1           # via bleach
-idna==2.6                 # via cryptography
+html5lib==0.999
+idna==2.7                 # via cryptography
 imagesize==1.0.0          # via sphinx
-inflect==0.2.5            # via jinja2-pluralize
-ipaddress==1.0.19         # via cryptography, faker
+inflect==0.3.1            # via jinja2-pluralize
+ipaddress==1.0.22         # via cryptography, faker
 isort==4.3.4
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.10              # via diff-cover, jinja2-pluralize, sphinx
+jsondiff==1.1.1
 jsonfield==2.0.2
 kombu==3.0.37             # via celery
 lazy-object-proxy==1.3.1  # via astroid
 markupsafe==1.0           # via jinja2
 mccabe==0.6.1             # via pylint
 mock==2.0.0
+more-itertools==4.2.0     # via pytest
 packaging==17.1           # via caniusepython3, sphinx
-path.py==11.0             # via edx-i18n-tools
-pbr==3.1.1                # via mock, stevedore
+path.py==8.2.1
+pbr==4.0.4                # via mock, stevedore
 pillow==3.4
-pip-tools==1.11.0
+pip-tools==2.0.2
 pkginfo==1.4.2            # via twine
 pluggy==0.6.0             # via pytest, tox
 pockets==0.6.2            # via sphinxcontrib-napoleon
 polib==1.1.0              # via edx-i18n-tools
 py==1.5.3                 # via pytest, pytest-catchlog, tox
-pycodestyle==2.3.1
+pycodestyle==2.4.0
 pycparser==2.18           # via cffi
 pydocstyle==2.1.1
 pygments==2.2.0           # via diff-cover, readme-renderer, sphinx
-pyjwt==1.6.1              # via djangorestframework-jwt, edx-rest-api-client
+pyjwt==1.6.4              # via djangorestframework-jwt, edx-rest-api-client
 pylint-celery==0.3        # via edx-lint
 pylint-django==0.7.2      # via edx-lint
 pylint-plugin-utils==0.2.6  # via pylint-celery, pylint-django
@@ -101,34 +102,33 @@ pymongo==3.6.1            # via edx-opaque-keys, event-tracking
 pyparsing==2.2.0          # via packaging
 pytest-catchlog==1.2.2
 pytest-cov==2.5.1
-pytest-django==3.1.2
-pytest==3.4.2             # via pytest-catchlog, pytest-cov, pytest-django
-python-dateutil==2.7.0    # via analytics-python, edx-drf-extensions, faker, freezegun
-pytz==2018.3              # via babel, celery, event-tracking
+pytest-django==3.3.2
+pytest==3.6.2             # via pytest-catchlog, pytest-cov, pytest-django
+python-dateutil==2.4.0
+pytz==2016.10
 pyyaml==3.12              # via edx-i18n-tools
-readme-renderer==17.4
+readme_renderer==0.7.0
 requests-toolbelt==0.8.0  # via twine
 requests==2.9.1
-responses==0.8.1
+responses==0.9.0
 restructuredtext-lint==1.1.3  # via doc8
 shortuuid==0.5.0          # via edx-django-oauth2-provider
 singledispatch==3.4.0.3   # via astroid, pylint
-six==1.11.0               # via analytics-python, astroid, bleach, cryptography, diff-cover, doc8, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, faker, freezegun, html5lib, mock, packaging, pip-tools, pockets, pydocstyle, pylint, pytest, python-dateutil, readme-renderer, responses, singledispatch, sphinx, sphinxcontrib-napoleon, stevedore, tox
+six==1.11.0               # via analytics-python, astroid, bleach, cryptography, diff-cover, doc8, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, faker, freezegun, html5lib, mock, more-itertools, packaging, pip-tools, pockets, pydocstyle, pylint, pytest, python-dateutil, readme-renderer, responses, singledispatch, sphinx, sphinxcontrib-napoleon, stevedore, tox
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==1.2.1    # via pydocstyle, sphinx
-sphinx==1.7.2
+sphinx==1.7.5
 sphinxcontrib-napoleon==0.6.1
-sphinxcontrib-websupport==1.0.1  # via sphinx
+sphinxcontrib-websupport==1.1.0  # via sphinx
 stevedore==1.28.0         # via doc8, edx-opaque-keys
-testfixtures==5.4.0
+testfixtures==6.2.0
 text-unidecode==1.2       # via faker
 tox-battery==0.5
-tox==2.9.1
-tqdm==4.19.8              # via twine
+tox==3.0.0
+tqdm==4.23.4              # via twine
 twine==1.11.0
 typing==3.6.4             # via sphinx
 unicodecsv==0.14.1
-virtualenv==15.2.0        # via tox
-webencodings==0.5.1       # via html5lib
-wheel==0.30.0
+virtualenv==16.0.0        # via tox
+wheel==0.31.1
 wrapt==1.10.11            # via astroid

--- a/requirements/test-ficus.in
+++ b/requirements/test-ficus.in
@@ -31,5 +31,15 @@ jsonfield==2.0.2                        # Provides a Django model field which se
 flaky==3.3.0                            # Rerun flaky tests automatically if they fail, up to a limit
 analytics-python==1.1.0                 # Used for Segment analytics
 event-tracking==0.2.4                   # Tracks context-aware semi-structured system events
+
+# These are packages that edx-enterprise uses that are pinned to previous versions in edx-platform.
+# We pin them here to make sure our tests are installing the same requirements
+# as the environment the production code will have.
+
 django-ipware==1.1.0
 bleach==1.4
+html5lib==0.999
+diff-cover==0.9.8
+path.py==8.2.1
+python-dateutil==2.4.0
+pytz==2016.10

--- a/requirements/test-ficus.txt
+++ b/requirements/test-ficus.txt
@@ -7,7 +7,8 @@
 amqp==1.4.9               # via kombu
 analytics-python==1.1.0
 anyjson==0.3.3            # via kombu
-attrs==17.4.0             # via pytest
+atomicwrites==1.1.5       # via pytest
+attrs==18.1.0             # via pytest
 billiard==3.3.0.23        # via celery
 bleach==1.4
 celery==3.1.18
@@ -15,8 +16,9 @@ cffi==1.11.5              # via cryptography
 cookies==2.2.1            # via responses
 coverage==4.5.1           # via pytest-cov
 cryptography==1.5.3
-ddt==1.1.2
+ddt==1.1.3
 defusedxml==0.5.0         # via djangorestframework-xml
+diff-cover==0.9.8
 django-config-models==0.1.5
 django-fernet-fields==0.5
 django-filter==0.11.0
@@ -37,37 +39,45 @@ edx-opaque-keys==0.4.0
 edx-rest-api-client==1.6.0
 enum34==1.1.6             # via cryptography
 event-tracking==0.2.4
-factory-boy==2.10.0
-faker==0.8.12             # via factory-boy
+factory-boy==2.11.1
+faker==0.8.16             # via factory-boy
 flaky==3.3.0
 freezegun==0.3.10
 funcsigs==1.0.2           # via mock, pytest
-html5lib==0.999           # via bleach
-idna==2.6                 # via cryptography
-ipaddress==1.0.19         # via cryptography, faker
+html5lib==0.999
+idna==2.7                 # via cryptography
+inflect==0.3.1            # via jinja2-pluralize
+ipaddress==1.0.22         # via cryptography, faker
+jinja2-pluralize==0.3.0   # via diff-cover
+jinja2==2.10              # via diff-cover, jinja2-pluralize
+jsondiff==1.1.1
 jsonfield==2.0.2
 kombu==3.0.37             # via celery
+markupsafe==1.0           # via jinja2
 mock==2.0.0
-pbr==3.1.1                # via mock, stevedore
+more-itertools==4.2.0     # via pytest
+path.py==8.2.1
+pbr==4.0.4                # via mock, stevedore
 pillow==3.4
 pluggy==0.6.0             # via pytest
 py==1.5.3                 # via pytest, pytest-catchlog
-pyasn1==0.4.2             # via cryptography
+pyasn1==0.4.3             # via cryptography
 pycparser==2.18           # via cffi
-pyjwt==1.6.1              # via djangorestframework-jwt, edx-rest-api-client
+pygments==2.2.0           # via diff-cover
+pyjwt==1.6.4              # via djangorestframework-jwt, edx-rest-api-client
 pymongo==3.6.1            # via edx-opaque-keys, event-tracking
 pytest-catchlog==1.2.2
 pytest-cov==2.5.1
-pytest-django==3.1.2
-pytest==3.4.2             # via pytest-catchlog, pytest-cov, pytest-django
-python-dateutil==2.7.0    # via analytics-python, edx-drf-extensions, faker, freezegun
-pytz==2018.3              # via celery, event-tracking
+pytest-django==3.3.2
+pytest==3.6.2             # via pytest-catchlog, pytest-cov, pytest-django
+python-dateutil==2.4.0
+pytz==2016.10
 requests==2.9.1
-responses==0.8.1
+responses==0.9.0
 shortuuid==0.5.0          # via edx-django-oauth2-provider
-six==1.11.0               # via analytics-python, cryptography, edx-opaque-keys, faker, freezegun, mock, pytest, python-dateutil, responses, stevedore
+six==1.11.0               # via analytics-python, bleach, cryptography, diff-cover, edx-opaque-keys, faker, freezegun, html5lib, mock, more-itertools, pytest, python-dateutil, responses, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 stevedore==1.28.0         # via edx-opaque-keys
-testfixtures==5.4.0
+testfixtures==6.2.0
 text-unidecode==1.2       # via faker
 unicodecsv==0.14.1

--- a/requirements/test-ginkgo.in
+++ b/requirements/test-ginkgo.in
@@ -32,5 +32,15 @@ jsonfield==2.0.2                        # Provides a Django model field which se
 flaky==3.3.0                            # Rerun flaky tests automatically if they fail, up to a limit
 analytics-python==1.1.0                 # Used for Segment analytics
 event-tracking==0.2.4                   # Tracks context-aware semi-structured system events
+
+# These are packages that edx-enterprise uses that are pinned to previous versions in edx-platform.
+# We pin them here to make sure our tests are installing the same requirements
+# as the environment the production code will have.
+
 django-ipware==1.1.0
 bleach==1.4
+html5lib==0.999
+diff-cover==0.9.8
+path.py==8.2.1
+python-dateutil==2.4.0
+pytz==2016.10

--- a/requirements/test-ginkgo.txt
+++ b/requirements/test-ginkgo.txt
@@ -7,7 +7,8 @@
 amqp==1.4.9               # via kombu
 analytics-python==1.1.0
 anyjson==0.3.3            # via kombu
-attrs==17.4.0             # via pytest
+atomicwrites==1.1.5       # via pytest
+attrs==18.1.0             # via pytest
 billiard==3.3.0.23        # via celery
 bleach==1.4
 celery==3.1.18
@@ -15,8 +16,9 @@ cffi==1.11.5              # via cryptography
 cookies==2.2.1            # via responses
 coverage==4.5.1           # via pytest-cov
 cryptography==1.5.3
-ddt==1.1.2
+ddt==1.1.3
 defusedxml==0.5.0         # via djangorestframework-xml
+diff-cover==0.9.8
 django-config-models==0.1.5
 django-fernet-fields==0.5
 django-filter==0.11.0
@@ -37,37 +39,45 @@ edx-opaque-keys==0.4.0
 edx-rest-api-client==1.7.1
 enum34==1.1.6             # via cryptography
 event-tracking==0.2.4
-factory-boy==2.10.0
-faker==0.8.12             # via factory-boy
+factory-boy==2.11.1
+faker==0.8.16             # via factory-boy
 flaky==3.3.0
 freezegun==0.3.10
 funcsigs==1.0.2           # via mock, pytest
-html5lib==0.999           # via bleach
-idna==2.6                 # via cryptography
-ipaddress==1.0.19         # via cryptography, faker
+html5lib==0.999
+idna==2.7                 # via cryptography
+inflect==0.3.1            # via jinja2-pluralize
+ipaddress==1.0.22         # via cryptography, faker
+jinja2-pluralize==0.3.0   # via diff-cover
+jinja2==2.10              # via diff-cover, jinja2-pluralize
+jsondiff==1.1.1
 jsonfield==2.0.2
 kombu==3.0.37             # via celery
+markupsafe==1.0           # via jinja2
 mock==2.0.0
-pbr==3.1.1                # via mock, stevedore
+more-itertools==4.2.0     # via pytest
+path.py==8.2.1
+pbr==4.0.4                # via mock, stevedore
 pillow==3.4
 pluggy==0.6.0             # via pytest
 py==1.5.3                 # via pytest, pytest-catchlog
-pyasn1==0.4.2             # via cryptography
+pyasn1==0.4.3             # via cryptography
 pycparser==2.18           # via cffi
-pyjwt==1.6.1              # via djangorestframework-jwt, edx-rest-api-client
+pygments==2.2.0           # via diff-cover
+pyjwt==1.6.4              # via djangorestframework-jwt, edx-rest-api-client
 pymongo==3.6.1            # via edx-opaque-keys, event-tracking
 pytest-catchlog==1.2.2
 pytest-cov==2.5.1
-pytest-django==3.1.2
-pytest==3.4.2             # via pytest-catchlog, pytest-cov, pytest-django
-python-dateutil==2.7.0    # via analytics-python, edx-drf-extensions, faker, freezegun
-pytz==2018.3              # via celery, event-tracking
+pytest-django==3.3.2
+pytest==3.6.2             # via pytest-catchlog, pytest-cov, pytest-django
+python-dateutil==2.4.0
+pytz==2016.10
 requests==2.9.1
-responses==0.8.1
+responses==0.9.0
 shortuuid==0.5.0          # via edx-django-oauth2-provider
-six==1.11.0               # via analytics-python, cryptography, edx-opaque-keys, faker, freezegun, mock, pytest, python-dateutil, responses, stevedore
+six==1.11.0               # via analytics-python, bleach, cryptography, diff-cover, edx-opaque-keys, faker, freezegun, html5lib, mock, more-itertools, pytest, python-dateutil, responses, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 stevedore==1.28.0         # via edx-opaque-keys
-testfixtures==5.4.0
+testfixtures==6.2.0
 text-unidecode==1.2       # via faker
 unicodecsv==0.14.1

--- a/requirements/test-hawthorn.in
+++ b/requirements/test-hawthorn.in
@@ -28,5 +28,15 @@ jsonfield==2.0.2                        # Provides a Django model field which se
 flaky==3.3.0                            # Rerun flaky tests automatically if they fail, up to a limit
 analytics-python==1.1.0                 # Used for Segment analytics
 event-tracking==0.2.4                   # Tracks context-aware semi-structured system events
+
+# These are packages that edx-enterprise uses that are pinned to previous versions in edx-platform.
+# We pin them here to make sure our tests are installing the same requirements
+# as the environment the production code will have.
+
 django-ipware==1.1.0
 bleach==1.4
+html5lib==0.999
+diff-cover==0.9.8
+path.py==8.2.1
+python-dateutil==2.4.0
+pytz==2016.10

--- a/requirements/test-hawthorn.txt
+++ b/requirements/test-hawthorn.txt
@@ -8,7 +8,8 @@ amqp==1.4.9               # via kombu
 analytics-python==1.1.0
 anyjson==0.3.3            # via kombu
 asn1crypto==0.24.0        # via cryptography
-attrs==17.4.0             # via pytest
+atomicwrites==1.1.5       # via pytest
+attrs==18.1.0             # via pytest
 billiard==3.3.0.23        # via celery
 bleach==1.4
 celery==3.1.18
@@ -16,8 +17,9 @@ cffi==1.11.5              # via cryptography
 cookies==2.2.1            # via responses
 coverage==4.5.1           # via pytest-cov
 cryptography==1.9
-ddt==1.1.2
+ddt==1.1.3
 defusedxml==0.5.0         # via djangorestframework-xml
+diff-cover==0.9.8
 django-config-models==0.1.8
 django-fernet-fields==0.5
 django-filter==1.0.4
@@ -27,7 +29,7 @@ django-multi-email-field==0.5.1
 django-object-actions==0.10.0
 django-simple-history==1.9.0
 django-waffle==0.12.0
-django==1.11.11
+django==1.11.13
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework-oauth==1.1.0
 djangorestframework-xml==1.3.0
@@ -38,36 +40,44 @@ edx-opaque-keys==0.4.0
 edx-rest-api-client==1.7.1
 enum34==1.1.6             # via cryptography
 event-tracking==0.2.4
-factory-boy==2.10.0
-faker==0.8.12             # via factory-boy
+factory-boy==2.11.1
+faker==0.8.16             # via factory-boy
 flaky==3.3.0
 freezegun==0.3.10
 funcsigs==1.0.2           # via mock, pytest
-html5lib==0.999           # via bleach
-idna==2.6                 # via cryptography
-ipaddress==1.0.19         # via cryptography, faker
+html5lib==0.999
+idna==2.7                 # via cryptography
+inflect==0.3.1            # via jinja2-pluralize
+ipaddress==1.0.22         # via cryptography, faker
+jinja2-pluralize==0.3.0   # via diff-cover
+jinja2==2.10              # via diff-cover, jinja2-pluralize
+jsondiff==1.1.1
 jsonfield==2.0.2
 kombu==3.0.37             # via celery
+markupsafe==1.0           # via jinja2
 mock==2.0.0
-pbr==3.1.1                # via mock, stevedore
+more-itertools==4.2.0     # via pytest
+path.py==8.2.1
+pbr==4.0.4                # via mock, stevedore
 pillow==3.4
 pluggy==0.6.0             # via pytest
 py==1.5.3                 # via pytest, pytest-catchlog
 pycparser==2.18           # via cffi
-pyjwt==1.6.1              # via djangorestframework-jwt, edx-rest-api-client
+pygments==2.2.0           # via diff-cover
+pyjwt==1.6.4              # via djangorestframework-jwt, edx-rest-api-client
 pymongo==3.6.1            # via edx-opaque-keys, event-tracking
 pytest-catchlog==1.2.2
 pytest-cov==2.5.1
-pytest-django==3.1.2
-pytest==3.4.2             # via pytest-catchlog, pytest-cov, pytest-django
-python-dateutil==2.7.0    # via analytics-python, edx-drf-extensions, faker, freezegun
-pytz==2018.3              # via celery, django, event-tracking
+pytest-django==3.3.2
+pytest==3.6.2             # via pytest-catchlog, pytest-cov, pytest-django
+python-dateutil==2.4.0
+pytz==2016.10
 requests==2.9.1
-responses==0.8.1
+responses==0.9.0
 shortuuid==0.5.0          # via edx-django-oauth2-provider
-six==1.11.0               # via analytics-python, cryptography, edx-opaque-keys, faker, freezegun, mock, pytest, python-dateutil, responses, stevedore
+six==1.11.0               # via analytics-python, bleach, cryptography, diff-cover, edx-opaque-keys, faker, freezegun, html5lib, mock, more-itertools, pytest, python-dateutil, responses, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 stevedore==1.28.0         # via edx-opaque-keys
-testfixtures==5.4.0
+testfixtures==6.2.0
 text-unidecode==1.2       # via faker
 unicodecsv==0.14.1

--- a/requirements/test-master.in
+++ b/requirements/test-master.in
@@ -26,5 +26,15 @@ jsonfield==2.0.2                        # Provides a Django model field which se
 flaky==3.3.0                            # Rerun flaky tests automatically if they fail, up to a limit
 analytics-python==1.1.0                 # Used for Segment analytics
 event-tracking==0.2.4                   # Tracks context-aware semi-structured system events
+
+# These are packages that edx-enterprise uses that are pinned to previous versions in edx-platform.
+# We pin them here to make sure our tests are installing the same requirements
+# as the environment the production code will have.
+
 django-ipware==1.1.0
 bleach==1.4
+html5lib==0.999
+diff-cover==0.9.8
+path.py==8.2.1
+python-dateutil==2.4.0
+pytz==2016.10

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -8,7 +8,8 @@ amqp==1.4.9               # via kombu
 analytics-python==1.1.0
 anyjson==0.3.3            # via kombu
 asn1crypto==0.24.0        # via cryptography
-attrs==17.4.0             # via pytest
+atomicwrites==1.1.5       # via pytest
+attrs==18.1.0             # via pytest
 billiard==3.3.0.23        # via celery
 bleach==1.4
 celery==3.1.18
@@ -16,8 +17,9 @@ cffi==1.11.5              # via cryptography
 cookies==2.2.1            # via responses
 coverage==4.5.1           # via pytest-cov
 cryptography==1.9
-ddt==1.1.2
+ddt==1.1.3
 defusedxml==0.5.0         # via djangorestframework-xml
+diff-cover==0.9.8
 django-config-models==0.1.8
 django-fernet-fields==0.5
 django-filter==1.0.4
@@ -38,36 +40,44 @@ edx-opaque-keys==0.4.0
 edx-rest-api-client==1.7.1
 enum34==1.1.6             # via cryptography
 event-tracking==0.2.4
-factory-boy==2.10.0
-faker==0.8.12             # via factory-boy
+factory-boy==2.11.1
+faker==0.8.16             # via factory-boy
 flaky==3.3.0
 freezegun==0.3.10
 funcsigs==1.0.2           # via mock, pytest
-html5lib==0.999           # via bleach
-idna==2.6                 # via cryptography
-ipaddress==1.0.19         # via cryptography, faker
+html5lib==0.999
+idna==2.7                 # via cryptography
+inflect==0.3.1            # via jinja2-pluralize
+ipaddress==1.0.22         # via cryptography, faker
+jinja2-pluralize==0.3.0   # via diff-cover
+jinja2==2.10              # via diff-cover, jinja2-pluralize
+jsondiff==1.1.1
 jsonfield==2.0.2
 kombu==3.0.37             # via celery
+markupsafe==1.0           # via jinja2
 mock==2.0.0
-pbr==3.1.1                # via mock, stevedore
+more-itertools==4.2.0     # via pytest
+path.py==8.2.1
+pbr==4.0.4                # via mock, stevedore
 pillow==3.4
 pluggy==0.6.0             # via pytest
 py==1.5.3                 # via pytest, pytest-catchlog
 pycparser==2.18           # via cffi
-pyjwt==1.6.1              # via djangorestframework-jwt, edx-rest-api-client
+pygments==2.2.0           # via diff-cover
+pyjwt==1.6.4              # via djangorestframework-jwt, edx-rest-api-client
 pymongo==3.6.1            # via edx-opaque-keys, event-tracking
 pytest-catchlog==1.2.2
 pytest-cov==2.5.1
-pytest-django==3.1.2
-pytest==3.4.2             # via pytest-catchlog, pytest-cov, pytest-django
-python-dateutil==2.7.0    # via analytics-python, edx-drf-extensions, faker, freezegun
-pytz==2018.3              # via celery, event-tracking
+pytest-django==3.3.2
+pytest==3.6.2             # via pytest-catchlog, pytest-cov, pytest-django
+python-dateutil==2.4.0
+pytz==2016.10
 requests==2.9.1
-responses==0.8.1
+responses==0.9.0
 shortuuid==0.5.0          # via edx-django-oauth2-provider
-six==1.11.0               # via analytics-python, cryptography, edx-opaque-keys, faker, freezegun, mock, pytest, python-dateutil, responses, stevedore
+six==1.11.0               # via analytics-python, bleach, cryptography, diff-cover, edx-opaque-keys, faker, freezegun, html5lib, mock, more-itertools, pytest, python-dateutil, responses, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 stevedore==1.28.0         # via edx-opaque-keys
-testfixtures==5.4.0
+testfixtures==6.2.0
 text-unidecode==1.2       # via faker
 unicodecsv==0.14.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,7 +8,8 @@ amqp==1.4.9               # via kombu
 analytics-python==1.1.0
 anyjson==0.3.3            # via kombu
 asn1crypto==0.24.0        # via cryptography
-attrs==17.4.0             # via pytest
+atomicwrites==1.1.5       # via pytest
+attrs==18.1.0             # via pytest
 billiard==3.3.0.23        # via celery
 bleach==1.4
 celery==3.1.18
@@ -16,8 +17,9 @@ cffi==1.11.5              # via cryptography
 cookies==2.2.1            # via responses
 coverage==4.5.1           # via pytest-cov
 cryptography==1.9
-ddt==1.1.2
+ddt==1.1.3
 defusedxml==0.5.0         # via djangorestframework-xml
+diff-cover==0.9.8
 django-config-models==0.1.8
 django-fernet-fields==0.5
 django-filter==1.0.4
@@ -38,36 +40,44 @@ edx-opaque-keys==0.4.0
 edx-rest-api-client==1.7.1
 enum34==1.1.6             # via cryptography
 event-tracking==0.2.4
-factory-boy==2.10.0
-faker==0.8.12             # via factory-boy
+factory-boy==2.11.1
+faker==0.8.16             # via factory-boy
 flaky==3.3.0
 freezegun==0.3.10
 funcsigs==1.0.2           # via mock, pytest
 html5lib==0.999
-idna==2.6                 # via cryptography
-ipaddress==1.0.19         # via cryptography, faker
+idna==2.7                 # via cryptography
+inflect==0.3.1            # via jinja2-pluralize
+ipaddress==1.0.22         # via cryptography, faker
+jinja2-pluralize==0.3.0   # via diff-cover
+jinja2==2.10              # via diff-cover, jinja2-pluralize
+jsondiff==1.1.1
 jsonfield==2.0.2
 kombu==3.0.37             # via celery
+markupsafe==1.0           # via jinja2
 mock==2.0.0
-pbr==3.1.1                # via mock, stevedore
-Pillow==3.4
+more-itertools==4.2.0     # via pytest
+path.py==8.2.1
+pbr==4.0.4                # via mock, stevedore
+pillow==3.4
 pluggy==0.6.0             # via pytest
 py==1.5.3                 # via pytest, pytest-catchlog
 pycparser==2.18           # via cffi
-pyjwt==1.6.1              # via djangorestframework-jwt, edx-rest-api-client
+pygments==2.2.0           # via diff-cover
+pyjwt==1.6.4              # via djangorestframework-jwt, edx-rest-api-client
 pymongo==3.6.1            # via edx-opaque-keys, event-tracking
 pytest-catchlog==1.2.2
 pytest-cov==2.5.1
-pytest-django==3.1.2
-pytest==3.4.2             # via pytest-catchlog, pytest-cov, pytest-django
-python-dateutil==2.7.0    # via analytics-python, edx-drf-extensions, faker, freezegun
-pytz==2018.3              # via celery, event-tracking
+pytest-django==3.3.2
+pytest==3.6.2             # via pytest-catchlog, pytest-cov, pytest-django
+python-dateutil==2.4.0
+pytz==2016.10
 requests==2.9.1
-responses==0.8.1
+responses==0.9.0
 shortuuid==0.5.0          # via edx-django-oauth2-provider
-six==1.11.0               # via analytics-python, bleach, cryptography, edx-opaque-keys, faker, freezegun, html5lib, mock, pytest, python-dateutil, responses, stevedore
+six==1.11.0               # via analytics-python, bleach, cryptography, diff-cover, edx-opaque-keys, faker, freezegun, html5lib, mock, more-itertools, pytest, python-dateutil, responses, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 stevedore==1.28.0         # via edx-opaque-keys
-testfixtures==5.4.0
+testfixtures==6.2.0
 text-unidecode==1.2       # via faker
 unicodecsv==0.14.1

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -4,16 +4,16 @@
 #
 #    pip-compile --output-file requirements/travis.txt requirements/travis.in
 #
-certifi==2018.1.18        # via requests
+certifi==2018.4.16        # via requests
 chardet==3.0.4            # via requests
 codecov==2.0.15
 coverage==4.5.1           # via codecov
-idna==2.6                 # via requests
+idna==2.7                 # via requests
 pluggy==0.6.0             # via tox
 py==1.5.3                 # via tox
-requests==2.18.4          # via codecov
+requests==2.19.1          # via codecov
 six==1.11.0               # via tox
 tox-battery==0.2.0
-tox==2.9.1
-urllib3==1.22             # via requests
-virtualenv==15.2.0        # via tox
+tox==3.0.0
+urllib3==1.23             # via requests
+virtualenv==16.0.0        # via tox

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -62,16 +62,16 @@ ENTERPRISE_CATALOGS_CONTAINS_CONTENT_ENDPOINT = reverse(
 )
 ENTERPRISE_CATALOGS_COURSE_ENDPOINT = reverse(
     # pylint: disable=anomalous-backslash-in-string
-    'enterprise-catalogs-courses/(?P<course-key>[^/+]+(/|\+)[^/+]+)',
+    r'enterprise-catalogs-courses/(?P<course-key>[^/+]+(/|\+)[^/+]+)',
     kwargs={'pk': FAKE_UUIDS[1], 'course_key': TEST_COURSE_KEY}
 )
 ENTERPRISE_CATALOGS_COURSE_RUN_ENDPOINT = reverse(
     # pylint: disable=anomalous-backslash-in-string
-    'enterprise-catalogs-course-runs/(?P<course-id>[^/+]+(/|\+)[^/+]+(/|\+)[^/?]+)',
+    r'enterprise-catalogs-course-runs/(?P<course-id>[^/+]+(/|\+)[^/+]+(/|\+)[^/?]+)',
     kwargs={'pk': FAKE_UUIDS[1], 'course_id': TEST_COURSE}
 )
 ENTERPRISE_CATALOGS_PROGRAM_ENDPOINT = reverse(
-    'enterprise-catalogs-programs/(?P<program-uuid>[^/]+)',
+    r'enterprise-catalogs-programs/(?P<program-uuid>[^/]+)',
     kwargs={'pk': FAKE_UUIDS[1], 'program_uuid': FAKE_UUIDS[3]}
 )
 ENTERPRISE_COURSE_ENROLLMENT_LIST_ENDPOINT = reverse('enterprise-course-enrollment-list')


### PR DESCRIPTION
**Description:** I wasn't able to run make upgrade and make requirements in order to run manage.py to make migrations, so I went down a rabbit hole that led to pinning readme_renderer in doc.in and html5lib in the release.in files. This is all to keep us at bleach==1.4, which is what edx-platform is pinned to.

**JIRA:** In service of ENT-1006, but not directly related.

**Dependencies:** n/a

**Merge deadline:** soon?

**Installation instructions:** 

**Testing instructions:**

Pull this repo, checkout this branch. Create a virtual environment and run `make upgrade`, then `make requirements`. There should be no errors.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
