### PR TITLE
ENT-1244. Add filtering by slug to with_access_to

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ----------
 
+[0.73.5] - 2018-09-21
+---------------------
+* Added ability to query enterprises by slug on the with_access_to endpoint
+
 [0.73.4] - 2018-09-17
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.73.4"
+__version__ = "0.73.5"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -207,10 +207,13 @@ class EnterpriseCustomerViewSet(EnterpriseReadWriteModelViewSet):
         """
         self.queryset = self.queryset.order_by('name')
         enterprise_id = self.request.query_params.get('enterprise_id', None)
+        enterprise_slug = self.request.query_params.get('enterprise_slug', None)
         enterprise_name = self.request.query_params.get('search', None)
 
         if enterprise_id is not None:
             self.queryset = self.queryset.filter(uuid=enterprise_id)
+        elif enterprise_slug is not None:
+            self.queryset = self.queryset.filter(slug=enterprise_slug)
         elif enterprise_name is not None:
             self.queryset = self.queryset.filter(name__icontains=enterprise_name)
         return self.list(request, *args, **kwargs)

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -889,6 +889,13 @@ class TestEnterpriseAPIViews(APITest):
         # Staff user with group permission filtering on search param with results.
         (True, False, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access'], 'search': 'test'}, True, None),
+        # Staff user with group permission filtering on slug with results.
+        (True, False, ['enterprise_enrollment_api_access'],
+         {'permissions': ['enterprise_enrollment_api_access'], 'slug': TEST_SLUG}, True, None),
+        # Staff user with group permissions filtering on slug with no results.
+        (True, False, ['enterprise_enrollment_api_access'],
+         {'permissions': ['enterprise_enrollment_api_access'], 'slug': 'blah'}, False,
+         {'count': 0, 'next': None, 'previous': None, 'results': []}),
     )
     @ddt.unpack
     def test_enterprise_customer_with_access_to(


### PR DESCRIPTION
This PR adds the ability to filter the with_access_to call by enterprise slug. This is needed for our enterprise admin dashboard frontend.

This Builds on #366 (so that tests run) so that should merge first
