### PR TITLE
Add logging to EnterpriseCustomerCatalog-related exception workflows.

### DIFF
--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -628,7 +628,7 @@ class CourseEnrollmentView(NonAtomicView):
             if not modes:
                 LOGGER.warning(
                     'No course modes found for EnterpriseCustomerCatalog [{enterprise_catalog_uuid}]'.format(
-                        enterprise_catalog_uuid=enterprise_catalog_uuid,
+                        enterprise_catalog_uuid=enterprise_catalog,
                     )
                 )
                 messages.add_generic_info_message_for_error(request)

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -626,6 +626,11 @@ class CourseEnrollmentView(NonAtomicView):
             modes = [mode for mode in modes if mode['slug'] in enterprise_catalog.enabled_course_modes]
             modes.sort(key=lambda course_mode: enterprise_catalog.enabled_course_modes.index(course_mode['slug']))
             if not modes:
+                LOGGER.warning(
+                    'No course modes found for EnterpriseCustomerCatalog [{enterprise_catalog_uuid}]'.format(
+                        enterprise_catalog_uuid=enterprise_catalog_uuid,
+                    )
+                )
                 messages.add_generic_info_message_for_error(request)
 
         return modes
@@ -651,6 +656,11 @@ class CourseEnrollmentView(NonAtomicView):
                     uuid=enterprise_catalog_uuid
                 )
             except (ValueError, EnterpriseCustomerCatalog.DoesNotExist):
+                LOGGER.warning(
+                    'EnterpriseCustomerCatalog [{enterprise_catalog_uuid}] does not exist'.format(
+                        enterprise_catalog_uuid=enterprise_catalog_uuid,
+                    )
+                )
                 messages.add_generic_info_message_for_error(request)
 
         course = None
@@ -664,6 +674,7 @@ class CourseEnrollmentView(NonAtomicView):
                     enterprise_customer.site
                 ).get_course_and_course_run(course_run_id)
             except ImproperlyConfigured:
+                LOGGER.warning('CourseCatalogApiServiceClient is improperly configured.')
                 messages.add_generic_info_message_for_error(request)
                 return enterprise_customer, course, course_run, course_modes
 


### PR DESCRIPTION
**Description:** Several exception workflows may be encountered during the process of loading EnterpriseCustomerCatalog information during the generation of the B2B course landing page.  Some of these workflows write to the system log, and some do not, which can create troubleshooting insanity.  This PR adds some logging to some of the workflows.  More logging should/can/will be added as needed.

**JIRA:** How about a [Zendesk ticket](https://edxsupport.zendesk.com/agent/tickets/917793) instead.

**Dependencies:** None

**Merge deadline:** Soon!

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**  I think the easiest way to test would be to hit the B2B landing page with either an invalid catalog UUID value or an invalid course key -- the system should record log entries for these scenarios.  I'm not actually sure how to test the ImproperlyConfigured exception path.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

