### PR TITLE
ENT-1052 discount by enterprise catalog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.70.3] - 2018-06-29
+---------------------
+
+* Apply enterprise catalog conditional offer by the provided enterprise catalog UUID.
+
 [0.70.2] - 2018-06-28
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.70.2"
+__version__ = "0.70.3"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api_client/ecommerce.py
+++ b/enterprise/api_client/ecommerce.py
@@ -44,7 +44,7 @@ class EcommerceApiClient(object):
         self.user = user
         self.client = ecommerce_api_client(user)
 
-    def get_course_final_price(self, mode, currency='$'):
+    def get_course_final_price(self, mode, currency='$', enterprise_catalog_uuid=None):
         """
         Get course mode's SKU discounted price after applying any entitlement available for this user.
 
@@ -53,7 +53,11 @@ class EcommerceApiClient(object):
 
         """
         try:
-            price_details = self.client.baskets.calculate.get(sku=[mode['sku']])
+            price_details = self.client.baskets.calculate.get(
+                sku=[mode['sku']],
+                username=self.user.username,
+                enterprise_customer_catalog_uuid=enterprise_catalog_uuid,
+            )
         except (SlumberBaseException, ConnectionError, Timeout) as exc:
             LOGGER.exception('Failed to get price details for sku %s due to: %s', mode['sku'], str(exc))
             price_details = {}

--- a/enterprise/templates/enterprise/enterprise_course_enrollment_page.html
+++ b/enterprise/templates/enterprise/enterprise_course_enrollment_page.html
@@ -50,6 +50,7 @@
           {% if course_enrollable %}
             <form method="POST">
               <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}" />
+              <input type="hidden" name="enterprise_customer_catalog_uuid" value="{{ enterprise_customer_catalog_uuid }}" />
               {% if course_modes|length > 1 %}<div class="caption">{{ select_mode_text }}</div>{% endif %}
               {% for course_mode in course_modes %}
               <div class="radio-block">


### PR DESCRIPTION
@asadiqbal08 @saleem-latif @muhammad-ammar @irfanuddinahmad @georgebabey 
**Description:** Add/Show discount for enterprise learners by provided valid enterprise catalog UUID.

**JIRA:** [ENT-1052](https://openedx.atlassian.net/browse/ENT-1052)

**Remaining tasks:** Unittests

**Dependencies:**

1. edx-platform: https://github.com/edx/edx-platform/pull/18470
2. Ecommerce: https://github.com/edx/ecommerce/pull/1830

**Merge deadline:** 29 Jun 2018

**Installation instructions:** 

1. Checkout edx-platform to branch `zub/ENT-1052-discount-by-enterprise-catalog`.
2. Install `edx-enterprise` from this branch `zub/ENT-1052-discount-by-enterprise-catalog` in `edx-platform`.
3. Checkout ecommerce to  branch `zub/ENT-1052-discount-by-enterprise-catalog`.
4. In ecommerce django admin (admin/waffle/switch/) verify following waffle flags:
```
force_anonymous_user_response_for_basket_calculate = False
enable_enterprise_offers = True
enable_enterprise_on_runtime = True
```

**Testing instructions:**

1. Create an enterprise with 2 catalogs with a verified course (both catalogs should have this verified course)
2. For catalog A, create enterprise offer with 100% discount.
3. For catalog B, create enterprise offer with 15% discount.
4. Now access the enterprise course enrollment URL with the `UUID` of catalog A, i.e. `http://zubair.localhost:8000/enterprise/72416e52-8c77-4860-9584-15e5b06220fb/course/course-v1:edX+TEST_01+2016_R1/enroll/?enterprise_customer_catalog_uuid=a113c7e2-13ac-46ae-9e24-b75bf7c0058d`
5. Verify that learner sees 100 discount on verified seat for verified course
6. Clicking on 'Continue' button (after consenting) user is redirect to courseware page after automatic enrollment (100% discount).
7. Now access the enterprise course enrollment URL with the `UUID` of catalog B, i.e. `http://zubair.localhost:8000/enterprise/72416e52-8c77-4860-9584-15e5b06220fb/course/course-v1:edX+TEST_01+2016_R1/enroll/?enterprise_customer_catalog_uuid=6eca3efb-f3a0-4c08-806f-c6e6b65d61cb`
8. Verify that learner sees 15 discount on verified seat for verified course
9. Clicking on 'Continue' button (after consenting) user is redirect to basket page with 15% discount applied by the learner's enterprise.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
