### PR TITLE
WL-1908: Provide customer success team ability to add ECE records

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[1.3.10] - 2019-04-03
+---------------------
+
+* Provide ability to add ECE even if course is closed from manage learners admin interface.
+
 [1.3.9] - 2019-03-29
 --------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.3.9"
+__version__ = "1.3.10"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/test_utils/fake_enrollment_api.py
+++ b/test_utils/fake_enrollment_api.py
@@ -180,3 +180,23 @@ def enroll_user_in_course(user, course_id, mode):
         "mode": mode,
         "created": datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ")
     }
+
+
+def get_course_enrollment(username, course_id):
+    """
+    Fake implementation.
+    """
+    try:
+        course_details = COURSE_DETAILS[course_id]
+    except KeyError:
+        _raise_client_error(
+            "enrollment", "No course '{}' found for enrollment".format(course_id)
+        )
+
+    return {
+        "user": username,
+        "course_details": course_details,
+        "is_active": True,
+        "mode": 'verified',
+        "created": datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ")
+    }


### PR DESCRIPTION
Provide customer success team ability to add ECE records via "Manage Learners" admin tool
If Enrollment window is closed and there is already a SCE(student CourseEnrollment) record.

**Description:** Describe in a couple of sentence what this PR adds

**JIRA:** [WL-1908](https://openedx.atlassian.net/browse/WL-1908)

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happend instead - check failed.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
