### PR TITLE
ENT-1067 SuccessFactors: Fetch image url base on content type

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,12 @@ Change Log
 
 Unreleased
 ----------
+
+[0.71.2] - 2018-07-23
+---------------------
+
+* Add thumbnail images in exported metadata content by content type.
+
 [0.71.1] - 2018-07-23
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.71.1"
+__version__ = "0.71.2"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/degreed/exporters/content_metadata.py
+++ b/integrated_channels/degreed/exporters/content_metadata.py
@@ -68,7 +68,13 @@ class DegreedContentMetadataExporter(ContentMetadataExporter):  # pylint: disabl
         """
         Return the image URI of the content item.
         """
-        return (content_metadata_item.get('image') or {}).get('src', '') or ''
+        image_url = ''
+        if content_metadata_item['content_type'] in ['course', 'program']:
+            image_url = content_metadata_item.get('card_image_url')
+        elif content_metadata_item['content_type'] == 'courserun':
+            image_url = content_metadata_item.get('image_url')
+
+        return image_url
 
     def transform_program_key(self, content_metadata_item):
         """

--- a/integrated_channels/sap_success_factors/exporters/content_metadata.py
+++ b/integrated_channels/sap_success_factors/exporters/content_metadata.py
@@ -90,7 +90,13 @@ class SapSuccessFactorsContentMetadataExporter(ContentMetadataExporter):  # pyli
         """
         Return the image URI of the content item.
         """
-        return (content_metadata_item.get('image') or {}).get('src', '') or ''
+        image_url = ''
+        if content_metadata_item['content_type'] in ['course', 'program']:
+            image_url = content_metadata_item.get('card_image_url')
+        elif content_metadata_item['content_type'] == 'courserun':
+            image_url = content_metadata_item.get('image_url')
+
+        return image_url
 
     def transform_launch_points(self, content_metadata_item):
         """

--- a/tests/test_integrated_channels/test_degreed/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_degreed/test_exporters/test_content_metadata.py
@@ -55,3 +55,64 @@ class TestDegreedContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin)
             'course-v1:edX+DemoX+Demo_Course',
             FAKE_UUIDS[3],
         ])
+
+    @ddt.data(
+        (
+            {
+                'aggregation_key': 'course:edX+DemoX',
+                'title': 'edX Demonstration Course',
+                'key': 'edX+DemoX',
+                'content_type': 'course',
+                'card_image_url': 'https://edx.devstack.lms:18000/'
+                                  'asset-v1:edX+DemoX+Demo_Course+type@asset+block@images_course_image.jpg',
+                'short_description': 'Some short description.',
+                'full_description': 'Detailed description of edx demo course.',
+            },
+            'https://edx.devstack.lms:18000/asset-v1:edX+DemoX+Demo_Course+type@asset+block@images_course_image.jpg'
+        ),
+        (
+            {
+                'number': 'DemoX',
+                'org': 'edX',
+                'seat_types': ['verified', 'audit'],
+                'key': 'course-v1:edX+DemoX+Demo_Course',
+                'availability': 'Current',
+                'title': 'edX Demonstration Course',
+                'content_type': 'courserun',
+                'image_url': 'https://edx.devstack.lms:18000/'
+                             'asset-v1:edX+DemoX+Demo_Course+type@asset+block@images_course_image.jpg',
+            },
+            'https://edx.devstack.lms:18000/asset-v1:edX+DemoX+Demo_Course+type@asset+block@images_course_image.jpg'
+        ),
+        (
+            {
+
+                'uuid': '5742ec8d-25ce-43b7-a158-6dad82034ca2',
+                'title': 'edX Demonstration program',
+                'published': True,
+                'language': [],
+                'type': 'Verified Certificate',
+                'status': 'active',
+                'content_type': 'program',
+                'card_image_url': 'https://edx.devstack.discovery/'
+                                  'media/programs/banner_images/5742ec8d-25ce-43b7-a158-6dad82034ca2.jpg',
+            },
+            'https://edx.devstack.discovery/media/programs/banner_images/5742ec8d-25ce-43b7-a158-6dad82034ca2.jpg',
+        ),
+        (
+            {
+                'title': 'INVALID COURSE',
+                'content_type': 'INVALID-CONTENT_TYPE',
+            },
+            '',
+        ),
+    )
+    @responses.activate
+    @ddt.unpack
+    def test_transform_image(self, content_metadata_item, expected_thumbnail_url):
+        """
+        Transforming a image gives back the thumbnail URI by checking the
+        content type of the provided `content_metadata_item`.
+        """
+        exporter = DegreedContentMetadataExporter('fake-user', self.config)
+        assert exporter.transform_image(content_metadata_item) == expected_thumbnail_url

