### PR TITLE
Revert "Remove a GET side-effect from consent flow"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[1.2.8] - 2019-01-22
+--------------------
+
+* Revert 1.2.4 to restore DSC functionality.
+
 [1.2.7] - 2019-01-18
 --------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.2.7"
+__version__ = "1.2.8"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/urls.py
+++ b/enterprise/urls.py
@@ -19,6 +19,13 @@ urlpatterns = [
         name='grant_data_sharing_permissions'
     ),
     url(
+        r'^enterprise/handle_consent_enrollment/(?P<enterprise_uuid>[^/]+)/course/{}/$'.format(
+            settings.COURSE_ID_PATTERN
+        ),
+        ENTERPRISE_ROUTER,
+        name='enterprise_handle_consent_enrollment'
+    ),
+    url(
         r'^enterprise/(?P<enterprise_uuid>[^/]+)/course/{}/enroll/$'.format(COURSE_KEY_URL_PATTERN),
         ENTERPRISE_ROUTER,
         name='enterprise_course_enrollment_page'

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -13,7 +13,7 @@ import pytz
 import waffle
 from dateutil.parser import parse
 from ipware.ip import get_ip
-from six.moves.urllib.parse import parse_qs, urlencode, urljoin, urlparse  # pylint: disable=import-error
+from six.moves.urllib.parse import urlencode, urljoin  # pylint: disable=import-error
 
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
@@ -364,87 +364,6 @@ class GrantDataSharingPermissions(View):
             })
         return context_data
 
