### PR TITLE
ENT-1082:  Added management command to send course enrollment info.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.72.6] - 2018-08-17
+---------------------
+
+* Added management command to send course enrollment and course completion info for enterprise customers.
+
 [0.72.5] - 2018-08-09
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.72.5"
+__version__ = "0.72.6"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/utils.py
+++ b/integrated_channels/utils.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, unicode_literals
 
 import datetime
 from itertools import islice
+from string import Formatter
 
 from six.moves import range
 
@@ -53,3 +54,69 @@ def chunks(dictionary, chunk_size):
     iterable = iter(dictionary)
     for __ in range(0, len(dictionary), chunk_size):
         yield {key: dictionary[key] for key in islice(iterable, chunk_size)}
+
+
+def strfdelta(tdelta, fmt='{D:02}d {H:02}h {M:02}m {S:02}s', input_type='timedelta'):
+    """
+    Convert a datetime.timedelta object or a regular number to a custom-formatted string.
+
+    This function works like the strftime() method works for datetime.datetime
+    objects.
+
+    The fmt argument allows custom formatting to be specified.  Fields can
+    include seconds, minutes, hours, days, and weeks.  Each field is optional.
+
+    Arguments:
+        tdelta (datetime.timedelta, int): time delta object containing the duration or an integer
+            to go with the input_type.
+        fmt (str): Expected format of the time delta. place holders can only be one of the following.
+            1. D to extract days from time delta
+            2. H to extract hours from time delta
+            3. M to extract months from time delta
+            4. S to extract seconds from timedelta
+        input_type (str):  The input_type argument allows tdelta to be a regular number instead of the
+            default, which is a datetime.timedelta object.
+            Valid input_type strings:
+                1. 's', 'seconds',
+                2. 'm', 'minutes',
+                3. 'h', 'hours',
+                4. 'd', 'days',
+                5. 'w', 'weeks'
+    Returns:
+        (str): timedelta object interpolated into a string following the given format.
+
+    Examples:
+        '{D:02}d {H:02}h {M:02}m {S:02}s' --> '05d 08h 04m 02s' (default)
+        '{W}w {D}d {H}:{M:02}:{S:02}'     --> '4w 5d 8:04:02'
+        '{D:2}d {H:2}:{M:02}:{S:02}'      --> ' 5d  8:04:02'
+        '{H}h {S}s'                       --> '72h 800s'
+    """
+    # Convert tdelta to integer seconds.
+    if input_type == 'timedelta':
+        remainder = int(tdelta.total_seconds())
+    elif input_type in ['s', 'seconds']:
+        remainder = int(tdelta)
+    elif input_type in ['m', 'minutes']:
+        remainder = int(tdelta)*60
+    elif input_type in ['h', 'hours']:
+        remainder = int(tdelta)*3600
+    elif input_type in ['d', 'days']:
+        remainder = int(tdelta)*86400
+    elif input_type in ['w', 'weeks']:
+        remainder = int(tdelta)*604800
+    else:
+        raise ValueError(
+            'input_type is not valid. Valid input_type strings are: "timedelta", "s", "m", "h", "d", "w"'
+        )
+
+    f = Formatter()
+    desired_fields = [field_tuple[1] for field_tuple in f.parse(fmt)]
+    possible_fields = ('W', 'D', 'H', 'M', 'S')
+    constants = {'W': 604800, 'D': 86400, 'H': 3600, 'M': 60, 'S': 1}
+    values = {}
+
+    for field in possible_fields:
+        if field in desired_fields and field in constants:
+            values[field], remainder = divmod(remainder, constants[field])
+
+    return f.format(fmt, **values)

--- a/integrated_channels/xapi/management/__init__.py
+++ b/integrated_channels/xapi/management/__init__.py
@@ -1,0 +1,3 @@
+"""
+Enterprise xAPI management commands and related functions.
+"""

--- a/integrated_channels/xapi/management/commands/__init__.py
+++ b/integrated_channels/xapi/management/commands/__init__.py
@@ -1,0 +1,3 @@
+"""
+Enterprise xAPI management commands and related functions.
+"""

