### PR TITLE
ENT-1427 | Updating grades api call in lms client

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ----------
 
+
+[1.2.0] - 2018-12-19
+---------------------
+
+* Updating the course grade api url called in lms api
+ 
 [1.1.4] - 2018-12-19
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.1.4"
+__version__ = "1.2.0"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api_client/lms.py
+++ b/enterprise/api_client/lms.py
@@ -405,7 +405,7 @@ class GradesApiClient(JwtLmsApiClient):
     Note that this API client requires a JWT token, and so it keeps its token alive.
     """
 
-    API_BASE_URL = settings.LMS_INTERNAL_ROOT_URL + '/api/grades/v0/'
+    API_BASE_URL = settings.LMS_INTERNAL_ROOT_URL + '/api/grades/v1/'
     APPEND_SLASH = True
 
     @JwtLmsApiClient.refresh_token
@@ -432,7 +432,7 @@ class GradesApiClient(JwtLmsApiClient):
         * ``letter_grade``: A letter grade as defined in grading_policy (e.g. 'A' 'B' 'C' for 6.002x) or None
 
         """
-        results = self.client.course_grade(course_id).users().get(username=username)
+        results = self.client.courses(course_id).get(username=username)
         for row in results:
             if row.get('username') == username:
                 return row

--- a/tests/test_enterprise/api_client/test_lms.py
+++ b/tests/test_enterprise/api_client/test_lms.py
@@ -597,7 +597,7 @@ def test_get_course_grades_not_found():
     course_id = "course-v1:edX+DemoX+Demo_Course"
     responses.add(
         responses.GET,
-        _url("course_grades", "course_grade/{course}/users/?username={user}".format(course=course_id, user=username)),
+        _url("course_grades", "courses/{course}/?username={user}".format(course=course_id, user=username)),
         match_querystring=True,
         status=404
     )
@@ -620,7 +620,7 @@ def test_get_course_grade_no_results():
     }]
     responses.add(
         responses.GET,
-        _url("course_grades", "course_grade/{course}/users/?username={user}".format(course=course_id, user=username)),
+        _url("course_grades", "courses/{course}/?username={user}".format(course=course_id, user=username)),
         match_querystring=True,
         json=expected_response,
     )
@@ -643,7 +643,7 @@ def test_get_course_grade():
     }]
     responses.add(
         responses.GET,
-        _url("course_grades", "course_grade/{course}/users/?username={user}".format(course=course_id, user=username)),
+        _url("course_grades", "courses/{course}/?username={user}".format(course=course_id, user=username)),
         match_querystring=True,
         json=expected_response,
     )

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -548,8 +548,8 @@ def stub_transmit_learner_data_apis(testcase, certificate, self_paced, end_date,
         responses.add(
             responses.GET,
             urljoin(lms_api.GradesApiClient.API_BASE_URL,
-                    "course_grade/{course}/users/?username={user}".format(course=testcase.course_id,
-                                                                          user=user.username)),
+                    "courses/{course}/?username={user}".format(course=testcase.course_id,
+                                                               user=user.username)),
             match_querystring=True,
             json=[dict(
                 username=user.username,


### PR DESCRIPTION
**Description:** Updating the course grade url for the lms api (because the lms api changed)

**JIRA:** https://openedx.atlassian.net/browse/ENT-1427

**Dependencies:** None

**Merge deadline:** ASAP

**Installation instructions:** None

**Testing instructions:**

Verify completion events that were once failing are no longer failing (are successfully reporting).

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
