### PR TITLE
ENT-1730 Adding feature specific permission checks to edx-enterprise endpoints

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[1.4.0] - 2019-04-08
+--------------------
+
+* Add new rbac permission checks to enterprise api endpoints.
+
 [1.3.11] - 2019-04-07
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.3.11"
+__version__ = "1.4.0"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/utils.py
+++ b/enterprise/api/utils.py
@@ -6,6 +6,8 @@ from __future__ import absolute_import, unicode_literals
 
 from django.conf import settings
 
+from enterprise.models import EnterpriseCustomerCatalog
+
 SERVICE_USERNAMES = (
     'ECOMMERCE_SERVICE_WORKER_USERNAME',
     'ENTERPRISE_SERVICE_WORKER_USERNAME'
@@ -17,3 +19,13 @@ def get_service_usernames():
     Return the set of service usernames that are given extended permissions in the API.
     """
     return {getattr(settings, username, None) for username in SERVICE_USERNAMES}
+
+
+def get_enterprise_customer_from_catalog_id(catalog_id):
+    """
+    Get the enterprise customer id given an enterprise customer catalog id.
+    """
+    try:
+        return str(EnterpriseCustomerCatalog.objects.get(pk=catalog_id).enterprise_customer.uuid)
+    except EnterpriseCustomerCatalog.DoesNotExist:
+        return None

--- a/enterprise/api/v1/permissions.py
+++ b/enterprise/api/v1/permissions.py
@@ -4,7 +4,10 @@
 
 from __future__ import absolute_import, unicode_literals
 
+import waffle
 from rest_framework import permissions
+
+from enterprise.constants import ENTERPRISE_ROLE_BASED_ACCESS_CONTROL_SWITCH
 
 
 class IsInEnterpriseGroup(permissions.BasePermission):
@@ -16,6 +19,9 @@ class IsInEnterpriseGroup(permissions.BasePermission):
     message = u'User is not allowed to access the view.'
 
     def has_permission(self, request, view):
+        if waffle.switch_is_active(ENTERPRISE_ROLE_BASED_ACCESS_CONTROL_SWITCH):
+            return True
+
         return (
             super(IsInEnterpriseGroup, self).has_permission(request, view) and (
                 request.user.groups.filter(name__in=self.ALLOWED_API_GROUPS).exists() or
@@ -37,6 +43,9 @@ class IsAdminUserOrInGroup(permissions.IsAdminUser):
         Returns True if the requesting user is either 'staff' or belong to specific group, False otherwise.
         It will also check for group membership against a list of groups in the permissions query parameter.
         """
+        if waffle.switch_is_active(ENTERPRISE_ROLE_BASED_ACCESS_CONTROL_SWITCH):
+            return True
+
         return (
             super(IsAdminUserOrInGroup, self).has_permission(request, view) or
             request.user.groups.filter(name__in=self.ALLOWED_API_GROUPS).exists() or

--- a/enterprise/constants.py
+++ b/enterprise/constants.py
@@ -102,6 +102,8 @@ ENTERPRISE_ENROLLMENT_API_ADMIN_ROLE = 'enrollment_api_admin'
 # context to give access to all resources
 ALL_ACCESS_CONTEXT = '*'
 
+ENTERPRISE_ROLE_BASED_ACCESS_CONTROL_SWITCH = 'enterprise_role_based_access_control'
+
 
 def json_serialized_course_modes():
     """

--- a/enterprise/migrations/0067_add_role_based_access_control_switch.py
+++ b/enterprise/migrations/0067_add_role_based_access_control_switch.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+from enterprise.constants import ENTERPRISE_ROLE_BASED_ACCESS_CONTROL_SWITCH
+
+
+def create_switch(apps, schema_editor):
+    """Create the `role_based_access_control` switch if it does not already exist."""
+    Switch = apps.get_model('waffle', 'Switch')
+    Switch.objects.update_or_create(name=ENTERPRISE_ROLE_BASED_ACCESS_CONTROL_SWITCH, defaults={'active': False})
+
+
+def delete_switch(apps, schema_editor):
+    """Delete the `role_based_access_control` switch."""
+    Switch = apps.get_model('waffle', 'Switch')
+    Switch.objects.filter(name=ENTERPRISE_ROLE_BASED_ACCESS_CONTROL_SWITCH).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('enterprise', '0066_add_system_wide_enterprise_operator_role'),
+        ('waffle', '0001_initial')
+    ]
+
+    operations = [
+        migrations.RunPython(create_switch, delete_switch),
+    ]

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -1800,7 +1800,7 @@ class EnterpriseRoleAssignmentContextMixin(object):
             )
             return None
 
-        return enterprise_user.enterprise_customer.uuid
+        return str(enterprise_user.enterprise_customer.uuid)
 
     def get_context(self):
         """

--- a/enterprise/rules.py
+++ b/enterprise/rules.py
@@ -1,0 +1,126 @@
+"""
+Rules needed to restrict access to the enterprise data api.
+"""
+from __future__ import absolute_import, unicode_literals
+
+import rules
+import waffle
+from edx_rbac.utils import (
+    get_decoded_jwt_from_request,
+    get_request_or_stub,
+    request_user_has_implicit_access_via_jwt,
+    user_has_access_via_database,
+)
+
+from enterprise.constants import (
+    ENTERPRISE_CATALOG_ADMIN_ROLE,
+    ENTERPRISE_DASHBOARD_ADMIN_ROLE,
+    ENTERPRISE_ENROLLMENT_API_ADMIN_ROLE,
+    ENTERPRISE_ROLE_BASED_ACCESS_CONTROL_SWITCH,
+)
+from enterprise.models import EnterpriseFeatureUserRoleAssignment
+
+
+@rules.predicate
+def has_implicit_access_to_dashboard(user, obj):  # pylint: disable=unused-argument
+    """
+    Check that if request user has implicit access to `ENTERPRISE_DASHBOARD_ADMIN_ROLE` feature role.
+
+    Returns:
+        boolean: whether the request user has access or not
+    """
+    request = get_request_or_stub()
+    decoded_jwt = get_decoded_jwt_from_request(request)
+    return request_user_has_implicit_access_via_jwt(decoded_jwt, ENTERPRISE_DASHBOARD_ADMIN_ROLE)
+
+
+@rules.predicate
+def has_explicit_access_to_dashboard(user, obj):  # pylint: disable=unused-argument
+    """
+    Check that if request user has explicit access to `ENTERPRISE_DASHBOARD_ADMIN_ROLE` feature role.
+
+    Returns:
+        boolean: whether the request user has access or not
+    """
+    return user_has_access_via_database(
+        user,
+        ENTERPRISE_DASHBOARD_ADMIN_ROLE,
+        EnterpriseFeatureUserRoleAssignment
+    )
+
+
+@rules.predicate
+def has_implicit_access_to_catalog(user, obj):  # pylint: disable=unused-argument
+    """
+    Check that if request user has implicit access to `ENTERPRISE_CATALOG_ADMIN_ROLE` feature role.
+
+    Returns:
+        boolean: whether the request user has access or not
+    """
+    request = get_request_or_stub()
+    decoded_jwt = get_decoded_jwt_from_request(request)
+    return request_user_has_implicit_access_via_jwt(decoded_jwt, ENTERPRISE_CATALOG_ADMIN_ROLE, obj)
+
+
+@rules.predicate
+def has_explicit_access_to_catalog(user, obj):
+    """
+    Check that if request user has explicit access to `ENTERPRISE_CATALOG_ADMIN_ROLE` feature role.
+
+    Returns:
+        boolean: whether the request user has access or not
+    """
+    return user_has_access_via_database(
+        user,
+        ENTERPRISE_CATALOG_ADMIN_ROLE,
+        EnterpriseFeatureUserRoleAssignment,
+        obj
+    )
+
+
+@rules.predicate
+def has_implicit_access_to_enrollment_api(user, obj):  # pylint: disable=unused-argument
+    """
+    Check that if request user has implicit access to `ENTERPRISE_ENROLLMENT_API_ADMIN_ROLE` feature role.
+
+    Returns:
+        boolean: whether the request user has access or not
+    """
+    request = get_request_or_stub()
+    decoded_jwt = get_decoded_jwt_from_request(request)
+    return request_user_has_implicit_access_via_jwt(decoded_jwt, ENTERPRISE_ENROLLMENT_API_ADMIN_ROLE, obj)
+
+
+@rules.predicate
+def has_explicit_access_to_enrollment_api(user, obj):
+    """
+    Check that if request user has explicit access to `ENTERPRISE_ENROLLMENT_API_ADMIN_ROLE` feature role.
+
+    Returns:
+        boolean: whether the request user has access or not
+    """
+    return user_has_access_via_database(
+        user,
+        ENTERPRISE_ENROLLMENT_API_ADMIN_ROLE,
+        EnterpriseFeatureUserRoleAssignment,
+        obj
+    )
+
+
+@rules.predicate
+def rbac_permissions_disabled(user, obj):  # pylint: disable=unused-argument
+    """
+    Temporary check for rbac based permissions being enabled.
+    """
+    return not waffle.switch_is_active(ENTERPRISE_ROLE_BASED_ACCESS_CONTROL_SWITCH)
+
+
+rules.add_perm('enterprise.can_access_admin_dashboard',
+               rbac_permissions_disabled | has_implicit_access_to_dashboard | has_explicit_access_to_dashboard)
+
+rules.add_perm('enterprise.can_view_catalog',
+               rbac_permissions_disabled | has_implicit_access_to_catalog | has_explicit_access_to_catalog)
+
+rules.add_perm('enterprise.can_enroll_learners',
+               rbac_permissions_disabled | has_implicit_access_to_enrollment_api |
+               has_explicit_access_to_enrollment_api)

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -7,4 +7,4 @@ jsondiff==1.1.1                         # Used to detect content metadata change
 django-countries==4.6.1
 -e git+https://github.com/edx/TinCanPython.git@0.0.5.py.35#egg=tincan==0.0.5.py.35
 django-simple-history==2.7.0
-edx-rbac==0.1.5
+edx-rbac==0.1.11

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -22,7 +22,7 @@ chardet==3.0.4            # via requests
 click-log==0.1.8          # via edx-lint
 click==7.0                # via click-log, code-annotations, edx-lint, pip-tools
 code-annotations==0.2.1
-configparser==3.7.3       # via pydocstyle, pylint
+configparser==3.7.4       # via pydocstyle, pylint
 cryptography==2.4.2
 defusedxml==0.5.0         # via djangorestframework-xml
 diff-cover==0.9.8
@@ -49,7 +49,7 @@ edx-drf-extensions==2.0.1
 edx-i18n-tools==0.4.8
 edx-lint==1.1.1
 edx-opaque-keys==0.4.4
-edx-rbac==0.1.5
+edx-rbac==0.1.11
 edx-rest-api-client==1.9.2
 enum34==1.1.6             # via astroid, cryptography
 filelock==3.0.10          # via tox
@@ -60,21 +60,21 @@ html5lib==0.999
 idna==2.8                 # via cryptography, requests
 inflect==2.1.0            # via jinja2-pluralize
 ipaddress==1.0.22         # via cryptography
-isort==4.3.15
+isort==4.3.17
 jinja2-pluralize==0.3.0   # via diff-cover
-jinja2==2.10              # via diff-cover, jinja2-pluralize
+jinja2==2.10.1            # via diff-cover, jinja2-pluralize
 jsondiff==1.1.1
 jsonfield==2.0.2
 kombu==3.0.37             # via celery
 lazy-object-proxy==1.3.1  # via astroid
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via pylint
-newrelic==4.14.0.115      # via edx-django-utils
+newrelic==4.16.1.117      # via edx-django-utils
 packaging==19.0           # via caniusepython3
 path.py==8.2.1
 pbr==5.1.3                # via stevedore
 pillow==5.4.1
-pip-tools==3.5.0
+pip-tools==3.6.0
 pkginfo==1.5.0.1          # via twine
 pluggy==0.9.0             # via tox
 polib==1.1.0              # via edx-i18n-tools
@@ -82,7 +82,7 @@ psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 py==1.8.0                 # via tox
 pycodestyle==2.5.0
 pycparser==2.19           # via cffi
-pycryptodomex==3.7.3      # via pyjwkest
+pycryptodomex==3.8.1      # via pyjwkest
 pydocstyle==3.0.0
 pygments==2.3.1           # via diff-cover
 pyjwkest==1.3.2           # via edx-drf-extensions
@@ -92,13 +92,14 @@ pylint-django==0.7.2      # via edx-lint
 pylint-plugin-utils==0.5  # via pylint-celery, pylint-django
 pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.7.2            # via edx-opaque-keys
-pyparsing==2.3.1          # via packaging
+pyparsing==2.4.0          # via packaging
 python-dateutil==2.4.0
 pytz==2016.10
 pyyaml==5.1               # via code-annotations, edx-i18n-tools
 requests-toolbelt==0.9.1  # via twine
 requests==2.21.0
 rest-condition==1.0.3     # via edx-drf-extensions
+rules==2.0.1
 semantic-version==2.6.0   # via edx-drf-extensions
 shortuuid==0.5.0          # via edx-django-oauth2-provider
 singledispatch==3.4.0.3   # via astroid, pylint
@@ -106,10 +107,10 @@ six==1.12.0               # via astroid, bleach, cryptography, diff-cover, edx-d
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==1.2.1    # via pydocstyle
 stevedore==1.30.1         # via code-annotations, edx-opaque-keys
-testfixtures==6.6.1
+testfixtures==6.6.2
 toml==0.10.0              # via tox
 tox-battery==0.5.1
-tox==3.7.0
+tox==3.8.6
 tqdm==4.31.1              # via twine
 twine==1.11.0
 unicodecsv==0.14.1

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -44,7 +44,7 @@ edx-django-oauth2-provider==1.3.5
 edx-django-utils==1.0.3   # via edx-drf-extensions
 edx-drf-extensions==2.0.1
 edx-opaque-keys==0.4.4
-edx-rbac==0.1.5
+edx-rbac==0.1.11
 edx-rest-api-client==1.9.2
 edx-sphinx-theme==1.4.0
 enum34==1.1.6             # via cryptography
@@ -56,12 +56,12 @@ imagesize==1.1.0          # via sphinx
 inflect==2.1.0            # via jinja2-pluralize
 ipaddress==1.0.22         # via cryptography
 jinja2-pluralize==0.3.0   # via diff-cover
-jinja2==2.10              # via diff-cover, jinja2-pluralize, sphinx
+jinja2==2.10.1            # via diff-cover, jinja2-pluralize, sphinx
 jsondiff==1.1.1
 jsonfield==2.0.2
 kombu==3.0.37             # via celery
 markupsafe==1.1.1         # via jinja2
-newrelic==4.14.0.115      # via edx-django-utils
+newrelic==4.16.1.117      # via edx-django-utils
 packaging==19.0           # via sphinx
 path.py==8.2.1
 pbr==5.1.3                # via stevedore
@@ -69,19 +69,20 @@ pillow==5.4.1
 pockets==0.7.2            # via sphinxcontrib-napoleon
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 pycparser==2.19           # via cffi
-pycryptodomex==3.7.3      # via pyjwkest
+pycryptodomex==3.8.1      # via pyjwkest
 pygments==2.3.1           # via diff-cover, readme-renderer, sphinx
 pyjwkest==1.3.2           # via edx-drf-extensions
 pyjwt==1.7.1              # via djangorestframework-jwt, edx-rest-api-client
 pymongo==3.7.2            # via edx-opaque-keys
-pyparsing==2.3.1          # via packaging
+pyparsing==2.4.0          # via packaging
 python-dateutil==2.4.0
 pytz==2016.10
 pyyaml==5.1               # via code-annotations
 readme_renderer==0.7.0
 requests==2.21.0
 rest-condition==1.0.3     # via edx-drf-extensions
-restructuredtext-lint==1.2.2  # via doc8
+restructuredtext-lint==1.3.0  # via doc8
+rules==2.0.1
 semantic-version==2.6.0   # via edx-drf-extensions
 shortuuid==0.5.0          # via edx-django-oauth2-provider
 six==1.12.0               # via bleach, cryptography, diff-cover, doc8, edx-drf-extensions, edx-opaque-keys, edx-rbac, edx-sphinx-theme, html5lib, packaging, pockets, pyjwkest, python-dateutil, readme-renderer, sphinx, sphinxcontrib-napoleon, stevedore
@@ -91,7 +92,7 @@ sphinx==1.8.5
 sphinxcontrib-napoleon==0.6.1
 sphinxcontrib-websupport==1.1.0  # via sphinx
 stevedore==1.30.1         # via code-annotations, doc8, edx-opaque-keys
-testfixtures==6.6.1
+testfixtures==6.6.2
 typing==3.6.6             # via sphinx
 unicodecsv==0.14.1
 urllib3==1.24.1           # via requests

--- a/requirements/js_test.txt
+++ b/requirements/js_test.txt
@@ -13,11 +13,11 @@ glob2==0.6                # via jasmine-core
 jaraco.functools==2.0     # via tempora
 jasmine-core==2.99.1      # via jasmine
 jasmine==2.9.0
-jinja2==2.10              # via jasmine
+jinja2==2.10.1            # via jasmine
 markupsafe==1.1.1         # via jinja2
 more-itertools==5.0.0     # via cheroot, cherrypy, jaraco.functools
 ordereddict==1.1          # via jasmine-core
-portend==2.3              # via cherrypy
+portend==2.4              # via cherrypy
 pytz==2018.9              # via tempora
 pyyaml==3.10              # via jasmine
 selenium==3.6.0           # via jasmine

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -26,7 +26,7 @@ chardet==3.0.4            # via doc8, requests
 click-log==0.1.8          # via edx-lint
 click==7.0                # via click-log, code-annotations, edx-lint, pip-tools
 code-annotations==0.2.1
-configparser==3.7.3       # via pydocstyle, pylint
+configparser==3.7.4       # via pydocstyle, pylint
 cookies==2.2.1            # via responses
 coverage==4.5.3           # via pytest-cov
 cryptography==2.4.2
@@ -58,7 +58,7 @@ edx-drf-extensions==2.0.1
 edx-i18n-tools==0.4.8
 edx-lint==1.1.1
 edx-opaque-keys==0.4.4
-edx-rbac==0.1.5
+edx-rbac==0.1.11
 edx-rest-api-client==1.9.2
 edx-sphinx-theme==1.4.0
 enum34==1.1.6             # via astroid, cryptography
@@ -75,9 +75,9 @@ idna==2.8                 # via cryptography, requests
 imagesize==1.1.0          # via sphinx
 inflect==2.1.0            # via jinja2-pluralize
 ipaddress==1.0.22         # via cryptography, faker
-isort==4.3.15
+isort==4.3.17
 jinja2-pluralize==0.3.0   # via diff-cover
-jinja2==2.10              # via diff-cover, jinja2-pluralize, sphinx
+jinja2==2.10.1            # via diff-cover, jinja2-pluralize, sphinx
 jsondiff==1.1.1
 jsonfield==2.0.2
 kombu==3.0.37             # via celery
@@ -86,13 +86,13 @@ markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via pylint
 mock==2.0.0
 more-itertools==5.0.0     # via pytest
-newrelic==4.14.0.115      # via edx-django-utils
+newrelic==4.16.1.117      # via edx-django-utils
 packaging==19.0           # via caniusepython3, sphinx
 path.py==8.2.1
 pathlib2==2.3.3           # via pytest, pytest-django
 pbr==5.1.3                # via mock, stevedore
 pillow==5.4.1
-pip-tools==3.5.0
+pip-tools==3.6.0
 pkginfo==1.5.0.1          # via twine
 pluggy==0.9.0             # via pytest, tox
 pockets==0.7.2            # via sphinxcontrib-napoleon
@@ -101,7 +101,7 @@ psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 py==1.8.0                 # via pytest, pytest-catchlog, tox
 pycodestyle==2.5.0
 pycparser==2.19           # via cffi
-pycryptodomex==3.7.3      # via pyjwkest
+pycryptodomex==3.8.1      # via pyjwkest
 pydocstyle==3.0.0
 pygments==2.3.1           # via diff-cover, readme-renderer, sphinx
 pyjwkest==1.3.2           # via edx-drf-extensions
@@ -111,11 +111,11 @@ pylint-django==0.7.2      # via edx-lint
 pylint-plugin-utils==0.5  # via pylint-celery, pylint-django
 pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.7.2            # via edx-opaque-keys
-pyparsing==2.3.1          # via packaging
+pyparsing==2.4.0          # via packaging
 pytest-catchlog==1.2.2
 pytest-cov==2.6.1
 pytest-django==3.4.8
-pytest==4.3.1             # via pytest-catchlog, pytest-cov, pytest-django
+pytest==4.4.0             # via pytest-catchlog, pytest-cov, pytest-django
 python-dateutil==2.4.0
 pytz==2016.10
 pyyaml==5.1               # via code-annotations, edx-i18n-tools
@@ -124,7 +124,8 @@ requests-toolbelt==0.9.1  # via twine
 requests==2.21.0
 responses==0.10.6
 rest-condition==1.0.3     # via edx-drf-extensions
-restructuredtext-lint==1.2.2  # via doc8
+restructuredtext-lint==1.3.0  # via doc8
+rules==2.0.1
 scandir==1.10.0           # via pathlib2
 semantic-version==2.6.0   # via edx-drf-extensions
 shortuuid==0.5.0          # via edx-django-oauth2-provider
@@ -136,11 +137,11 @@ sphinx==1.8.5
 sphinxcontrib-napoleon==0.6.1
 sphinxcontrib-websupport==1.1.0  # via sphinx
 stevedore==1.30.1         # via code-annotations, doc8, edx-opaque-keys
-testfixtures==6.6.1
+testfixtures==6.6.2
 text-unidecode==1.2       # via faker
 toml==0.10.0              # via tox
 tox-battery==0.5.1
-tox==3.7.0
+tox==3.8.6
 tqdm==4.31.1              # via twine
 twine==1.11.0
 typing==3.6.6             # via sphinx

--- a/requirements/test-master.in
+++ b/requirements/test-master.in
@@ -23,6 +23,7 @@ django-waffle==0.12.0                   # Allows ability to add and control flag
 testfixtures                            # Mock objects for unit tests and doc tests
 jsonfield==2.0.2                        # Provides a Django model field which serializes/deserializes JSON objects
 flaky==3.5.3                            # Rerun flaky tests automatically if they fail, up to a limit
+rules==2.0.1                            # For rules based permissions
 
 # These are packages that edx-enterprise uses that are pinned to previous versions in edx-platform.
 # We pin them here to make sure our tests are installing the same requirements

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -45,7 +45,7 @@ edx-django-oauth2-provider==1.3.5
 edx-django-utils==1.0.3   # via edx-drf-extensions
 edx-drf-extensions==2.0.1
 edx-opaque-keys==0.4.4
-edx-rbac==0.1.5
+edx-rbac==0.1.11
 edx-rest-api-client==1.9.2
 enum34==1.1.6             # via cryptography
 factory-boy==2.11.1
@@ -59,14 +59,14 @@ idna==2.8                 # via cryptography, requests
 inflect==2.1.0            # via jinja2-pluralize
 ipaddress==1.0.22         # via cryptography, faker
 jinja2-pluralize==0.3.0   # via diff-cover
-jinja2==2.10              # via diff-cover, jinja2-pluralize
+jinja2==2.10.1            # via diff-cover, jinja2-pluralize
 jsondiff==1.1.1
 jsonfield==2.0.2
 kombu==3.0.37             # via celery
 markupsafe==1.1.1         # via jinja2
 mock==2.0.0
 more-itertools==5.0.0     # via pytest
-newrelic==4.14.0.115      # via edx-django-utils
+newrelic==4.16.1.117      # via edx-django-utils
 path.py==8.2.1
 pathlib2==2.3.3           # via pytest, pytest-django
 pbr==5.1.3                # via mock, stevedore
@@ -75,7 +75,7 @@ pluggy==0.9.0             # via pytest
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 py==1.8.0                 # via pytest, pytest-catchlog
 pycparser==2.19           # via cffi
-pycryptodomex==3.7.3      # via pyjwkest
+pycryptodomex==3.8.1      # via pyjwkest
 pygments==2.3.1           # via diff-cover
 pyjwkest==1.3.2           # via edx-drf-extensions
 pyjwt==1.7.1              # via djangorestframework-jwt, edx-rest-api-client
@@ -83,20 +83,21 @@ pymongo==3.7.2            # via edx-opaque-keys
 pytest-catchlog==1.2.2
 pytest-cov==2.6.1
 pytest-django==3.4.8
-pytest==4.3.1             # via pytest-catchlog, pytest-cov, pytest-django
+pytest==4.4.0             # via pytest-catchlog, pytest-cov, pytest-django
 python-dateutil==2.4.0
 pytz==2016.10
 pyyaml==5.1               # via code-annotations
 requests==2.21.0
 responses==0.10.6
 rest-condition==1.0.3     # via edx-drf-extensions
+rules==2.0.1
 scandir==1.10.0           # via pathlib2
 semantic-version==2.6.0   # via edx-drf-extensions
 shortuuid==0.5.0          # via edx-django-oauth2-provider
 six==1.12.0               # via bleach, cryptography, diff-cover, edx-drf-extensions, edx-opaque-keys, edx-rbac, faker, freezegun, html5lib, mock, more-itertools, pathlib2, pyjwkest, pytest, python-dateutil, responses, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 stevedore==1.30.1         # via code-annotations, edx-opaque-keys
-testfixtures==6.6.1
+testfixtures==6.6.2
 text-unidecode==1.2       # via faker
 unicodecsv==0.14.1
 urllib3==1.24.1           # via requests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -45,7 +45,7 @@ edx-django-oauth2-provider==1.3.5
 edx-django-utils==1.0.3   # via edx-drf-extensions
 edx-drf-extensions==2.0.1
 edx-opaque-keys==0.4.4
-edx-rbac==0.1.5
+edx-rbac==0.1.11
 edx-rest-api-client==1.9.2
 enum34==1.1.6             # via cryptography
 factory-boy==2.11.1
@@ -59,14 +59,14 @@ idna==2.8                 # via cryptography, requests
 inflect==2.1.0            # via jinja2-pluralize
 ipaddress==1.0.22         # via cryptography, faker
 jinja2-pluralize==0.3.0   # via diff-cover
-jinja2==2.10              # via diff-cover, jinja2-pluralize
+jinja2==2.10.1            # via diff-cover, jinja2-pluralize
 jsondiff==1.1.1
 jsonfield==2.0.2
 kombu==3.0.37             # via celery
 markupsafe==1.1.1         # via jinja2
 mock==2.0.0
 more-itertools==5.0.0     # via pytest
-newrelic==4.14.0.115      # via edx-django-utils
+newrelic==4.16.1.117      # via edx-django-utils
 path.py==8.2.1
 pathlib2==2.3.3           # via pytest, pytest-django
 pbr==5.1.3                # via mock, stevedore
@@ -75,7 +75,7 @@ pluggy==0.9.0             # via pytest
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 py==1.8.0                 # via pytest, pytest-catchlog
 pycparser==2.19           # via cffi
-pycryptodomex==3.7.3      # via pyjwkest
+pycryptodomex==3.8.1      # via pyjwkest
 pygments==2.3.1           # via diff-cover
 pyjwkest==1.3.2           # via edx-drf-extensions
 pyjwt==1.7.1              # via djangorestframework-jwt, edx-rest-api-client
@@ -83,20 +83,21 @@ pymongo==3.7.2            # via edx-opaque-keys
 pytest-catchlog==1.2.2
 pytest-cov==2.6.1
 pytest-django==3.4.8
-pytest==4.3.1             # via pytest-catchlog, pytest-cov, pytest-django
+pytest==4.4.0             # via pytest-catchlog, pytest-cov, pytest-django
 python-dateutil==2.4.0
 pytz==2016.10
 pyyaml==5.1               # via code-annotations
 requests==2.21.0
 responses==0.10.6
 rest-condition==1.0.3     # via edx-drf-extensions
+rules==2.0.1
 scandir==1.10.0           # via pathlib2
 semantic-version==2.6.0   # via edx-drf-extensions
 shortuuid==0.5.0          # via edx-django-oauth2-provider
 six==1.12.0               # via bleach, cryptography, diff-cover, edx-drf-extensions, edx-opaque-keys, edx-rbac, faker, freezegun, html5lib, mock, more-itertools, pathlib2, pyjwkest, pytest, python-dateutil, responses, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 stevedore==1.30.1         # via code-annotations, edx-opaque-keys
-testfixtures==6.6.1
+testfixtures==6.6.2
 text-unidecode==1.2       # via faker
 unicodecsv==0.14.1
 urllib3==1.24.1           # via requests

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -16,6 +16,6 @@ requests==2.21.0          # via codecov
 six==1.12.0               # via tox
 toml==0.10.0              # via tox
 tox-battery==0.5.1
-tox==3.7.0
+tox==3.8.6
 urllib3==1.24.1           # via requests
 virtualenv==16.4.3        # via tox

--- a/tests/test_enterprise/api/test_permissions.py
+++ b/tests/test_enterprise/api/test_permissions.py
@@ -8,8 +8,10 @@ from __future__ import absolute_import, unicode_literals
 from rest_framework.parsers import JSONParser
 from rest_framework.request import Request
 from rest_framework.test import APIRequestFactory, APITestCase, force_authenticate
+from waffle.models import Switch
 
 from enterprise.api.v1.permissions import HasEnterpriseDataAPIAccess, HasEnterpriseEnrollmentAPIAccess
+from enterprise.constants import ENTERPRISE_ROLE_BASED_ACCESS_CONTROL_SWITCH
 from test_utils.factories import GroupFactory, UserFactory
 
 
@@ -46,6 +48,7 @@ class TestIsAdminUserOrInGroupPermissions(PermissionsTestMixin, APITestCase):
         self.user = UserFactory(email='test@example.com', password='test', is_staff=True)
 
     def test_is_staff_or_user_in_group_permissions(self):
+        Switch.objects.update_or_create(name=ENTERPRISE_ROLE_BASED_ACCESS_CONTROL_SWITCH, defaults={'active': False})
         for group_name in self.permissions_class_map:
             group = GroupFactory(name=group_name)
             group.user_set.add(self.user)
@@ -53,23 +56,32 @@ class TestIsAdminUserOrInGroupPermissions(PermissionsTestMixin, APITestCase):
             self.assertTrue(self.permissions_class_map[group_name].has_permission(request, None))
 
     def test_not_staff_and_not_in_group_permissions(self):
+        Switch.objects.update_or_create(name=ENTERPRISE_ROLE_BASED_ACCESS_CONTROL_SWITCH, defaults={'active': False})
         user = UserFactory(email='test@example.com', password='test', is_staff=False)
         for group_name in self.permissions_class_map:
             request = self.get_request(user=user)
             self.assertFalse(self.permissions_class_map[group_name].has_permission(request, None))
 
     def test_staff_but_not_in_group_permissions(self):
+        Switch.objects.update_or_create(name=ENTERPRISE_ROLE_BASED_ACCESS_CONTROL_SWITCH, defaults={'active': False})
         user = UserFactory(email='test@example.com', password='test', is_staff=True)
         for group_name in self.permissions_class_map:
             request = self.get_request(user=user)
             self.assertTrue(self.permissions_class_map[group_name].has_permission(request, None))
 
     def test_not_staff_but_in_group_permissions(self):
+        Switch.objects.update_or_create(name=ENTERPRISE_ROLE_BASED_ACCESS_CONTROL_SWITCH, defaults={'active': False})
         user = UserFactory(email='test@example.com', password='test', is_staff=False)
         for group_name in self.permissions_class_map:
             group = GroupFactory(name=group_name)
             group.user_set.add(user)
             request = self.get_request(user=user)
+            self.assertTrue(self.permissions_class_map[group_name].has_permission(request, None))
+
+    def test_rbac_permissions_enabled(self):
+        Switch.objects.update_or_create(name=ENTERPRISE_ROLE_BASED_ACCESS_CONTROL_SWITCH, defaults={'active': True})
+        for group_name in self.permissions_class_map:
+            request = self.get_request(user=self.user)
             self.assertTrue(self.permissions_class_map[group_name].has_permission(request, None))
 
 
@@ -90,6 +102,7 @@ class TestIsInEnterpriseGroupPermissions(PermissionsTestMixin, APITestCase):
         self.user = UserFactory(email='test@example.com', password='test', is_staff=True)
 
     def test_is_staff_and_user_in_group_permissions(self):
+        Switch.objects.update_or_create(name=ENTERPRISE_ROLE_BASED_ACCESS_CONTROL_SWITCH, defaults={'active': False})
         for group_name in self.permissions_class_map:
             group = GroupFactory(name=group_name)
             group.user_set.add(self.user)
@@ -97,21 +110,30 @@ class TestIsInEnterpriseGroupPermissions(PermissionsTestMixin, APITestCase):
             self.assertTrue(self.permissions_class_map[group_name].has_permission(request, None))
 
     def test_not_staff_and_not_in_group_permissions(self):
+        Switch.objects.update_or_create(name=ENTERPRISE_ROLE_BASED_ACCESS_CONTROL_SWITCH, defaults={'active': False})
         user = UserFactory(email='test@example.com', password='test', is_staff=False)
         for group_name in self.permissions_class_map:
             request = self.get_request(user=user)
             self.assertFalse(self.permissions_class_map[group_name].has_permission(request, None))
 
     def test_staff_but_not_in_group_permissions(self):
+        Switch.objects.update_or_create(name=ENTERPRISE_ROLE_BASED_ACCESS_CONTROL_SWITCH, defaults={'active': False})
         user = UserFactory(email='test@example.com', password='test', is_staff=True)
         for group_name in self.permissions_class_map:
             request = self.get_request(user=user)
             self.assertFalse(self.permissions_class_map[group_name].has_permission(request, None))
 
     def test_not_staff_but_in_group_permissions(self):
+        Switch.objects.update_or_create(name=ENTERPRISE_ROLE_BASED_ACCESS_CONTROL_SWITCH, defaults={'active': False})
         user = UserFactory(email='test@example.com', password='test', is_staff=False)
         for group_name in self.permissions_class_map:
             group = GroupFactory(name=group_name)
             group.user_set.add(user)
             request = self.get_request(user=user)
+            self.assertTrue(self.permissions_class_map[group_name].has_permission(request, None))
+
+    def test_rbac_permissions_enabled(self):
+        Switch.objects.update_or_create(name=ENTERPRISE_ROLE_BASED_ACCESS_CONTROL_SWITCH, defaults={'active': True})
+        for group_name in self.permissions_class_map:
+            request = self.get_request(user=self.user)
             self.assertTrue(self.permissions_class_map[group_name].has_permission(request, None))

--- a/tests/test_enterprise/test_rules.py
+++ b/tests/test_enterprise/test_rules.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for the `edx-enterprise` models module.
+"""
+
+from __future__ import absolute_import, unicode_literals, with_statement
+
+import ddt
+import mock
+from pytest import mark
+from waffle.models import Switch
+
+from enterprise.constants import (
+    ENTERPRISE_ADMIN_ROLE,
+    ENTERPRISE_CATALOG_ADMIN_ROLE,
+    ENTERPRISE_DASHBOARD_ADMIN_ROLE,
+    ENTERPRISE_ENROLLMENT_API_ADMIN_ROLE,
+    ENTERPRISE_ROLE_BASED_ACCESS_CONTROL_SWITCH,
+)
+from enterprise.models import EnterpriseFeatureRole, EnterpriseFeatureUserRoleAssignment
+from test_utils import TEST_UUID, APITest, factories
+
+
+@mark.django_db()
+@ddt.ddt
+class TestEnterpriseRBACPermissions(APITest):
+    """
+    Test defined django rules for authorization checks.
+    """
+
+    @ddt.data(
+        'enterprise.can_access_admin_dashboard',
+        'enterprise.can_view_catalog',
+        'enterprise.can_enroll_learners',
+    )
+    def test_permissions_rbac_disabled(self, permission):
+        Switch.objects.update_or_create(name=ENTERPRISE_ROLE_BASED_ACCESS_CONTROL_SWITCH, defaults={'active': False})
+        assert self.user.has_perm(permission, TEST_UUID)
+
+    @mock.patch('enterprise.rules.get_request_or_stub')
+    @ddt.data(
+        'enterprise.can_access_admin_dashboard',
+        'enterprise.can_view_catalog',
+        'enterprise.can_enroll_learners',
+    )
+    def test_has_implicit_access(self, permission, get_request_or_stub_mock):
+        Switch.objects.update_or_create(name=ENTERPRISE_ROLE_BASED_ACCESS_CONTROL_SWITCH, defaults={'active': True})
+        get_request_or_stub_mock.return_value = self.get_request_with_jwt_cookie(ENTERPRISE_ADMIN_ROLE, TEST_UUID)
+        assert self.user.has_perm(permission, TEST_UUID)
+
+    @mock.patch('enterprise.rules.get_request_or_stub')
+    @ddt.data(
+        ('enterprise.can_access_admin_dashboard', ENTERPRISE_DASHBOARD_ADMIN_ROLE),
+        ('enterprise.can_view_catalog', ENTERPRISE_CATALOG_ADMIN_ROLE),
+        ('enterprise.can_enroll_learners', ENTERPRISE_ENROLLMENT_API_ADMIN_ROLE),
+    )
+    @ddt.unpack
+    def test_has_explicit_access(self, permission, feature_role, get_request_or_stub_mock):
+        Switch.objects.update_or_create(name=ENTERPRISE_ROLE_BASED_ACCESS_CONTROL_SWITCH, defaults={'active': True})
+        get_request_or_stub_mock.return_value = self.get_request_with_jwt_cookie()
+        feature_role_object, __ = EnterpriseFeatureRole.objects.get_or_create(name=feature_role)
+        enterprise_customer = factories.EnterpriseCustomerFactory(uuid=TEST_UUID)
+        factories.EnterpriseCustomerUserFactory(
+            user_id=self.user.id,
+            enterprise_customer=enterprise_customer
+        )
+        EnterpriseFeatureUserRoleAssignment.objects.create(user=self.user, role=feature_role_object)
+        assert self.user.has_perm(permission, TEST_UUID)
+
+    @mock.patch('enterprise.rules.get_request_or_stub')
+    @ddt.data(
+        'enterprise.can_access_admin_dashboard',
+        'enterprise.can_view_catalog',
+        'enterprise.can_enroll_learners',
+    )
+    def test_access_denied(self, permission, get_request_or_stub_mock):
+        Switch.objects.update_or_create(name=ENTERPRISE_ROLE_BASED_ACCESS_CONTROL_SWITCH, defaults={'active': True})
+        get_request_or_stub_mock.return_value = self.get_request_with_jwt_cookie()
+        assert not self.user.has_perm(permission, TEST_UUID)


### PR DESCRIPTION
**Description:** 
Remaining work:
- [x] make sure we check that the user's enterprise matches with the request's in the predicates
- [x] map the system wide roles to the feature specific role (just dashboard access for now)
- [x] apply each type of permission to the applicable endpoint in the api views
- [x] testing!

**JIRA:** https://openedx.atlassian.net/browse/ENT-1730

**Dependencies:** https://github.com/edx/edx-rbac/pull/14, https://github.com/edx/edx-rbac/pull/17

**Testing instructions:**
Waffle switch off:
- [x] a staff user in the enterprise_data_api_access group can hit the with_access_to endpoint and see all available enterprises.
- [x]  an enterprise user in the enterprise_data_api_access group can hit the with_access_to endpoint and see the enterprise they are linked to.
- [x]  a staff user with api credentials can hit any catalog related endpoint for any enterprise.
- [x]  an enterprise user with api credentials can hit any catalog related endpoint for their linked enterprise.
- [x]  a staff user in the enterprise_enrollment_api_access group can post enrollments to the enrollment api endpoint for any enterprise.
- [x]  an enterprise user in the enterprise_enrollment_api_access group can post enrollments to the enrollment api endpoint for their linked enterprise.
- [x]  staff users or enterprise users not in the enterprise_data_api_access group will not get any enterprise returned from the with_access_to endpoint.
- [x]  staff users or enterprise users not in the enterprise_enrollment_api_access group will not be able to post enrollments successfully to the enterprise enrollment api.

Waffle switch on:
We will need to put the following setting in edx-platform/lms/envs/devstack_docker.py:
```
SYSTEM_TO_FEATURE_ROLE_MAPPING = {
    ENTERPRISE_ADMIN_ROLE: [
        ENTERPRISE_DASHBOARD_ADMIN_ROLE
    ],
}
```
There will be a separate ticket to set this setting in production.
Note that this PR does not cover staff role access.
- [x] an enterprise user with the enterprise_admin system wide role will be able to hit the new dashboard-list endpoint and see their linked enterprise returned.
- [x] an enterprise user with the dashboard admin feature specific role will be able to hit the new dashboard-list endpoint and see their linked enterprise returned.
- [x] an enterprise user with the catalog admin feature specific role will be able to hit the catalog related endpoints for their linked enterprise.
- [x] an enterprise user with the enrollment api admin feature specific role will be able to post enrollments to the enrollment api for their linked enterprise.
- [x] enterprise users without any admin roles specified will not have access to the dashboard-list, catalog, or enrollment api endpoints. All other endpoints should behave as before with regards to access.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
