### PR TITLE
ENT-1007 Adding slug field to enterprise customer model

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.70.0] - 2018-06-26
+---------------------
+
+* Add unique slug field to EnterpriseCustomer.
+
 [0.69.6] - 2018-06-25
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.69.6"
+__version__ = "0.70.0"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/admin/__init__.py
+++ b/enterprise/admin/__init__.py
@@ -116,6 +116,7 @@ class EnterpriseCustomerAdmin(DjangoObjectActions, SimpleHistoryAdmin):
     """
     list_display = (
         'name',
+        'slug',
         'site',
         'active',
         'has_logo',

--- a/enterprise/admin/forms.py
+++ b/enterprise/admin/forms.py
@@ -316,6 +316,7 @@ class EnterpriseCustomerAdminForm(forms.ModelForm):
         model = EnterpriseCustomer
         fields = (
             "name",
+            "slug",
             "active",
             "site",
             "catalog",

--- a/enterprise/migrations/0051_add_enterprise_slug.py
+++ b/enterprise/migrations/0051_add_enterprise_slug.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.utils.text import slugify
+
+
+def populate_slug(apps, schema_editor):
+    EnterpriseCustomer = apps.get_model('enterprise', 'EnterpriseCustomer')
+
+    enterprises = EnterpriseCustomer.objects.all()
+    for enterprise in enterprises:
+        enterprise.slug = slugify(enterprise.name)
+        enterprise.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('enterprise', '0050_progress_v2'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='enterprisecustomer',
+            name='slug',
+            field=models.SlugField(default='default', help_text='A short string uniquely identifying this enterprise. Cannot contain spaces and should be a usable as a CSS class. Examples: "ubc", "mit-staging"', max_length=30, blank=True),
+        ),
+        migrations.AddField(
+            model_name='historicalenterprisecustomer',
+            name='slug',
+            field=models.SlugField(default='default', help_text='A short string uniquely identifying this enterprise. Cannot contain spaces and should be a usable as a CSS class. Examples: "ubc", "mit-staging"', max_length=30, blank=True),
+        ),
+        migrations.RunPython(populate_slug),
+    ]

--- a/enterprise/migrations/0052_create_unique_slugs.py
+++ b/enterprise/migrations/0052_create_unique_slugs.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('enterprise', '0051_add_enterprise_slug'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='enterprisecustomer',
+            name='slug',
+            field=models.SlugField(default='default', help_text='A short string uniquely identifying this enterprise. Cannot contain spaces and should be a usable as a CSS class. Examples: "ubc", "mit-staging"', unique=True, max_length=30),
+        ),
+        migrations.AlterField(
+            model_name='historicalenterprisecustomer',
+            name='slug',
+            field=models.SlugField(default='default', help_text='A short string uniquely identifying this enterprise. Cannot contain spaces and should be a usable as a CSS class. Examples: "ubc", "mit-staging"', max_length=30),
+        ),
+    ]

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -101,6 +101,13 @@ class EnterpriseCustomer(TimeStampedModel):
 
     uuid = models.UUIDField(primary_key=True, default=uuid4, editable=False)
     name = models.CharField(max_length=255, blank=False, null=False, help_text=_("Enterprise Customer name."))
+    slug = models.SlugField(
+        max_length=30, unique=True, default='default',
+        help_text=(
+            'A short string uniquely identifying this enterprise. '
+            'Cannot contain spaces and should be a usable as a CSS class. Examples: "ubc", "mit-staging"'
+        )
+    )
     catalog = models.PositiveIntegerField(
         null=True,
         blank=True,

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -5,6 +5,6 @@ edx-lint                  # For updating pylintrc
 edx-i18n-tools            # For i18n_tool dummy
 pip-tools                 # Requirements file management
 tox                       # virtualenv management for tests
-tox-battery==0.5          # Makes tox aware of requirements file changes (it's experimental, so keep it pinned)
+tox-battery==0.5.1        # Makes tox aware of requirements file changes (it's experimental, so keep it pinned)
 twine                     # Utility for PyPI package uploads
 wheel                     # For generation of wheels for PyPI

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -93,7 +93,7 @@ slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==1.2.1    # via pydocstyle
 stevedore==1.28.0         # via edx-opaque-keys
 testfixtures==6.2.0
-tox-battery==0.5
+tox-battery==0.5.1
 tox==3.0.0
 tqdm==4.23.4              # via twine
 twine==1.11.0

--- a/requirements/js_test.txt
+++ b/requirements/js_test.txt
@@ -20,4 +20,4 @@ pytz==2018.4              # via tempora
 pyyaml==3.10              # via jasmine
 selenium==3.6.0           # via jasmine
 six==1.11.0               # via cheroot, cherrypy, jasmine, more-itertools, tempora
-tempora==1.11             # via portend
+tempora==1.12             # via portend

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -123,7 +123,7 @@ sphinxcontrib-websupport==1.1.0  # via sphinx
 stevedore==1.28.0         # via doc8, edx-opaque-keys
 testfixtures==6.2.0
 text-unidecode==1.2       # via faker
-tox-battery==0.5
+tox-battery==0.5.1
 tox==3.0.0
 tqdm==4.23.4              # via twine
 twine==1.11.0

--- a/requirements/travis.in
+++ b/requirements/travis.in
@@ -2,4 +2,4 @@
 
 codecov                   # Code coverage reporting
 tox                       # Virtualenv management for tests
-tox-battery==0.2.0        # Makes tox aware of requirements file changes
+tox-battery==0.5.1        # Makes tox aware of requirements file changes

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -13,7 +13,7 @@ pluggy==0.6.0             # via tox
 py==1.5.3                 # via tox
 requests==2.19.1          # via codecov
 six==1.11.0               # via tox
-tox-battery==0.2.0
+tox-battery==0.5.1
 tox==3.0.0
 urllib3==1.23             # via requests
 virtualenv==16.0.0        # via tox

--- a/test_utils/factories.py
+++ b/test_utils/factories.py
@@ -77,6 +77,7 @@ class EnterpriseCustomerFactory(factory.django.DjangoModelFactory):
 
     uuid = factory.LazyAttribute(lambda x: UUID(FAKER.uuid4()))
     name = factory.LazyAttribute(lambda x: FAKER.company())
+    slug = factory.LazyAttribute(lambda x: FAKER.slug())
     active = True
     site = factory.SubFactory(SiteFactory)
     catalog = factory.LazyAttribute(lambda x: FAKER.random_int(min=0, max=1000000))

--- a/tests/test_admin/test_forms.py
+++ b/tests/test_admin/test_forms.py
@@ -539,7 +539,8 @@ class TestEnterpriseCustomerAdminForm(TestWithCourseCatalogApiMixin, unittest.Te
                 'enforce_data_sharing_consent': customer.enforce_data_sharing_consent,
                 'site': customer.site.id,
                 'name': customer.name,
-                'active': customer.active
+                'active': customer.active,
+                'slug': customer.slug,
             },
             instance=customer,
         )
@@ -571,7 +572,8 @@ class TestEnterpriseCustomerAdminForm(TestWithCourseCatalogApiMixin, unittest.Te
                 'enforce_data_sharing_consent': customer.enforce_data_sharing_consent,
                 'site': customer.site.id,
                 'name': customer.name,
-                'active': customer.active
+                'active': customer.active,
+                'slug': customer.slug,
             },
             instance=customer,
         )

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -129,6 +129,7 @@ class TestEnterpriseUtils(unittest.TestCase):
                 "modified",
                 "uuid",
                 "name",
+                "slug",
                 "catalog",
                 "active",
                 "hide_course_original_price",


### PR DESCRIPTION
**Description:** Adding slug field to enterprise customer model

**JIRA:** https://openedx.atlassian.net/browse/ENT-1007

**Dependencies:** n/a

**Merge deadline:** 

**Installation instructions:** 

**Testing instructions:**
Go to the business sandbox, where the migrations have been run, and see that the slugs are populated.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
