### PR TITLE
Jvasquez/search enterprise and order

### DIFF
--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -30,7 +30,7 @@ from enterprise.api.v1.decorators import enterprise_customer_required, require_a
 from enterprise.api.v1.permissions import HasEnterpriseEnrollmentAPIAccess, IsAdminUserOrInGroup
 from enterprise.api_client.discovery import CourseCatalogApiClient
 from enterprise.constants import COURSE_KEY_URL_PATTERN
-
+import re
 LOGGER = getLogger(__name__)
 
 
@@ -91,7 +91,6 @@ class EnterpriseCustomerViewSet(EnterpriseReadWriteModelViewSet):
     """
     API views for the ``enterprise-customer`` API endpoint.
     """
-
     queryset = models.EnterpriseCustomer.active_customers.all()
     serializer_class = serializers.EnterpriseCustomerSerializer
 
@@ -205,6 +204,10 @@ class EnterpriseCustomerViewSet(EnterpriseReadWriteModelViewSet):
         """
         Returns the list of enterprise customers the user has a specified group permission access to.
         """
+        enterprise_name = self.request.query_params.get('search', None)
+        if enterprise_name is not None:
+            filtered_enterprises = self.queryset.filter(name__icontains=enterprise_name)
+            self.queryset = filtered_enterprises
         return self.list(request, *args, **kwargs)
 
 
@@ -425,6 +428,7 @@ class EnterpriseCourseCatalogViewSet(EnterpriseWrapperApiViewSet):
         Returns:
             (Response): DRF response object containing course catalogs.
         """
+        print "MADE IT HERE"
         catalog_api = CourseCatalogApiClient(request.user)
         catalogs = catalog_api.get_paginated_catalogs(request.GET)
         self.ensure_data_exists(request, catalogs)

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -91,7 +91,7 @@ class EnterpriseCustomerViewSet(EnterpriseReadWriteModelViewSet):
     """
     API views for the ``enterprise-customer`` API endpoint.
     """
-    
+
     queryset = models.EnterpriseCustomer.active_customers.all()
     serializer_class = serializers.EnterpriseCustomerSerializer
 
@@ -431,7 +431,6 @@ class EnterpriseCourseCatalogViewSet(EnterpriseWrapperApiViewSet):
         Returns:
             (Response): DRF response object containing course catalogs.
         """
-        print "MADE IT HERE"
         catalog_api = CourseCatalogApiClient(request.user)
         catalogs = catalog_api.get_paginated_catalogs(request.GET)
         self.ensure_data_exists(request, catalogs)

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -91,6 +91,7 @@ class EnterpriseCustomerViewSet(EnterpriseReadWriteModelViewSet):
     """
     API views for the ``enterprise-customer`` API endpoint.
     """
+    
     queryset = models.EnterpriseCustomer.active_customers.all()
     serializer_class = serializers.EnterpriseCustomerSerializer
 

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -204,6 +204,8 @@ class EnterpriseCustomerViewSet(EnterpriseReadWriteModelViewSet):
         """
         Returns the list of enterprise customers the user has a specified group permission access to.
         """
+        self.queryset = self.queryset.order_by('name')
+        
         enterprise_name = self.request.query_params.get('search', None)
         if enterprise_name is not None:
             filtered_enterprises = self.queryset.filter(name__icontains=enterprise_name)

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -30,7 +30,7 @@ from enterprise.api.v1.decorators import enterprise_customer_required, require_a
 from enterprise.api.v1.permissions import HasEnterpriseEnrollmentAPIAccess, IsAdminUserOrInGroup
 from enterprise.api_client.discovery import CourseCatalogApiClient
 from enterprise.constants import COURSE_KEY_URL_PATTERN
-import re
+
 LOGGER = getLogger(__name__)
 
 


### PR DESCRIPTION
This PR is to return in alphabetical order the enterprise list. Also, to filter out enterprises based on the search query passed from the front-end portal.