### PR TITLE
Fix content filter default value not displaying in EnterpriseCustomer…

### DIFF
--- a/enterprise/admin/__init__.py
+++ b/enterprise/admin/__init__.py
@@ -110,6 +110,11 @@ class EnterpriseCustomerCatalogInline(admin.TabularInline):
     extra = 0
     can_delete = False
 
+    def get_formset(self, request, obj=None, **kwargs):
+        formset = super(EnterpriseCustomerCatalogInline, self).get_formset(request, obj, **kwargs)
+        formset.form.base_fields['content_filter'].initial = json.dumps(get_default_catalog_content_filter())
+        return formset
+
 
 @admin.register(EnterpriseCustomer)
 class EnterpriseCustomerAdmin(DjangoObjectActions, SimpleHistoryAdmin):


### PR DESCRIPTION
Fix content filter default value not displaying in EnterpriseCustomer admin form.

This PR adds the capability to display content filter default value to inline enterprise customer catalog admin form. 

[ENT-1099](https://openedx.atlassian.net/browse/ENT-1099)