--- a/integrated_channels/xapi/management/commands/send_course_completions.py
+++ b/integrated_channels/xapi/management/commands/send_course_completions.py
@@ -1,0 +1,198 @@
+# -*- coding: utf-8 -*-
+"""
+Send xAPI statements to the LRS configured via admin.
+"""
+
+from __future__ import absolute_import, unicode_literals
+
+import datetime
+from logging import getLogger
+
+from django.contrib.auth.models import User
+from django.core.management.base import BaseCommand, CommandError
+
+from enterprise.models import EnterpriseCustomer
+from enterprise.utils import NotConnectedToOpenEdX
+from integrated_channels.exceptions import ClientError
+from integrated_channels.xapi.models import XAPILRSConfiguration
+from integrated_channels.xapi.utils import send_course_completion_statement
+
+try:
+    from lms.djangoapps.grades.models import PersistentCourseGrade
+except ImportError:
+    PersistentCourseGrade = None
+
+try:
+    from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+except ImportError:
+    CourseOverview = None
+
+try:
+    from lms.djangoapps.grades.course_grade_factory import CourseGradeFactory  # pylint:disable=ungrouped-imports
+except ImportError:
+    CourseGradeFactory = None
+
+
+LOGGER = getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    Send course completion xAPI statements to enterprise customers.
+    """
+
+    def add_arguments(self, parser):
+        """
+        Add required arguments to the parser.
+        """
+        parser.add_argument(
+            '--days',
+            dest='days',
+            required=False,
+            type=int,
+            default=1,
+            help='Send xAPI analytics for learners who enrolled during last this number of days.'
+        )
+        parser.add_argument(
+            '--enterprise_customer_uuid',
+            dest='enterprise_customer_uuid',
+            type=str,
+            required=False,
+            help='Send xAPI analytics for this enterprise customer only.'
+        )
+        super(Command, self).add_arguments(parser)
+
+    @staticmethod
+    def parse_arguments(*args, **options):  # pylint: disable=unused-argument
+        """
+        Parse and validate arguments for the command.
+
+        Arguments:
+            *args: Positional arguments passed to the command
+            **options: Optional arguments passed to the command
+
+        Returns:
+            A tuple containing parsed values for
+            1. days (int): Integer showing number of days to lookup enterprise enrollments,
+                course completion etc and send to xAPI LRS
+            2. enterprise_customer_uuid (EnterpriseCustomer): Enterprise Customer if present then
+                send xAPI statements just for this enterprise.
+        """
+        days = options.get('days', 1)
+        enterprise_customer_uuid = options.get('enterprise_customer_uuid')
+        enterprise_customer = None
+
+        if enterprise_customer_uuid:
+            try:
+                # pylint: disable=no-member
+                enterprise_customer = EnterpriseCustomer.objects.get(uuid=enterprise_customer_uuid)
+            except EnterpriseCustomer.DoesNotExist:
+                raise CommandError('Enterprise customer with uuid "{enterprise_customer_uuid}" does not exist.'.format(
+                    enterprise_customer_uuid=enterprise_customer_uuid
+                ))
+
+        return days, enterprise_customer
+
+    def handle(self, *args, **options):
+        """
+        Send xAPI statements.
+        """
+        if not all((PersistentCourseGrade, CourseOverview, CourseGradeFactory)):
+            raise NotConnectedToOpenEdX("This package must be installed in an OpenEdX environment.")
+
+        days, enterprise_customer = self.parse_arguments(*args, **options)
+
+        if enterprise_customer:
+            try:
+                lrs_configuration = XAPILRSConfiguration.objects.get(
+                    active=True,
+                    enterprise_customer=enterprise_customer
+                )
+            except XAPILRSConfiguration.DoesNotExist:
+                raise CommandError('No xAPI Configuration found for "{enterprise_customer}"'.format(
+                    enterprise_customer=enterprise_customer.name
+                ))
+
+            # Send xAPI analytics data to the configured LRS
+            self.send_xapi_statements(lrs_configuration, days)
+        else:
+            for lrs_configuration in XAPILRSConfiguration.objects.filter(active=True):
+                self.send_xapi_statements(lrs_configuration, days)
+
+    def send_xapi_statements(self, lrs_configuration, days):
+        """
+        Send xAPI analytics data of the enterprise learners to the given LRS.
+
+        Arguments:
+            lrs_configuration (XAPILRSConfiguration): Configuration object containing LRS configurations
+                of the LRS where to send xAPI  learner analytics.
+            days (int): Include course enrollment of this number of days.
+        """
+        persistent_course_grades = self.get_course_completions(lrs_configuration.enterprise_customer, days)
+        users = self.prefetch_users(persistent_course_grades)
+        course_overviews = self.prefetch_courses(persistent_course_grades)
+
+        for persistent_course_grade in persistent_course_grades:
+            try:
+                user = users.get(persistent_course_grade.user_id)
+                course_overview = course_overviews.get(persistent_course_grade.course_id)
+                course_grade = CourseGradeFactory().read(user, course_key=persistent_course_grade.course_id)
+                send_course_completion_statement(lrs_configuration, user, course_overview, course_grade)
+            except ClientError:
+                LOGGER.exception(
+                    'Client error while sending course completion to xAPI for'
+                    ' enterprise customer {enterprise_customer}.'.format(
+                        enterprise_customer=lrs_configuration.enterprise_customer.name
+                    )
+                )
+
+    def get_course_completions(self, enterprise_customer, days):
+        """
+        Get course completions via PersistentCourseGrade for all the learners of given enterprise customer.
+
+        Arguments:
+            enterprise_customer (EnterpriseCustomer): Include Course enrollments for learners
+                of this enterprise customer.
+            days (int): Include course enrollment of this number of days.
+
+        Returns:
+            (list): A list of PersistentCourseGrade objects.
+        """
+        return PersistentCourseGrade.objects.filter(
+            passed_timestamp__gt=datetime.datetime.now() - datetime.timedelta(days=days)
+        ).filter(
+            user_id__in=enterprise_customer.enterprise_customer_users.values_list('user_id', flat=True)
+        )
+
+    @staticmethod
+    def prefetch_users(persistent_course_grades):
+        """
+        Prefetch Users from the list of user_ids present in the persistent_course_grades.
+
+        Arguments:
+            persistent_course_grades (list): A list of PersistentCourseGrade.
+
+        Returns:
+            (dict): A dictionary containing user_id to user mapping.
+        """
+        users = User.objects.filter(
+            id__in=[grade.user_id for grade in persistent_course_grades]
+        )
+        return {
+            user.id: user for user in users
+        }
+
+    @staticmethod
+    def prefetch_courses(persistent_course_grades):
+        """
+        Prefetch courses from the list of course_ids present in the persistent_course_grades.
+
+        Arguments:
+            persistent_course_grades (list): A list of PersistentCourseGrade.
+
+        Returns:
+            (dict): A dictionary containing course_id to course_overview mapping.
+        """
+        return CourseOverview.get_from_ids_if_exists(
+            [grade.course_id for grade in persistent_course_grades]
+        )

--- a/integrated_channels/xapi/management/commands/send_course_enrollments.py
+++ b/integrated_channels/xapi/management/commands/send_course_enrollments.py
@@ -1,0 +1,147 @@
+# -*- coding: utf-8 -*-
+"""
+Send xAPI statements to the LRS configured via admin.
+"""
+
+from __future__ import absolute_import, unicode_literals
+
+import datetime
+from logging import getLogger
+
+from django.core.management.base import BaseCommand, CommandError
+
+from enterprise.models import EnterpriseCustomer
+from enterprise.utils import NotConnectedToOpenEdX
+from integrated_channels.exceptions import ClientError
+from integrated_channels.xapi.models import XAPILRSConfiguration
+from integrated_channels.xapi.utils import send_course_enrollment_statement
+
+try:
+    from student.models import CourseEnrollment
+except ImportError:
+    CourseEnrollment = None
+
+
+LOGGER = getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    Send xAPI statements to all Enterprise Customers.
+    """
+
+    def add_arguments(self, parser):
+        """
+        Add required arguments to the parser.
+        """
+        parser.add_argument(
+            '--days',
+            dest='days',
+            required=False,
+            type=int,
+            default=1,
+            help='Send xAPI analytics for learners who enrolled during last this number of days.'
+        )
+        parser.add_argument(
+            '--enterprise_customer_uuid',
+            dest='enterprise_customer_uuid',
+            type=str,
+            required=False,
+            help='Send xAPI analytics for this enterprise customer only.'
+        )
+        super(Command, self).add_arguments(parser)
+
+    @staticmethod
+    def parse_arguments(*args, **options):  # pylint: disable=unused-argument
+        """
+        Parse and validate arguments for send_course_enrollments command.
+
+        Arguments:
+            *args: Positional arguments passed to the command
+            **options: optional arguments passed to the command
+
+        Returns:
+            A tuple containing parsed values for
+            1. days (int): Integer showing number of days to lookup enterprise enrollments,
+                course completion etc and send to xAPI LRS
+            2. enterprise_customer_uuid (EnterpriseCustomer): Enterprise Customer if present then
+                send xAPI statements just for this enterprise.
+        """
+        days = options.get('days', 1)
+        enterprise_customer_uuid = options.get('enterprise_customer_uuid')
+        enterprise_customer = None
+
+        if enterprise_customer_uuid:
+            try:
+                # pylint: disable=no-member
+                enterprise_customer = EnterpriseCustomer.objects.get(uuid=enterprise_customer_uuid)
+            except EnterpriseCustomer.DoesNotExist:
+                raise CommandError('Enterprise customer with uuid "{enterprise_customer_uuid}" does not exist.'.format(
+                    enterprise_customer_uuid=enterprise_customer_uuid
+                ))
+
+        return days, enterprise_customer
+
+    def handle(self, *args, **options):
+        """
+        Send xAPI statements.
+        """
+        if not CourseEnrollment:
+            raise NotConnectedToOpenEdX("This package must be installed in an OpenEdX environment.")
+
+        days, enterprise_customer = self.parse_arguments(*args, **options)
+
+        if enterprise_customer:
+            try:
+                lrs_configuration = XAPILRSConfiguration.objects.get(
+                    active=True,
+                    enterprise_customer=enterprise_customer
+                )
+            except XAPILRSConfiguration.DoesNotExist:
+                raise CommandError('No xAPI Configuration found for "{enterprise_customer}"'.format(
+                    enterprise_customer=enterprise_customer.name
+                ))
+
+            # Send xAPI analytics data to the configured LRS
+            self.send_xapi_statements(lrs_configuration, days)
+        else:
+            for lrs_configuration in XAPILRSConfiguration.objects.filter(active=True):
+                self.send_xapi_statements(lrs_configuration, days)
+
+    def send_xapi_statements(self, lrs_configuration, days):
+        """
+        Send xAPI analytics data of the enterprise learners to the given LRS.
+
+        Arguments:
+            lrs_configuration (XAPILRSConfiguration): Configuration object containing LRS configurations
+                of the LRS where to send xAPI  learner analytics.
+            days (int): Include course enrollment of this number of days.
+        """
+        for course_enrollment in self.get_course_enrollments(lrs_configuration.enterprise_customer, days):
+            try:
+                send_course_enrollment_statement(lrs_configuration, course_enrollment)
+            except ClientError:
+                LOGGER.exception(
+                    'Client error while sending course enrollment to xAPI for'
+                    ' enterprise customer {enterprise_customer}.'.format(
+                        enterprise_customer=lrs_configuration.enterprise_customer.name
+                    )
+                )
+
+    def get_course_enrollments(self, enterprise_customer, days):
+        """
+        Get course enrollments for all the learners of given enterprise customer.
+
+        Arguments:
+            enterprise_customer (EnterpriseCustomer): Include Course enrollments for learners
+                of this enterprise customer.
+            days (int): Include course enrollment of this number of days.
+
+        Returns:
+            (list): A list of CourseEnrollment objects.
+        """
+        return CourseEnrollment.objects.filter(
+            created__gt=datetime.datetime.now() - datetime.timedelta(days=days)
+        ).filter(
+            user_id__in=enterprise_customer.enterprise_customer_users.values_list('user_id', flat=True)
+        )

