### PR TITLE
[ENT-1083]: Write Serializer to Collect Learner and Enrollment data

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.72.3] - 2018-08-08
+---------------------
+
+* Added LearnerInfoSerializer and CourseInfoSerializer for serializing xAPI payload data.
+
 [0.72.2] - 2018-07-27
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.72.2"
+__version__ = "0.72.3"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/xapi/serializers.py
+++ b/integrated_channels/xapi/serializers.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+
+"""
+Serializers for xAPI data.
+"""
+from __future__ import absolute_import, unicode_literals
+
+from rest_framework import serializers
+
+from enterprise.api.v1.serializers import ImmutableStateSerializer
+from enterprise.models import EnterpriseCustomerUser
+
+
+class LearnerInfoSerializer(ImmutableStateSerializer):
+    """
+    Serializer for Learner info.
+
+    Model: User
+    """
+    lms_user_id = serializers.IntegerField(source='id')
+    user_username = serializers.CharField(source='username')
+    user_email = serializers.EmailField(source='email')
+    user_country_code = serializers.CharField(source='profile.country.code')
+    user_account_creation_date = serializers.DateTimeField(source='date_joined')
+
+    enterprise_user_id = serializers.SerializerMethodField()
+    enterprise_sso_uid = serializers.SerializerMethodField()
+
+    def get_enterprise_user_id(self, obj):
+        """
+        Get enterprise user id from user object.
+
+        Arguments:
+            obj (User): Django User object
+
+        Returns:
+            (int): Primary Key identifier for enterprise user object.
+        """
+        try:
+            enterprise_learner = EnterpriseCustomerUser.objects.get(user_id=obj.id)
+        except EnterpriseCustomerUser.DoesNotExist:
+            return
+
+        return enterprise_learner.id
+
+    def get_enterprise_sso_uid(self, obj):
+        """
+        Get enterprise SSO UID.
+
+        Arguments:
+            obj (User): Django User object
+
+        Returns:
+            (str): string containing UUID for enterprise customer's Identity Provider.
+        """
+        try:
+            enterprise_learner = EnterpriseCustomerUser.objects.get(user_id=obj.id)
+        except EnterpriseCustomerUser.DoesNotExist:
+            return
+
+        return enterprise_learner.get_remote_id()
+
+
+class CourseInfoSerializer(ImmutableStateSerializer):
+    """
+    Serializer for course info.
+
+    Model: CourseOverview
+    """
+    course_id = serializers.CharField(source='id')
+    course_title = serializers.CharField(source='display_name')
+    course_description = serializers.CharField(source='short_description')
+    course_details_url = serializers.CharField(source='marketing_url')
+    course_effort = serializers.CharField(source='effort')
+    course_duration = serializers.SerializerMethodField()
+
+    def get_course_duration(self, obj):
+        """
+        Get course's duration as a timedelta.
+
+        Arguments:
+            obj (CourseOverview): CourseOverview object
+
+        Returns:
+            (timedelta): Duration of a course.
+        """
+        return obj.end - obj.start if obj.start and obj.end else None

