### PR TITLE
Handle large catalog queries

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,11 +15,16 @@ Unreleased
 ----------
 
 
+[1.2.1] - 2018-12-21
+---------------------
+
+* Handle /search/all/ endpoint large catalog queries to discovery through HTTP POST
+
 [1.2.0] - 2018-12-19
 ---------------------
 
 * Updating the course grade api url called in lms api
- 
+
 [1.1.4] - 2018-12-19
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -1263,7 +1263,8 @@ class EnterpriseCustomerCatalog(TimeStampedModel):
         """
         updated_content_filter = self.content_filter.copy()
         updated_content_filter[content_id_field_name] = content_id_values
-        results = CourseCatalogApiServiceClient().get_search_results(updated_content_filter) or []
+        response = CourseCatalogApiServiceClient().get_catalog_results(updated_content_filter, traverse_pagination=True)
+        results = response.get('results', [])
         return {x[content_id_field_name] for x in results}
 
     def contains_courses(self, content_ids):
@@ -1278,7 +1279,7 @@ class EnterpriseCustomerCatalog(TimeStampedModel):
 
         content_ids_in_catalog = self.content_filter_ids
         if not content_ids_in_catalog:
-            content_ids_in_catalog = self._filter_members('key', course_keys)
+            content_ids_in_catalog = self._filter_members('key', list(course_keys))
 
         return set(content_ids).issubset(content_ids_in_catalog) or course_keys.issubset(content_ids_in_catalog)
 

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -1188,8 +1188,8 @@ class TestEnterpriseAPIViews(APITest):
         assert response == expected_result
 
     @ddt.data(
-        (False, {'course_run_ids': ['fake1', 'fake2']}, None),
-        (False, {'program_uuids': ['fake1', 'fake2']}, None),
+        (False, {'course_run_ids': ['fake1', 'fake2']}, {}),
+        (False, {'program_uuids': ['fake1', 'fake2']}, {}),
         (
             True,
             {
@@ -1198,7 +1198,12 @@ class TestEnterpriseAPIViews(APITest):
                     fake_catalog_api.FAKE_COURSE_RUN2['key']
                 ]
             },
-            [fake_catalog_api.FAKE_COURSE_RUN, fake_catalog_api.FAKE_COURSE_RUN2]
+            {
+                'results': [
+                    fake_catalog_api.FAKE_COURSE_RUN,
+                    fake_catalog_api.FAKE_COURSE_RUN2
+                ]
+            }
         ),
         (
             True,
@@ -1208,7 +1213,12 @@ class TestEnterpriseAPIViews(APITest):
                     fake_catalog_api.FAKE_SEARCH_ALL_PROGRAM_RESULT_2['uuid']
                 ]
             },
-            [fake_catalog_api.FAKE_SEARCH_ALL_PROGRAM_RESULT_1, fake_catalog_api.FAKE_SEARCH_ALL_PROGRAM_RESULT_2]
+            {
+                'results': [
+                    fake_catalog_api.FAKE_SEARCH_ALL_PROGRAM_RESULT_1,
+                    fake_catalog_api.FAKE_SEARCH_ALL_PROGRAM_RESULT_2
+                ]
+            }
         ),
     )
     @ddt.unpack
@@ -1227,7 +1237,7 @@ class TestEnterpriseAPIViews(APITest):
         )
 
         mock_catalog_api_client.return_value = mock.Mock(
-            get_search_results=mock.Mock(return_value=search_results)
+            get_catalog_results=mock.Mock(return_value=search_results)
         )
 
         response = self.client.get(ENTERPRISE_CATALOGS_CONTAINS_CONTENT_ENDPOINT + '?' + urlencode(query_params, True))
@@ -1282,7 +1292,7 @@ class TestEnterpriseAPIViews(APITest):
         )
 
         mock_catalog_api_client.return_value = mock.Mock(
-            get_search_results=mock.Mock(return_value=None)
+            get_catalog_results=mock.Mock(return_value={})
         )
 
         response = self.client.get(ENTERPRISE_CATALOGS_CONTAINS_CONTENT_ENDPOINT + '?' + urlencode(query_params, True))
@@ -1360,12 +1370,12 @@ class TestEnterpriseAPIViews(APITest):
                 user_id=self.user.id,
                 enterprise_customer=enterprise_customer
             )
-        search_results = None
+        search_results = {}
         if is_course_run_in_catalog:
-            search_results = [fake_catalog_api.FAKE_COURSE_RUN]
+            search_results = {'results': [fake_catalog_api.FAKE_COURSE_RUN]}
 
         mock_catalog_api_client.return_value = mock.Mock(
-            get_search_results=mock.Mock(return_value=search_results),
+            get_catalog_results=mock.Mock(return_value=search_results),
             get_course_run=mock.Mock(return_value=mocked_course_run),
         )
         response = self.client.get(ENTERPRISE_CATALOGS_COURSE_RUN_ENDPOINT)
@@ -1424,12 +1434,12 @@ class TestEnterpriseAPIViews(APITest):
                 user_id=self.user.id,
                 enterprise_customer=enterprise_customer
             )
-        search_results = None
+        search_results = {}
         if is_course_in_catalog:
-            search_results = [fake_catalog_api.FAKE_COURSE]
+            search_results = {'results': [fake_catalog_api.FAKE_COURSE]}
 
         mock_catalog_api_client.return_value = mock.Mock(
-            get_search_results=mock.Mock(return_value=search_results),
+            get_catalog_results=mock.Mock(return_value=search_results),
             get_course_details=mock.Mock(return_value=mocked_course),
         )
         response = self.client.get(ENTERPRISE_CATALOGS_COURSE_ENDPOINT)
@@ -1496,12 +1506,12 @@ class TestEnterpriseAPIViews(APITest):
                 uuid=FAKE_UUIDS[1],
                 enterprise_customer=enterprise_customer,
             )
-        search_results = None
+        search_results = {}
         if is_program_in_catalog:
-            search_results = [fake_catalog_api.FAKE_SEARCH_ALL_PROGRAM_RESULT_1]
+            search_results = {'results': [fake_catalog_api.FAKE_SEARCH_ALL_PROGRAM_RESULT_1]}
 
         mock_catalog_api_client.return_value = mock.Mock(
-            get_search_results=mock.Mock(return_value=search_results),
+            get_catalog_results=mock.Mock(return_value=search_results),
             get_program_by_uuid=mock.Mock(return_value=mocked_program),
         )
         response = self.client.get(ENTERPRISE_CATALOGS_PROGRAM_ENDPOINT)
@@ -1708,8 +1718,8 @@ class TestEnterpriseAPIViews(APITest):
         )
 
     @ddt.data(
-        (False, {'course_run_ids': ['fake1', 'fake2']}, None),
-        (False, {'program_uuids': ['fake1', 'fake2']}, None),
+        (False, {'course_run_ids': ['fake1', 'fake2']}, {}),
+        (False, {'program_uuids': ['fake1', 'fake2']}, {}),
         (
             True,
             {
@@ -1718,7 +1728,12 @@ class TestEnterpriseAPIViews(APITest):
                     fake_catalog_api.FAKE_COURSE_RUN2['key']
                 ]
             },
-            [fake_catalog_api.FAKE_COURSE_RUN, fake_catalog_api.FAKE_COURSE_RUN2]
+            {
+                'results': [
+                    fake_catalog_api.FAKE_COURSE_RUN,
+                    fake_catalog_api.FAKE_COURSE_RUN2
+                ]
+            }
         ),
         (
             True,
@@ -1728,7 +1743,12 @@ class TestEnterpriseAPIViews(APITest):
                     fake_catalog_api.FAKE_SEARCH_ALL_PROGRAM_RESULT_2['uuid']
                 ]
             },
-            [fake_catalog_api.FAKE_SEARCH_ALL_PROGRAM_RESULT_1, fake_catalog_api.FAKE_SEARCH_ALL_PROGRAM_RESULT_2]
+            {
+                'results': [
+                    fake_catalog_api.FAKE_SEARCH_ALL_PROGRAM_RESULT_1,
+                    fake_catalog_api.FAKE_SEARCH_ALL_PROGRAM_RESULT_2
+                ]
+            }
         ),
     )
     @ddt.unpack
@@ -1745,7 +1765,7 @@ class TestEnterpriseAPIViews(APITest):
         )
 
         mock_catalog_api_client.return_value = mock.Mock(
-            get_search_results=mock.Mock(return_value=search_results)
+            get_catalog_results=mock.Mock(return_value=search_results)
         )
 
         response = self.client.get(ENTERPRISE_CUSTOMER_CONTAINS_CONTENT_ENDPOINT + '?' + urlencode(query_params, True))

--- a/tests/test_enterprise/views/test_course_enrollment_view.py
+++ b/tests/test_enterprise/views/test_course_enrollment_view.py
@@ -305,8 +305,8 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
             enabled_course_modes=enabled_course_modes,
         )
         catalog_api_client_models_mock.return_value = mock.Mock(
-            get_search_results=mock.Mock(
-                return_value=[fake_catalog_api.FAKE_SEARCH_ALL_COURSE_RESULT]
+            get_catalog_results=mock.Mock(
+                return_value={'results': [fake_catalog_api.FAKE_SEARCH_ALL_COURSE_RESULT]}
             ),
             get_course_and_course_run=mock.Mock(
                 return_value=(fake_catalog_api.FAKE_COURSE, fake_catalog_api.FAKE_COURSE_RUN)
@@ -496,8 +496,8 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
             enabled_course_modes=['invalid-course-mode'],
         )
         catalog_api_client_models_mock.return_value = mock.Mock(
-            get_search_results=mock.Mock(
-                return_value=[fake_catalog_api.FAKE_SEARCH_ALL_COURSE_RESULT]
+            get_catalog_results=mock.Mock(
+                return_value={'results': [fake_catalog_api.FAKE_SEARCH_ALL_COURSE_RESULT]}
             ),
             get_course_and_course_run=mock.Mock(
                 return_value=(fake_catalog_api.FAKE_COURSE, fake_catalog_api.FAKE_COURSE_RUN)
@@ -1463,8 +1463,8 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
             enabled_course_modes=['audit', 'professional'],
         )
         catalog_api_client_models_mock.return_value = mock.Mock(
-            get_search_results=mock.Mock(
-                return_value=[fake_catalog_api.FAKE_SEARCH_ALL_COURSE_RESULT]
+            get_catalog_results=mock.Mock(
+                return_value={'results': [fake_catalog_api.FAKE_SEARCH_ALL_COURSE_RESULT]}
             ),
             get_course_and_course_run=mock.Mock(
                 return_value=(fake_catalog_api.FAKE_COURSE, fake_catalog_api.FAKE_COURSE_RUN)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -190,7 +190,7 @@ class TestEnterpriseCustomer(unittest.TestCase):
         """
         mock_catalog_api = mock_catalog_api_class.return_value
         mock_catalog_api.is_course_in_catalog.return_value = False