--- a/integrated_channels/xapi/statements/base.py
+++ b/integrated_channels/xapi/statements/base.py
@@ -44,7 +44,7 @@ class EnterpriseStatement(Statement):
         return Activity(
             id=X_API_ACTIVITY_COURSE,
             definition=ActivityDefinition(
-                name=LanguageMap({'en-US': name}),
-                description=LanguageMap({'en-US': description}),
+                name=LanguageMap({'en-US': (name or '').encode("ascii", "ignore").decode('ascii')}),
+                description=LanguageMap({'en-US': (description or '').encode("ascii", "ignore").decode('ascii')}),
             ),
         )

--- a/integrated_channels/xapi/utils.py
+++ b/integrated_channels/xapi/utils.py
@@ -7,6 +7,8 @@ Utility functions for xAPI.
 from __future__ import absolute_import, unicode_literals
 
 from integrated_channels.xapi.client import EnterpriseXAPIClient
+from integrated_channels.xapi.serializers import CourseInfoSerializer, LearnerInfoSerializer
+from integrated_channels.xapi.statements.learner_course_completion import LearnerCourseCompletionStatement
 from integrated_channels.xapi.statements.learner_course_enrollment import LearnerCourseEnrollmentStatement
 
 
@@ -18,5 +20,36 @@ def send_course_enrollment_statement(lrs_configuration, course_enrollment):
          lrs_configuration (XAPILRSConfiguration): XAPILRSConfiguration instance where to send statements.
          course_enrollment (CourseEnrollment): Course enrollment object.
     """
-    statement = LearnerCourseEnrollmentStatement(course_enrollment.user, course_enrollment.course, {}, {})
+    user_details = LearnerInfoSerializer(course_enrollment.user)
+    course_details = CourseInfoSerializer(course_enrollment.course)
+
+    statement = LearnerCourseEnrollmentStatement(
+        course_enrollment.user,
+        course_enrollment.course,
+        user_details.data,
+        course_details.data,
+    )
+    EnterpriseXAPIClient(lrs_configuration).save_statement(statement)
+
+
+def send_course_completion_statement(lrs_configuration, user, course_overview, course_grade):
+    """
+    Send xAPI statement for course completion.
+
+    Arguments:
+         lrs_configuration (XAPILRSConfiguration): XAPILRSConfiguration instance where to send statements.
+         user (User): Django User object.
+         course_overview (CourseOverview): Course over view object containing course details.
+         course_grade (CourseGrade): course grade object.
+    """
+    user_details = LearnerInfoSerializer(user)
+    course_details = CourseInfoSerializer(course_overview)
+
+    statement = LearnerCourseCompletionStatement(
+        user,
+        course_overview,
+        user_details.data,
+        course_details.data,
+        course_grade,
+    )
     EnterpriseXAPIClient(lrs_configuration).save_statement(statement)

--- a/test_utils/__init__.py
+++ b/test_utils/__init__.py
@@ -10,6 +10,7 @@ from __future__ import absolute_import, unicode_literals
 
 import copy
 import json
+import logging
 import uuid
 
 from django.conf import settings
@@ -275,8 +276,38 @@ class APITest(APITestCase):
 
         Returns:
             dict object containing parsed json from response.content
-
         """
         if isinstance(content, bytes):
             content = content.decode('utf-8')
         return json.loads(content)
