### PR TITLE
ENT-1092 Gracefully handle invalid Enterprise Customer Catalog references in B2B enrollment workflow

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ Change Log
 
 Unreleased
 ----------
+[0.71.1] - 2018-07-23
+---------------------
+
+* Updated message for invalid Enterprise Customer Catalog references in B2B enrollment workflow.
 
 [0.71.0] - 2018-07-20
 ---------------------

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.71.0"
+__version__ = "0.71.1"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/messages.py
+++ b/enterprise/messages.py
@@ -109,8 +109,8 @@ def add_generic_info_message_for_error(request):
         request,
         _(
             '{strong_start}Something happened.{strong_end} '
-            '{span_start}This course is not available. '
-            'Please start over and select a different course.{span_end}'
+            '{span_start}This course link is currently invalid. '
+            'Please reach out to your Administrator for assistance to this course.{span_end}'
         ).format(
             span_start='<span>',
             span_end='</span>',

--- a/tests/test_enterprise/views/test_course_enrollment_view.py
+++ b/tests/test_enterprise/views/test_course_enrollment_view.py
@@ -438,7 +438,8 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
             (
                 messages.INFO,
                 '<strong>Something happened.</strong> '
-                '<span>This course is not available. Please start over and select a different course.</span>'
+                '<span>This course link is currently invalid. '
+                'Please reach out to your Administrator for assistance to this course.</span>'
             )
         ]
         response = self.client.get(enterprise_landing_page_url)
@@ -530,7 +531,8 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
             (
                 messages.INFO,
                 '<strong>Something happened.</strong> '
-                '<span>This course is not available. Please start over and select a different course.</span>'
+                '<span>This course link is currently invalid. '
+                'Please reach out to your Administrator for assistance to this course.</span>'
             )
         ]
         response = self.client.get(enterprise_landing_page_url)
@@ -1016,7 +1018,8 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
             (
                 messages.INFO,
                 '<strong>Something happened.</strong> '
-                '<span>This course is not available. Please start over and select a different course.</span>'
+                '<span>This course link is currently invalid. '
+                'Please reach out to your Administrator for assistance to this course.</span>'
             )
         ]
         self._assert_django_test_client_messages(response, expected_log_messages)
@@ -1063,7 +1066,8 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
             (
                 messages.INFO,
                 '<strong>Something happened.</strong> '
-                '<span>This course is not available. Please start over and select a different course.</span>'
+                '<span>This course link is currently invalid. '
+                'Please reach out to your Administrator for assistance to this course.</span>'
             )
         ]
         self._assert_django_test_client_messages(response, expected_log_messages)
@@ -1111,7 +1115,8 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
             (
                 messages.INFO,
                 '<strong>Something happened.</strong> '
-                '<span>This course is not available. Please start over and select a different course.</span>'
+                '<span>This course link is currently invalid. '
+                'Please reach out to your Administrator for assistance to this course.</span>'
             )
         ]
         self._assert_django_test_client_messages(response, expected_log_messages)


### PR DESCRIPTION
**Description:** 
Gracefully handle invalid Enterprise Customer Catalog references in B2B enrollment workflow

**JIRA:** 
https://openedx.atlassian.net/browse/ENT-1092

**Test Instructions:**
1: Hit a course run URL with an invalid catalog UUID, or a catalog which doesn't exist for the provided enterprise.
2: Verify that the following message is returned:
"This course link is currently invalid. Please reach out to your Administrator for assistance to this course."