### PR TITLE
ENT-1149: Include all potentially-applicable enrollment records in management command query

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.72.5] - 2018-08-09
+---------------------
+
+* Revise management command query to include all potentially-applicable enrollment records
+
 [0.72.4] - 2018-08-08
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.72.4"
+__version__ = "0.72.5"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name


### PR DESCRIPTION
ENT-1149: Include all potentially-applicable enrollment records in management command query

**Description:** Revises query to better-match CourseEnrollment records which should have corresponding EnterpriseCourseEnrollment records, but do not.

**JIRA:** https://openedx.atlassian.net/browse/ENT-1149

**Testing instructions:**

1. Connect to read replica database
2. Run the original query
3. Run the new query
4. Observe recordset that is orders of magnitude larger for new query vs. old query
5. Decide if new query is returning more accurate results vs. old query

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Commits are (reasonably) squashed
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)