### PR TITLE
WL-1893: Query indexed field of UserSocialAuth

### DIFF
--- a/enterprise/tpa_pipeline.py
+++ b/enterprise/tpa_pipeline.py
@@ -79,17 +79,12 @@ def get_user_from_social_auth(tpa_provider, tpa_username):
     Find the LMS user from the LMS model `UserSocialAuth`.
 
     Arguments:
-        tpa_provider (str): Slug for the third party auth
+        tpa_provider (third_party_auth.provider): third party auth provider object
         tpa_username (str): Username returned by the third party auth
 
     """
-    user_id = '{provider}:{username}'.format(
-        provider=tpa_provider.split('-')[-1],
-        username=tpa_username
-    )
+    user_social_auth = UserSocialAuth.objects.select_related('user').filter(
+        user__username=tpa_username, provider=tpa_provider.backend_name
+    ).first()
 
-    try:
-        user_social_auth = UserSocialAuth.objects.get(uid=user_id)
-        return user_social_auth.user
-    except UserSocialAuth.DoesNotExist:
-        return None
+    return user_social_auth.user if user_social_auth else None

--- a/integrated_channels/sap_success_factors/exporters/learner_data.py
+++ b/integrated_channels/sap_success_factors/exporters/learner_data.py
@@ -10,9 +10,9 @@ from logging import getLogger
 
 from django.apps import apps
 
-from enterprise.models import EnterpriseCustomer, EnterpriseCustomerUser, PendingEnterpriseCustomerUser
+from enterprise.models import EnterpriseCustomerUser, PendingEnterpriseCustomerUser
 from enterprise.tpa_pipeline import get_user_from_social_auth
-from enterprise.utils import parse_course_key
+from enterprise.utils import get_identity_provider, parse_course_key
 from integrated_channels.integrated_channel.exporters.learner_data import LearnerExporter
 from integrated_channels.sap_success_factors.client import SAPSuccessFactorsAPIClient
 from integrated_channels.utils import parse_datetime_to_epoch_millis
@@ -99,9 +99,9 @@ class SapSuccessFactorsLearnerManger(object):
         """
         sap_inactive_learners = self.client.get_inactive_sap_learners()
         enterprise_customer = self.enterprise_configuration.enterprise_customer
-        try:
-            tpa_provider = enterprise_customer.enterprise_customer_identity_provider.provider_id
-        except EnterpriseCustomer.enterprise_customer_identity_provider.RelatedObjectDoesNotExist:
+        provider_id = enterprise_customer.identity_provider
+        tpa_provider = get_identity_provider(provider_id)
+        if not tpa_provider:
             LOGGER.info(
                 'Enterprise customer {%s} has no associated identity provider',
                 enterprise_customer.name


### PR DESCRIPTION
Query indexed field of UserSocialAuth model to improve performance of `unlink_inactive_sap_learners` management command

**Description:** Describe in a couple of sentence what this PR adds

**JIRA:** Link to JIRA ticket

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happend instead - check failed.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
