### PR TITLE
ENT-1211: Fixed 500 error on enterprise customer screen.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[0.73.2] - 2018-09-11
+---------------------
+
+* Fixed 500 error on enterprise customer admin screen.
+
 [0.73.1] - 2018-08-30
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.73.1"
+__version__ = "0.73.2"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -44,13 +44,14 @@ try:
 except ImportError:
     get_url = None
 
-try:
-    # Try to import identity provider registry if third_party_auth is present
-    from third_party_auth.provider import Registry
-except ImportError:
-    Registry = None
-
 LOGGER = logging.getLogger(__name__)
+
+try:
+    from third_party_auth.provider import Registry  # pylint: disable=unused-import
+except ImportError as exception:
+    LOGGER.warning("Could not import Registry from third_party_auth.provider")
+    LOGGER.warning(exception)
+    Registry = None
 
 
 class NotConnectedToOpenEdX(Exception):
@@ -107,6 +108,13 @@ def get_identity_provider(provider_id):
         Instance of ProviderConfig or None.
     """
     try:
+        from third_party_auth.provider import Registry   # pylint: disable=redefined-outer-name
+    except ImportError as exception:
+        LOGGER.warning("Could not import Registry from third_party_auth.provider")
+        LOGGER.warning(exception)
+        Registry = None  # pylint: disable=redefined-outer-name
+
+    try:
         return Registry and Registry.get(provider_id)
     except ValueError:
         return None
@@ -119,6 +127,13 @@ def get_idp_choices():
     Return:
         A list of choices of all identity providers, None if it can not get any available identity provider.
     """
+    try:
+        from third_party_auth.provider import Registry   # pylint: disable=redefined-outer-name
+    except ImportError as exception:
+        LOGGER.warning("Could not import Registry from third_party_auth.provider")
+        LOGGER.warning(exception)
+        Registry = None  # pylint: disable=redefined-outer-name
+
     first = [("", "-"*7)]
     if Registry:
         return first + [(idp.provider_id, idp.name) for idp in Registry.enabled()]

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -264,13 +264,13 @@ class TestEnterpriseDecorators(unittest.TestCase):
         # Assert that view function was called.
         assert view_function.called
 
-    @mock.patch('enterprise.utils.Registry')
-    def test_force_fresh_session_param_not_received(self, mock_registry):
+    @mock.patch('enterprise.decorators.get_identity_provider')
+    def test_force_fresh_session_param_not_received(self, mock_get_identity_provider):
         """
         Test that the force_fresh_session decorator redirects authenticated
         users with the appropriate provider config depending on the IdPs configuration.
         """
-        mock_registry.get.return_value.configure_mock(
+        mock_get_identity_provider.return_value.configure_mock(
             provider_id=self.provider_id,
         )
         view_function = mock_view_function()

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -69,44 +69,6 @@ class TestEnterpriseUtils(unittest.TestCase):
         self.customer = EnterpriseCustomerFactory(uuid=self.uuid)
         EnterpriseCustomerIdentityProviderFactory(provider_id=self.provider_id, enterprise_customer=self.customer)
 
-    def test_get_idp_choices(self):
-        """
-        Test get_idp_choices returns correct options for choice field or returns None if
-        thirdParty_auth is not installed.
-        """
-        options = utils.get_idp_choices()
-        self.assertIsNone(options)
-        expected_list = [('', '-'*7), ('test1', 'test1'), ('test2', 'test2')]
-
-        with mock.patch('enterprise.utils.Registry') as mock_registry:
-            mock_registry.enabled = mock_get_available_idps(['test1', 'test2'])
-
-            choices = utils.get_idp_choices()
-            self.assertListEqual(choices, expected_list)
-
-    def test_get_identity_provider(self):
-        """
-        Test get_identity_provider returns correct value.
-        """
-        faker = FakerFactory.create()
-        name = faker.name()
-        provider_id = faker.slug()  # pylint: disable=no-member
-
-        # test that get_identity_provider returns None if third_party_auth is not available.
-        identity_provider = utils.get_identity_provider(provider_id=provider_id)
-        assert identity_provider is None
-
-        # test that get_identity_provider does not return None if third_party_auth is  available.
-        with mock.patch('enterprise.utils.Registry') as mock_registry:
-            mock_registry.get.return_value.configure_mock(name=name, provider_id=provider_id)
-            identity_provider = utils.get_identity_provider(provider_id=provider_id)
-            assert identity_provider is not None
-
-        # Test that with an invalid provider ID, the function returns None
-        with mock.patch('enterprise.utils.Registry') as mock_registry:
-            mock_registry.get.side_effect = ValueError
-            assert utils.get_identity_provider('bad#$@#$providerid') is None
-
     @ddt.unpack
     @ddt.data(
         (


### PR DESCRIPTION
**Description:** 
This PR fixes the 500 error on enterprise customer admin screen.

I have moved the imports from top to inside method definition because otherwise `ImportError` is raised and that causes the issues we are seeing.

**JIRA:** [ENT-1211](https://openedx.atlassian.net/browse/ENT-1211)

**Installation instructions:** Simply install edx-enterprise through this branch.

**Testing instructions:**

1. Open enterprise customer details page.
2. Try to update "ENTERPRISE CUSTOMER IDENTITY PROVIDERS"
3. Make sure dropdown menu is displayed instead of the text field
4. Make sure adding/updating identity provider is not throwing errors.

**Merge checklist:**

- [x] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [x] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [x] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [x] Called `make static` for webpack bundling if any static content was updated.
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [x] Translations are updated
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** This is a quick fix to the CAT-2 bug, We need to make sure why are the imports failing on the top.