+
+
+class MockLoggingHandler(logging.Handler):
+    """
+    Mock logging handler to help check for logging statements.
+    """
+
+    def __init__(self, *args, **kwargs):
+        """
+        Reset messages with each initialization.
+        """
+        self.reset()
+        logging.Handler.__init__(self, *args, **kwargs)
+
+    def emit(self, record):
+        """
+        Override to catch messages and store them messages in our internal dicts.
+        """
+        self.messages[record.levelname.lower()].append(record.getMessage())
+
+    def reset(self):
+        """
+        Clear out all messages, also called to initially populate messages dict.
+        """
+        self.messages = {
+            'debug': [],
+            'info': [],
+            'warning': [],
+            'error': [],
+            'critical': [],
+        }

--- a/tests/test_integrated_channels/test_utils.py
+++ b/tests/test_integrated_channels/test_utils.py
@@ -6,9 +6,11 @@ Tests for the utilities used by integration channels.
 from __future__ import absolute_import, unicode_literals, with_statement
 
 import unittest
+from datetime import timedelta
 
 import ddt
 import mock
+from pytest import raises
 
 from enterprise.api_client.lms import parse_lms_api_datetime
 from integrated_channels import utils
@@ -39,3 +41,55 @@ class TestIntegratedChannelsUtils(unittest.TestCase):
     @ddt.unpack
     def test_parse_datetime_to_epoch(self, iso8601, epoch):
         assert utils.parse_datetime_to_epoch_millis(iso8601) == epoch
