### PR TITLE
ENT-1125 Adjustments/additions to enterprise api around django group access

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.72.2] - 2018-07-27
+---------------------
+
+* Added endpoint to check a user's authorization to Enterprises based on membership in a given django group.
+
 [0.72.1] - 2018-07-26
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.72.1"
+__version__ = "0.72.2"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/v1/permissions.py
+++ b/enterprise/api/v1/permissions.py
@@ -18,10 +18,13 @@ class IsAdminUserOrInGroup(permissions.IsAdminUser):
     def has_permission(self, request, view):
         """
         Returns True if the requesting user is either 'staff' or belong to specific group, False otherwise.
+        It will also check for group membership against a list of groups in the permissions query parameter.
         """
-        return super(IsAdminUserOrInGroup, self).has_permission(request, view) or request.user.groups.filter(
-            name__in=self.ALLOWED_API_GROUPS
-        ).exists()
+        return (
+            super(IsAdminUserOrInGroup, self).has_permission(request, view) or
+            request.user.groups.filter(name__in=self.ALLOWED_API_GROUPS).exists() or
+            request.user.groups.filter(name__in=request.query_params.getlist('permissions')).exists()
+        )
 
 
 class HasEnterpriseEnrollmentAPIAccess(IsAdminUserOrInGroup):
@@ -32,3 +35,13 @@ class HasEnterpriseEnrollmentAPIAccess(IsAdminUserOrInGroup):
     def __init__(self):
         """ Initialize the class with a API_ALLOWED_GROUPS """
         self.ALLOWED_API_GROUPS = [u'enterprise_enrollment_api_access', ]  # pylint: disable=invalid-name
+
+
+class HasEnterpriseDataAPIAccess(IsAdminUserOrInGroup):
+    """
+    Find the requesting user is either staff or belong to enterprise_data_api_access group.
+    It will return a 403 forbidden response with a message if the user is not authorized to access the view.
+    """
+    def __init__(self):
+        """ Initialize the class with a API_ALLOWED_GROUPS """
+        self.ALLOWED_API_GROUPS = [u'enterprise_data_api_access', ]  # pylint: disable=invalid-name

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -17,6 +17,7 @@ from django.utils.translation import ugettext_lazy as _
 from enterprise import models, utils
 from enterprise.api.v1.mixins import EnterpriseCourseContextSerializerMixin
 from enterprise.api_client.lms import ThirdPartyAuthApiClient
+from enterprise.constants import ENTERPRISE_PERMISSION_GROUPS
 from enterprise.utils import track_enrollment
 
 
@@ -261,12 +262,13 @@ class EnterpriseCustomerUserReadOnlySerializer(serializers.ModelSerializer):
     class Meta:
         model = models.EnterpriseCustomerUser
         fields = (
-            'id', 'enterprise_customer', 'user_id', 'user', 'data_sharing_consent_records'
+            'id', 'enterprise_customer', 'user_id', 'user', 'data_sharing_consent_records', 'groups'
         )
 
     user = UserSerializer()
     enterprise_customer = EnterpriseCustomerSerializer()
     data_sharing_consent_records = serializers.SerializerMethodField()
+    groups = serializers.SerializerMethodField()
 
     def get_data_sharing_consent_records(self, obj):
         """
@@ -279,6 +281,14 @@ class EnterpriseCustomerUserReadOnlySerializer(serializers.ModelSerializer):
             list of dict: The serialized DataSharingConsent records associated with the EnterpriseCustomerUser.
         """
         return [record.serialize() for record in obj.data_sharing_consent_records]
+
+    def get_groups(self, obj):
+        """
+        Return the enterprise related django groups that this user is a part of.
+        """
+        if obj.user:
+            return [group.name for group in obj.user.groups.filter(name__in=ENTERPRISE_PERMISSION_GROUPS)]
+        return []
 
 
 class EnterpriseCustomerUserWriteSerializer(serializers.ModelSerializer):

--- a/enterprise/constants.py
+++ b/enterprise/constants.py
@@ -84,6 +84,12 @@ DEFAULT_CATALOG_CONTENT_FILTER = {
     ]
 }
 
+# Django groups specific to granting permission to enterprise admins.
+ENTERPRISE_PERMISSION_GROUPS = [
+    'enterprise_enrollment_api_access',
+    'enterprise_data_api_access',
+]
+
 
 def json_serialized_course_modes():
     """


### PR DESCRIPTION
**Description:**

**JIRA:** https://openedx.atlassian.net/browse/ENT-1125

**Dependencies:** n/a

**Merge deadline:** ASAP

**Installation instructions:** 

**Testing instructions:** 
Deployed on the business sandbox.

Using a staff user, hit the following endpoint: https://business.sandbox.edx.org/enterprise/api/v1/enterprise-customer/with_access_to?permissions=enterprise_enrollment_api_access
A list of all the enterprises should get returned.

Using a non-staff, enterprise "admin" user that is part of the enterprise_enrollment_api_access group, hit the same endpoint. You should only get only the enterprise that is linked to the user back.

If you use a non-staff user who is not linked to any enterprise but happens to have group membership, the result should be an empty list of enterprises.

If you use a non-staff user that is linked but is not part of the group, you should get an authorization related error message.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
