### PR TITLE
Assign enterprise roles to existing enterprise users

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[1.3.4] - 2019-03-21
+--------------------
+
+* Management command to assign enterprise roles to users.
+
 [1.3.3] - 2019-03-21
 --------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.3.3"
+__version__ = "1.3.4"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/constants.py
+++ b/enterprise/constants.py
@@ -85,9 +85,10 @@ DEFAULT_CATALOG_CONTENT_FILTER = {
 }
 
 # Django groups specific to granting permission to enterprise admins.
+ENTERPRISE_DATA_API_ACCESS_GROUP = 'enterprise_data_api_access'
 ENTERPRISE_PERMISSION_GROUPS = [
     'enterprise_enrollment_api_access',
-    'enterprise_data_api_access',
+    ENTERPRISE_DATA_API_ACCESS_GROUP,
 ]
 
 ENTERPRISE_LEARNER_ROLE = 'enterprise_learner'

--- a/enterprise/management/commands/assign_enterprise_user_roles.py
+++ b/enterprise/management/commands/assign_enterprise_user_roles.py
@@ -1,0 +1,134 @@
+"""
+Management command for assigning enterprise roles to existing enterprise users.
+"""
+from __future__ import absolute_import, unicode_literals
+
+import logging
+from time import sleep
+
+from django.contrib.auth.models import User
+from django.core.management.base import BaseCommand, CommandError
+
+from enterprise.constants import ENTERPRISE_ADMIN_ROLE, ENTERPRISE_DATA_API_ACCESS_GROUP, ENTERPRISE_LEARNER_ROLE
+from enterprise.models import EnterpriseCustomerUser, SystemWideEnterpriseRole, SystemWideEnterpriseUserRoleAssignment
+
+LOGGER = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    Management command for assigning enterprise roles to existing enterprise users.
+
+    Example usage:
+        $ ./manage.py assign_enterprise_user_roles --role=enterprise_admin
+        $ ./manage.py assign_enterprise_user_roles --role=enterprise_learner
+    """
+    help = 'Assigns enterprise roles to existing enterprise users.'
+
+    def add_arguments(self, parser):
+        """
+        Entry point for subclassed commands to add custom arguments.
+        """
+        parser.add_argument(
+            '--role',
+            action='store',
+            dest='role',
+            default=None,
+            help='Role to assign users role assignments.'
+        )
+        parser.add_argument(
+            '--batch-limit',
+            action='store',
+            dest='batch_limit',
+            default=100,
+            help='Number of users in each batch of conditional offer migration.',
+            type=int,
+        )
+
+        parser.add_argument(
+            '--batch-offset',
+            action='store',
+            dest='batch_offset',
+            default=0,
+            help='Which index to start batching from.',
+            type=int,
+        )
+
+        parser.add_argument(
+            '--batch-sleep',
+            action='store',
+            dest='batch_sleep',
+            default=10,
+            help='How long to sleep between batches.',
+            type=int,
+        )
+
+    def _get_enterprise_admin_users_batch(self, start, end):
+        """
+        Returns a batched queryset of User objects.
+        """
+        LOGGER.info('Fetching new batch of enterprise admin users from indexes: %s to %s', start, end)
+        return User.objects.filter(groups__name=ENTERPRISE_DATA_API_ACCESS_GROUP, is_staff=False)[start:end]
+
+    def _get_enterprise_customer_users_batch(self, start, end):
+        """
+        Returns a batched queryset of EnterpriseCustomerUser objects.
+        """
+        LOGGER.info('Fetching new batch of enterprise customer users from indexes: %s to %s', start, end)
+        return User.objects.filter(pk__in=EnterpriseCustomerUser.objects.values('user_id'))[start:end]
+
+    def _assign_enterprise_role_to_users(self, _get_batch_method, options):
+        """
+        Assigns enterprise role to users.
+        """
+        role_name = options['role']
+        batch_limit = options['batch_limit']
+        batch_sleep = options['batch_sleep']
+        batch_offset = options['batch_offset']
+
+        current_batch_index = batch_offset
+
+        users_batch = _get_batch_method(
+            batch_offset,
+            batch_offset + batch_limit
+        )
+
+        enterprise_role = SystemWideEnterpriseRole.objects.get(name=role_name)
+        while users_batch.count() > 0:
+            for index, user in enumerate(users_batch):
+                LOGGER.info(
+                    'Processing user with index %s and id %s',
+                    current_batch_index + index, user.id
+                )
+                SystemWideEnterpriseUserRoleAssignment.objects.get_or_create(
+                    user=user,
+                    role=enterprise_role
+                )
+
+            sleep(batch_sleep)
+            current_batch_index += len(users_batch)
+            users_batch = _get_batch_method(
+                current_batch_index,
+                current_batch_index + batch_limit
+            )
+
+    def handle(self, *args, **options):
+        """
+        Entry point for managment command execution.
+        """
+        LOGGER.info('Starting assigning enterprise roles to users!')
+
+        role = options['role']
+        if role == ENTERPRISE_ADMIN_ROLE:
+            # Assign admin role to non-staff users with enterprise data api access.
+            self._assign_enterprise_role_to_users(self._get_enterprise_admin_users_batch, options)
+        elif role == ENTERPRISE_LEARNER_ROLE:
+            # Assign enterprise learner role to enterprise customer users.
+            self._assign_enterprise_role_to_users(self._get_enterprise_customer_users_batch, options)
+        else:
+            raise CommandError('Please provide a valid role name. Supported roles are {admin} and {learner}'.format(
+                admin=ENTERPRISE_ADMIN_ROLE,
+                learner=ENTERPRISE_LEARNER_ROLE
+            ))
+
+        LOGGER.info('Successfully finished assigning enterprise roles to users!')


### PR DESCRIPTION
**Description:**

This PR creates a management command that assigns enterprise roles to existing enterprise users.

1. This will  find existing users with `enterprise_data_api_access` django group and assigns an `enterprise_admin` role to them.
2. This also assigns existing `EnterpriseCustomerUsers` an `enterprise_learner` role.

**JIRA:** 
https://openedx.atlassian.net/browse/ENT-1685
Main ticket: https://openedx.atlassian.net/browse/ENT-1554