### PR TITLE
WL-1915: Added availability key to default content filter for ECC

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[1.4.3] - 2019-04-11
+--------------------
+
+* Added `availability` key to default content filter for ECC.
+
 [1.4.2] - 2019-04-11
 --------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.4.2"
+__version__ = "1.4.3"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/constants.py
+++ b/enterprise/constants.py
@@ -81,6 +81,11 @@ DEFAULT_CATALOG_CONTENT_FILTER = {
         'Introductory',
         'Intermediate',
         'Advanced'
+    ],
+    'availability': [
+        'Current',
+        'Starting Soon',
+        'Upcoming'
     ]
 }
 

--- a/enterprise/settings/test.py
+++ b/enterprise/settings/test.py
@@ -186,6 +186,11 @@ ENTERPRISE_CUSTOMER_CATALOG_DEFAULT_CONTENT_FILTER = {
         'Introductory',
         'Intermediate',
         'Advanced'
+    ],
+    'availability': [
+        'Current',
+        'Starting Soon',
+        'Upcoming'
     ]
 }
 

--- a/tests/test_enterprise/test_signals.py
+++ b/tests/test_enterprise/test_signals.py
@@ -206,6 +206,11 @@ class TestDefaultContentFilter(unittest.TestCase):
                 'level_type': [
                     'Introductory',
                     'Intermediate'
+                ],
+                'availability': [
+                    'Current',
+                    'Starting Soon',
+                    'Upcoming'
                 ]
             },
             {
@@ -213,6 +218,11 @@ class TestDefaultContentFilter(unittest.TestCase):
                 'level_type': [
                     'Introductory',
                     'Intermediate'
+                ],
+                'availability': [
+                    'Current',
+                    'Starting Soon',
+                    'Upcoming'
                 ]
             }
         ),


### PR DESCRIPTION
**Description:** Added availability key to default content filter for ECC

**JIRA:** Link to JIRA ticket

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happend instead - check failed.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