+
+    @ddt.data(
+        (
+            timedelta(days=18, hours=7, minutes=19, seconds=26),
+            '{D:02}d {H:02}h {M:02}m {S:02}s',
+            'timedelta',
+            '18d 07h 19m 26s',
+        ),
+        (
+            18*24*60*60 + 7*60*60 + 19*60 + 26,  # seconds in 18d 7h 19m 26s
+            '{D:02}d {H:02}h {M:02}m {S:02}s',
+            'seconds',
+            '18d 07h 19m 26s',
+        ),
+        (
+            18*24*60 + 7*60 + 19,  # minutes in 18d 7h 19m
+            '{D:02}d {H:02}h {M:02}m',
+            'minutes',
+            '18d 07h 19m',
+        ),
+        (
+            18*24 + 7,  # hours in 18d 7h
+            '{D:02}d {H:02}h',
+            'hours',
+            '18d 07h',
+        ),
+        (
+            18,  # 18 days
+            '{D:02}d',
+            'days',
+            '18d',
+        ),
+        (
+            7,  # 7 weeks
+            '{D:02}d',
+            'weeks',
+            '49d',
+        ),
+        (
+            timedelta(days=18),
+            '{W} weeks {D} days.',
+            'timedelta',
+            '2 weeks 4 days.',
+        ),
+    )
+    @ddt.unpack
+    def test_strfdelta(self, duration, fmt, input_type, expected):
+        assert utils.strfdelta(duration, fmt, input_type) == expected
+
+    def test_strfdelta_value_error(self):
+        with raises(ValueError):
+            utils.strfdelta(timedelta(days=1), input_type='invalid_type')

