### PR TITLE
ENT-1135 Move fields from DegreedGlobalConfiguration to DegreedEnterpriseCustomerConfig

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.72.4] - 2018-08-08
+---------------------
+
+* Move some fields from Global Degreed Configuration to Enterprise Degreed Configuration.
+
 [0.72.3] - 2018-08-08
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.72.3"
+__version__ = "0.72.4"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/degreed/admin/__init__.py
+++ b/integrated_channels/degreed/admin/__init__.py
@@ -17,13 +17,9 @@ class DegreedGlobalConfigurationAdmin(ConfigurationModelAdmin):
     """
 
     list_display = (
-        "degreed_base_url",
         "completion_status_api_path",
         "course_api_path",
         "oauth_api_path",
-        "degreed_user_id",
-        "degreed_user_password",
-        "provider_id",
     )
 
     class Meta(object):
@@ -42,6 +38,10 @@ class DegreedEnterpriseCustomerConfigurationAdmin(admin.ModelAdmin):
         "key",
         "secret",
         "degreed_company_id",
+        "degreed_base_url",
+        "degreed_user_id",
+        "degreed_user_password",
+        "provider_id",
     )
 
     readonly_fields = (

--- a/integrated_channels/degreed/client.py
+++ b/integrated_channels/degreed/client.py
@@ -57,7 +57,10 @@ class DegreedAPIClient(IntegratedChannelApiClient):
             HTTPError: if we received a failure response code from Degreed
         """
         return self._post(
-            urljoin(self.global_degreed_config.degreed_base_url, self.global_degreed_config.completion_status_api_path),
+            urljoin(
+                self.enterprise_configuration.degreed_base_url,
+                self.global_degreed_config.completion_status_api_path
+            ),
             payload,
             self.COMPLETION_PROVIDER_SCOPE
         )
@@ -77,7 +80,10 @@ class DegreedAPIClient(IntegratedChannelApiClient):
             HTTPError: if we received a failure response code from Degreed
         """
         return self._delete(
-            urljoin(self.global_degreed_config.degreed_base_url, self.global_degreed_config.completion_status_api_path),
+            urljoin(
+                self.enterprise_configuration.degreed_base_url,
+                self.global_degreed_config.completion_status_api_path
+            ),
             payload,
             self.COMPLETION_PROVIDER_SCOPE
         )
@@ -131,7 +137,7 @@ class DegreedAPIClient(IntegratedChannelApiClient):
         """
         try:
             status_code, response_body = getattr(self, '_' + http_method)(
-                urljoin(self.global_degreed_config.degreed_base_url, self.global_degreed_config.course_api_path),
+                urljoin(self.enterprise_configuration.degreed_base_url, self.global_degreed_config.course_api_path),
                 serialized_data,
                 self.CONTENT_PROVIDER_SCOPE
             )
@@ -193,8 +199,8 @@ class DegreedAPIClient(IntegratedChannelApiClient):
             oauth_access_token, expires_at = self._get_oauth_access_token(
                 self.enterprise_configuration.key,
                 self.enterprise_configuration.secret,
-                self.global_degreed_config.degreed_user_id,
-                self.global_degreed_config.degreed_user_password,
+                self.enterprise_configuration.degreed_user_id,
+                self.enterprise_configuration.degreed_user_password,
                 scope
             )
             session = requests.Session()
