### PR TITLE
ENT-1121 version bump

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.72.7] - 2018-08-20
+---------------------
+
+* Added preview field that takes user to Discovery with elastic search results for the catalog
+
 [0.72.6] - 2018-08-17
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.72.6"
+__version__ = "0.72.7"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name


### PR DESCRIPTION
**Description:** 
This PR bumps the enterprise version from 0.72.6 to 0.72.7

**JIRA:**
https://openedx.atlassian.net/browse/ENT-1121

**Related PR:** https://github.com/edx/edx-enterprise/pull/357