### PR TITLE
ENT-769 Remove SailThru Flags

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.73.1] - 2018-08-30
+---------------------
+
+* Remove the SailThru flags for enterprise learner when un-linking it from enterprise.
+
 [0.73.0] - 2018-08-21
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.73.0"
+__version__ = "0.73.1"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name


### PR DESCRIPTION
**Description:** Remove the SailThru Flags for enterprise learner. 

**JIRA:** [ENT-769](https://openedx.atlassian.net/browse/ENT-769)

**Testing Instructions:**

1. Go to login page and signin with third party auth e.g. TestShib 
2. Go to enterprise customer -> [Manage learner screen](https://business.sandbox.edx.org/admin/enterprise/enterprisecustomer/2f4235e7-c3e9-40ec-8d91-a7af697e4ea8/manage_learners) in Django admin. You see the user (that linked above) is linked with the Enterprise customer. 
3. After signing with identity provider, Go to user linked account screen and you can see user is linked with the provider account. 
4. In that screen, click on the "Unlink This Account" button and visit the enterprise customer -> Manage learner screen in Django admin again. You will see the user is no more linked with that Enterprise Customer. We are following the same approach when user [click on the "unlink" button in Django admin manage user screen.](https://business.sandbox.edx.org/admin/enterprise/enterprisecustomer/2f4235e7-c3e9-40ec-8d91-a7af697e4ea8/manage_learners)
5. Also verify that, SailThru flags should be removed for that learner. 
##### NOTE: SailThru Flags: 

- is_enterprise_learner should be False
- EnterpriseCustomer should be None for that learner. 
