### PR TITLE
Added the ability to unenroll in the enrollment API

### DIFF
--- a/enterprise/api_client/lms.py
+++ b/enterprise/api_client/lms.py
@@ -236,6 +236,27 @@ class EnrollmentApiClient(LmsApiClient):
             }
         )
 
+    def unenroll_user_from_course(self, username, course_id):
+        """
+        Call the enrollment API to unenroll the user in the course specified by course_id.
+        Args:
+            username (str): The username by which the user goes on the OpenEdx platform
+            course_id (str): The string value of the course's unique identifier
+        Returns:
+            bool: Whether the unenrollment succeeded
+        """
+        enrollment = self.get_course_enrollment(username, course_id)
+        if enrollment and enrollment['is_active']:
+            response = self.client.enrollment.post({
+                'user': username,
+                'course_details': {'course_id': course_id},
+                'is_active': False,
+                'mode': enrollment['mode']
+                })
+            return not response['is_active']
+        else:
+            return False
+
     def get_course_enrollment(self, username, course_id):
         """
         Query the enrollment API to get information about a single course enrollment.

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -689,6 +689,16 @@ class EnterpriseCustomerUser(TimeStampedModel):
                 )
             )
 
+    def unenroll(self, course_run_id):
+        """
+        Unenroll a user from a course track.
+        """
+        enrollment_api_client = EnrollmentApiClient()
+        if enrollment_api_client.unenroll_user_from_course(self.username, course_run_id):
+            EnterpriseCourseEnrollment.objects.filter(enterprise_customer_user=self, course_id=course_run_id).delete()
+            return True
+        return False
+
     def update_session(self, request):
         """Update the session of a request for this learner."""
         request.session['enterprise_customer'] = self.enterprise_customer.serialized

--- a/tests/test_enterprise/api_client/test_lms.py
+++ b/tests/test_enterprise/api_client/test_lms.py
@@ -324,6 +324,61 @@ def test_get_enrolled_courses():
     actual_response = client.get_enrolled_courses(user)
     assert actual_response == expected_response
 
+@responses.activate
+def test_unenroll():
+    user = "some_user"
+    course_id = "course-v1:edx+DemoX+Demo_Course"
+    mode = 'audit'
+    is_active = True
+    expected_response = dict(user=user, course_details={'course_id': course_id}, mode=mode, is_active=is_active)
+    responses.add(
+        responses.GET,
+        _url(
+            "enrollment",
+            "enrollment/{username},{course_id}".format(username=user, course_id=course_id),
+        ),
+        json=expected_response
+    )
+    expected_response = dict(user=user, is_active=False)
+    responses.add(
+        responses.POST,
+        _url(
+            "enrollment",
+            "enrollment",
+        ),
+        json=expected_response
+    )
+    client = lms_api.EnrollmentApiClient()
+    unenrolled = client.unenroll_user_from_course(user, course_id)
+    assert unenrolled
+
+@responses.activate
+def test_unenroll_already_unenrolled():
+    user = "some_user"
+    course_id = "course-v1:edx+DemoX+Demo_Course"
+    mode = 'audit'
+    expected_response = dict(user=user, course_details={'course_id': course_id}, mode=mode, is_active=False)
+    responses.add(
+        responses.GET,
+        _url(
+            "enrollment",
+            "enrollment/{username},{course_id}".format(username=user, course_id=course_id),
+        ),
+        json=expected_response
+    )
+    expected_response = dict(user=user, is_active=False)
+    responses.add(
+        responses.POST,
+        _url(
+            "enrollment",
+            "enrollment",
+        ),
+        json=expected_response
+    )
+    client = lms_api.EnrollmentApiClient()
+    unenrolled = client.unenroll_user_from_course(user, course_id)
+    assert not unenrolled
+
 
 def test_enroll_locally_raises():
     with raises(NotConnectedToOpenEdX):


### PR DESCRIPTION
**Description:** Adds an optional field, ``is_active`` to support unenrollment in the course-enrollments endpoint.

**JIRA:** Link to JIRA ticket

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happend instead - check failed.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
