### PR TITLE
ENT-1074 Attempt to send SAPSF learner data transmissions with course keys first

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.70.5] - 2018-07-06
+---------------------
+
+* Send learner data transmissions to integrated channels by course key and course run id.
+
 [0.70.4] - 2018-07-03
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.70.4"
+__version__ = "0.70.5"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/integrated_channel/transmitters/learner_data.py
+++ b/integrated_channels/integrated_channel/transmitters/learner_data.py
@@ -49,9 +49,16 @@ class LearnerTransmitter(Transmitter):
             app_label=kwargs.get('app_label', 'integrated_channel'),
             model_name=kwargs.get('model_name', 'LearnerDataTransmissionAudit'),
         )
+        # Since we have started sending courses to integrated channels instead of course runs,
+        # we need to attempt to send transmissions with course keys and course run ids in order to
+        # ensure that we account for whether courses or course runs exist in the integrated channel.
+        # The exporters have been changed to return multiple transmission records to attempt,
+        # one by course key and one by course run id.
+        # If the transmission with the course key succeeds, the next one will get skipped.
+        # If it fails, the one with the course run id will be attempted and (presumably) succeed.
         for learner_data in payload.export():
             serialized_payload = learner_data.serialize(enterprise_configuration=self.enterprise_configuration)
-            LOGGER.info('Attempting to transmit serialized payload: %s', serialized_payload)
+            LOGGER.debug('Attempting to transmit serialized payload: %s', serialized_payload)
 
             enterprise_enrollment_id = learner_data.enterprise_course_enrollment_id
             if learner_data.completed_timestamp is None:

--- a/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_learner_data.py
+++ b/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_learner_data.py
@@ -37,6 +37,7 @@ class TestLearnerExporter(unittest.TestCase):
     def setUp(self):
         self.user = factories.UserFactory(username='C3PO', id=1)
         self.course_id = 'course-v1:edX+DemoX+DemoCourse'
+        self.course_key = 'edX+DemoX'
         self.enterprise_customer = factories.EnterpriseCustomerFactory()
         self.enterprise_customer_user = factories.EnterpriseCustomerUserFactory(
             user_id=self.user.id,
@@ -88,13 +89,14 @@ class TestLearnerExporter(unittest.TestCase):
             course_id=self.course_id,
         )
         exporter = LearnerExporter('fake-user', self.config)
-        learner_data_record = exporter.get_learner_data_record(
+        learner_data_records = exporter.get_learner_data_records(
             enterprise_course_enrollment,
             completed_date=completed_date,
             grade='A+',
             is_passing=is_passing,
         )
 
+        learner_data_record = learner_data_records[0]
         assert learner_data_record.enterprise_course_enrollment_id == enterprise_course_enrollment.id
         assert learner_data_record.course_id == enterprise_course_enrollment.course_id
         assert learner_data_record.course_completed == (completed_date is not None and is_passing)
@@ -165,14 +167,15 @@ class TestLearnerExporter(unittest.TestCase):
         )
 
         learner_data = list(self.exporter.export())
-        assert len(learner_data) == 1
+        assert len(learner_data) == 2
+        assert learner_data[0].course_id == self.course_key
+        assert learner_data[1].course_id == self.course_id
 
-        report = learner_data[0]
-        assert report.enterprise_course_enrollment_id == enrollment.id
-        assert report.course_id == self.course_id
-        assert not report.course_completed
-        assert report.completed_timestamp is None
-        assert report.grade == LearnerExporter.GRADE_INCOMPLETE
+        for report in learner_data:
+            assert report.enterprise_course_enrollment_id == enrollment.id
+            assert not report.course_completed
+            assert report.completed_timestamp is None
+            assert report.grade == LearnerExporter.GRADE_INCOMPLETE
 
     @mock.patch('enterprise.models.EnrollmentApiClient')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CourseApiClient')
@@ -237,14 +240,15 @@ class TestLearnerExporter(unittest.TestCase):
         )
 
         learner_data = list(self.exporter.export())
-        assert len(learner_data) == 1
+        assert len(learner_data) == 2
+        assert learner_data[0].course_id == self.course_key
+        assert learner_data[1].course_id == self.course_id
 
