### PR TITLE
Include EnterpriseCustomer name in branding configuration

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.72.6] - 2018-08-10
+---------------------
+
+* Add the `EnterpriseCustomer`'s name to the `/enterprise-customer-branding` endpoint.
+
 [0.72.5] - 2018-08-09
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.72.5"
+__version__ = "0.72.6"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -82,16 +82,23 @@ class EnterpriseCustomerBrandingConfigurationSerializer(serializers.ModelSeriali
     class Meta:
         model = models.EnterpriseCustomerBrandingConfiguration
         fields = (
-            'enterprise_customer', 'enterprise_slug', 'logo'
+            'enterprise_customer', 'enterprise_slug', 'logo', 'enterprise_name',
         )
 
     enterprise_slug = serializers.SerializerMethodField()
+    enterprise_name = serializers.SerializerMethodField()
 
     def get_enterprise_slug(self, obj):
         """
         Return the slug of the associated enterprise customer.
         """
         return obj.enterprise_customer.slug
+
+    def get_enterprise_name(self, obj):
+        """
+        Return the name of the associated enterprise customer.
+        """
+        return obj.enterprise_customer.name
 
 
 class EnterpriseCustomerEntitlementSerializer(serializers.ModelSerializer):

--- a/test_utils/__init__.py
+++ b/test_utils/__init__.py
@@ -39,6 +39,7 @@ TEST_COURSE_KEY = 'edX+DemoX'
 TEST_UUID = 'd2098bfb-2c78-44f1-9eb2-b94475356a3f'
 TEST_USER_ID = 1
 TEST_SLUG = 'test-enterprise-customer'
+TEST_ENTERPRISE_NAME = 'Test Enterprise Customer'
 
 
 def get_magic_name(value):

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -37,6 +37,7 @@ from test_utils import (
     FAKE_UUIDS,
     TEST_COURSE,
     TEST_COURSE_KEY,
+    TEST_ENTERPRISE_NAME,
     TEST_PASSWORD,
     TEST_SLUG,
     TEST_USERNAME,
@@ -224,7 +225,7 @@ class TestEnterpriseAPIViews(APITest):
                 [{
                     'id': 1, 'user_id': 0,
                     'enterprise_customer__uuid': FAKE_UUIDS[0],
-                    'enterprise_customer__name': 'Test Enterprise Customer', 'enterprise_customer__catalog': 1,
+                    'enterprise_customer__name': TEST_ENTERPRISE_NAME, 'enterprise_customer__catalog': 1,
                     'enterprise_customer__active': True, 'enterprise_customer__enable_data_sharing_consent': True,
                     'enterprise_customer__enforce_data_sharing_consent': 'at_enrollment',
                     'enterprise_customer__site__domain': 'example.com',
@@ -246,7 +247,7 @@ class TestEnterpriseAPIViews(APITest):
                 [{
                     'id': 1, 'user_id': 0,
                     'enterprise_customer__uuid': FAKE_UUIDS[0],
-                    'enterprise_customer__name': 'Test Enterprise Customer', 'enterprise_customer__catalog': 1,
+                    'enterprise_customer__name': TEST_ENTERPRISE_NAME, 'enterprise_customer__catalog': 1,
                     'enterprise_customer__active': True, 'enterprise_customer__enable_data_sharing_consent': True,
                     'enterprise_customer__enforce_data_sharing_consent': 'at_enrollment',
                     'enterprise_customer__site__domain': 'example.com',
@@ -268,7 +269,7 @@ class TestEnterpriseAPIViews(APITest):
                 [{
                     'id': 1, 'user_id': 0,
                     'enterprise_customer__uuid': FAKE_UUIDS[0],
-                    'enterprise_customer__name': 'Test Enterprise Customer', 'enterprise_customer__catalog': 1,
+                    'enterprise_customer__name': TEST_ENTERPRISE_NAME, 'enterprise_customer__catalog': 1,
                     'enterprise_customer__active': True, 'enterprise_customer__enable_data_sharing_consent': True,
                     'enterprise_customer__enforce_data_sharing_consent': 'at_enrollment',
                     'enterprise_customer__site__domain': 'example.com',
@@ -290,7 +291,7 @@ class TestEnterpriseAPIViews(APITest):
                 [{
                     'id': 1, 'user_id': 0,
                     'enterprise_customer__uuid': FAKE_UUIDS[0],
-                    'enterprise_customer__name': 'Test Enterprise Customer', 'enterprise_customer__catalog': 1,
+                    'enterprise_customer__name': TEST_ENTERPRISE_NAME, 'enterprise_customer__catalog': 1,
                     'enterprise_customer__active': True, 'enterprise_customer__enable_data_sharing_consent': True,
                     'enterprise_customer__enforce_data_sharing_consent': 'at_enrollment',
                     'enterprise_customer__site__domain': 'example.com',
@@ -311,7 +312,7 @@ class TestEnterpriseAPIViews(APITest):
             [
                 factories.EnterpriseCustomerFactory,
                 [{
-                    'uuid': FAKE_UUIDS[0], 'name': 'Test Enterprise Customer',
+                    'uuid': FAKE_UUIDS[0], 'name': TEST_ENTERPRISE_NAME,
                     'catalog': 1, 'active': True, 'enable_data_sharing_consent': True,
                     'enforce_data_sharing_consent': 'at_enrollment',
                     'site__domain': 'example.com', 'site__name': 'example.com',
@@ -465,7 +466,7 @@ class TestEnterpriseAPIViews(APITest):
         self.create_items(
             factories.EnterpriseCustomerFactory,
             [{
-                'uuid': FAKE_UUIDS[0], 'name': 'Test Enterprise Customer',
+                'uuid': FAKE_UUIDS[0], 'name': TEST_ENTERPRISE_NAME,
                 'catalog': 1, 'active': True, 'enable_data_sharing_consent': True,
                 'enforce_data_sharing_consent': 'at_enrollment',
                 'site__domain': 'example.com', 'site__name': 'example.com',
@@ -686,13 +687,13 @@ class TestEnterpriseAPIViews(APITest):
             ENTERPRISE_CUSTOMER_LIST_ENDPOINT,
             itemgetter('uuid'),
             [{
-                'uuid': FAKE_UUIDS[0], 'name': 'Test Enterprise Customer', 'slug': TEST_SLUG,
+                'uuid': FAKE_UUIDS[0], 'name': TEST_ENTERPRISE_NAME, 'slug': TEST_SLUG,
                 'catalog': 1, 'active': True, 'enable_data_sharing_consent': True,
                 'enforce_data_sharing_consent': 'at_enrollment',
                 'site__domain': 'example.com', 'site__name': 'example.com',
             }],
             [{
-                'uuid': FAKE_UUIDS[0], 'name': 'Test Enterprise Customer', 'slug': TEST_SLUG,
+                'uuid': FAKE_UUIDS[0], 'name': TEST_ENTERPRISE_NAME, 'slug': TEST_SLUG,
                 'catalog': 1, 'active': True, 'enable_data_sharing_consent': True,
                 'enforce_data_sharing_consent': 'at_enrollment',
                 'branding_configuration': None, 'enterprise_customer_entitlements': [],
@@ -710,7 +711,7 @@ class TestEnterpriseAPIViews(APITest):
             [{
                 'id': 1, 'user_id': 0,
                 'enterprise_customer__uuid': FAKE_UUIDS[0],
-                'enterprise_customer__name': 'Test Enterprise Customer',
+                'enterprise_customer__name': TEST_ENTERPRISE_NAME,
                 'enterprise_customer__slug': TEST_SLUG, 'enterprise_customer__catalog': 1,
                 'enterprise_customer__active': True, 'enterprise_customer__enable_data_sharing_consent': True,
                 'enterprise_customer__enforce_data_sharing_consent': 'at_enrollment',
@@ -721,7 +722,7 @@ class TestEnterpriseAPIViews(APITest):
             [{
                 'id': 1, 'user_id': 0, 'user': None, 'data_sharing_consent_records': [], 'groups': [],
                 'enterprise_customer': {
-                    'uuid': FAKE_UUIDS[0], 'name': 'Test Enterprise Customer', 'slug': TEST_SLUG,
+                    'uuid': FAKE_UUIDS[0], 'name': TEST_ENTERPRISE_NAME, 'slug': TEST_SLUG,
                     'catalog': 1, 'active': True, 'enable_data_sharing_consent': True,
                     'enforce_data_sharing_consent': 'at_enrollment',
                     'branding_configuration': None, 'enterprise_customer_entitlements': [],
@@ -766,7 +767,7 @@ class TestEnterpriseAPIViews(APITest):
             [{
                 'provider_id': FAKE_UUIDS[0],
                 'enterprise_customer__uuid': FAKE_UUIDS[1],
-                'enterprise_customer__name': 'Test Enterprise Customer',
+                'enterprise_customer__name': TEST_ENTERPRISE_NAME,
                 'enterprise_customer__slug': TEST_SLUG, 'enterprise_customer__catalog': 1,
                 'enterprise_customer__active': True, 'enterprise_customer__enable_data_sharing_consent': True,
                 'enterprise_customer__enforce_data_sharing_consent': 'at_enrollment',
@@ -775,7 +776,7 @@ class TestEnterpriseAPIViews(APITest):
 
             }],
             [{
-                'uuid': FAKE_UUIDS[1], 'name': 'Test Enterprise Customer', 'slug': TEST_SLUG,
+                'uuid': FAKE_UUIDS[1], 'name': TEST_ENTERPRISE_NAME, 'slug': TEST_SLUG,
                 'catalog': 1, 'active': True, 'enable_data_sharing_consent': True,
                 'enforce_data_sharing_consent': 'at_enrollment',
                 'branding_configuration': None, 'enterprise_customer_entitlements': [],
@@ -794,11 +795,13 @@ class TestEnterpriseAPIViews(APITest):
                 'enterprise_customer__uuid': FAKE_UUIDS[0],
                 'enterprise_customer__slug': TEST_SLUG,
                 'logo': 'enterprise/branding/1/1_logo.png',
+                'enterprise_customer__name': TEST_ENTERPRISE_NAME,
             }],
             [{
                 'enterprise_customer': FAKE_UUIDS[0],
                 'enterprise_slug': TEST_SLUG,
                 'logo': 'http://testserver/enterprise/branding/1/1_logo.png',
+                'enterprise_name': TEST_ENTERPRISE_NAME,
             }],
         ),
     )
@@ -880,7 +883,7 @@ class TestEnterpriseAPIViews(APITest):
          and serialize the ``EnterpriseCustomer`` objects the user has access to.
         """
         enterprise_customer_data = {
-            'uuid': FAKE_UUIDS[0], 'name': 'Test Enterprise Customer', 'slug': TEST_SLUG,
+            'uuid': FAKE_UUIDS[0], 'name': TEST_ENTERPRISE_NAME, 'slug': TEST_SLUG,
             'catalog': 1, 'active': True, 'enable_data_sharing_consent': True,
             'enforce_data_sharing_consent': 'at_enrollment',
             'site__domain': 'example.com', 'site__name': 'example.com',
@@ -911,7 +914,7 @@ class TestEnterpriseAPIViews(APITest):
         response = self.load_json(response.content)
         if has_access_to_enterprise:
             assert response['results'][0] == {
-                'uuid': FAKE_UUIDS[0], 'name': 'Test Enterprise Customer', 'slug': TEST_SLUG,
+                'uuid': FAKE_UUIDS[0], 'name': TEST_ENTERPRISE_NAME, 'slug': TEST_SLUG,
                 'catalog': 1, 'active': True, 'enable_data_sharing_consent': True,
                 'enforce_data_sharing_consent': 'at_enrollment',
                 'branding_configuration': None, 'enterprise_customer_entitlements': [],
@@ -935,17 +938,21 @@ class TestEnterpriseAPIViews(APITest):
                 'enterprise_customer__uuid': FAKE_UUIDS[0],
                 'enterprise_customer__slug': TEST_SLUG,
                 'logo': 'enterprise/branding/1/1_logo.png',
+                'enterprise_customer__name': TEST_ENTERPRISE_NAME,
+
             },
             {
                 'enterprise_customer__uuid': FAKE_UUIDS[1],
                 'enterprise_customer__slug': 'another-slug',
                 'logo': 'enterprise/branding/2/2_logo.png',
+                'enterprise_customer__name': TEST_ENTERPRISE_NAME,
             },
         ]
         expected_item = {
             'enterprise_customer': FAKE_UUIDS[0],
             'enterprise_slug': TEST_SLUG,
             'logo': 'http://testserver/enterprise/branding/1/1_logo.png',
+            'enterprise_name': TEST_ENTERPRISE_NAME,
         }
         self.create_items(factory, model_items)
         response = self.client.get(settings.TEST_SERVER + ENTERPRISE_CUSTOMER_BRANDING_DETAIL_ENDPOINT)


### PR DESCRIPTION
**Description:** 

Includes the `EnterpriseCustomer` name in the branding configuration API response.

**Testing instructions:**

Verify that the enterprise customer name is returned in the API response for the `/enterprise-customer-branding` endpoint.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
