### PR TITLE
ENT-1177 Modifying permissions and with_access_to to restrict staff user access

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.73.0] - 2018-08-21
+---------------------
+
+* Changed permission logic and added filtering options for the enterprise with_access_to endpoint.
+
 [0.72.7] - 2018-08-20
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.72.7"
+__version__ = "0.73.0"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/tests/test_enterprise/api/test_permissions.py
+++ b/tests/test_enterprise/api/test_permissions.py
@@ -29,21 +29,20 @@ class PermissionsTestMixin(object):
         return Request(request, parsers=(JSONParser(),))
 
 
-class TestEnterpriseAPIPermissions(PermissionsTestMixin, APITestCase):
+class TestIsAdminUserOrInGroupPermissions(PermissionsTestMixin, APITestCase):
     """
     Tests for Enterprise API permissions.
     """
 
     permissions_class_map = {
         'enterprise_enrollment_api_access': HasEnterpriseEnrollmentAPIAccess(),
-        'enterprise_data_api_access': HasEnterpriseDataAPIAccess(),
     }
 
     def setUp(self):
         """
         Setup the test cases.
         """
-        super(TestEnterpriseAPIPermissions, self).setUp()
+        super(TestIsAdminUserOrInGroupPermissions, self).setUp()
         self.user = UserFactory(email='test@example.com', password='test', is_staff=True)
 
     def test_is_staff_or_user_in_group_permissions(self):
@@ -64,6 +63,50 @@ class TestEnterpriseAPIPermissions(PermissionsTestMixin, APITestCase):
         for group_name in self.permissions_class_map:
             request = self.get_request(user=user)
             self.assertTrue(self.permissions_class_map[group_name].has_permission(request, None))
+
+    def test_not_staff_but_in_group_permissions(self):
+        user = UserFactory(email='test@example.com', password='test', is_staff=False)
+        for group_name in self.permissions_class_map:
+            group = GroupFactory(name=group_name)
+            group.user_set.add(user)
+            request = self.get_request(user=user)
+            self.assertTrue(self.permissions_class_map[group_name].has_permission(request, None))
+
+
+class TestIsInEnterpriseGroupPermissions(PermissionsTestMixin, APITestCase):
+    """
+    Tests for Enterprise API permissions.
+    """
+
+    permissions_class_map = {
+        'enterprise_data_api_access': HasEnterpriseDataAPIAccess(),
+    }
+
+    def setUp(self):
+        """
+        Setup the test cases.
+        """
+        super(TestIsInEnterpriseGroupPermissions, self).setUp()
+        self.user = UserFactory(email='test@example.com', password='test', is_staff=True)
+
+    def test_is_staff_and_user_in_group_permissions(self):
+        for group_name in self.permissions_class_map:
+            group = GroupFactory(name=group_name)
+            group.user_set.add(self.user)
+            request = self.get_request(user=self.user)
+            self.assertTrue(self.permissions_class_map[group_name].has_permission(request, None))
+
+    def test_not_staff_and_not_in_group_permissions(self):
+        user = UserFactory(email='test@example.com', password='test', is_staff=False)
+        for group_name in self.permissions_class_map:
+            request = self.get_request(user=user)
+            self.assertFalse(self.permissions_class_map[group_name].has_permission(request, None))
+
+    def test_staff_but_not_in_group_permissions(self):
+        user = UserFactory(email='test@example.com', password='test', is_staff=True)
+        for group_name in self.permissions_class_map:
+            request = self.get_request(user=user)
+            self.assertFalse(self.permissions_class_map[group_name].has_permission(request, None))
 
     def test_not_staff_but_in_group_permissions(self):
         user = UserFactory(email='test@example.com', password='test', is_staff=False)


### PR DESCRIPTION
**Description:** We now need to restrict data api access for staff users on the basis of their group membership. To do this, there is a new permission class that only checks the user's group membership, regardless of whether or not they are staff. The with_access_to endpoint will use this new permission class and rely on the existing filtering to provide the correct list of enterprises for the user, so staff users will still see all enterprises whereas enterprise users will only see what they are linked to. Filtering on the name or enterprise id has also been included to accommodate the portal frontend, as well as the data api itself which will be modified to use the with_access_to endpoint.

**JIRA:** https://openedx.atlassian.net/browse/ENT-1177

**Dependencies:** https://github.com/edx/app-permissions/pull/699/files must be merged before this can land.

**Merge deadline:**

**Installation instructions:** 

**Testing instructions:**
Currently deployed on the business sandbox.
Hitting the following endpoint (https://business.sandbox.edx.org/enterprise/api/v1/enterprise-customer/with_access_to?permissions=enterprise_data_api_access), test the following:
For non-staff users:
- the results should be empty if the user is in the django group but not linked to any enterprises
- the results should say the user does not have permission if they are not in the django group, regardless of them being linked to an enterprise
- the results should return the enterprise the user is linked to if the user is in the django group and linked to an enterprise

For staff users:
- the results should say the user does not have permission if they are not in the django group
- the results should return all of the enterprises if the user is in the django group.

Additionally, we've added some filtering parameters, search and enterprise_id, that if given should filter the results further. search takes a string, and will filter out enterprises whose names do not match the string (case insensitive). enterprise_id takes a uuid and will filter to the enterprise with the matching uuid.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