-    def handle_consent_enrollment(
-            self,
-            user,
-            enterprise_uuid,
-            course_id,
-            enrollment_course_mode,
-            enterprise_catalog_uuid,
-            path
-    ):
-        """
-        Handle the enrollment of enterprise learner in the provided course.
-
-        Based on `enterprise_uuid` in URL, the view will decide which
-        enterprise customer's course enrollment record should be created.
-
-        Depending on the value of query parameter `course_mode` then learner
-        will be either redirected to LMS dashboard for audit modes or
-        redirected to ecommerce basket flow for payment of premium modes.
-        """
-        # Redirect the learner to LMS dashboard in case no course mode is
-        # provided as query parameter `course_mode`
-        if not enrollment_course_mode:
-            return redirect(LMS_DASHBOARD_URL)
-
-        enrollment_api_client = EnrollmentApiClient()
-        course_modes = enrollment_api_client.get_course_modes(course_id)
-        if not course_modes:
-            raise Http404
-
-        # Verify that the request user belongs to the enterprise against the
-        # provided `enterprise_uuid`.
-        enterprise_customer = get_enterprise_customer_or_404(enterprise_uuid)
-        enterprise_customer_user = get_enterprise_customer_user(user.id, enterprise_customer.uuid)
-
-        selected_course_mode = None
-        for course_mode in course_modes:
-            if course_mode['slug'] == enrollment_course_mode:
-                selected_course_mode = course_mode
-                break
-
-        if not selected_course_mode:
-            return redirect(LMS_DASHBOARD_URL)
-
-        # Create the Enterprise backend database records for this course
-        # enrollment
-        _, created = EnterpriseCourseEnrollment.objects.get_or_create(
-            enterprise_customer_user=enterprise_customer_user,
-            course_id=course_id,
-        )
-        if created:
-            track_enrollment('course-landing-page-enrollment', user.id, course_id, path)
-
-        DataSharingConsent.objects.update_or_create(
-            username=enterprise_customer_user.username,
-            course_id=course_id,
-            enterprise_customer=enterprise_customer_user.enterprise_customer,
-            defaults={
-                'granted': True
-            },
-        )
-
-        audit_modes = getattr(settings, 'ENTERPRISE_COURSE_ENROLLMENT_AUDIT_MODES', ['audit', 'honor'])
-        if selected_course_mode['slug'] in audit_modes:
-            # In case of Audit course modes enroll the learner directly through
-            # enrollment API client and redirect the learner to dashboard.
-            enrollment_api_client.enroll_user_in_course(
-                user.username, course_id, selected_course_mode['slug']
-            )
-
-            return redirect(LMS_COURSEWARE_URL.format(course_id=course_id))
-
-        # redirect the enterprise learner to the ecommerce flow in LMS
-        # Note: LMS start flow automatically detects the paid mode
-        premium_flow = LMS_START_PREMIUM_COURSE_FLOW_URL.format(course_id=course_id)
-        if enterprise_catalog_uuid:
-            premium_flow += '?catalog={catalog_uuid}'.format(
-                catalog_uuid=enterprise_catalog_uuid
-            )
-
-        return redirect(premium_flow)
-
     @method_decorator(login_required)
     def get(self, request):
         """
@@ -569,23 +488,94 @@ class GrantDataSharingPermissions(View):
 
             consent_record.granted = consent_provided
             consent_record.save()
-        if consent_provided:
-            query_params = parse_qs(urlparse(success_url).query)
-            # parse_qs creates lists of values so we need grab single value
-            course_mode = query_params.get('course_mode')
-            course_mode = course_mode[0] if course_mode else None
-            catalog_uuid = query_params.get('catalog')
-            catalog_uuid = catalog_uuid[0] if catalog_uuid else None
-            # Will redirect user
-            return self.handle_consent_enrollment(
-                request.user,
-                enterprise_uuid,
-                course_id,
-                course_mode,
-                catalog_uuid,
-                request.get_full_path()
+
+        return redirect(success_url if consent_provided else failure_url)
+
+
+class HandleConsentEnrollment(View):
+    """
+    Handle enterprise course enrollment at providing data sharing consent.
+
+    View handles the case for enterprise course enrollment after successful
+    consent.
+    """
+
+    @method_decorator(enterprise_login_required)
+    def get(self, request, enterprise_uuid, course_id):
+        """
+        Handle the enrollment of enterprise learner in the provided course.
+
+        Based on `enterprise_uuid` in URL, the view will decide which
+        enterprise customer's course enrollment record should be created.
+
+        Depending on the value of query parameter `course_mode` then learner
+        will be either redirected to LMS dashboard for audit modes or
+        redirected to ecommerce basket flow for payment of premium modes.
+        """
+        enrollment_course_mode = request.GET.get('course_mode')
+        enterprise_catalog_uuid = request.GET.get('catalog')
+
+        # Redirect the learner to LMS dashboard in case no course mode is
+        # provided as query parameter `course_mode`
+        if not enrollment_course_mode:
+            return redirect(LMS_DASHBOARD_URL)
+
+        enrollment_api_client = EnrollmentApiClient()
+        course_modes = enrollment_api_client.get_course_modes(course_id)
+        if not course_modes:
+            raise Http404
+
+        # Verify that the request user belongs to the enterprise against the
+        # provided `enterprise_uuid`.
+        enterprise_customer = get_enterprise_customer_or_404(enterprise_uuid)
+        enterprise_customer_user = get_enterprise_customer_user(request.user.id, enterprise_customer.uuid)
+
+        selected_course_mode = None
+        for course_mode in course_modes:
+            if course_mode['slug'] == enrollment_course_mode:
+                selected_course_mode = course_mode
+                break
+
+        if not selected_course_mode:
+            return redirect(LMS_DASHBOARD_URL)
+
+        # Create the Enterprise backend database records for this course
+        # enrollment
+        __, created = EnterpriseCourseEnrollment.objects.get_or_create(
+            enterprise_customer_user=enterprise_customer_user,
+            course_id=course_id,
+        )
+        if created:
+            track_enrollment('course-landing-page-enrollment', request.user.id, course_id, request.get_full_path())
+
+        DataSharingConsent.objects.update_or_create(
+            username=enterprise_customer_user.username,
+            course_id=course_id,
+            enterprise_customer=enterprise_customer_user.enterprise_customer,
+            defaults={
+                'granted': True
+            },
+        )
+
+        audit_modes = getattr(settings, 'ENTERPRISE_COURSE_ENROLLMENT_AUDIT_MODES', ['audit', 'honor'])
+        if selected_course_mode['slug'] in audit_modes:
+            # In case of Audit course modes enroll the learner directly through
+            # enrollment API client and redirect the learner to dashboard.
+            enrollment_api_client.enroll_user_in_course(
+                request.user.username, course_id, selected_course_mode['slug']
             )
-        return redirect(failure_url)
+
+            return redirect(LMS_COURSEWARE_URL.format(course_id=course_id))
+
+        # redirect the enterprise learner to the ecommerce flow in LMS
+        # Note: LMS start flow automatically detects the paid mode
+        premium_flow = LMS_START_PREMIUM_COURSE_FLOW_URL.format(course_id=course_id)
+        if enterprise_catalog_uuid:
+            premium_flow += '?catalog={catalog_uuid}'.format(
+                catalog_uuid=enterprise_catalog_uuid
+            )
+
+        return redirect(premium_flow)
 
 
 class CourseEnrollmentView(NonAtomicView):
@@ -947,6 +937,18 @@ class CourseEnrollmentView(NonAtomicView):
             # the learner to course specific DSC with enterprise UUID from
             # there the learner will be directed to the ecommerce flow after
             # providing DSC.
+            query_string_params = {
+                'course_mode': selected_course_mode_name,
+            }
+            if enterprise_catalog_uuid:
+                query_string_params.update({'catalog': enterprise_catalog_uuid})
+
+            next_url = '{handle_consent_enrollment_url}?{query_string}'.format(
+                handle_consent_enrollment_url=reverse(
+                    'enterprise_handle_consent_enrollment', args=[enterprise_customer.uuid, course_id]
+                ),
+                query_string=urlencode(query_string_params)
+            )
 
             failure_url = reverse('enterprise_course_run_enrollment_page', args=[enterprise_customer.uuid, course_id])
             if request.META['QUERY_STRING']:
@@ -963,20 +965,17 @@ class CourseEnrollmentView(NonAtomicView):
                     query_string=request.META['QUERY_STRING']
                 )
 
-            query_string_params = {
-                'failure_url': failure_url,
-                'enterprise_customer_uuid': enterprise_customer.uuid,
-                'course_id': course_id,
-                'course_mode': selected_course_mode_name,
-            }
-
-            if enterprise_catalog_uuid:
-                query_string_params.update({'catalog': enterprise_catalog_uuid})
-
             return redirect(
                 '{grant_data_sharing_url}?{params}'.format(
                     grant_data_sharing_url=reverse('grant_data_sharing_permissions'),
-                    params=urlencode(query_string_params)
+                    params=urlencode(
+                        {
+                            'next': next_url,
+                            'failure_url': failure_url,
+                            'enterprise_customer_uuid': enterprise_customer.uuid,
+                            'course_id': course_id,
+                        }
+                    )
                 )
             )
 
@@ -1370,9 +1369,11 @@ class RouterView(NonAtomicView):
     # pylint: disable=invalid-name
     COURSE_ENROLLMENT_VIEW_URL = '/enterprise/{}/course/{}/enroll/'
     PROGRAM_ENROLLMENT_VIEW_URL = '/enterprise/{}/program/{}/enroll/'
+    HANDLE_CONSENT_ENROLLMENT_VIEW_URL = '/enterprise/handle_consent_enrollment/{}/course/{}/'
     VIEWS = {
         COURSE_ENROLLMENT_VIEW_URL: CourseEnrollmentView,
         PROGRAM_ENROLLMENT_VIEW_URL: ProgramEnrollmentView,
+        HANDLE_CONSENT_ENROLLMENT_VIEW_URL: HandleConsentEnrollment,
     }
 
     @staticmethod

--- a/tests/test_enterprise/views/test_course_enrollment_view.py
+++ b/tests/test_enterprise/views/test_course_enrollment_view.py
@@ -1401,6 +1401,12 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
         assert response.status_code == 302
 
         expected_url_format = '/enterprise/grant_data_sharing_permissions?{}'
+        consent_enrollment_url = '/enterprise/handle_consent_enrollment/{}/course/{}/?{}'.format(
+            enterprise_customer_uuid, course_id, urlencode({
+                'course_mode': 'audit',
+                'catalog': enterprise_customer_catalog.uuid
+            })
+        )
         expected_failure_url = '{course_enrollment_url}?{query_string}'.format(
             course_enrollment_url=reverse(
                 'enterprise_course_run_enrollment_page', args=[enterprise_customer.uuid, course_id]
@@ -1412,11 +1418,10 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
             expected_url_format.format(
                 urlencode(
                     {
+                        'next': consent_enrollment_url,
                         'failure_url': expected_failure_url,
                         'enterprise_customer_uuid': enterprise_customer_uuid,
                         'course_id': course_id,
-                        'course_mode': 'audit',
-                        'catalog': enterprise_customer_catalog.uuid
                     }
                 )
             ),
@@ -1489,6 +1494,12 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
         assert response.status_code == 302
 
         expected_url_format = '/enterprise/grant_data_sharing_permissions?{}'
+        consent_enrollment_url = '/enterprise/handle_consent_enrollment/{}/course/{}/?{}'.format(
+            enterprise_customer_uuid, course_id, urlencode({
+                'course_mode': 'audit',
+                'catalog': enterprise_customer_catalog.uuid
+            })
+        )
         expected_failure_url = '{course_enrollment_url}?{query_string}'.format(
             course_enrollment_url=reverse(
                 'enterprise_course_run_enrollment_page', args=[enterprise_customer.uuid, course_id]
@@ -1503,11 +1514,10 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
             expected_url_format.format(
                 urlencode(
                     {
+                        'next': consent_enrollment_url,
                         'failure_url': expected_failure_url,
                         'enterprise_customer_uuid': enterprise_customer_uuid,
                         'course_id': course_id,
-                        'course_mode': 'audit',
-                        'catalog': enterprise_customer_catalog.uuid
                     }
                 )
             ),

--- a/tests/test_enterprise/views/test_grant_data_sharing_permissions.py
+++ b/tests/test_enterprise/views/test_grant_data_sharing_permissions.py
@@ -9,7 +9,6 @@ import ddt
 import mock
 from dateutil.parser import parse
 from pytest import mark
-from six.moves.urllib.parse import urlencode  # pylint: disable=import-error
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -17,12 +16,10 @@ from django.core.urlresolvers import reverse
 from django.test import Client, TestCase
 
 from enterprise.models import EnterpriseCourseEnrollment
-from enterprise.views import LMS_COURSEWARE_URL, LMS_DASHBOARD_URL, LMS_START_PREMIUM_COURSE_FLOW_URL
 from test_utils import fake_render
 from test_utils.factories import (
     DataSharingConsentFactory,
     DataSharingConsentTextOverridesFactory,
-    EnterpriseCustomerCatalogFactory,
     EnterpriseCustomerFactory,
     EnterpriseCustomerUserFactory,
     UserFactory,
@@ -402,8 +399,8 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
     @mock.patch('enterprise.models.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.reverse')
     @ddt.data(
-        (True, True, '/dashboard'),
-        (False, True, '/dashboard'),
+        (True, True, '/successful_enrollment'),
+        (False, True, '/successful_enrollment'),
         (True, False, '/failure_url'),
         (False, False, '/failure_url'),
     )
@@ -555,260 +552,6 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
         dsc.refresh_from_db()
         assert dsc.granted is False
 
-    @mock.patch('enterprise.views.CourseApiClient')
-    @mock.patch('enterprise.models.CourseCatalogApiServiceClient')
-    def test_handle_consent_enrollment_without_course_mode(
-            self,
-            course_catalog_api_client_mock,
-            course_api_client_mock,
-            *args
-    ):  # pylint: disable=unused-argument,invalid-name
-        """
-        Verify that user is redirected to LMS dashboard if course_mode is not
-        passed in the redirect_url.
-        """
-        self._login()
-        course_id = 'course-v1:edX+DemoX+Demo_Course'
-        enterprise_customer = EnterpriseCustomerFactory(
-            name='Starfleet Academy',
-            enable_data_sharing_consent=True,
-            enforce_data_sharing_consent='at_enrollment',
-        )
-        course_catalog_api_client_mock.return_value.program_exists.return_value = True
-        course_api_client_mock.return_value.get_course_details.return_value = {'name': 'edX Demo Course'}
-        post_data = {
-            'enterprise_customer_uuid': enterprise_customer.uuid,
-            'course_id': course_id,
-            'redirect_url': '/successful_enrollment?',
-            'failure_url': '/failure_url',
-            'data_sharing_consent': True
-        }
-
-        resp = self.client.post(self.url, post_data)
-        self.assertRedirects(resp, LMS_DASHBOARD_URL, fetch_redirect_response=False)
-
-    @mock.patch('enterprise.views.EnrollmentApiClient')
-    @mock.patch('enterprise.views.CourseApiClient')
-    @mock.patch('enterprise.models.CourseCatalogApiServiceClient')
-    def test_handle_consent_enrollment_with_no_course_modes_for_course(
-            self,
-            course_catalog_api_client_mock,
-            course_api_client_mock,
-            enrollment_api_mock,
-            *args
-    ):  # pylint: disable=unused-argument,invalid-name
-        """
-        Verify that user gets HTTP 404 response if there are no course modes
-        for the course id delivered
-        """
-        self._login()
-        course_id = 'course-v1:edX+DemoX+Demo_Course'
-        enterprise_customer = EnterpriseCustomerFactory(
-            name='Starfleet Academy',
-            enable_data_sharing_consent=True,
-            enforce_data_sharing_consent='at_enrollment',
-        )
-        course_catalog_api_client_mock.return_value.program_exists.return_value = True
-        course_api_client_mock.return_value.get_course_details.return_value = {'name': 'edX Demo Course'}
-        enrollment_api_mock.return_value.get_course_modes.return_value = ()
-        post_data = {
-            'enterprise_customer_uuid': enterprise_customer.uuid,
-            'course_id': course_id,
-            'redirect_url': '/successful_enrollment?{}'.format(
-                urlencode({'course_mode': 'audit'})
-            ),
-            'failure_url': '/failure_url',
-            'data_sharing_consent': True
-        }
-
-        resp = self.client.post(self.url, post_data)
-
-        assert resp.status_code == 404
-
-    @mock.patch('enterprise.views.EnrollmentApiClient')
-    @mock.patch('enterprise.views.CourseApiClient')
-    @mock.patch('enterprise.models.CourseCatalogApiServiceClient')
-    def test_handle_consent_enrollment_with_no_matching_course_modes(
-            self,
-            course_catalog_api_client_mock,
-            course_api_client_mock,
-            enrollment_api_mock,
-            *args
-    ):  # pylint: disable=unused-argument,invalid-name
-        """
-        Verify that user gets HTTP 404 response if there are no course modes
-        for the course id delivered
-        """
-        self._login()
-        course_id = 'course-v1:edX+DemoX+Demo_Course'
-        enterprise_customer = EnterpriseCustomerFactory(
-            name='Starfleet Academy',
-            enable_data_sharing_consent=True,
-            enforce_data_sharing_consent='at_enrollment',
-        )
-        course_catalog_api_client_mock.return_value.program_exists.return_value = True
-        course_api_client_mock.return_value.get_course_details.return_value = {'name': 'edX Demo Course'}
-        enrollment_api_mock.return_value.get_course_modes.return_value = (
-            {
-                "slug": "professional",
-                "name": "Professional Track",
-                "min_price": 100,
-                "sku": "sku-audit",
-            },
-            {
-                "slug": "audit",
-                "name": "Audit Track",
-                "min_price": 0,
-                "sku": "sku-audit",
-            },
-        )
-        post_data = {
-            'enterprise_customer_uuid': enterprise_customer.uuid,
-            'course_id': course_id,
-            'redirect_url': '/successful_enrollment?{}'.format(
-                urlencode({'course_mode': 'some-invalid-course-mode'})
-            ),
-            'failure_url': '/failure_url',
-            'data_sharing_consent': True
-        }
-
-        resp = self.client.post(self.url, post_data)
-
-        assert resp.url.endswith('/dashboard')  # pylint: disable=no-member
-        assert resp.status_code == 302
-
-    @mock.patch('enterprise.views.EnrollmentApiClient')
-    @mock.patch('enterprise.views.CourseApiClient')
-    @mock.patch('enterprise.models.CourseCatalogApiServiceClient')
-    def test_handle_consent_enrollment_with_audit_course_mode(
-            self,
-            course_catalog_api_client_mock,
-            course_api_client_mock,
-            enrollment_api_mock,
-            *args
-    ):  # pylint: disable=unused-argument,invalid-name
-        """
-        Verify that user is redirected to course in case the provided
-        course mode is audit track.
-        """
-        self._login()
-        course_id = 'course-v1:edX+DemoX+Demo_Course'
-        enterprise_customer = EnterpriseCustomerFactory(
-            name='Starfleet Academy',
-            enable_data_sharing_consent=True,
-            enforce_data_sharing_consent='at_enrollment',
-        )
-        ecu = EnterpriseCustomerUserFactory(
-            user_id=self.user.id,
-            enterprise_customer=enterprise_customer
-        )
-        enterprise_catalog = EnterpriseCustomerCatalogFactory(enterprise_customer=enterprise_customer)
-        course_catalog_api_client_mock.return_value.program_exists.return_value = True
-        course_api_client_mock.return_value.get_course_details.return_value = {'name': 'edX Demo Course'}
-        enrollment_api_mock.return_value.get_course_modes.return_value = (
-            {
-                "slug": "professional",
-                "name": "Professional Track",
-                "min_price": 100,
-                "sku": "sku-audit",
-            },
-            {
-                "slug": "audit",
-                "name": "Audit Track",
-                "min_price": 0,
-                "sku": "sku-audit",
-            },
-        )
-        post_data = {
-            'enterprise_customer_uuid': enterprise_customer.uuid,
-            'course_id': course_id,
-            'redirect_url': '/successful_enrollment?{}'.format(
-                urlencode({
-                    'course_mode': 'audit',
-                    'catalog': enterprise_catalog.uuid,
-                })
-            ),
-            'failure_url': '/failure_url',
-            'data_sharing_consent': True
-        }
-
-        resp = self.client.post(self.url, post_data)
-        redirect_url = LMS_COURSEWARE_URL.format(course_id=course_id)
-        self.assertRedirects(resp, redirect_url, fetch_redirect_response=False)
-        self.assertTrue(EnterpriseCourseEnrollment.objects.filter(
-            enterprise_customer_user__enterprise_customer=enterprise_customer,
-            enterprise_customer_user__user_id=ecu.user_id,
-            course_id=course_id
-        ).exists())
-
-    @mock.patch('enterprise.views.EnrollmentApiClient')
-    @mock.patch('enterprise.views.CourseApiClient')
-    @mock.patch('enterprise.models.CourseCatalogApiServiceClient')
-    def test_handle_consent_enrollment_with_verified_course_mode(
-            self,
-            course_catalog_api_client_mock,
-            course_api_client_mock,
-            enrollment_api_mock,
-            *args
-    ):  # pylint: disable=unused-argument,invalid-name
-        """
-        Verify that user is redirected to course in case the provided
-        course mode is audit track.
-        """
-        self._login()
-        course_id = 'course-v1:edX+DemoX+Demo_Course'
-        enterprise_customer = EnterpriseCustomerFactory(
-            name='Starfleet Academy',
-            enable_data_sharing_consent=True,
-            enforce_data_sharing_consent='at_enrollment',
-        )
-        ecu = EnterpriseCustomerUserFactory(
-            user_id=self.user.id,
-            enterprise_customer=enterprise_customer
-        )
-        enterprise_catalog = EnterpriseCustomerCatalogFactory(enterprise_customer=enterprise_customer)
-        course_catalog_api_client_mock.return_value.program_exists.return_value = True
-        course_api_client_mock.return_value.get_course_details.return_value = {'name': 'edX Demo Course'}
-        enrollment_api_mock.return_value.get_course_modes.return_value = (
-            {
-                "slug": "professional",
-                "name": "Professional Track",
-                "min_price": 100,
-                "sku": "sku-audit",
-            },
-            {
-                "slug": "audit",
-                "name": "Audit Track",
-                "min_price": 0,
-                "sku": "sku-audit",
-            },
-        )
-        post_data = {
-            'enterprise_customer_uuid': enterprise_customer.uuid,
-            'course_id': course_id,
-            'redirect_url': '/successful_enrollment?{}'.format(
-                urlencode({
-                    'course_mode': 'professional',
-                    'catalog': enterprise_catalog.uuid,
-                })
-            ),
-            'failure_url': '/failure_url',
-            'data_sharing_consent': True
-        }
-
-        resp = self.client.post(self.url, post_data)
-        redirect_url = LMS_START_PREMIUM_COURSE_FLOW_URL.format(course_id=course_id)
-        redirect_url += '?catalog={catalog_uuid}'.format(
-            catalog_uuid=enterprise_catalog.uuid
-        )
-        self.assertRedirects(resp, redirect_url, fetch_redirect_response=False)
-
-        self.assertTrue(EnterpriseCourseEnrollment.objects.filter(
-            enterprise_customer_user__enterprise_customer=enterprise_customer,
-            enterprise_customer_user__user_id=ecu.user_id,
-            course_id=course_id
-        ).exists())
-
 
 @mark.django_db
 @ddt.ddt
@@ -827,7 +570,7 @@ class TestProgramDataSharingPermissions(TestCase):
     }
     valid_post_params = {
         'enterprise_customer_uuid': 'fake-uuid',
-        'redirect_url': 'http://lms.example.com/dashboard',
+        'redirect_url': 'https://google.com/',
         'failure_url': 'https://facebook.com/',
         'program_uuid': 'fake-program-uuid',
         'data_sharing_consent': 'true',
@@ -927,7 +670,7 @@ class TestProgramDataSharingPermissions(TestCase):
         self._login()
         response = self.client.post(self.url, self.valid_post_params, follow=False)
         consent_record.save.assert_called_once()
-        self.assertRedirects(response, 'http://lms.example.com/dashboard', fetch_redirect_response=False)
+        self.assertRedirects(response, 'https://google.com/', fetch_redirect_response=False)
 
     def test_post_program_consent_not_provided(self):
         consent_record = self.get_data_sharing_consent.return_value
@@ -949,7 +692,7 @@ class TestProgramDataSharingPermissions(TestCase):
         params['defer_creation'] = 'True'
         response = self.client.post(self.url, params, follow=False)
         consent_record.save.assert_not_called()
-        self.assertRedirects(response, 'http://lms.example.com/dashboard', fetch_redirect_response=False)
+        self.assertRedirects(response, 'https://google.com/', fetch_redirect_response=False)
 
     @ddt.data(False, True)
     @mock.patch('enterprise.views.render', side_effect=fake_render)

--- a/tests/test_enterprise/views/test_handle_consent_enrollment.py
+++ b/tests/test_enterprise/views/test_handle_consent_enrollment.py
@@ -1,0 +1,310 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for the ``HandleConsentEnrollment`` view of the Enterprise app.
+"""
+
+from __future__ import absolute_import, unicode_literals
+
+import ddt
+import mock
+from faker import Factory as FakerFactory
+from pytest import mark
+from six.moves.urllib.parse import urlencode  # pylint: disable=import-error
+
+from django.core.urlresolvers import reverse
+from django.test import Client, TestCase
+
+from enterprise.models import EnterpriseCourseEnrollment
+from enterprise.views import LMS_COURSEWARE_URL, LMS_DASHBOARD_URL, LMS_START_PREMIUM_COURSE_FLOW_URL
+from test_utils.factories import (
+    EnterpriseCustomerCatalogFactory,
+    EnterpriseCustomerFactory,
+    EnterpriseCustomerIdentityProviderFactory,
+    EnterpriseCustomerUserFactory,
+    UserFactory,
+)
+from test_utils.mixins import EnterpriseViewMixin
+
+
+@mark.django_db
+@ddt.ddt
+class TestHandleConsentEnrollmentView(EnterpriseViewMixin, TestCase):
+    """
+    Test HandleConsentEnrollment.
+    """
+
+    def setUp(self):
+        self.user = UserFactory.create(is_staff=True, is_active=True)
+        self.user.set_password("QWERTY")
+        self.user.save()
+        self.client = Client()
+        self.demo_course_id = 'course-v1:edX+DemoX+Demo_Course'
+        self.dummy_demo_course_modes = [
+            {
+                "slug": "professional",
+                "name": "Professional Track",
+                "min_price": 100,
+                "sku": "sku-audit",
+            },
+            {
+                "slug": "audit",
+                "name": "Audit Track",
+                "min_price": 0,
+                "sku": "sku-audit",
+            },
+        ]
+        super(TestHandleConsentEnrollmentView, self).setUp()
+
+    def _login(self):
+        """
+        Log user in.
+        """
+        assert self.client.login(username=self.user.username, password="QWERTY")
+
+    def _setup_registry_mock(self, registry_mock, provider_id):
+        """
+        Sets up the SSO Registry object
+        """
+        registry_mock.get.return_value.configure_mock(provider_id=provider_id)
+
+    @mock.patch('enterprise.views.ProgramDataExtender')
+    @mock.patch('enterprise.utils.Registry')
+    def test_handle_consent_enrollment_without_course_mode(
+            self,
+            registry_mock,
+            *args
+    ):  # pylint: disable=unused-argument
+        """
+        Verify that user is redirected to LMS dashboard in case there is
+        no parameter `course_mode` in the request querystring.
+        """
+        course_id = self.demo_course_id
+        enterprise_customer = EnterpriseCustomerFactory(
+            name='Starfleet Academy',
+            enable_data_sharing_consent=True,
+            enforce_data_sharing_consent='at_enrollment',
+            enable_audit_enrollment=True,
+        )
+        faker = FakerFactory.create()
+        provider_id = faker.slug()  # pylint: disable=no-member
+        self._setup_registry_mock(registry_mock, provider_id)
+        EnterpriseCustomerIdentityProviderFactory(provider_id=provider_id, enterprise_customer=enterprise_customer)
+        self._login()
+        handle_consent_enrollment_url = self._append_fresh_login_param(
+            reverse(
+                'enterprise_handle_consent_enrollment',
+                args=[enterprise_customer.uuid, course_id],
+            )
+        )
+        response = self.client.get(handle_consent_enrollment_url)
+        redirect_url = LMS_DASHBOARD_URL
+        self.assertRedirects(response, redirect_url, fetch_redirect_response=False)
+
+    @mock.patch('enterprise.views.ProgramDataExtender')
+    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.utils.Registry')
+    def test_handle_consent_enrollment_404(
+            self,
+            registry_mock,
+            enrollment_api_client_mock,
+            *args
+    ):  # pylint: disable=unused-argument
+        """
+        Verify that user gets HTTP 404 response if there is no enterprise in
+        database against the provided enterprise UUID or if enrollment API
+        client is unable to get course modes for the provided course id.
+        """
+        course_id = self.demo_course_id
+        enrollment_client = enrollment_api_client_mock.return_value
+        enrollment_client.get_course_modes.return_value = {}
+        enterprise_customer = EnterpriseCustomerFactory(
+            name='Starfleet Academy',
+            enable_data_sharing_consent=True,
+            enforce_data_sharing_consent='at_enrollment',
+            enable_audit_enrollment=True,
+        )
+        faker = FakerFactory.create()
+        provider_id = faker.slug()  # pylint: disable=no-member
+        self._setup_registry_mock(registry_mock, provider_id)
+        EnterpriseCustomerIdentityProviderFactory(provider_id=provider_id, enterprise_customer=enterprise_customer)
+        self._login()
+        handle_consent_enrollment_url = self._append_fresh_login_param(
+            '{consent_enrollment_url}?{params}'.format(
+                consent_enrollment_url=reverse(
+                    'enterprise_handle_consent_enrollment', args=[enterprise_customer.uuid, course_id]
+                ),
+                params=urlencode({'course_mode': 'professional'})
+            )
+        )
+        response = self.client.get(handle_consent_enrollment_url)
+        assert response.status_code == 404
+
+    @mock.patch('enterprise.views.ProgramDataExtender')
+    @mock.patch('enterprise.views.get_enterprise_customer_user')
+    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.utils.Registry')
+    def test_handle_consent_enrollment_with_invalid_course_mode(
+            self,
+            registry_mock,
+            enrollment_api_client_mock,
+            get_ec_user_mock,
+            *args
+    ):  # pylint: disable=unused-argument
+        """
+        Verify that user is redirected to LMS dashboard in case the provided
+        course mode does not exist.
+        """
+        course_id = self.demo_course_id
+        enterprise_customer = EnterpriseCustomerFactory(
+            name='Starfleet Academy',
+            enable_data_sharing_consent=True,
+            enforce_data_sharing_consent='at_enrollment',
+            enable_audit_enrollment=True,
+        )
+        faker = FakerFactory.create()
+        provider_id = faker.slug()  # pylint: disable=no-member
+        self._setup_registry_mock(registry_mock, provider_id)
+        EnterpriseCustomerIdentityProviderFactory(provider_id=provider_id, enterprise_customer=enterprise_customer)
+        enterprise_customer_user = EnterpriseCustomerUserFactory(
+            user_id=self.user.id,
+            enterprise_customer=enterprise_customer
+        )
+        enrollment_client = enrollment_api_client_mock.return_value
+        enrollment_client.get_course_modes.return_value = self.dummy_demo_course_modes
+        mocked_enterprise_customer_user = get_ec_user_mock.return_value
+        mocked_enterprise_customer_user.return_value = enterprise_customer_user
+        self._login()
+        handle_consent_enrollment_url = self._append_fresh_login_param(
+            '{consent_enrollment_url}?{params}'.format(
+                consent_enrollment_url=reverse(
+                    'enterprise_handle_consent_enrollment', args=[enterprise_customer.uuid, course_id]
+                ),
+                params=urlencode({'course_mode': 'some-invalid-course-mode'})
+            )
+        )
+        response = self.client.get(handle_consent_enrollment_url)
+        redirect_url = LMS_DASHBOARD_URL
+        self.assertRedirects(response, redirect_url, fetch_redirect_response=False)
+
+    @mock.patch('enterprise.views.ProgramDataExtender')
+    @mock.patch('enterprise.views.track_enrollment')
+    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.utils.Registry')
+    def test_handle_consent_enrollment_with_audit_course_mode(
+            self,
+            registry_mock,
+            enrollment_api_client_mock,
+            track_enrollment_mock,
+            *args
+    ):  # pylint: disable=unused-argument
+        """
+        Verify that user is redirected to course in case the provided
+        course mode is audit track.
+        """
+        course_id = self.demo_course_id
+        enterprise_customer = EnterpriseCustomerFactory(
+            name='Starfleet Academy',
+            enable_data_sharing_consent=True,
+            enforce_data_sharing_consent='at_enrollment',
+            enable_audit_enrollment=True,
+        )
+        faker = FakerFactory.create()
+        provider_id = faker.slug()  # pylint: disable=no-member
+        self._setup_registry_mock(registry_mock, provider_id)
+        EnterpriseCustomerIdentityProviderFactory(provider_id=provider_id, enterprise_customer=enterprise_customer)
+        enterprise_customer_user = EnterpriseCustomerUserFactory(
+            user_id=self.user.id,
+            enterprise_customer=enterprise_customer
+        )
+        enrollment_client = enrollment_api_client_mock.return_value
+        enrollment_client.get_course_modes.return_value = self.dummy_demo_course_modes
+        self._login()
+        handle_consent_enrollment_url = self._append_fresh_login_param(
+            '{consent_enrollment_url}?{params}'.format(
+                consent_enrollment_url=reverse(
+                    'enterprise_handle_consent_enrollment', args=[enterprise_customer.uuid, course_id]
+                ),
+                params=urlencode({'course_mode': 'audit'})
+            )
+        )
+        response = self.client.get(handle_consent_enrollment_url)
+        redirect_url = LMS_COURSEWARE_URL.format(course_id=course_id)
+        self.assertRedirects(response, redirect_url, fetch_redirect_response=False)
+
+        self.assertTrue(EnterpriseCourseEnrollment.objects.filter(
+            enterprise_customer_user__enterprise_customer=enterprise_customer,
+            enterprise_customer_user__user_id=enterprise_customer_user.user_id,
+            course_id=course_id
+        ).exists())
+
+        track_enrollment_mock.assert_called_once_with(
+            'course-landing-page-enrollment',
+            enterprise_customer_user.user_id,
+            course_id,
+            handle_consent_enrollment_url,
+        )
+
+    @mock.patch('enterprise.views.ProgramDataExtender')
+    @mock.patch('enterprise.views.track_enrollment')
+    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.utils.Registry')
+    def test_handle_consent_enrollment_with_professional_course_mode(
+            self,
+            registry_mock,
+            enrollment_api_client_mock,
+            track_enrollment_mock,
+            *args
+    ):  # pylint: disable=unused-argument
+        """
+        Verify that user is redirected to course in case the provided
+        course mode is audit track.
+        """
+        course_id = self.demo_course_id
+        enterprise_customer = EnterpriseCustomerFactory(
+            name='Starfleet Academy',
+            enable_data_sharing_consent=True,
+            enforce_data_sharing_consent='at_enrollment',
+            enable_audit_enrollment=True,
+        )
+        enterprise_catalog = EnterpriseCustomerCatalogFactory(enterprise_customer=enterprise_customer)
+        faker = FakerFactory.create()
+        provider_id = faker.slug()  # pylint: disable=no-member
+        self._setup_registry_mock(registry_mock, provider_id)
+        EnterpriseCustomerIdentityProviderFactory(provider_id=provider_id, enterprise_customer=enterprise_customer)
+        enterprise_customer_user = EnterpriseCustomerUserFactory(
+            user_id=self.user.id,
+            enterprise_customer=enterprise_customer
+        )
+        enrollment_client = enrollment_api_client_mock.return_value
+        enrollment_client.get_course_modes.return_value = self.dummy_demo_course_modes
+        self._login()
+        handle_consent_enrollment_url = self._append_fresh_login_param(
+            '{consent_enrollment_url}?{params}'.format(
+                consent_enrollment_url=reverse(
+                    'enterprise_handle_consent_enrollment', args=[enterprise_customer.uuid, course_id]
+                ),
+                params=urlencode({
+                    'course_mode': 'professional',
+                    'catalog': enterprise_catalog.uuid
+                })
+            )
+        )
+        response = self.client.get(handle_consent_enrollment_url)
+        redirect_url = LMS_START_PREMIUM_COURSE_FLOW_URL.format(course_id=course_id)
+        redirect_url += '?catalog={catalog_uuid}'.format(
+            catalog_uuid=enterprise_catalog.uuid
+        )
+        self.assertRedirects(response, redirect_url, fetch_redirect_response=False)
+
+        self.assertTrue(EnterpriseCourseEnrollment.objects.filter(
+            enterprise_customer_user__enterprise_customer=enterprise_customer,
+            enterprise_customer_user__user_id=enterprise_customer_user.user_id,
+            course_id=course_id
+        ).exists())
+
+        track_enrollment_mock.assert_called_once_with(
+            'course-landing-page-enrollment',
+            enterprise_customer_user.user_id,
+            course_id,
+            handle_consent_enrollment_url,
+        )

