### PR TITLE
WL-1906 | Added an extra check of user's enrollment in Enterprise API.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,3 +25,4 @@ Robert Raposa <rraposa@edx.org>
 Irfan Ahmad <iahmad@edx.org>
 Brian Wilson <brian@edx.org>
 Troy Sankey <tsankey@edx.org>
+Hasnain Naveed <hasnain@edx.org>

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[1.4.1] - 2019-04-10
+---------------------
+
+* Update `RouterView` if user is already enrolled in course run of a course then user will land on that course_run.
+
 [1.4.0] - 2019-04-08
 --------------------
 

--- a/test_utils/fake_enrollment_api.py
+++ b/test_utils/fake_enrollment_api.py
@@ -200,3 +200,13 @@ def get_course_enrollment(username, course_id):
         "mode": 'verified',
         "created": datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ")
     }
+
+
+def get_enrolled_courses(username):
+    """
+    Fake implementation.
+    """
+    return [
+        get_course_enrollment(username, 'course-v1:edX+DemoX+Demo_Course'),
+        get_course_enrollment(username, 'course-v1:HarvardX+CoolScience+2016')
+    ]


### PR DESCRIPTION
**Description:** Added an extra check of user's enrollment in `RouterView`

**JIRA:** [WL-1906](https://openedx.atlassian.net/browse/WL-1906)

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happend instead - check failed.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