-        report = learner_data[0]
-        assert report.enterprise_course_enrollment_id == enrollment.id
-        assert report.course_id == self.course_id
-        assert report.course_completed
-        assert report.completed_timestamp == self.NOW_TIMESTAMP
-        assert report.grade == LearnerExporter.GRADE_PASSING
+        for report in learner_data:
+            assert report.enterprise_course_enrollment_id == enrollment.id
+            assert report.course_completed
+            assert report.completed_timestamp == self.NOW_TIMESTAMP
+            assert report.grade == LearnerExporter.GRADE_PASSING
 
     @mock.patch('enterprise.models.EnrollmentApiClient')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.GradesApiClient')
@@ -269,14 +273,15 @@ class TestLearnerExporter(unittest.TestCase):
         )
 
         learner_data = list(self.exporter.export())
-        assert len(learner_data) == 1
+        assert len(learner_data) == 2
+        assert learner_data[0].course_id == self.course_key
+        assert learner_data[1].course_id == self.course_id
 
-        report = learner_data[0]
-        assert report.enterprise_course_enrollment_id == enrollment.id
-        assert report.course_id == self.course_id
-        assert not report.course_completed
-        assert report.completed_timestamp is None
-        assert report.grade is None
+        for report in learner_data:
+            assert report.enterprise_course_enrollment_id == enrollment.id
+            assert not report.course_completed
+            assert report.completed_timestamp is None
+            assert report.grade is None
 
     @ddt.data(
         # passing grade with no course end date
@@ -323,14 +328,15 @@ class TestLearnerExporter(unittest.TestCase):
         with freeze_time(self.NOW):
             learner_data = list(self.exporter.export())
 
-        assert len(learner_data) == 1
+        assert len(learner_data) == 2
+        assert learner_data[0].course_id == self.course_key
+        assert learner_data[1].course_id == self.course_id
 
-        report = learner_data[0]
-        assert report.enterprise_course_enrollment_id == enrollment.id
-        assert report.course_id == self.course_id
-        assert report.course_completed == (passing and expected_completion is not None)
-        assert report.completed_timestamp == expected_completion
-        assert report.grade == expected_grade
+        for report in learner_data:
+            assert report.enterprise_course_enrollment_id == enrollment.id
+            assert report.course_completed == (passing and expected_completion is not None)
+            assert report.completed_timestamp == expected_completion
+            assert report.grade == expected_grade
 
     @ddt.data(
         ('self', LearnerExporter.GRADE_PASSING),
@@ -419,38 +425,42 @@ class TestLearnerExporter(unittest.TestCase):
         with freeze_time(self.NOW):
             learner_data = list(self.exporter.export())
 
-        assert len(learner_data) == 3
+        assert len(learner_data) == 6
 
-        report1 = learner_data[0]
-        assert report1.enterprise_course_enrollment_id == enrollment1.id
-        assert report1.course_id == self.course_id
-        assert not report1.course_completed
-        assert report1.completed_timestamp is None
-        assert report1.grade == LearnerExporter.GRADE_INCOMPLETE
+        assert learner_data[0].course_id == self.course_key
+        assert learner_data[1].course_id == self.course_id
+        for report1 in learner_data[0:1]:
+            assert report1.enterprise_course_enrollment_id == enrollment1.id
+            assert not report1.course_completed
+            assert report1.completed_timestamp is None
+            assert report1.grade == LearnerExporter.GRADE_INCOMPLETE
 
-        report2 = learner_data[1]
-        assert report2.enterprise_course_enrollment_id == enrollment3.id
-        assert report2.course_id == self.course_id
-        assert not report2.course_completed
-        assert report2.completed_timestamp is None
-        assert report2.grade == LearnerExporter.GRADE_INCOMPLETE
+        assert learner_data[2].course_id == self.course_key
+        assert learner_data[3].course_id == self.course_id
+        for report2 in learner_data[2:3]:
+            assert report2.enterprise_course_enrollment_id == enrollment3.id
+            assert not report2.course_completed
+            assert report2.completed_timestamp is None
+            assert report2.grade == LearnerExporter.GRADE_INCOMPLETE
 
-        report3 = learner_data[2]
-        assert report3.enterprise_course_enrollment_id == enrollment2.id
-        assert report3.course_id == course_id2
-        assert report3.course_completed
-        assert report3.completed_timestamp == self.NOW_TIMESTAMP
-        assert report3.grade == grade
+        assert learner_data[4].course_id == self.course_key
+        assert learner_data[5].course_id == course_id2
+        for report3 in learner_data[4:5]:
+            assert report3.enterprise_course_enrollment_id == enrollment2.id
+            # assert report3.course_id == course_id2
+            assert report3.course_completed
+            assert report3.completed_timestamp == self.NOW_TIMESTAMP
+            assert report3.grade == grade
 
     @ddt.data(
-        (True, True, 'audit', 1),
+        (True, True, 'audit', 2),
         (True, False, 'audit', 0),
         (False, True, 'audit', 0),
         (False, False, 'audit', 0),
-        (True, True, 'verified', 1),
-        (True, False, 'verified', 1),
-        (False, True, 'verified', 1),
-        (False, False, 'verified', 1),
+        (True, True, 'verified', 2),
+        (True, False, 'verified', 2),
+        (False, True, 'verified', 2),
+        (False, False, 'verified', 2),
     )
     @ddt.unpack
     @mock.patch('enterprise.models.EnrollmentApiClient')
@@ -498,9 +508,10 @@ class TestLearnerExporter(unittest.TestCase):
 
         assert len(learner_data) == expected_data_len
 
-        if expected_data_len == 1:
-            report = learner_data[0]
-            assert report.enterprise_course_enrollment_id == enrollment.id
-            assert report.course_id == self.course_id
-            assert report.course_completed
-            assert report.grade == LearnerExporter.GRADE_PASSING
+        if expected_data_len == 2:
+            assert learner_data[0].course_id == self.course_key
+            assert learner_data[1].course_id == self.course_id
+            for report in learner_data:
+                assert report.enterprise_course_enrollment_id == enrollment.id
+                assert report.course_completed
+                assert report.grade == LearnerExporter.GRADE_PASSING

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -355,6 +355,7 @@ class TestTransmitCourseMetadataManagementCommand(unittest.TestCase, EnterpriseM
 
 
 COURSE_ID = 'course-v1:edX+DemoX+DemoCourse'
+COURSE_KEY = 'edX+DemoX'
 
 # Mock passing certificate data
 MOCK_PASSING_CERTIFICATE = dict(
@@ -594,6 +595,7 @@ def get_expected_output(**expected_completion):
     Returns the expected JSON record logged by the ``transmit_learner_data`` command.
     """
     action = 'Successfully sent completion status call for'
+    action2 = 'Skipping previously sent'
     if expected_completion['timestamp'] == NOW_TIMESTAMP:
         degreed_timestamp = '"{}"'.format(NOW_TIMESTAMP_FORMATTED)
     elif expected_completion['timestamp'] == PAST_TIMESTAMP:
@@ -601,6 +603,7 @@ def get_expected_output(**expected_completion):
     else:
         degreed_timestamp = 'null'
         action = 'Skipping in-progress'
+        action2 = action
 
     degreed_output_template = (
         '{{'
@@ -629,7 +632,7 @@ def get_expected_output(**expected_completion):
         "[<SAPSuccessFactorsEnterpriseCustomerConfiguration for Enterprise Spaghetti Enterprise>]",
         "Attempting to transmit serialized payload: " + sapsf_output_template.format(
             user_id='remote-user-id',
-            course_id=COURSE_ID,
+            course_id=COURSE_KEY,
             provider_id="SAP",
             **expected_completion
         ),
@@ -640,7 +643,21 @@ def get_expected_output(**expected_completion):
             provider_id="SAP",
             **expected_completion
         ),
+        "{} enterprise enrollment 2".format(action2),
+        "Attempting to transmit serialized payload: " + sapsf_output_template.format(
+            user_id='remote-user-id',
+            course_id=COURSE_KEY,
+            provider_id="SAP",
+            **expected_completion
+        ),
         "{} enterprise enrollment 3".format(action),
+        "Attempting to transmit serialized payload: " + sapsf_output_template.format(
+            user_id='remote-user-id',
+            course_id=COURSE_ID,
+            provider_id="SAP",
+            **expected_completion
+        ),
+        "{} enterprise enrollment 3".format(action2),
         "Learner data transmission task for integrated channel configuration "
         "[<SAPSuccessFactorsEnterpriseCustomerConfiguration for Enterprise Spaghetti Enterprise>] took [0.0] seconds",
 
@@ -649,16 +666,28 @@ def get_expected_output(**expected_completion):
         "[<DegreedEnterpriseCustomerConfiguration for Enterprise Spaghetti Enterprise>]",
         "Attempting to transmit serialized payload: " + degreed_output_template.format(
             user_email='example@email.com',
-            course_id=COURSE_ID,
+            course_id=COURSE_KEY,
             timestamp=degreed_timestamp
         ),
         "{} enterprise enrollment 2".format(action),
+        "Attempting to transmit serialized payload: " + degreed_output_template.format(
+            user_email='example@email.com',
+            course_id=COURSE_ID,
+            timestamp=degreed_timestamp
+        ),
+        "{} enterprise enrollment 2".format(action2),
+        "Attempting to transmit serialized payload: " + degreed_output_template.format(
+            user_email='example2@email.com',
+            course_id=COURSE_KEY,
+            timestamp=degreed_timestamp
+        ),
+        "{} enterprise enrollment 3".format(action),
         "Attempting to transmit serialized payload: " + degreed_output_template.format(
             user_email='example2@email.com',
             course_id=COURSE_ID,
             timestamp=degreed_timestamp
         ),
-        "{} enterprise enrollment 3".format(action),
+        "{} enterprise enrollment 3".format(action2),
         "Learner data transmission task for integrated channel configuration "
         "[<DegreedEnterpriseCustomerConfiguration for Enterprise Spaghetti Enterprise>] took [0.0] seconds"
     ]
@@ -739,7 +768,7 @@ class TestLearnerDataTransmitIntegration(unittest.TestCase):
         using all the ways we can invoke it.
         """
         with transmit_learner_data_context(command_kwargs, certificate, self_paced, end_date, passed) as (args, kwargs):
-            with LogCapture(level=logging.INFO) as log_capture:
+            with LogCapture(level=logging.DEBUG) as log_capture:
                 expected_output = get_expected_output(**expected_completion)
                 call_command('transmit_learner_data', *args, **kwargs)
                 for index, message in enumerate(expected_output):


### PR DESCRIPTION
**Description:** Since we have started sending courses to SuccessFactors instead of course runs, we need to attempt to send transmissions with course keys and course run ids in order to ensure that we account for whether courses or course runs exist in the SuccessFactors instance. If the transmission with the course key succeeds, the next one will get skipped. If it fails, the one with the course run id will be attempted and (presumably) succeed.

**JIRA:** https://openedx.atlassian.net/browse/ENT-1074

**Dependencies:** n/a

**Merge deadline:** ASAP

**Installation instructions:** 

**Testing instructions:** 
I've _sort of_ tested this on the business sandbox, but I am having issues testing the successful transmission of course key because a content object with a course key doesn't seem to exist on the success factors instance and I can't figure out how to get it there. However, I feel reasonably confident because I have written specific unit test cases for it.
I used the following enrollment link and the user mtd_learner9: https://business.sandbox.edx.org/enterprise/d583b097-7bd9-4a7e-a98d-c15dea220354/course/NYIF+CM2.x/enroll/?catalog=573f379d-9238-4a10-9064-22b7b03cda21&utm_medium=enterprise&utm_source=successfactors-company
Note that if it takes you to login with an existing account, you can go to /register to create a new account instead, just make sure you don't have an active ecommerce session on the sandbox.
I completed the course, and ran the following command on the business sandbox:
```
$ edxapp
$ ./manage.py lms --settings=aws transmit_learner_data --enterprise_customer d583b097-7bd9-4a7e-a98d-c15dea220354 --api_user staff
```
Then, look in mysql, you should see the course transmission attempts with the course run id one succeeding.
```
mysql> select * from sap_success_factors_sapsuccessfactorslearnerdatatransmission3ce5 order by id desc limit 5;
```

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
