### PR TITLE
ENT-1169 Request codes api

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[1.0.5] - 2018-11-14
+---------------------
+
+* Added enterprise api for requesting additional coupon codes.
+
 [1.0.4] - 2018-11-07
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.0.4"
+__version__ = "1.0.5"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/urls.py
+++ b/enterprise/api/urls.py
@@ -6,8 +6,6 @@ from __future__ import absolute_import, unicode_literals
 
 from django.conf.urls import include, url
 
-from enterprise.api.v1.urls import router as api_v1_router
-
 urlpatterns = [
-    url(r'^v1/', include(api_v1_router.urls), name='api')
+    url(r'^v1/', include('enterprise.api.v1.urls'), name='api')
 ]

--- a/enterprise/api/v1/urls.py
+++ b/enterprise/api/v1/urls.py
@@ -6,6 +6,8 @@ from __future__ import absolute_import, unicode_literals
 
 from rest_framework.routers import DefaultRouter
 
+from django.conf.urls import url
+
 from enterprise.api.v1 import views
 
 router = DefaultRouter()  # pylint: disable=invalid-name
@@ -29,3 +31,13 @@ router.register(
     views.EnterpriseCustomerReportingConfigurationViewSet,
     'enterprise-customer-reporting',
 )
+
+urlpatterns = [
+    url(
+        r'^request_codes$',
+        views.CouponCodesView.as_view(),
+        name='request-codes'
+    ),
+]
+
+urlpatterns += router.urls

--- a/enterprise/apps.py
+++ b/enterprise/apps.py
@@ -19,6 +19,7 @@ class EnterpriseConfig(AppConfig):
     name = "enterprise"
     valid_image_extensions = [".png", ]
     valid_max_image_size = getattr(settings, 'ENTERPRISE_CUSTOMER_LOGO_IMAGE_SIZE', 512)  # Value in KB's
+    customer_success_email = getattr(settings, 'ENTERPRISE_CUSTOMER_SUCCESS_EMAIL', 'customersuccess@edx.org')
 
     @property
     def auth_user_model(self):

--- a/enterprise/errors.py
+++ b/enterprise/errors.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+"""
+Errors thrown by the APIs in the Enterprise application.
+"""
+
+from __future__ import absolute_import, unicode_literals
+
+
+class CodesAPIRequestError(Exception):
+    """There was a problem with a request to the Codes application's APIs."""
+
+    pass


### PR DESCRIPTION
**Description:** An API to “Request More Codes”. This will trigger a notification to customersuccess@edx.org

**JIRA:** https://openedx.atlassian.net/browse/ENT-1169

**Testing instructions:**

1. Use any REST client to POST to ... enterprise/api/v1/request_codes
2. Test with and without the following json object
    {
      "email": "bob@alice.com",
      "enterprise_name": "IBM",
      "number_of_codes": "50"
    }
3. Expect a HTTP 200 response for correct input and email to customersuccess@edx.org
4. Expect a HTTP 400 response for incorrect input.
5. Expect a HTTP 500 response for an email send issue.