--- a/tests/test_integrated_channels/test_xapi/test_commands/test_send_course_completions.py
+++ b/tests/test_integrated_channels/test_xapi/test_commands/test_send_course_completions.py
@@ -1,0 +1,250 @@
+# -*- coding: utf-8 -*-
+"""
+Test xAPI management command to send course completion data.
+"""
+
+from __future__ import absolute_import, unicode_literals
+
+import logging
+import unittest
+import uuid
+
+import mock
+from pytest import mark, raises
+
+from django.core.management import CommandError, call_command
+
+from enterprise.utils import NotConnectedToOpenEdX
+from integrated_channels.exceptions import ClientError
+from test_utils import MockLoggingHandler, factories
+
+
+@mark.django_db
+class TestSendCourseCompletions(unittest.TestCase):
+    """
+    Tests for the ``send_course_completions`` management command.
+    """
+
+    @mock.patch(
+        'integrated_channels.xapi.management.commands.send_course_completions.PersistentCourseGrade',
+        mock.MagicMock()
+    )
+    @mock.patch(
+        'integrated_channels.xapi.management.commands.send_course_completions.CourseGradeFactory',
+        mock.MagicMock()
+    )
+    @mock.patch(
+        'integrated_channels.xapi.management.commands.send_course_completions.CourseOverview',
+        mock.MagicMock()
+    )
+    def test_parse_arguments(self):
+        """
+        Make sure command runs only when correct arguments are passed.
+        """
+        enterprise_uuid = str(uuid.uuid4())
+        # Make sure CommandError is raised when enterprise customer with given uuid does not exist.
+        with raises(
+            CommandError,
+            match='Enterprise customer with uuid "{enterprise_customer_uuid}" '
+                  'does not exist.'.format(enterprise_customer_uuid=enterprise_uuid)
+        ):
+            call_command('send_course_completions', days=1, enterprise_customer_uuid=enterprise_uuid)
+
+    @mock.patch(
+        'integrated_channels.xapi.management.commands.send_course_completions.PersistentCourseGrade',
+        mock.MagicMock()
+    )
+    @mock.patch(
+        'integrated_channels.xapi.management.commands.send_course_completions.CourseGradeFactory',
+        mock.MagicMock()
+    )
+    @mock.patch(
+        'integrated_channels.xapi.management.commands.send_course_completions.CourseOverview',
+        mock.MagicMock()
+    )
+    def test_error_for_missing_lrs_configuration(self):
+        """
+        Make sure CommandError is raised if XAPILRSConfiguration does not exis for the given enterprise customer.
+        """
+        enterprise_customer = factories.EnterpriseCustomerFactory()
+        with raises(
+            CommandError,
+            match='No xAPI Configuration found for '
+                  '"{enterprise_customer}"'.format(enterprise_customer=enterprise_customer.name)
+        ):
+            call_command('send_course_completions', days=1, enterprise_customer_uuid=enterprise_customer.uuid)
+
+    @mock.patch(
+        'integrated_channels.xapi.management.commands.send_course_completions.CourseGradeFactory',
+        mock.MagicMock()
+    )
+    @mock.patch(
+        'integrated_channels.xapi.management.commands.send_course_completions.send_course_completion_statement',
+        mock.MagicMock()
+    )
+    @mock.patch(
+        'integrated_channels.xapi.management.commands.send_course_completions.CourseOverview',
+        mock.MagicMock()
+    )
+    def test_get_course_completions(self):
+        """
+        Make sure NotConnectedToOpenEdX is raised when enterprise app is not installed in Open edX environment.
+        """
+        xapi_config = factories.XAPILRSConfigurationFactory()
+        with raises(
+            NotConnectedToOpenEdX,
+            match='This package must be installed in an OpenEdX environment.'
+        ):
+            call_command(
+                'send_course_completions',
+                days=1,
+                enterprise_customer_uuid=xapi_config.enterprise_customer.uuid,
+            )
+
+        # Verify that get_course_completions returns PersistentCourseGrade records
+        with mock.patch(
+            'integrated_channels.xapi.management.commands.send_course_completions.PersistentCourseGrade'
+        ) as mock_completions:
+            call_command('send_course_completions')
+            assert mock_completions.objects.filter.called
+
+    def test_prefetch_users(self):
+        """
+        Make sure prefetch_users method works as expected.
+        """
+        # Import is placed here because if placed at the top it affects mocking.
+        from integrated_channels.xapi.management.commands.send_course_completions import Command
+
+        user = factories.UserFactory()
+        expected = {user.id: user}
+        assert Command.prefetch_users([mock.Mock(user_id=user.id)]) == expected
+
+    @mock.patch(
+        'integrated_channels.xapi.management.commands.send_course_completions.CourseGradeFactory',
+        mock.MagicMock()
+    )
+    @mock.patch(
+        'integrated_channels.xapi.management.commands.send_course_completions.PersistentCourseGrade',
+        mock.MagicMock()
+    )
+    @mock.patch(
+        'integrated_channels.xapi.management.commands.send_course_completions.CourseOverview',
+        mock.MagicMock()
+    )
+    @mock.patch(
+        'integrated_channels.xapi.management.commands.send_course_completions.User',
+        mock.MagicMock()
+    )
+    @mock.patch(
+        'integrated_channels.xapi.management.commands.send_course_completions.Command.get_course_completions',
+        mock.MagicMock(return_value=[mock.MagicMock()])
+    )
+    @mock.patch(
+        'integrated_channels.xapi.management.commands.send_course_completions.send_course_completion_statement',
+        mock.Mock(side_effect=ClientError('EnterpriseXAPIClient request failed.'))
+    )
+    def test_command_client_error(self):
+        """
+        Make command handles networking issues gracefully.
+        """
+        logger = logging.getLogger('integrated_channels.xapi.management.commands.send_course_completions')
+        handler = MockLoggingHandler(level="DEBUG")
+        logger.addHandler(handler)
+
+        xapi_config = factories.XAPILRSConfigurationFactory()
+        call_command('send_course_completions', enterprise_customer_uuid=xapi_config.enterprise_customer.uuid)
+        expected_message = (
+            'Client error while sending course completion to xAPI for enterprise '
+            'customer {enterprise_customer}.'.format(enterprise_customer=xapi_config.enterprise_customer.name)
+        )
+
+        assert handler.messages['error'][0] == expected_message
+
+    @mock.patch(
+        'integrated_channels.xapi.management.commands.send_course_completions.CourseOverview',
+        mock.MagicMock()
+    )
+    @mock.patch(
+        'integrated_channels.xapi.management.commands.send_course_completions.Command.get_course_completions',
+        mock.MagicMock(return_value=[mock.MagicMock()])
+    )
+    @mock.patch(
+        'integrated_channels.xapi.management.commands.send_course_completions.send_course_completion_statement',
+        mock.Mock(side_effect=ClientError('EnterpriseXAPIClient request failed.'))
+    )
+    def test_command_grade_factory(self):
+        """
+        Make sure NotConnectedToOpenEdX is raised when enterprise app is not installed in Open edX environment.
+        """
+        # Make sure NotConnectedToOpenEdX is raised if called out side of edx-platform
+        xapi_config = factories.XAPILRSConfigurationFactory()
+        with raises(
+            NotConnectedToOpenEdX,
+            match='This package must be installed in an OpenEdX environment.'
+        ):
+            call_command(
+                'send_course_completions',
+                enterprise_customer_uuid=xapi_config.enterprise_customer.uuid,
+            )
+
+    @mock.patch(
+        'integrated_channels.xapi.management.commands.send_course_completions.PersistentCourseGrade',
+        mock.MagicMock()
+    )
+    @mock.patch(
+        'integrated_channels.xapi.management.commands.send_course_completions.CourseGradeFactory',
+        mock.MagicMock()
+    )
+    @mock.patch(
+        'integrated_channels.xapi.management.commands.send_course_completions.CourseOverview',
+        mock.MagicMock()
+    )
+    @mock.patch(
+        'integrated_channels.xapi.management.commands.send_course_completions.User',
+        mock.MagicMock()
+    )
+    # pylint: disable=invalid-name
+    @mock.patch(
+        'integrated_channels.xapi.management.commands.send_course_completions.Command.get_course_completions',
+        mock.MagicMock(return_value=[mock.MagicMock()])
+    )
+    @mock.patch('integrated_channels.xapi.management.commands.send_course_completions.send_course_completion_statement')
+    def test_command(self, mock_send_course_completion_statement):
+        """
+        Make command runs successfully and sends correct data to the LRS.
+        """
+        xapi_config = factories.XAPILRSConfigurationFactory()
+        call_command('send_course_completions', enterprise_customer_uuid=xapi_config.enterprise_customer.uuid)
+
+        assert mock_send_course_completion_statement.called
+
+    @mock.patch(
+        'integrated_channels.xapi.management.commands.send_course_completions.PersistentCourseGrade',
+        mock.MagicMock()
+    )
+    @mock.patch(
+        'integrated_channels.xapi.management.commands.send_course_completions.CourseGradeFactory',
+        mock.MagicMock()
+    )
+    @mock.patch(
+        'integrated_channels.xapi.management.commands.send_course_completions.CourseOverview',
+        mock.MagicMock()
+    )
+    @mock.patch(
+        'integrated_channels.xapi.management.commands.send_course_completions.User',
+        mock.MagicMock()
+    )
+    # pylint: disable=invalid-name
+    @mock.patch(
+        'integrated_channels.xapi.management.commands.send_course_completions.Command.get_course_completions',
+        mock.MagicMock(return_value=[mock.MagicMock()])
+    )
+    @mock.patch('integrated_channels.xapi.management.commands.send_course_completions.send_course_completion_statement')
+    def test_command_once_for_all_customers(self, mock_send_course_completion_statement):
+        """
+        Make command runs successfully and sends correct data to the LRS.
+        """
+        factories.XAPILRSConfigurationFactory.create_batch(5)
+        call_command('send_course_completions')
+
+        assert mock_send_course_completion_statement.call_count == 5

