### PR TITLE
ENT-1748: Revise course load exception message in CourseEnrollmentView

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[1.4.4] - 2019-04-11
+--------------------
+
+* Revise course load exception message in CourseEnrollmentView.
+
 [1.4.3] - 2019-04-11
 --------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.4.3"
+__version__ = "1.4.4"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -846,17 +846,25 @@ class CourseEnrollmentView(NonAtomicView):
                 return enterprise_customer, course, course_run, course_modes
 
         if not course or not course_run:
+            course_id = course['key'] if course else "Not Found"
+            course_title = course['title'] if course else "Not Found"
+            course_run_title = course_run['title'] if course_run else "Not Found"
+            enterprise_catalog_title = enterprise_catalog['title'] if enterprise_catalog else "Not Found"
             # The specified course either does not exist in the specified
             # EnterpriseCustomerCatalog, or does not exist at all in the
             # discovery service.
             LOGGER.warning(
-                'Failed to fetch course [{course}] or course run [{course_run}] details for '
-                'course run [{course_run_id}] enterprise [{enterprise_uuid}] '
-                'catalog [{enterprise_catalog_uuid}]'.format(
-                    course=course,
-                    course_run=course_run,
+                'Failed to fetch details for course "{course_title}" [{course_id}] '
+                'or course run "{course_run_title}" [{course_run_id}] '
+                'for enterprise "{enterprise_name}" [{enterprise_uuid}] '
+                'with catalog "{enterprise_catalog_title}" [{enterprise_catalog_uuid}]'.format(
+                    course_title=course_title,
+                    course_id=course_id,
+                    course_run_title=course_run_title,
                     course_run_id=course_run_id,
+                    enterprise_name=enterprise_customer.name,
                     enterprise_uuid=enterprise_customer.uuid,
+                    enterprise_catalog_title=enterprise_catalog_title,
                     enterprise_catalog_uuid=enterprise_catalog_uuid,
                 )
             )


### PR DESCRIPTION
**Description:** The original exception message dumped full course or course_run object data into the exception message, which made it hard to decipher what the issue was.  This change revises the exception message to only include key and name info.

**JIRA:** https://openedx.atlassian.net/browse/ENT-1748

**Dependencies:** None

**Merge deadline:** No hard deadline


**Merge checklist:**

- [ ] ~~Check that the versions of the requirements in the `platform-master.in` file match edx-platform.~~
- [ ] ~~New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)~~
- [ ] ~~Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).~~
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] ~~Called `make static` for webpack bundling if any static content was updated.~~
- [ ] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [ ] ~~Documentation updated (not only docstrings)~~
- [x] Commits are (reasonably) squashed
- [ ] ~~Translations are updated~~
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
