### PR TITLE
ENT-1405 Include Enterprise Catalog UUID in Enterprise Customer django admin inline

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[1.2.10] - 2019-01-30
+---------------------
+
+* Include Enterprise Catalog UUID in Enterprise Customer django admin inline.
+
 [1.2.9] - 2019-01-23
 --------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.2.9"
+__version__ = "1.2.10"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -1222,8 +1222,10 @@ class EnterpriseCustomerCatalog(TimeStampedModel):
         """
         return (
             "<EnterpriseCustomerCatalog '{title}' "
+            "with UUID '{uuid}' "
             "for EnterpriseCustomer {enterprise_customer_name}>".format(
                 title=self.title,
+                uuid=self.uuid,
                 enterprise_customer_name=self.enterprise_customer.name
             )
         )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -852,8 +852,9 @@ class TestEnterpriseCustomerCatalog(unittest.TestCase):
             title=title,
             enterprise_customer=factories.EnterpriseCustomerFactory(name=name)
         )
-        expected_str = "<EnterpriseCustomerCatalog '{title}' for EnterpriseCustomer {name}>".format(
+        expected_str = "<EnterpriseCustomerCatalog '{title}' with UUID '{uuid}' for EnterpriseCustomer {name}>".format(
             title=title,
+            uuid=enterprise_catalog.uuid,
             name=name
         )
         self.assertEqual(method(enterprise_catalog), expected_str)


### PR DESCRIPTION
**Description:** This PR adds the catalog uuid back into the text of its string representation.

**JIRA:** https://openedx.atlassian.net/browse/ENT-1405

**Dependencies:** n/a

**Merge deadline:** asap

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

On the business sandbox, go to the Enterprise Customer edit screen. See that each attached enterprise catalog now includes the UUID in the string representation.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