--- a/tests/test_integrated_channels/test_xapi/test_commands/test_send_course_enrollments.py
+++ b/tests/test_integrated_channels/test_xapi/test_commands/test_send_course_enrollments.py
@@ -1,0 +1,152 @@
+# -*- coding: utf-8 -*-
+"""
+Test xAPI management command to send course enrollments data.
+"""
+
+from __future__ import absolute_import, unicode_literals
+
+import logging
+import unittest
+import uuid
+
+import mock
+from pytest import mark, raises
+
+from django.core.management import CommandError, call_command
+
+from enterprise.utils import NotConnectedToOpenEdX
+from integrated_channels.exceptions import ClientError
+from test_utils import MockLoggingHandler, factories
+
+
+@mark.django_db
+class TestSendCourseEnrollments(unittest.TestCase):
+    """
+    Tests for the ``send_course_enrollments`` management command.
+    """
+
+    @mock.patch(
+        'integrated_channels.xapi.management.commands.send_course_enrollments.CourseEnrollment',
+        mock.MagicMock()
+    )
+    def test_parse_arguments(self):
+        """
+        Make sure command runs only when correct arguments are passed.
+        """
+        enterprise_uuid = str(uuid.uuid4())
+        # Make sure CommandError is raised when enterprise customer with given uuid does not exist.
+        with raises(
+            CommandError,
+            match='Enterprise customer with uuid "{enterprise_customer_uuid}" '
+                  'does not exist.'.format(enterprise_customer_uuid=enterprise_uuid)
+        ):
+            call_command('send_course_enrollments', days=1, enterprise_customer_uuid=enterprise_uuid)
+
+    @mock.patch(
+        'integrated_channels.xapi.management.commands.send_course_enrollments.CourseEnrollment',
+        mock.MagicMock()
+    )
+    def test_error_for_missing_lrs_configuration(self):
+        """
+        Make sure CommandError is raised if XAPILRSConfiguration does not exis for the given enterprise customer.
+        """
+        enterprise_customer = factories.EnterpriseCustomerFactory()
+        with raises(
+            CommandError,
+            match='No xAPI Configuration found for '
+                  '"{enterprise_customer}"'.format(enterprise_customer=enterprise_customer.name)
+        ):
+            call_command('send_course_enrollments', days=1, enterprise_customer_uuid=enterprise_customer.uuid)
+
+    @mock.patch(
+        'integrated_channels.xapi.management.commands.send_course_enrollments.send_course_enrollment_statement',
+        mock.MagicMock()
+    )
+    def test_get_course_enrollments(self):
+        """
+        Make sure NotConnectedToOpenEdX is raised when enterprise app is not installed in Open edX environment.
+        """
+        xapi_config = factories.XAPILRSConfigurationFactory()
+        with raises(
+            NotConnectedToOpenEdX,
+            match='This package must be installed in an OpenEdX environment.'
+        ):
+            call_command(
+                'send_course_enrollments',
+                days=1,
+                enterprise_customer_uuid=xapi_config.enterprise_customer.uuid,
+            )
+
+        # Verify that get_course_enrollments returns CourseEnrollment records
+        with mock.patch(
+            'integrated_channels.xapi.management.commands.send_course_enrollments.CourseEnrollment'
+        ) as mock_enrollments:
+            call_command('send_course_enrollments')
+            assert mock_enrollments.objects.filter.called
+
+    @mock.patch(
+        'integrated_channels.xapi.management.commands.send_course_enrollments.CourseEnrollment',
+        mock.MagicMock()
+    )
+    # pylint: disable=invalid-name
+    @mock.patch(
+        'integrated_channels.xapi.management.commands.send_course_enrollments.Command.get_course_enrollments',
+        mock.MagicMock(return_value=[mock.MagicMock()])
+    )
+    @mock.patch('integrated_channels.xapi.management.commands.send_course_enrollments.send_course_enrollment_statement')
+    def test_command(self, mock_send_course_enrollment_statement):
+        """
+        Make command runs successfully and sends correct data to the LRS.
+        """
+        xapi_config = factories.XAPILRSConfigurationFactory()
+        call_command('send_course_enrollments', enterprise_customer_uuid=xapi_config.enterprise_customer.uuid)
+
+        assert mock_send_course_enrollment_statement.called
+
+    @mock.patch(
+        'integrated_channels.xapi.management.commands.send_course_enrollments.CourseEnrollment',
+        mock.MagicMock()
+    )
+    @mock.patch(
+        'integrated_channels.xapi.management.commands.send_course_enrollments.Command.get_course_enrollments',
+        mock.MagicMock(return_value=[mock.MagicMock()])
+    )
+    @mock.patch(
+        'integrated_channels.xapi.management.commands.send_course_enrollments.send_course_enrollment_statement',
+        mock.Mock(side_effect=ClientError('EnterpriseXAPIClient request failed.'))
+    )
+    def test_command_client_error(self):
+        """
+        Make command handles networking issues gracefully.
+        """
+        logger = logging.getLogger('integrated_channels.xapi.management.commands.send_course_enrollments')
+        handler = MockLoggingHandler(level="DEBUG")
+        logger.addHandler(handler)
+
+        xapi_config = factories.XAPILRSConfigurationFactory()
+        call_command('send_course_enrollments', enterprise_customer_uuid=xapi_config.enterprise_customer.uuid)
+        expected_message = (
+            'Client error while sending course enrollment to xAPI for enterprise '
+            'customer {enterprise_customer}.'.format(enterprise_customer=xapi_config.enterprise_customer.name)
+        )
+
+        assert handler.messages['error'][0] == expected_message
+
+    @mock.patch(
+        'integrated_channels.xapi.management.commands.send_course_enrollments.CourseEnrollment',
+        mock.MagicMock()
+    )
+    # pylint: disable=invalid-name
+    @mock.patch(
+        'integrated_channels.xapi.management.commands.send_course_enrollments.Command.get_course_enrollments',
+        mock.MagicMock(return_value=[mock.MagicMock()])
+    )
+    @mock.patch('integrated_channels.xapi.management.commands.send_course_enrollments.send_course_enrollment_statement')
+    def test_command_once_for_all_customers(self, mock_send_course_enrollment_statement):
+        """
+        Make command runs successfully and sends correct data to the LRS.
+        """
+        factories.XAPILRSConfigurationFactory.create_batch(5)
+        call_command('send_course_enrollments')
+
+        assert mock_send_course_enrollment_statement.call_count == 5