@@ -223,7 +229,7 @@ class DegreedAPIClient(IntegratedChannelApiClient):
             RequestException: If an unexpected response format was received that we could not parse.
         """
         response = requests.post(
-            urljoin(self.global_degreed_config.degreed_base_url, self.global_degreed_config.oauth_api_path),
+            urljoin(self.enterprise_configuration.degreed_base_url, self.global_degreed_config.oauth_api_path),
             data={
                 'grant_type': 'password',
                 'username': user_id,

--- a/integrated_channels/degreed/migrations/0005_auto_20180807_1302.py
+++ b/integrated_channels/degreed/migrations/0005_auto_20180807_1302.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('degreed', '0004_auto_20180306_1251'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='degreedglobalconfiguration',
+            name='degreed_base_url',
+        ),
+        migrations.RemoveField(
+            model_name='degreedglobalconfiguration',
+            name='degreed_user_id',
+        ),
+        migrations.RemoveField(
+            model_name='degreedglobalconfiguration',
+            name='degreed_user_password',
+        ),
+        migrations.RemoveField(
+            model_name='degreedglobalconfiguration',
+            name='provider_id',
+        ),
+        migrations.AddField(
+            model_name='degreedenterprisecustomerconfiguration',
+            name='degreed_base_url',
+            field=models.CharField(help_text='The base URL used for API requests to Degreed, i.e. https://degreed.com.', max_length=255, verbose_name='Degreed Base URL', blank=True),
+        ),
+        migrations.AddField(
+            model_name='degreedenterprisecustomerconfiguration',
+            name='degreed_user_id',
+            field=models.CharField(help_text='The Degreed User ID provided to the content provider by Degreed. It is required for getting the OAuth access token.', max_length=255, verbose_name='Degreed User ID', blank=True),
+        ),
+        migrations.AddField(
+            model_name='degreedenterprisecustomerconfiguration',
+            name='degreed_user_password',
+            field=models.CharField(help_text='The Degreed User Password provided to the content provider by Degreed. It is required for getting the OAuth access token.', max_length=255, verbose_name='Degreed User Password', blank=True),
+        ),
+        migrations.AddField(
+            model_name='degreedenterprisecustomerconfiguration',
+            name='provider_id',
+            field=models.CharField(default='EDX', help_text='The provider code that Degreed gives to the content provider.', max_length=100, verbose_name='Provider Code'),
+        ),
+        migrations.AddField(
+            model_name='historicaldegreedenterprisecustomerconfiguration',
+            name='degreed_base_url',
+            field=models.CharField(help_text='The base URL used for API requests to Degreed, i.e. https://degreed.com.', max_length=255, verbose_name='Degreed Base URL', blank=True),
+        ),
+        migrations.AddField(
+            model_name='historicaldegreedenterprisecustomerconfiguration',
+            name='degreed_user_id',
+            field=models.CharField(help_text='The Degreed User ID provided to the content provider by Degreed. It is required for getting the OAuth access token.', max_length=255, verbose_name='Degreed User ID', blank=True),
+        ),
+        migrations.AddField(
+            model_name='historicaldegreedenterprisecustomerconfiguration',
+            name='degreed_user_password',
+            field=models.CharField(help_text='The Degreed User Password provided to the content provider by Degreed. It is required for getting the OAuth access token.', max_length=255, verbose_name='Degreed User Password', blank=True),
+        ),
+        migrations.AddField(
+            model_name='historicaldegreedenterprisecustomerconfiguration',
+            name='provider_id',
+            field=models.CharField(default='EDX', help_text='The provider code that Degreed gives to the content provider.', max_length=100, verbose_name='Provider Code'),
+        ),
+    ]

--- a/integrated_channels/degreed/models.py
+++ b/integrated_channels/degreed/models.py
@@ -29,12 +29,6 @@ class DegreedGlobalConfiguration(ConfigurationModel):
     The global configuration for integrating with Degreed.
     """
 
-    degreed_base_url = models.CharField(
-        max_length=255,
-        verbose_name="Degreed Base URL",
-        help_text="The base URL used for API requests to Degreed, i.e. https://degreed.com."
-    )
-
     completion_status_api_path = models.CharField(
         max_length=255,
         verbose_name="Completion Status API Path",
@@ -54,33 +48,6 @@ class DegreedGlobalConfiguration(ConfigurationModel):
             "The API path for making OAuth-related POST requests to Degreed. "
             "This will be used to gain the OAuth access token which is required for other API calls."
         )
-    )
-
-    degreed_user_id = models.CharField(
-        max_length=255,
-        blank=True,
-        verbose_name="Degreed User ID",
-        help_text=(
-            "The Degreed User ID provided to the content provider by Degreed. "
-            "It is required for getting the OAuth access token."
-        )
-    )
-
-    degreed_user_password = models.CharField(
-        max_length=255,
-        blank=True,
-        verbose_name="Degreed User Password",
-        help_text=(
-            "The Degreed User Password provided to the content provider by Degreed. "
-            "It is required for getting the OAuth access token."
-        )
-    )
-
-    provider_id = models.CharField(
-        max_length=100,
-        default='EDX',
-        verbose_name="Provider Code",
-        help_text="The provider code that Degreed gives to the content provider."
     )
 
     class Meta:
@@ -132,6 +99,40 @@ class DegreedEnterpriseCustomerConfiguration(EnterpriseCustomerPluginConfigurati
         help_text="The organization code provided to the enterprise customer by Degreed."
     )
 
+    degreed_base_url = models.CharField(
+        max_length=255,
+        blank=True,
+        verbose_name="Degreed Base URL",
+        help_text="The base URL used for API requests to Degreed, i.e. https://degreed.com."
+    )
+
+    degreed_user_id = models.CharField(
+        max_length=255,
+        blank=True,
+        verbose_name="Degreed User ID",
+        help_text=(
+            "The Degreed User ID provided to the content provider by Degreed. "
+            "It is required for getting the OAuth access token."
+        )
+    )
+
+    degreed_user_password = models.CharField(
+        max_length=255,
+        blank=True,
+        verbose_name="Degreed User Password",
+        help_text=(
+            "The Degreed User Password provided to the content provider by Degreed. "
+            "It is required for getting the OAuth access token."
+        )
+    )
+
+    provider_id = models.CharField(
+        max_length=100,
+        default='EDX',
+        verbose_name="Provider Code",
+        help_text="The provider code that Degreed gives to the content provider."
+    )
+
     history = HistoricalRecords()
 
     class Meta(object):
