### PR TITLE
WL-1895: Skip operations if we don't have any inactive learners

### DIFF
--- a/integrated_channels/sap_success_factors/client.py
+++ b/integrated_channels/sap_success_factors/client.py
@@ -312,7 +312,10 @@ class SAPSuccessFactorsAPIClient(IntegratedChannelApiClient):  # pylint: disable
 
         if 'error' in sap_inactive_learners:
             LOGGER.warning(
-                'SAP searchStudent API returned response with error message "%s" and with error code "%s".',
+                'SAP searchStudent API for customer %s and base url %s returned response with '
+                'error message "%s" and with error code "%s".',
+                self.enterprise_configuration.enterprise_customer.name,
+                self.enterprise_configuration.sapsf_base_url,
                 sap_inactive_learners['error'].get('message'),
                 sap_inactive_learners['error'].get('code'),
             )

--- a/integrated_channels/sap_success_factors/exporters/learner_data.py
+++ b/integrated_channels/sap_success_factors/exporters/learner_data.py
@@ -99,6 +99,13 @@ class SapSuccessFactorsLearnerManger(object):
         """
         sap_inactive_learners = self.client.get_inactive_sap_learners()
         enterprise_customer = self.enterprise_configuration.enterprise_customer
+        if not sap_inactive_learners:
+            LOGGER.info(
+                'Enterprise customer {%s} has no SAPSF inactive learners',
+                enterprise_customer.name
+            )
+            return
+
         provider_id = enterprise_customer.identity_provider
         tpa_provider = get_identity_provider(provider_id)
         if not tpa_provider:

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -1085,7 +1085,10 @@ class TestUnlinkSAPLearnersManagementCommand(unittest.TestCase, EnterpriseMockMi
         expected_messages = [
             'Processing learners to unlink inactive users using configuration: '
             '[<SAPSuccessFactorsEnterpriseCustomerConfiguration for Enterprise Veridian Dynamics>]',
-            '''SAP searchStudent API returned response with error message "The property 'InvalidProperty', used in '''
-            '''a query expression, is not defined in type 'com.sap.lms.odata.Student'." and with error code "None".'''
+            '''SAP searchStudent API for customer Veridian Dynamics '''
+            '''and base url http://enterprise.successfactors.com/ returned response with error message '''
+            '''"The property 'InvalidProperty', used in '''
+            '''a query expression, is not defined in type 'com.sap.lms.odata.Student'." and with error code "None".''',
+            'Enterprise customer {Veridian Dynamics} has no SAPSF inactive learners',
         ]
         self.assert_info_logs_sap_learners_unlink(expected_messages)


### PR DESCRIPTION
This PR has changes to skip any further operations if we SAPSF does not return any inactive learners. It would prevent exception raised due to unavailability of inactive learners.

**JIRA:** Link to JIRA ticket

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happend instead - check failed.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