--- a/tests/test_integrated_channels/test_xapi/test_utils.py
+++ b/tests/test_integrated_channels/test_xapi/test_utils.py
@@ -6,13 +6,14 @@ Test for xAPI utility functions.
 from __future__ import absolute_import, unicode_literals
 
 import unittest
+from datetime import datetime, timedelta
 
 import mock
 from faker import Factory as FakerFactory
 from pytest import mark
 
 from integrated_channels.xapi.client import EnterpriseXAPIClient
-from integrated_channels.xapi.utils import send_course_enrollment_statement
+from integrated_channels.xapi.utils import send_course_completion_statement, send_course_enrollment_statement
 from test_utils import factories
 
 
@@ -24,12 +25,26 @@ class TestUtils(unittest.TestCase):
 
     def setUp(self):
         super(TestUtils, self).setUp()
-        faker = FakerFactory.create()
+        self.faker = FakerFactory.create()
 
         self.user = factories.UserFactory()
+        self.user.profile = mock.Mock(country=mock.Mock(code='PK'))
+
+        now = datetime.now()
         # pylint: disable=no-member
-        self.course_overview = mock.Mock(display_name=faker.text(max_nb_chars=25), short_description=faker.text())
+        self.course_overview_mock_data = dict(
+            id=self.faker.text(max_nb_chars=25),  # pylint: disable=no-member
+            display_name=self.faker.text(max_nb_chars=25),  # pylint: disable=no-member
+            short_description=self.faker.text(),  # pylint: disable=no-member
+            marketing_url=self.faker.url(),  # pylint: disable=no-member
+            effort=self.faker.text(max_nb_chars=10),  # pylint: disable=no-member
+            start=now,
+            end=now + timedelta(weeks=3, days=4),
+        )
+        self.course_overview = mock.Mock(**self.course_overview_mock_data)
+
         self.course_enrollment = mock.Mock(user=self.user, course=self.course_overview)
+        self.course_grade = mock.Mock(percent=0.80, passed=True)
 
         self.x_api_lrs_config = factories.XAPILRSConfigurationFactory()
         self.x_api_client = EnterpriseXAPIClient(self.x_api_lrs_config)
@@ -37,8 +52,22 @@ class TestUtils(unittest.TestCase):
     @mock.patch('integrated_channels.xapi.client.RemoteLRS', mock.MagicMock())
     def test_send_course_enrollment_statement(self):
         """
-        Verify that send_course_enrollment_statement sends XAPI statement to LRS.
+        Verify that send_course_enrollment_statement sends xAPI statement to LRS.
         """
         send_course_enrollment_statement(self.x_api_lrs_config, self.course_enrollment)
+
+        self.x_api_client.lrs.save_statement.assert_called()  # pylint: disable=no-member
+
+    @mock.patch('integrated_channels.xapi.client.RemoteLRS', mock.MagicMock())
+    def test_send_course_completion_statement(self):
+        """
+        Verify that send_course_completion_statement sends xAPI statement to LRS.
+        """
+        send_course_completion_statement(
+            self.x_api_lrs_config,
+            self.user,
+            self.course_overview,
+            self.course_grade,
+        )
 
         self.x_api_client.lrs.save_statement.assert_called()  # pylint: disable=no-member


### PR DESCRIPTION
**Description:** 

Write management commands to send xAPI statements.
These management commands would iterate through all xAPI configurations and be sending learner enrollment and course completion data for each configuration and its associated enterprise customer.

**JIRA:** [ENT-1082](https://openedx.atlassian.net/browse/ENT-1082)

**Merge checklist:**

- [x] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [x] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [x] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [x] Called `make static` for webpack bundling if any static content was updated.
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [x] Translations are updated
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)
