### PR TITLE
ENT-1008 Modify branding config api to look up by enterprise slug

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.70.2] - 2018-06-28
+---------------------
+
+* Modify enterprise branding config API to use enterprise slug as the lookup_field.
+
 [0.70.1] - 2018-06-27
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.70.1"
+__version__ = "0.70.2"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -81,8 +81,16 @@ class EnterpriseCustomerBrandingConfigurationSerializer(serializers.ModelSeriali
     class Meta:
         model = models.EnterpriseCustomerBrandingConfiguration
         fields = (
-            'enterprise_customer', 'logo'
+            'enterprise_customer', 'enterprise_slug', 'logo'
         )
+
+    enterprise_slug = serializers.SerializerMethodField()
+
+    def get_enterprise_slug(self, obj):
+        """
+        Return the slug of the associated enterprise customer.
+        """
+        return obj.enterprise_customer.slug
 
 
 class EnterpriseCustomerEntitlementSerializer(serializers.ModelSerializer):
@@ -105,9 +113,9 @@ class EnterpriseCustomerSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.EnterpriseCustomer
         fields = (
-            'uuid', 'name', 'catalog', 'active', 'site', 'enable_data_sharing_consent', 'enforce_data_sharing_consent',
-            'branding_configuration', 'enterprise_customer_entitlements', 'identity_provider',
-            'enable_audit_enrollment', 'replace_sensitive_sso_username',
+            'uuid', 'name', 'slug', 'catalog', 'active', 'site', 'enable_data_sharing_consent',
+            'enforce_data_sharing_consent', 'branding_configuration', 'enterprise_customer_entitlements',
+            'identity_provider', 'enable_audit_enrollment', 'replace_sensitive_sso_username',
         )
 
     site = SiteSerializer()

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -97,7 +97,7 @@ class EnterpriseCustomerViewSet(EnterpriseReadWriteModelViewSet):
 
     USER_ID_FILTER = 'enterprise_customer_users__user_id'
     FIELDS = (
-        'uuid', 'name', 'catalog', 'active', 'site', 'enable_data_sharing_consent',
+        'uuid', 'slug', 'name', 'catalog', 'active', 'site', 'enable_data_sharing_consent',
         'enforce_data_sharing_consent',
     )
     filter_fields = FIELDS
@@ -272,10 +272,11 @@ class EnterpriseCustomerBrandingConfigurationViewSet(EnterpriseReadOnlyModelView
 
     USER_ID_FILTER = 'enterprise_customer__enterprise_customer_users__user_id'
     FIELDS = (
-        'enterprise_customer',
+        'enterprise_customer__slug',
     )
     filter_fields = FIELDS
     ordering_fields = FIELDS
+    lookup_field = 'enterprise_customer__slug'
 
 
 class EnterpriseCustomerEntitlementViewSet(EnterpriseReadOnlyModelViewSet):

--- a/test_utils/__init__.py
+++ b/test_utils/__init__.py
@@ -38,6 +38,7 @@ TEST_COURSE = 'course-v1:edX+DemoX+Demo_Course'
 TEST_COURSE_KEY = 'edX+DemoX'
 TEST_UUID = 'd2098bfb-2c78-44f1-9eb2-b94475356a3f'
 TEST_USER_ID = 1
+TEST_SLUG = 'test-enterprise-customer'
 
 
 def get_magic_name(value):

--- a/test_utils/factories.py
+++ b/test_utils/factories.py
@@ -18,6 +18,7 @@ from consent.models import DataSharingConsent, DataSharingConsentTextOverrides
 from enterprise.models import (
     EnterpriseCourseEnrollment,
     EnterpriseCustomer,
+    EnterpriseCustomerBrandingConfiguration,
     EnterpriseCustomerCatalog,
     EnterpriseCustomerEntitlement,
     EnterpriseCustomerIdentityProvider,
@@ -205,7 +206,7 @@ class EnterpriseCustomerEntitlementFactory(factory.django.DjangoModelFactory):
     EnterpriseCustomerEntitlement factory.
 
     Creates an instance of EnterpriseCustomerEntitlement with minimal boilerplate - uses this class' attributes as
-    default parameters for EnterpriseCustomerBrandingFactory constructor.
+    default parameters for EnterpriseCustomerEntitlementFactory constructor.
     """
 
     class Meta(object):
@@ -217,6 +218,26 @@ class EnterpriseCustomerEntitlementFactory(factory.django.DjangoModelFactory):
 
     id = factory.LazyAttribute(lambda x: FAKER.random_int(min=1))
     entitlement_id = factory.LazyAttribute(lambda x: FAKER.random_int(min=1))
+    enterprise_customer = factory.SubFactory(EnterpriseCustomerFactory)
+
+
+class EnterpriseCustomerBrandingConfigurationFactory(factory.django.DjangoModelFactory):
+    """
+    EnterpriseCustomerBrandingConfiguration factory.
+
+    Creates an instance of EnterpriseCustomerBrandingConfiguration with minimal boilerplate - uses this class'
+     attributes as default parameters for EnterpriseCustomerBrandingFactory constructor.
+    """
+
+    class Meta(object):
+        """
+        Meta for EnterpriseCustomerBrandingConfigurationFactory.
+        """
+
+        model = EnterpriseCustomerBrandingConfiguration
+
+    id = factory.LazyAttribute(lambda x: FAKER.random_int(min=1))
+    logo = factory.LazyAttribute(lambda x: FAKER.image_url())
     enterprise_customer = factory.SubFactory(EnterpriseCustomerFactory)
 
 


### PR DESCRIPTION
**Description:** We need an api that takes the enterprise slug and returns the branding config. The existing branding config api isn't used and lists details by id, but we would rarely ever know the specific branding config id, so I changed it to use enterprise slug.

**JIRA:** https://openedx.atlassian.net/browse/ENT-1008

**Dependencies:** n/a

**Merge deadline:** 

**Installation instructions:** 

**Testing instructions:**
Hit the following endpoint on the business sandbox using JWT authentication: https://business.sandbox.edx.org/enterprise/api/v1/enterprise-customer-branding/
This should list all branding configs and now include the enterprise slug.
Then hit https://business.sandbox.edx.org/enterprise/api/v1/enterprise-customer-branding/aviato
(or use any enterprise slug value you wish)
This should return just the branding config details for the appropriate enterprise.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
