### PR TITLE
Refactor and move JwtBuilder to user_authn

### DIFF
--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "0.73.6"
+__version__ = "0.74.0"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api_client/discovery.py
+++ b/enterprise/api_client/discovery.py
@@ -24,7 +24,7 @@ from enterprise.utils import (
 )
 
 try:
-    from openedx.core.lib.token_utils import JwtBuilder
+    from openedx.core.djangoapps.oauth_dispatch import jwt as JwtBuilder
 except ImportError:
     JwtBuilder = None
 
@@ -52,9 +52,7 @@ def course_discovery_api_client(user, catalog_url):
               "installed in an Open edX environment.")
         )
 
-    scopes = ['email', 'profile']
-    expires_in = settings.OAUTH_ID_TOKEN_EXPIRATION
-    jwt = JwtBuilder(user).build_token(scopes, expires_in)
+    jwt = JwtBuilder.create_jwt_for_user(user)
     return EdxRestApiClient(catalog_url, jwt=jwt)
 
 

--- a/enterprise/api_client/lms.py
+++ b/enterprise/api_client/lms.py
@@ -27,7 +27,7 @@ except ImportError:
     embargo_api = None
 
 try:
-    from openedx.core.lib.token_utils import JwtBuilder
+    from openedx.core.djangoapps.oauth_dispatch import jwt as JwtBuilder
 except ImportError:
     JwtBuilder = None
 
@@ -83,8 +83,7 @@ class JwtLmsApiClient(object):
             raise NotConnectedToOpenEdX("This package must be installed in an OpenEdX environment.")
 
         now = int(time())
-        scopes = ['profile', 'email']
-        jwt = JwtBuilder(self.user).build_token(scopes, self.expires_in)
+        jwt = JwtBuilder.create_jwt_for_user(self.user)
         self.client = EdxRestApiClient(
             self.API_BASE_URL, append_slash=self.APPEND_SLASH, jwt=jwt,
         )

--- a/enterprise/decorators.py
+++ b/enterprise/decorators.py
@@ -132,7 +132,7 @@ def enterprise_login_required(view):
         # Now verify if the user is logged in. If user is not logged in then
         # send the user to the login screen to sign in with an
         # Enterprise-linked IdP and the pipeline will get them back here.
-        if not request.user.is_authenticated():
+        if not request.user.is_authenticated:
             parsed_current_url = urlparse(request.get_full_path())
             parsed_query_string = parse_qs(parsed_current_url.query)
             parsed_query_string.update({

--- a/test_utils/fake_enterprise_api.py
+++ b/test_utils/fake_enterprise_api.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, unicode_literals
 from hashlib import md5
 
 import responses
+import six
 from faker import Factory as FakerFactory
 from opaque_keys.edx.keys import CourseKey
 from rest_framework.reverse import reverse
@@ -48,7 +49,7 @@ class EnterpriseMockMixin(object):
         """
         course_detail = {
             'uuid': FakerFactory.create().uuid4(),  # pylint: disable=no-member
-            'key': course_run_key.to_deprecated_string(),
+            'key': six.text_type(course_run_key),
             'aggregation_key': 'courserun:{org}+{course}'.format(
                 org=course_run_key.org, course=course_run_key.course
             ),
@@ -79,7 +80,7 @@ class EnterpriseMockMixin(object):
                 settings.LMS_ROOT_URL,
                 reverse(
                     'enterprise_course_run_enrollment_page',
-                    args=[enterprise_uuid, course_run_key.to_deprecated_string()],
+                    args=[enterprise_uuid, six.text_type(course_run_key)],
                 )
             ),
             'content_language': None,
@@ -106,7 +107,7 @@ class EnterpriseMockMixin(object):
         """
         DRY method to generate dummy course product SKU.
         """
-        md5_hash = md5(course_run_key.to_deprecated_string().encode('utf-8'))
+        md5_hash = md5(six.text_type(course_run_key).encode('utf-8'))
         digest = md5_hash.hexdigest()[-7:]
         sku = digest.upper()
         return sku


### PR DESCRIPTION
**Description:** Replace usage of deprecated `JwtBuilder` class with new function in the `user_authn` Django app in edx-platform.

**JIRA:** https://openedx.atlassian.net/browse/ARCH-248

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
