### PR TITLE
ENT-143:Remove Errors On Transmitting Learner Data

### DIFF
--- a/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_learner_data.py
+++ b/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_learner_data.py
@@ -265,7 +265,9 @@ class TestLearnerExporter(unittest.TestCase):
         )
 
         # Mock grades data not found
-        mock_grades_api.return_value.get_course_grade.side_effect = HttpNotFoundError
+        mock_grades_api.return_value.get_course_grade.side_effect = HttpNotFoundError(
+            'No grade record found for course={}, username={}'.format(self.course_id, self.user.username)
+        )
 
         # Mock enrollment data
         mock_enrollment_api.return_value.get_course_enrollment.return_value = dict(


### PR DESCRIPTION
**Description:** 
- We were getting errors when running the transmit_learner_data command
  if there were users that had an enterprise enrollment but no
  enrollment for the actual course yet
- This change removes that error, instead an INFO message is printed
  with the format:
   ```User [HannahAbbott] not enrolled in course [course-v1:TestX+TEST101+2018], enterprise enrollment [2]``

**JIRA:** https://openedx.atlassian.net/browse/ENT-1439

**Dependencies:** None

**Merge deadline:** None

**Installation instructions:** None

**Testing instructions:**
1. Create enroll enterprise customer enrollment for a course, but don't actually enroll the user in the course
2. Run the following management command (replace arguments as appropriate): ```./manage.py lms --settings=devstack_docker transmit_learner_data --api_user=edx --enterprise_customer=53ad158d73b346289a5533427c6885e2```

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

