### PR TITLE
ENT-1052 pass catalog value only when provided

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.70.6] - 2018-07-09
+---------------------
+
+* Pass catalog value only when provided on enterprise course enrollment page.
+
 [0.70.5] - 2018-07-06
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.70.5"
+__version__ = "0.70.6"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/templates/enterprise/enterprise_course_enrollment_page.html
+++ b/enterprise/templates/enterprise/enterprise_course_enrollment_page.html
@@ -50,7 +50,9 @@
           {% if course_enrollable %}
             <form method="POST">
               <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}" />
-              <input type="hidden" name="catalog" value="{{ catalog }}" />
+              {% if catalog %}
+                <input type="hidden" name="catalog" value="{{ catalog }}" />
+              {% endif %}
               {% if course_modes|length > 1 %}<div class="caption">{{ select_mode_text }}</div>{% endif %}
               {% for course_mode in course_modes %}
               <div class="radio-block">


### PR DESCRIPTION
**Description:** Add/Show discount for enterprise learners by provided valid enterprise catalog `UUID`. This enterprise catalog `UUID` can be provided by passing the queryparam `catalog={enterprise_catalog_uuid}` to enterprise course enrollment urls. If catalog `UUID` is provided in course enrollment url then the default enterprise coupon (first enterprise offer) will be applied.

**JIRA:** [ENT-1052](https://openedx.atlassian.net/browse/ENT-1052)

**Dependencies:**

1. ecommerce: https://github.com/edx/ecommerce/pull/1851

**Installation instructions:**  
1. Checkout edx-platform to branch ``.
2. Install `edx-enterprise` from branch `zub/ENT-1052-pass-catalog-input-only-when-provided` in `edx-platform`.
3. Checkout ecommerce to branch ``.
4. In ecommerce django admin (admin/waffle/switch/) verify following waffle flags:
```
force_anonymous_user_response_for_basket_calculate = False
enable_enterprise_offers = True
enable_enterprise_on_runtime = True
```
**Testing instructions:**

1. Create an enterprise with 2 catalogs with a verified course (both catalogs should have this verified course)
2. For catalog A, create enterprise offer with 100% discount.
3. For catalog B, create enterprise offer with 15% discount.
4. Now access the enterprise course enrollment URL with the `UUID` of catalog A, i.e. `http://zubair.localhost:8000/enterprise/72416e52-8c77-4860-9584-15e5b06220fb/course/course-v1:edX+TEST_01+2016_R1/enroll/?catalog=a113c7e2-13ac-46ae-9e24-b75bf7c0058d`
5. Verify that learner sees 100 discount on verified seat for verified course
6. Clicking on 'Continue' button (after consenting) user is redirect to courseware page after automatic enrollment (100% discount).
7. Now access the enterprise course enrollment URL with the `UUID` of catalog B, i.e. `http://zubair.localhost:8000/enterprise/72416e52-8c77-4860-9584-15e5b06220fb/course/course-v1:edX+TEST_01+2016_R1/enroll/?catalog=6eca3efb-f3a0-4c08-806f-c6e6b65d61cb`
8. Verify that learner sees 15 discount on verified seat for verified course
9. Clicking on 'Continue' button (after consenting) user is redirect to basket page with 15% discount applied by the learner's enterprise.
10. Now access the enterprise course enrollment URL without the catalog `UUID`, i.e. `http://zubair.localhost:8000/enterprise/72416e52-8c77-4860-9584-15e5b06220fb/course/course-v1:edX+TEST_01+2016_R1/enroll/`
11. Now verify that course enrollment page shows the 100% discount offered by the first enterprise offer.
12. Also verify the clicking on  button (after consenting) user is redirect to courseware page after automatic enrollment (100% discount).