-        mock_catalog_api.get_search_results.return_value = [fake_catalog_api.FAKE_COURSE_RUN]
+        mock_catalog_api.get_catalog_results.return_value = {'results': [fake_catalog_api.FAKE_COURSE_RUN]}
 
         # Test with no discovery service catalog.
         enterprise_customer = factories.EnterpriseCustomerFactory(catalog=None)
@@ -203,7 +203,7 @@ class TestEnterpriseCustomer(unittest.TestCase):
         assert enterprise_customer.catalog_contains_course(fake_catalog_api.FAKE_COURSE_RUN['key']) is True
 
         # Test when EnterpriseCustomerCatalogs do not contain the course run.
-        mock_catalog_api.get_search_results.return_value = None
+        mock_catalog_api.get_catalog_results.return_value = {}
         assert enterprise_customer.catalog_contains_course(fake_catalog_api.FAKE_COURSE_RUN['key']) is False
 
 


### PR DESCRIPTION
**Description:** Support large catalog queries using POST.

**JIRA:** [ENT-1416
](https://openedx.atlassian.net/browse/ENT-1416)

**Testing instructions:**

1. [This](https://business.sandbox.edx.org/admin/enterprise/enterprisecustomercatalog/c58fad29-7221-4416-b5f9-6e8ca18cdc8c/change/) is a big catalog.
2. Open https://business.sandbox.edx.org/enterprise/api/v1/enterprise_catalogs/c58fad29-7221-4416-b5f9-6e8ca18cdc8c/contains_content_items/?course_run_ids=course-v1:UniversityX+GB123+2018_1 and the response should be 
```
<root>
<contains_content_items>True</contains_content_items>
</root>
```
3. On stage and prod, this api hit will return the below response due to very large catalog
```
<root>
<contains_content_items>False</contains_content_items>
</root>
```
**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
