### PR TITLE
Move default_content_filter to signals.py for consistency

### DIFF
--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -28,8 +28,6 @@ from django.core.files.storage import default_storage
 from django.core.urlresolvers import reverse
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
-from django.db.models.signals import post_save
-from django.dispatch import receiver
 from django.template import Context, Template
 from django.utils.encoding import force_bytes, force_text, python_2_unicode_compatible
 from django.utils.functional import cached_property, lazy
@@ -48,7 +46,6 @@ from enterprise.utils import (
     CourseEnrollmentDowngradeError,
     CourseEnrollmentPermissionError,
     get_configuration_value,
-    get_default_catalog_content_filter,
     parse_course_key,
 )
 from enterprise.validators import validate_image_extension, validate_image_size
@@ -1430,16 +1427,6 @@ class EnterpriseCustomerCatalog(TimeStampedModel):
             url = utils.update_query_parameters(url, {'audit': 'true'})
 
         return utils.update_query_parameters(url, {'catalog': self.uuid})
-
-
-@receiver(post_save, sender=EnterpriseCustomerCatalog, dispatch_uid='default_content_filter')
-def default_content_filter(sender, instance, **kwargs):     # pylint: disable=unused-argument
-    """
-    Set default value for `EnterpriseCustomerCatalog.content_filter` if not already set.
-    """
-    if kwargs['created'] and not instance.content_filter:
-        instance.content_filter = get_default_catalog_content_filter()
-        instance.save()
 
 
 @python_2_unicode_compatible

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -19,7 +19,6 @@ from django.core.files import File
 from django.core.files.storage import Storage
 from django.core.urlresolvers import reverse
 from django.http import QueryDict
-from django.test import override_settings
 from django.test.testcases import TransactionTestCase
 
 from consent.errors import InvalidProxyConsent
@@ -1040,49 +1039,6 @@ class TestEnterpriseCustomerCatalog(unittest.TestCase):
         )
         enterprise_catalog.save()
         assert EnterpriseCustomerCatalog.objects.get(uuid=uuid).title == title
-
-    @ddt.data(
-        (
-            {
-                'content_type': 'course',
-                'partner': 'edx'
-            },
-            {
-                'content_type': 'course',
-                'partner': 'edx'
-            }
-        ),
-        (
-            {
-                'content_type': 'course',
-                'level_type': [
-                    'Introductory',
-                    'Intermediate'
-                ]
-            },
-            {
-                'content_type': 'course',
-                'level_type': [
-                    'Introductory',
-                    'Intermediate'
-                ]
-            }
-        ),
-        # if the value is not set is settings, it picks default value from constant.
-        (
-            {},
-            {'content_type': 'course'}
-        )
-    )
-    @ddt.unpack
-    @mock.patch('enterprise.utils.DEFAULT_CATALOG_CONTENT_FILTER', {'content_type': 'course'})
-    def test_default_content_filter(self, default_content_filter, expected_content_filter):
-        """
-        Test that `EnterpriseCustomerCatalog`.content_filter is saved with correct default content filter.
-        """
-        with override_settings(ENTERPRISE_CUSTOMER_CATALOG_DEFAULT_CONTENT_FILTER=default_content_filter):
-            enterprise_catalog = factories.EnterpriseCustomerCatalogFactory()
-            assert enterprise_catalog.content_filter == expected_content_filter
 
 
 @mark.django_db


### PR DESCRIPTION
This PR moves `default_content_filter` signal to `signals.py` where rest of the signals are placed.