--- a/tests/test_integrated_channels/test_xapi/test_serializers.py
+++ b/tests/test_integrated_channels/test_xapi/test_serializers.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+"""
+Test for xAPI serializers.
+"""
+
+from __future__ import absolute_import, unicode_literals
+
+import unittest
+from datetime import datetime, timedelta
+
+import mock
+from faker import Factory as FakerFactory
+from pytest import mark
+
+from integrated_channels.xapi.serializers import CourseInfoSerializer, LearnerInfoSerializer
+from test_utils import factories
+
+TEST_ENTERPRISE_SSO_UID = 'saml-user-id'
+
+
+@mark.django_db
+class TestLearnerInfoSerializer(unittest.TestCase):
+    """
+    Tests for the ``LearnerInfoSerializer`` model.
+    """
+
+    def setUp(self):
+        super(TestLearnerInfoSerializer, self).setUp()
+        self.user = factories.UserFactory()
+        self.enterprise_customer_user = factories.EnterpriseCustomerUserFactory(user_id=self.user.id)
+        # pylint: disable=invalid-name
+        self.enterprise_customer_identity_provider = factories.EnterpriseCustomerIdentityProviderFactory(
+            enterprise_customer=self.enterprise_customer_user.enterprise_customer
+        )
+
+        self.expected_data = {
+            'enterprise_sso_uid': TEST_ENTERPRISE_SSO_UID,
+            'lms_user_id': self.user.id,
+            'enterprise_user_id': self.enterprise_customer_user.id,
+            'user_username': self.user.username,
+            'user_account_creation_date': self.user.date_joined.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            'user_country_code': 'PK',
+            'user_email': self.user.email
+        }
+
+    @mock.patch('enterprise.models.ThirdPartyAuthApiClient')
+    def test_data(self, mock_third_party_api):
+        """
+        Verify that serializer data is as expected.
+        """
+        mock_third_party_api.return_value.get_remote_id.return_value = TEST_ENTERPRISE_SSO_UID
+
+        with mock.patch.object(self.user, 'profile', create=True) as mock_user_profile:
+            mock_user_profile.country.code = 'PK'
+            assert LearnerInfoSerializer(self.user).data == self.expected_data
+
+    def test_data_with_no_enterprise_customer_user(self):
+        """
+        Verify that serializer data is as expected in case when user does not belong to an enterprise.
+        """
+        # Remove the link between the user and enterprise customer
+        self.enterprise_customer_user.delete()
+
+        # update expected data
+        self.expected_data.update(enterprise_sso_uid=None, enterprise_user_id=None)
+
+        with mock.patch.object(self.user, 'profile', create=True) as mock_user_profile:
+            mock_user_profile.country.code = 'PK'
+            assert LearnerInfoSerializer(self.user).data == self.expected_data
+
+
+@mark.django_db
+class TestCourseInfoSerializer(unittest.TestCase):
+    """
+    Tests for the ``CourseInfoSerializer`` model.
+    """
+
+    def setUp(self):
+        super(TestCourseInfoSerializer, self).setUp()
+        self.faker = FakerFactory.create()
+        self.course_overview = factories.UserFactory()
+
+        now = datetime.now()
+        self.course_overview_mock_data = dict(
+            id=self.faker.text(max_nb_chars=25),  # pylint: disable=no-member
+            display_name=self.faker.text(max_nb_chars=25),  # pylint: disable=no-member
+            short_description=self.faker.text(),  # pylint: disable=no-member
+            marketing_url=self.faker.url(),  # pylint: disable=no-member
+            effort=self.faker.text(max_nb_chars=10),  # pylint: disable=no-member
+            start=now,
+            end=now + timedelta(weeks=3, days=4),
+        )
+        self.course_overview = mock.Mock(**self.course_overview_mock_data)
+
+        self.expected_data = {
+            'course_description': self.course_overview_mock_data['short_description'],
+            'course_title': self.course_overview_mock_data['display_name'],
+            'course_duration': self.course_overview_mock_data['end'] - self.course_overview_mock_data['start'],
+            'course_effort': self.course_overview_mock_data['effort'],
+            'course_details_url': self.course_overview_mock_data['marketing_url'],
+            'course_id': self.course_overview_mock_data['id'],
+        }
+
+    def test_data(self):
+        """
+        Verify that serializer data is as expected.
+        """
+
+        assert CourseInfoSerializer(self.course_overview).data == self.expected_data


### PR DESCRIPTION
**Description:** 
Write utility functions/serializers to collect learner and enrollment data that would be sent as part of the xAPI statement.

**JIRA:** [ENT-1083](https://openedx.atlassian.net/browse/ENT-1083)

**Dependencies:**  https://github.com/edx/edx-enterprise/pull/328

**Merge checklist:**

- [x] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [x] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [x] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [x] Called `make static` for webpack bundling if any static content was updated.
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [x] Translations are updated
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)
