### PR TITLE
Assign an enterprise learner role to EnterpriseCustomerUser

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[1.3.5] - 2019-03-22
+--------------------
+
+* Assign an enterprise learner role to new EnterpriseCustomerUser.
+
 [1.3.4] - 2019-03-21
 --------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.3.4"
+__version__ = "1.3.5"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -10,6 +10,7 @@ from contextlib import contextmanager
 from datetime import datetime, timedelta
 
 import ddt
+import factory
 import mock
 import responses
 from faker import Factory as FakerFactory
@@ -21,6 +22,7 @@ from testfixtures import LogCapture
 from django.contrib.auth.models import User
 from django.core.management import call_command
 from django.core.management.base import CommandError
+from django.db.models import signals
 from django.utils import timezone
 
 from enterprise.api_client import lms as lms_api
@@ -1103,6 +1105,7 @@ class TestUnlinkSAPLearnersManagementCommand(unittest.TestCase, EnterpriseMockMi
 
 @ddt.ddt
 @mark.django_db
+@factory.django.mute_signals(signals.post_save)
 class TestMigrateEnterpriseUserRolesCommand(unittest.TestCase):
     """
     Test the assign_enterprise_user_roles management command.


### PR DESCRIPTION
**Description:**
This PR creates a `post_save` signal that will assign a enterprise learner role to EnterpriseCustomerUser whenever a new record is created.

*JIRA:** 
https://openedx.atlassian.net/browse/ENT-1686
Main ticket: https://openedx.atlassian.net/browse/ENT-1554
