### PR TITLE
Change default content filter to include only courses

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.70.7] - 2018-07-12
+---------------------
+
+* Make customer catalog content filter's default value configurable.
+
 [0.70.6] - 2018-07-09
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.70.6"
+__version__ = "0.70.7"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/admin/__init__.py
+++ b/enterprise/admin/__init__.py
@@ -4,6 +4,8 @@ Django admin integration for enterprise app.
 """
 from __future__ import absolute_import, unicode_literals
 
+import json
+
 from django.conf.urls import url
 from django.contrib import admin
 from django.contrib.auth import settings
@@ -41,7 +43,7 @@ from enterprise.models import (
     EnterpriseCourseEnrollment,
     EnterpriseCustomerCatalog,
 )
-from enterprise.utils import get_all_field_names
+from enterprise.utils import get_all_field_names, get_default_catalog_content_filter
 
 
 class EnterpriseCustomerBrandingConfigurationInline(admin.StackedInline):
@@ -515,6 +517,11 @@ class EnterpriseCustomerCatalogAdmin(admin.ModelAdmin):
         'enterprise_customer__name',
         'enterprise_customer__uuid',
     )
+
+    def get_form(self, request, obj=None, **kwargs):
+        form = super(EnterpriseCustomerCatalogAdmin, self).get_form(request, obj, **kwargs)
+        form.base_fields['content_filter'].initial = json.dumps(get_default_catalog_content_filter())
+        return form
 
 
 @admin.register(EnterpriseCustomerReportingConfiguration)

--- a/enterprise/constants.py
+++ b/enterprise/constants.py
@@ -74,6 +74,17 @@ ALLOWED_TAGS = [
 ]
 
 
+DEFAULT_CATALOG_CONTENT_FILTER = {
+    'content_type': 'course',
+    'partner': 'edx',
+    'level_type': [
+        'Introductory',
+        'Intermediate',
+        'Advanced'
+    ]
+}
+
+
 def json_serialized_course_modes():
     """
     :return: serialized course modes.

--- a/enterprise/settings/test.py
+++ b/enterprise/settings/test.py
@@ -162,6 +162,16 @@ USE_TZ = True
 
 MKTG_URLS = {}
 
+ENTERPRISE_CUSTOMER_CATALOG_DEFAULT_CONTENT_FILTER = {
+    'content_type': 'course',
+    'partner': 'edx',
+    'level_type': [
+        'Introductory',
+        'Intermediate',
+        'Advanced'
+    ]
+}
+
 ################################### TRACKING ###################################
 
 LMS_SEGMENT_KEY = 'SOME_KEY'

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -32,7 +32,7 @@ from django.utils.text import slugify
 from django.utils.translation import ugettext as _
 from django.utils.translation import ungettext
 
-from enterprise.constants import ALLOWED_TAGS, PROGRAM_TYPE_DESCRIPTION
+from enterprise.constants import ALLOWED_TAGS, DEFAULT_CATALOG_CONTENT_FILTER, PROGRAM_TYPE_DESCRIPTION
 
 try:
     from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
@@ -795,3 +795,10 @@ def get_content_metadata_item_id(content_metadata_item):
     if content_metadata_item['content_type'] == 'program':
         return content_metadata_item['uuid']
     return content_metadata_item['key']
+
+
+def get_default_catalog_content_filter():
+    """
+    Return default enterprise customer catalog content filter.
+    """
+    return settings.ENTERPRISE_CUSTOMER_CATALOG_DEFAULT_CONTENT_FILTER or DEFAULT_CATALOG_CONTENT_FILTER

--- a/test_utils/factories.py
+++ b/test_utils/factories.py
@@ -276,7 +276,6 @@ class EnterpriseCustomerCatalogFactory(factory.django.DjangoModelFactory):
 
     uuid = factory.LazyAttribute(lambda x: UUID(FAKER.uuid4()))
     enterprise_customer = factory.SubFactory(EnterpriseCustomerFactory)
-    content_filter = {}
 
 
 class DataSharingConsentFactory(factory.django.DjangoModelFactory):


### PR DESCRIPTION
[ENT-1070](https://openedx.atlassian.net/browse/ENT-1070)

This PR adds a default content filter value to `EnterpriseCustomerCatalog` model, which is configurable by open edX.

Related platform PR: https://github.com/edx/edx-platform/pull/18551

[Business Sandbox Admin URL](https://business.sandbox.edx.org/admin/enterprise/enterprisecustomercatalog/add)