### PR TITLE
ENT-1199: SuccessFactors: Submit batch/chunk of OCN items to tenants until error status

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ----------
 
+[0.73.6] - 2018-10-04
+---------------------
+* SuccessFactors: Submit batch/chunk of OCN items to tenants until error status
+
 [0.73.5] - 2018-09-21
 ---------------------
 * Added ability to query enterprises by slug on the with_access_to endpoint

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.73.5"
+__version__ = "0.73.6"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name


### PR DESCRIPTION
**Description:** 
Currently, the edX system breaks up the set of OCN items into the specified batch/chunk size defined in a customer's SAPSuccessFactorsEnterpriseCustomerConfiguration record. The system then submits "total records/batch size" number of transactions to the SuccessFactors Learning API, one after the other. For example, given a total set of 100 records, and a batch size of 20, the edX system would submit 5 requests to the API.
Unfortunately, the SuccessFactors Learning API has a throttle constraint which currently allows for only one API request in a given cycle. So in the example above, the first request would be accepted, and the remaining four would be denied.
We keep trying to submit until we get a rate error exceeded or any error status and then will stop

**JIRA:** [ENT-1199](https://openedx.atlassian.net/browse/ENT-1199)

**Merge checklist:**

- [x] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [x] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [x] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [x] Called `make static` for webpack bundling if any static content was updated.
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [x] Translations are updated
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)