### PR TITLE
ENT-1752: Update permission checks for edx-enterprise

### DIFF
--- a/enterprise/rules.py
+++ b/enterprise/rules.py
@@ -16,6 +16,7 @@ from enterprise.constants import (
     ENTERPRISE_CATALOG_ADMIN_ROLE,
     ENTERPRISE_DASHBOARD_ADMIN_ROLE,
     ENTERPRISE_ENROLLMENT_API_ADMIN_ROLE,
+    ENTERPRISE_OPERATOR_ROLE,
     ENTERPRISE_ROLE_BASED_ACCESS_CONTROL_SWITCH,
 )
 from enterprise.models import EnterpriseFeatureUserRoleAssignment
@@ -115,12 +116,49 @@ def rbac_permissions_disabled(user, obj):  # pylint: disable=unused-argument
     return not waffle.switch_is_active(ENTERPRISE_ROLE_BASED_ACCESS_CONTROL_SWITCH)
 
 
-rules.add_perm('enterprise.can_access_admin_dashboard',
-               rbac_permissions_disabled | has_implicit_access_to_dashboard | has_explicit_access_to_dashboard)
+@rules.predicate
+def open_edx_operator_has_implicit_access(user, obj):  # pylint: disable=unused-argument
+    """
+    Check that if request user has implicit access to `ENTERPRISE_OPERATOR_ROLE` feature role.
 
-rules.add_perm('enterprise.can_view_catalog',
-               rbac_permissions_disabled | has_implicit_access_to_catalog | has_explicit_access_to_catalog)
+    Returns:
+        boolean: whether the request user has access or not
+    """
+    request = get_request_or_stub()
+    decoded_jwt = get_decoded_jwt_from_request(request)
+    return request_user_has_implicit_access_via_jwt(decoded_jwt, ENTERPRISE_OPERATOR_ROLE, obj)
 
-rules.add_perm('enterprise.can_enroll_learners',
-               rbac_permissions_disabled | has_implicit_access_to_enrollment_api |
-               has_explicit_access_to_enrollment_api)
+
+@rules.predicate
+def open_edx_operator_has_explicit_access(user, obj):
+    """
+    Check that if request user has explicit access to `ENTERPRISE_OPERATOR_ROLE` feature role.
+
+    Returns:
+        boolean: whether the request user has access or not
+    """
+    return user_has_access_via_database(
+        user,
+        ENTERPRISE_OPERATOR_ROLE,
+        EnterpriseFeatureUserRoleAssignment,
+        obj
+    )
+
+
+rules.add_perm(
+    'enterprise.can_access_admin_dashboard',
+    rbac_permissions_disabled | open_edx_operator_has_implicit_access | open_edx_operator_has_explicit_access |
+    has_implicit_access_to_dashboard | has_explicit_access_to_dashboard
+)
+
+rules.add_perm(
+    'enterprise.can_view_catalog',
+    rbac_permissions_disabled | open_edx_operator_has_implicit_access | open_edx_operator_has_explicit_access |
+    has_implicit_access_to_catalog | has_explicit_access_to_catalog
+)
+
+rules.add_perm(
+    'enterprise.can_enroll_learners',
+    rbac_permissions_disabled | open_edx_operator_has_implicit_access | open_edx_operator_has_explicit_access |
+    has_implicit_access_to_enrollment_api | has_explicit_access_to_enrollment_api
+)

--- a/tests/test_enterprise/test_rules.py
+++ b/tests/test_enterprise/test_rules.py
@@ -15,6 +15,7 @@ from enterprise.constants import (
     ENTERPRISE_CATALOG_ADMIN_ROLE,
     ENTERPRISE_DASHBOARD_ADMIN_ROLE,
     ENTERPRISE_ENROLLMENT_API_ADMIN_ROLE,
+    ENTERPRISE_OPERATOR_ROLE,
     ENTERPRISE_ROLE_BASED_ACCESS_CONTROL_SWITCH,
 )
 from enterprise.models import EnterpriseFeatureRole, EnterpriseFeatureUserRoleAssignment
@@ -53,6 +54,9 @@ class TestEnterpriseRBACPermissions(APITest):
         ('enterprise.can_access_admin_dashboard', ENTERPRISE_DASHBOARD_ADMIN_ROLE),
         ('enterprise.can_view_catalog', ENTERPRISE_CATALOG_ADMIN_ROLE),
         ('enterprise.can_enroll_learners', ENTERPRISE_ENROLLMENT_API_ADMIN_ROLE),
+        ('enterprise.can_access_admin_dashboard', ENTERPRISE_OPERATOR_ROLE),
+        ('enterprise.can_view_catalog', ENTERPRISE_OPERATOR_ROLE),
+        ('enterprise.can_enroll_learners', ENTERPRISE_OPERATOR_ROLE),
     )
     @ddt.unpack
     def test_has_explicit_access(self, permission, feature_role, get_request_or_stub_mock):


### PR DESCRIPTION
**Description:** 
Add settings to map the system-wide role to the same feature specific roles as `enterprise_admin`.
Add rules for checking if a user is an `edx_enterprise_operato`r (no enterprise affiliation required).
Modify permission checks to include this new rule.

**JIRA:** [ENT-1752](https://openedx.atlassian.net/browse/ENT-1752)

**Dependencies:** 
- https://github.com/edx/edx-enterprise/pull/444 needs to merge before this.

**Installation instructions:** 
Simply install this branch for the functionality

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happend instead - check failed.

**Merge checklist:**

- [x] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [x] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [x] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [x] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [x] Translations are updated
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

