### PR TITLE
Assign edx enterprise operator role

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[1.3.8] - 2019-03-29
+--------------------
+
+* Update `assign_enterprise_user_roles` management command to also assign enterprise operator role.
+
 [1.3.7] - 2019-03-28
 --------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.3.7"
+__version__ = "1.3.8"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name


### PR DESCRIPTION
The purpose of this PR is to add the capability to assign enterprise operator role to staff users with `enterprise_data_api_access` group in `assign_enterprise_user_roles` management command.

[ENT-1736](https://openedx.atlassian.net/browse/ENT-1736)