--- a/tests/test_enterprise/views/test_router_view.py
+++ b/tests/test_enterprise/views/test_router_view.py
@@ -32,6 +32,9 @@ class TestRouterView(TestCase):
         views.RouterView.PROGRAM_ENROLLMENT_VIEW_URL: mock.MagicMock(
             as_view=mock.MagicMock(return_value=lambda request, *args, **kwargs: 'program_enrollment_view')
         ),
+        views.RouterView.HANDLE_CONSENT_ENROLLMENT_VIEW_URL: mock.MagicMock(
+            as_view=mock.MagicMock(return_value=lambda request, *args, **kwargs: 'handle_consent_enrollment_view')
+        ),
     }
 
     def setUp(self):
@@ -138,6 +141,16 @@ class TestRouterView(TestCase):
             'program_uuid': '52ad909b-c57d-4ff1-bab3-999813a2479b'
         }
         assert views.RouterView().redirect(self.request, **self.kwargs) == 'program_enrollment_view'
+
+    def test_redirect_to_handle_consent_enrollment_view(self):
+        """
+        ``redirect`` properly redirects to ``enterprise.views.HandleConsentEnrollmentView``.
+        """
+        self.request = mock.MagicMock(path=reverse(
+            'enterprise_handle_consent_enrollment',
+            args=[self.enterprise_customer.uuid, self.course_run_id]
+        ))
+        assert views.RouterView().redirect(self.request, **self.kwargs) == 'handle_consent_enrollment_view'
 
     @mock.patch('enterprise.views.RouterView', new_callable=views.RouterView)
     def test_get_redirects_by_default(self, router_view_mock):


### PR DESCRIPTION
**Description:** This reverts commit 6f9f95ae1992e8ba45af620983e85e4f181ae773.

**JIRA:** https://openedx.atlassian.net/browse/ENT-1467

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

With the current version of edx-enterprise, attempt to redeem a coupon (https://ecommerce-business.sandbox.edx.org/coupons/offer/?code=6I74JCNLR3HO6VAP). The expected behavior should be the bug we are seeing, which is that after the user accepts DSC, they are redirected to the dashboard without being enrolled in the course.

Next, install this version of edx-enterprise, and attempt to redeem the same coupon. The redemption should succeed as expected.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
