### PR TITLE
ENT-1692: Revise course mode match exception message in CourseEnrollmentView

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[1.4.5] - 2019-04-12
+--------------------
+
+* Revise course mode match exception message in CourseEnrollmentView.
+
 [1.4.4] - 2019-04-11
 --------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.4.4"
+__version__ = "1.4.5"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -794,7 +794,9 @@ class CourseEnrollmentView(NonAtomicView):
             modes.sort(key=lambda course_mode: enterprise_catalog.enabled_course_modes.index(course_mode['slug']))
             if not modes:
                 LOGGER.warning(
-                    'No course modes found for EnterpriseCustomerCatalog [{enterprise_catalog_uuid}]'.format(
+                    'No matching course modes found for course run {course_run_id} in '
+                    'EnterpriseCustomerCatalog [{enterprise_catalog_uuid}]'.format(
+                        course_run_id=course_run_id,
                         enterprise_catalog_uuid=enterprise_catalog,
                     )
                 )


### PR DESCRIPTION
**Description:** Additionally records the course run id/key in the exception log message alongside the ECC id so we know which actual course run is lacking applicable modes.

**JIRA:** https://openedx.atlassian.net/browse/ENT-1692

**Dependencies:** None

**Merge deadline:** No hard deadline

**Merge checklist:**

- [ ] ~~Check that the versions of the requirements in the `platform-master.in` file match edx-platform.~~
- [ ] ~~New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)~~
- [ ] ~~Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).~~
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] ~~Called `make static` for webpack bundling if any static content was updated.~~
- [ ] All reviewers approved
- [ ] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [ ] ~~Documentation updated (not only docstrings)~~
- [x] Commits are (reasonably) squashed
- [ ] ~~Translations are updated~~
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
