### PR TITLE
ENT-1052 Rename enterprise customer catalog uuid in queryparam to catalog

### DIFF
--- a/enterprise/api_client/ecommerce.py
+++ b/enterprise/api_client/ecommerce.py
@@ -56,7 +56,7 @@ class EcommerceApiClient(object):
             price_details = self.client.baskets.calculate.get(
                 sku=[mode['sku']],
                 username=self.user.username,
-                enterprise_customer_catalog_uuid=enterprise_catalog_uuid,
+                catalog=enterprise_catalog_uuid,
             )
         except (SlumberBaseException, ConnectionError, Timeout) as exc:
             LOGGER.exception('Failed to get price details for sku %s due to: %s', mode['sku'], str(exc))

--- a/enterprise/templates/enterprise/enterprise_course_enrollment_page.html
+++ b/enterprise/templates/enterprise/enterprise_course_enrollment_page.html
@@ -50,7 +50,7 @@
           {% if course_enrollable %}
             <form method="POST">
               <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}" />
-              <input type="hidden" name="enterprise_customer_catalog_uuid" value="{{ enterprise_customer_catalog_uuid }}" />
+              <input type="hidden" name="catalog" value="{{ catalog }}" />
               {% if course_modes|length > 1 %}<div class="caption">{{ select_mode_text }}</div>{% endif %}
               {% for course_mode in course_modes %}
               <div class="radio-block">

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -525,7 +525,7 @@ class HandleConsentEnrollment(View):
         redirected to ecommerce basket flow for payment of premium modes.
         """
         enrollment_course_mode = request.GET.get('course_mode')
-        enterprise_catalog_uuid = request.GET.get('enterprise_customer_catalog_uuid')
+        enterprise_catalog_uuid = request.GET.get('catalog')
 
         # Redirect the learner to LMS dashboard in case no course mode is
         # provided as query parameter `course_mode`
@@ -583,7 +583,7 @@ class HandleConsentEnrollment(View):
         # Note: LMS start flow automatically detects the paid mode
         premium_flow = LMS_START_PREMIUM_COURSE_FLOW_URL.format(course_id=course_id)
         if enterprise_catalog_uuid:
-            premium_flow += '?enterprise_customer_catalog_uuid={catalog_uuid}'.format(
+            premium_flow += '?catalog={catalog_uuid}'.format(
                 catalog_uuid=enterprise_catalog_uuid
             )
 
@@ -636,7 +636,7 @@ class CourseEnrollmentView(NonAtomicView):
                 mode['final_price'] = EcommerceApiClient(request.user).get_course_final_price(
                     mode=mode,
                     enterprise_catalog_uuid=request.GET.get(
-                        'enterprise_customer_catalog_uuid'
+                        'catalog'
                     ) if request.method == 'GET' else None,
                 )
             result.append(mode)
@@ -771,7 +771,7 @@ class CourseEnrollmentView(NonAtomicView):
         """
         context_data = get_global_context(request, enterprise_customer)
         enterprise_catalog_uuid = request.GET.get(
-            'enterprise_customer_catalog_uuid'
+            'catalog'
         ) if request.method == 'GET' else None
         html_template_for_rendering = 'enterprise/enterprise_course_enrollment_error_page.html'
         if course and course_run:
@@ -841,7 +841,7 @@ class CourseEnrollmentView(NonAtomicView):
                 'course_level_type': course_level_type,
                 'premium_modes': premium_modes,
                 'expected_learning_items': expected_learning_items,
-                'enterprise_customer_catalog_uuid': enterprise_catalog_uuid,
+                'catalog': enterprise_catalog_uuid,
                 'staff': staff,
                 'discount_text': self.ENT_DISCOUNT_TEXT_FORMAT.format(
                     enterprise_customer_name=enterprise_customer.name,
@@ -886,7 +886,7 @@ class CourseEnrollmentView(NonAtomicView):
         except EnterpriseCourseEnrollment.DoesNotExist:
             enterprise_course_enrollment = None
 
-        enterprise_catalog_uuid = request.POST.get('enterprise_customer_catalog_uuid')
+        enterprise_catalog_uuid = request.POST.get('catalog')
         selected_course_mode_name = request.POST.get('course_mode')
         selected_course_mode = None
         for course_mode in course_modes:
@@ -937,7 +937,7 @@ class CourseEnrollmentView(NonAtomicView):
                 'course_mode': selected_course_mode_name,
             }
             if enterprise_catalog_uuid:
