### PR TITLE
Find users for feature specific enterprise roles

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[1.4.2] - 2019-04-11
+--------------------
+
+* Update `assign_enterprise_user_roles` management command to also assign catalog and enrollment api admin roles.
+
 [1.4.1] - 2019-04-10
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.4.1"
+__version__ = "1.4.2"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/constants.py
+++ b/enterprise/constants.py
@@ -86,8 +86,9 @@ DEFAULT_CATALOG_CONTENT_FILTER = {
 
 # Django groups specific to granting permission to enterprise admins.
 ENTERPRISE_DATA_API_ACCESS_GROUP = 'enterprise_data_api_access'
+ENTERPRISE_ENROLLMENT_API_ACCESS_GROUP = 'enterprise_enrollment_api_access'
 ENTERPRISE_PERMISSION_GROUPS = [
-    'enterprise_enrollment_api_access',
+    ENTERPRISE_ENROLLMENT_API_ACCESS_GROUP,
     ENTERPRISE_DATA_API_ACCESS_GROUP,
 ]
 
@@ -103,6 +104,10 @@ ENTERPRISE_ENROLLMENT_API_ADMIN_ROLE = 'enrollment_api_admin'
 ALL_ACCESS_CONTEXT = '*'
 
 ENTERPRISE_ROLE_BASED_ACCESS_CONTROL_SWITCH = 'enterprise_role_based_access_control'
+
+OAUTH2_PROVIDER_APPLICATION_MODEL = 'oauth2_provider.Application'
+
+EDX_ORG_NAME = 'edX, Inc'
 
 
 def json_serialized_course_modes():

--- a/enterprise/management/commands/assign_enterprise_user_roles.py
+++ b/enterprise/management/commands/assign_enterprise_user_roles.py
@@ -6,16 +6,28 @@ from __future__ import absolute_import, unicode_literals
 import logging
 from time import sleep
 
+from django.apps import apps
 from django.contrib.auth.models import User
 from django.core.management.base import BaseCommand, CommandError
 
 from enterprise.constants import (
+    EDX_ORG_NAME,
     ENTERPRISE_ADMIN_ROLE,
+    ENTERPRISE_CATALOG_ADMIN_ROLE,
     ENTERPRISE_DATA_API_ACCESS_GROUP,
+    ENTERPRISE_ENROLLMENT_API_ACCESS_GROUP,
+    ENTERPRISE_ENROLLMENT_API_ADMIN_ROLE,
     ENTERPRISE_LEARNER_ROLE,
     ENTERPRISE_OPERATOR_ROLE,
+    OAUTH2_PROVIDER_APPLICATION_MODEL,
 )
-from enterprise.models import EnterpriseCustomerUser, SystemWideEnterpriseRole, SystemWideEnterpriseUserRoleAssignment
+from enterprise.models import (
+    EnterpriseCustomerUser,
+    EnterpriseFeatureRole,
+    EnterpriseFeatureUserRoleAssignment,
+    SystemWideEnterpriseRole,
+    SystemWideEnterpriseUserRoleAssignment,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -27,6 +39,9 @@ class Command(BaseCommand):
     Example usage:
         $ ./manage.py assign_enterprise_user_roles --role=enterprise_admin
         $ ./manage.py assign_enterprise_user_roles --role=enterprise_learner
+        $ ./manage.py assign_enterprise_user_roles --role=enterprise_openedx_operator
+        $ ./manage.py assign_enterprise_user_roles --role=catalog_admin
+        $ ./manage.py assign_enterprise_user_roles --role=enrollment_api_admin
     """
     help = 'Assigns enterprise roles to existing enterprise users.'
 
@@ -68,6 +83,12 @@ class Command(BaseCommand):
             type=int,
         )
 
+    def _get_enterprise_customer_user_ids(self):
+        """
+        Returns a queryset containing user ids.
+        """
+        return EnterpriseCustomerUser.objects.values('user_id')
+
     def _get_enterprise_admin_users_batch(self, start, end):
         """
         Returns a batched queryset of User objects.
@@ -87,9 +108,27 @@ class Command(BaseCommand):
         Returns a batched queryset of EnterpriseCustomerUser objects.
         """
         LOGGER.info('Fetching new batch of enterprise customer users from indexes: %s to %s', start, end)
-        return User.objects.filter(pk__in=EnterpriseCustomerUser.objects.values('user_id'))[start:end]
+        return User.objects.filter(pk__in=self._get_enterprise_customer_user_ids())[start:end]
 
-    def _assign_enterprise_role_to_users(self, _get_batch_method, options):
+    def _get_enterprise_enrollment_api_admin_users_batch(self, start, end):     # pylint: disable=invalid-name
+        """
+        Returns a batched queryset of User objects.
+        """
+        LOGGER.info('Fetching new batch of enterprise enrollment admin users from indexes: %s to %s', start, end)
+        return User.objects.filter(groups__name=ENTERPRISE_ENROLLMENT_API_ACCESS_GROUP, is_staff=False)[start:end]
+
+    def _get_enterprise_catalog_admin_users_batch(self, start, end):
+        """
+        Returns a batched queryset of User objects.
+        """
+        Application = apps.get_model(OAUTH2_PROVIDER_APPLICATION_MODEL)     # pylint: disable=invalid-name
+        LOGGER.info('Fetching new batch of enterprise catalog admin users from indexes: %s to %s', start, end)
+        catalog_admin_user_ids = Application.objects.filter(
+            user_id__in=self._get_enterprise_customer_user_ids()
+        ).exclude(name=EDX_ORG_NAME).values('user_id')
+        return User.objects.filter(pk__in=catalog_admin_user_ids)[start:end]
+
+    def _assign_enterprise_role_to_users(self, _get_batch_method, options, is_feature_role=False):
         """
         Assigns enterprise role to users.
         """
@@ -105,14 +144,21 @@ class Command(BaseCommand):
             batch_offset + batch_limit
         )
 
-        enterprise_role = SystemWideEnterpriseRole.objects.get(name=role_name)
+        role_class = SystemWideEnterpriseRole
+        role_assignment_class = SystemWideEnterpriseUserRoleAssignment
+
+        if is_feature_role:
+            role_class = EnterpriseFeatureRole
+            role_assignment_class = EnterpriseFeatureUserRoleAssignment
+
+        enterprise_role = role_class.objects.get(name=role_name)
         while users_batch.count() > 0:
             for index, user in enumerate(users_batch):
                 LOGGER.info(
                     'Processing user with index %s and id %s',
                     current_batch_index + index, user.id
                 )
-                SystemWideEnterpriseUserRoleAssignment.objects.get_or_create(
+                role_assignment_class.objects.get_or_create(
                     user=user,
                     role=enterprise_role
                 )
@@ -140,6 +186,12 @@ class Command(BaseCommand):
         elif role == ENTERPRISE_LEARNER_ROLE:
             # Assign enterprise learner role to enterprise customer users.
             self._assign_enterprise_role_to_users(self._get_enterprise_customer_users_batch, options)
+        elif role == ENTERPRISE_ENROLLMENT_API_ADMIN_ROLE:
+            # Assign enterprise enrollment api admin to non-staff users with enterprise data api access.
+            self._assign_enterprise_role_to_users(self._get_enterprise_enrollment_api_admin_users_batch, options, True)
+        elif role == ENTERPRISE_CATALOG_ADMIN_ROLE:
+            # Assign enterprise catalog admin role to users with having credentials in catalog.
+            self._assign_enterprise_role_to_users(self._get_enterprise_catalog_admin_users_batch, options, True)
         else:
             raise CommandError('Please provide a valid role name. Supported roles are {admin} and {learner}'.format(
                 admin=ENTERPRISE_ADMIN_ROLE,


### PR DESCRIPTION
**Description:** 

This PR adds two feature specific role assignment functionality to the `assign_enterprise_user_roles` management command.

> For two of the feature specific roles, enterprise admins do not get mapped to them automatically.
We need to find the users who currently hit the enterprise catalog endpoints and grant them the feature specific catalog role. The best proxy would be any user who is linked to an enterprise but has also been granted client credentials api keys.
We also need to find the users who are in the enrollment_api_access_group and grant them the feature specific enrollment api admin role.

**JIRA:**
https://openedx.atlassian.net/browse/ENT-1785

** Testing Instructions **

a) _enrollment api admin role_
1. Create user and assign `enterprise_enrollment_api_access` group to him.
2. Run `/manage.py lms assign_enterprise_user_roles --role=enrollment_api_admin` in LMS.
3. Observe that `EnterpriseFeatureUserRoleAssignment` record has been created for the user.

b) _catalog admin_
1. Create user object.
2. Create a recod for the user in `oauth_provider_application` admin table for the user.
3. Create an enterprise customer user record for the user.
4. Run `/manage.py lms assign_enterprise_user_roles --role=catalog_admin` in LMS.
5. Observe that `EnterpriseFeatureUserRoleAssignment` record has been created for the user.