@@ -157,13 +158,6 @@ class DegreedEnterpriseCustomerConfiguration(EnterpriseCustomerPluginConfigurati
         Returns an capitalized identifier for this channel class, unique among subclasses.
         """
         return 'DEGREED'
-
-    @property
-    def provider_id(self):
-        '''
-        Fetch ``provider_id`` from global configuration settings
-        '''
-        return DegreedGlobalConfiguration.current().provider_id
 
     def get_learner_data_transmitter(self):
         """

--- a/test_utils/factories.py
+++ b/test_utils/factories.py
@@ -445,13 +445,9 @@ class DegreedGlobalConfigurationFactory(factory.django.DjangoModelFactory):
         model = DegreedGlobalConfiguration
 
     id = factory.LazyAttribute(lambda x: FAKER.random_int(min=1))
-    degreed_base_url = factory.LazyAttribute(lambda x: FAKER.file_path())
     completion_status_api_path = factory.LazyAttribute(lambda x: FAKER.file_path())
     course_api_path = factory.LazyAttribute(lambda x: FAKER.file_path())
     oauth_api_path = factory.LazyAttribute(lambda x: FAKER.file_path())
-    degreed_user_id = factory.LazyAttribute(lambda x: FAKER.user_name())
-    degreed_user_password = factory.LazyAttribute(lambda x: FAKER.word())
-    provider_id = 'DEGREED'
 
 
 class DegreedEnterpriseCustomerConfigurationFactory(factory.django.DjangoModelFactory):
@@ -471,6 +467,10 @@ class DegreedEnterpriseCustomerConfigurationFactory(factory.django.DjangoModelFa
     enterprise_customer = factory.SubFactory(EnterpriseCustomerFactory)
     active = True
     degreed_company_id = factory.LazyAttribute(lambda x: FAKER.company())
+    degreed_base_url = factory.LazyAttribute(lambda x: FAKER.file_path())
+    degreed_user_id = factory.LazyAttribute(lambda x: FAKER.user_name())
+    degreed_user_password = factory.LazyAttribute(lambda x: FAKER.word())
+    provider_id = 'DEGREED'
 
 
 class DegreedLearnerDataTransmissionAuditFactory(factory.django.DjangoModelFactory):

--- a/tests/test_integrated_channels/test_degreed/test_client.py
+++ b/tests/test_integrated_channels/test_degreed/test_client.py
@@ -50,17 +50,17 @@ class TestDegreedApiClient(unittest.TestCase):
         self.access_token = "access_token"
         self.expected_token_response_body = {"expires_in": self.expires_in, "access_token": self.access_token}
         factories.DegreedGlobalConfigurationFactory(
-            degreed_base_url=self.url_base,
             completion_status_api_path=self.completion_status_api_path,
             course_api_path=self.course_api_path,
             oauth_api_path=self.oauth_api_path,
-            degreed_user_id=self.user_id,
-            degreed_user_password=self.user_pass,
         )
         self.enterprise_config = factories.DegreedEnterpriseCustomerConfigurationFactory(
             key=self.client_id,
             secret=self.client_secret,
             degreed_company_id=self.company_id,
+            degreed_base_url=self.url_base,
+            degreed_user_id=self.user_id,
+            degreed_user_password=self.user_pass,
         )
 
     @responses.activate

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -76,9 +76,7 @@ class TestTransmitCourseMetadataManagementCommand(unittest.TestCase, EnterpriseM
             enterprise_customer=self.enterprise_customer,
             key='key',
             secret='secret',
-            degreed_company_id='Degreed Company'
-        )
-        self.degreed_global_configuration = factories.DegreedGlobalConfigurationFactory(
+            degreed_company_id='Degreed Company',
             degreed_base_url='https://www.degreed.com/',
         )
         self.sapsf = factories.SAPSuccessFactorsEnterpriseCustomerConfigurationFactory(
@@ -158,6 +156,7 @@ class TestTransmitCourseMetadataManagementCommand(unittest.TestCase, EnterpriseM
             key='key',
             secret='secret',
             degreed_company_id='Degreed Company',
+            degreed_base_url='https://www.degreed.com/',
             active=True,
         )
         dummy_sapsf = factories.SAPSuccessFactorsEnterpriseCustomerConfigurationFactory(
@@ -439,9 +438,9 @@ class TestTransmitLearnerData(unittest.TestCase):
             secret='secret',
             degreed_company_id='Degreed Company',
             active=True,
+            degreed_base_url='https://www.degreed.com/',
         )
         self.degreed_global_configuration = factories.DegreedGlobalConfigurationFactory(
-            degreed_base_url='https://www.degreed.com/',
             oauth_api_path='oauth/token',
         )
         self.sapsf = factories.SAPSuccessFactorsEnterpriseCustomerConfigurationFactory(


### PR DESCRIPTION
**Description:** Some of the fields we placed on the global configuration can change from customer to customer, so they need to be moved to the customer specific configuration.

**JIRA:** https://openedx.atlassian.net/browse/ENT-1135

**Dependencies:** n/a

**Merge deadline:** ASAP

**Installation instructions:** 

**Testing instructions:**
On the sandbox, change the catalog query of the Degreed catalog, so that a different set of courses are in the catalog. Check the integrated_channel_contentmetadataitemtransmission table to see what content has been transmitted already to Degreed.

Run the transmit course metadata command:
`$ ./manage.py lms --settings=aws transmit_content_metadata --catalog_user=staff`

Inspect the integrated_channel_contentmetadataitemtransmission table to see that courses have been added or removed as expected.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