--- a/tests/test_integrated_channels/test_sap_success_factors/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_sap_success_factors/test_exporters/test_content_metadata.py
@@ -149,3 +149,64 @@ class TestSapSuccessFactorsContentMetadataExporter(unittest.TestCase, Enterprise
                 'locale': 'English',
                 'value': expected_title
             }]
+
+    @ddt.data(
+        (
+            {
+                'aggregation_key': 'course:edX+DemoX',
+                'title': 'edX Demonstration Course',
+                'key': 'edX+DemoX',
+                'content_type': 'course',
+                'card_image_url': 'https://edx.devstack.lms:18000/'
+                                  'asset-v1:edX+DemoX+Demo_Course+type@asset+block@images_course_image.jpg',
+                'short_description': 'Some short description.',
+                'full_description': 'Detailed description of edx demo course.',
+            },
+            'https://edx.devstack.lms:18000/asset-v1:edX+DemoX+Demo_Course+type@asset+block@images_course_image.jpg'
+        ),
+        (
+            {
+                'number': 'DemoX',
+                'org': 'edX',
+                'seat_types': ['verified', 'audit'],
+                'key': 'course-v1:edX+DemoX+Demo_Course',
+                'availability': 'Current',
+                'title': 'edX Demonstration Course',
+                'content_type': 'courserun',
+                'image_url': 'https://edx.devstack.lms:18000/'
+                             'asset-v1:edX+DemoX+Demo_Course+type@asset+block@images_course_image.jpg',
+            },
+            'https://edx.devstack.lms:18000/asset-v1:edX+DemoX+Demo_Course+type@asset+block@images_course_image.jpg'
+        ),
+        (
+            {
+
+                'uuid': '5742ec8d-25ce-43b7-a158-6dad82034ca2',
+                'title': 'edX Demonstration program',
+                'published': True,
+                'language': [],
+                'type': 'Verified Certificate',
+                'status': 'active',
+                'content_type': 'program',
+                'card_image_url': 'https://edx.devstack.discovery/'
+                                  'media/programs/banner_images/5742ec8d-25ce-43b7-a158-6dad82034ca2.jpg',
+            },
+            'https://edx.devstack.discovery/media/programs/banner_images/5742ec8d-25ce-43b7-a158-6dad82034ca2.jpg',
+        ),
+        (
+            {
+                'title': 'INVALID COURSE',
+                'content_type': 'INVALID-CONTENT_TYPE',
+            },
+            '',
+        ),
+    )
+    @responses.activate
+    @ddt.unpack
+    def test_transform_image(self, content_metadata_item, expected_thumbnail_url):
+        """
+        Transforming a image gives back the thumbnail URI by checking the
+        content type of the provided `content_metadata_item`.
+        """
+        exporter = SapSuccessFactorsContentMetadataExporter('fake-user', self.config)
+        assert exporter.transform_image(content_metadata_item) == expected_thumbnail_url


### PR DESCRIPTION
**Description:** For `SAP SuccessFactors` add thumbnail images in exported metadata content by content type. Previously we were unable to fetch the image url as the content structure we were expecting earlier was changed due to modified endpoints. 

**JIRA:** [ENT-1067](https://openedx.atlassian.net/browse/ENT-1067)

**Dependencies:** N/A

**Installation instructions:** Install `edx-enterprise` from branch `zub/ENT-1067-add-courses-thumbnail-uri` in `edx-platform`.

**Testing instructions:**

1. Create an enterprise with a catalog which contains different content types, e.g. `course`, `course_run` and `program` and also make sure that each content type item have images (`image_url` or `card_image_url`) set in course discovery service.
2. Create integrated channel for SAP Success Factors and add it as an IDP for the above enterprise
3. Run `transmit_content_metadata` command, .e.g. `./manage.py lms --settings=aws transmit_content_metadata --catalog_user=enterprise_worker`
4. Verify that all types of content metadata pushed contains `thumbnailURI`

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [ ] Translations are updated
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