-                query_string_params.update({'enterprise_customer_catalog_uuid': enterprise_catalog_uuid})
+                query_string_params.update({'catalog': enterprise_catalog_uuid})
 
             next_url = '{handle_consent_enrollment_url}?{query_string}'.format(
                 handle_consent_enrollment_url=reverse(
@@ -981,7 +981,7 @@ class CourseEnrollmentView(NonAtomicView):
         # Note: LMS start flow automatically detects the paid mode
         premium_flow = LMS_START_PREMIUM_COURSE_FLOW_URL.format(course_id=course_id)
         if enterprise_catalog_uuid:
-            premium_flow += '?enterprise_customer_catalog_uuid={catalog_uuid}'.format(
+            premium_flow += '?catalog={catalog_uuid}'.format(
                 catalog_uuid=enterprise_catalog_uuid
             )
 

--- a/tests/test_enterprise/views/test_course_enrollment_view.py
+++ b/tests/test_enterprise/views/test_course_enrollment_view.py
@@ -1298,9 +1298,9 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
         if enrollment_mode == 'professional':
             enterprise_catalog_uuid = str(enterprise_customer.enterprise_customer_catalogs.first().uuid)
             post_data.update({
-                'enterprise_customer_catalog_uuid': enterprise_catalog_uuid
+                'catalog': enterprise_catalog_uuid
             })
-            expected_redirect_url += '?enterprise_customer_catalog_uuid={}'.format(enterprise_catalog_uuid)
+            expected_redirect_url += '?catalog={}'.format(enterprise_catalog_uuid)
 
         response = self.client.post(course_enrollment_page_url, post_data)
 
@@ -1361,7 +1361,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
         )
         response = self.client.post(
             course_enrollment_page_url,
-            {'course_mode': 'audit', 'enterprise_customer_catalog_uuid': enterprise_customer_catalog.uuid}
+            {'course_mode': 'audit', 'catalog': enterprise_customer_catalog.uuid}
         )
 
         assert response.status_code == 302
@@ -1370,7 +1370,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
         consent_enrollment_url = '/enterprise/handle_consent_enrollment/{}/course/{}/?{}'.format(
             enterprise_customer_uuid, course_id, urlencode({
                 'course_mode': 'audit',
-                'enterprise_customer_catalog_uuid': enterprise_customer_catalog.uuid
+                'catalog': enterprise_customer_catalog.uuid
             })
         )
         expected_failure_url = '{course_enrollment_url}?{query_string}'.format(
@@ -1455,7 +1455,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
         )
         response = self.client.post(
             course_enrollment_page_url,
-            {'course_mode': 'audit', 'enterprise_customer_catalog_uuid': enterprise_customer_catalog.uuid}
+            {'course_mode': 'audit', 'catalog': enterprise_customer_catalog.uuid}
         )
         assert response.status_code == 302
 
@@ -1463,7 +1463,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
         consent_enrollment_url = '/enterprise/handle_consent_enrollment/{}/course/{}/?{}'.format(
             enterprise_customer_uuid, course_id, urlencode({
                 'course_mode': 'audit',
-                'enterprise_customer_catalog_uuid': enterprise_customer_catalog.uuid
+                'catalog': enterprise_customer_catalog.uuid
             })
         )
         expected_failure_url = '{course_enrollment_url}?{query_string}'.format(
@@ -1592,14 +1592,14 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
         response = self.client.post(
             course_enrollment_page_url, {
                 'course_mode': 'professional',
-                'enterprise_customer_catalog_uuid': enterprise_catalog_uuid
+                'catalog': enterprise_catalog_uuid
             }
         )
 
         assert response.status_code == 302
         self.assertRedirects(
             response,
-            'http://lms.example.com/verify_student/start-flow/{}/?enterprise_customer_catalog_uuid={}'.format(
+            'http://lms.example.com/verify_student/start-flow/{}/?catalog={}'.format(
                 'course-v1:edX+DemoX+Demo_Course',
                 enterprise_catalog_uuid
             ),

--- a/tests/test_enterprise/views/test_handle_consent_enrollment.py
+++ b/tests/test_enterprise/views/test_handle_consent_enrollment.py
@@ -285,13 +285,13 @@ class TestHandleConsentEnrollmentView(EnterpriseViewMixin, TestCase):
                 ),
                 params=urlencode({
                     'course_mode': 'professional',
-                    'enterprise_customer_catalog_uuid': enterprise_catalog.uuid
+                    'catalog': enterprise_catalog.uuid
                 })
             )
         )
         response = self.client.get(handle_consent_enrollment_url)
         redirect_url = LMS_START_PREMIUM_COURSE_FLOW_URL.format(course_id=course_id)
-        redirect_url += '?enterprise_customer_catalog_uuid={catalog_uuid}'.format(
+        redirect_url += '?catalog={catalog_uuid}'.format(
             catalog_uuid=enterprise_catalog.uuid
         )
         self.assertRedirects(response, redirect_url, fetch_redirect_response=False)


### PR DESCRIPTION
**Description:** Add/Show discount for enterprise learners by provided valid enterprise catalog `UUID`. This enterprise catalog `UUID` can be provided by passing the queryparam `catalog={enterprise_catalog_uuid}` to enterprise course enrollment urls.

**JIRA:** [ENT-1052](https://openedx.atlassian.net/browse/ENT-1052)

**Dependencies:**

1. edx-platform: https://github.com/edx/edx-platform/pull/18508
2. ecommerce: https://github.com/edx/ecommerce/pull/1844/

**Installation instructions:**  
1. Checkout edx-platform to branch `zub/ENT-1052-rename-enterprise-customer-catalog-uuid-queryparam`.
2. Install `edx-enterprise` from branch `zub/ENT-1052-rename-enterprise-customer-catalog-uuid-queryparam` in `edx-platform`.
3. Checkout ecommerce to branch `zub/ENT-1052-rename-enterprise-customer-catalog-uuid-queryparam`.
4. In ecommerce django admin (admin/waffle/switch/) verify following waffle flags:
```
force_anonymous_user_response_for_basket_calculate = False
enable_enterprise_offers = True
enable_enterprise_on_runtime = True
```
**Testing instructions:**

1. Create an enterprise with 2 catalogs with a verified course (both catalogs should have this verified course)
2. For catalog A, create enterprise offer with 100% discount.
3. For catalog B, create enterprise offer with 15% discount.
4. Now access the enterprise course enrollment URL with the `UUID` of catalog A, i.e. `http://zubair.localhost:8000/enterprise/72416e52-8c77-4860-9584-15e5b06220fb/course/course-v1:edX+TEST_01+2016_R1/enroll/?catalog=a113c7e2-13ac-46ae-9e24-b75bf7c0058d`
5. Verify that learner sees 100 discount on verified seat for verified course
6. Clicking on 'Continue' button (after consenting) user is redirect to courseware page after automatic enrollment (100% discount).
7. Now access the enterprise course enrollment URL with the `UUID` of catalog B, i.e. `http://zubair.localhost:8000/enterprise/72416e52-8c77-4860-9584-15e5b06220fb/course/course-v1:edX+TEST_01+2016_R1/enroll/?catalog=6eca3efb-f3a0-4c08-806f-c6e6b65d61cb`
8. Verify that learner sees 15 discount on verified seat for verified course
9. Clicking on 'Continue' button (after consenting) user is redirect to basket page with 15% discount applied by the learner's enterprise.