### PR TITLE
fix the link to the documentation which was giving a 404

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ enterprise
     :alt: Codecov
 
 .. image:: http://edx-enterprise.readthedocs.io/en/latest/?badge=latest
-    :target: http://edx-enterprise.readthedocs.io/en/latest/
+    :target: http://open-edx-enterprise-service-documentation.readthedocs.io/en/latest/
     :alt: Documentation
 
 .. image:: https://img.shields.io/pypi/pyversions/edx-enterprise.svg


### PR DESCRIPTION
trivial change to fix the broken 404 link to the documentation.