### PR TITLE
WL-1911 We are masking discovery call failures from the client, and we should stop.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[1.4.6] - 2019-04-17
+--------------------
+
+* Stop masking discovery call failures from the client for enterprise catalog endpoint calls.
+
 [1.4.5] - 2019-04-12
 --------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.4.5"
+__version__ = "1.4.6"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -385,9 +385,6 @@ class EnterpriseCustomerCatalogViewSet(EnterpriseReadOnlyModelViewSet):
 
     @method_decorator(require_at_least_one_query_parameter('course_run_ids', 'program_uuids'))
     @detail_route()
-    @permission_required(
-        'enterprise.can_view_catalog',
-        fn=lambda request, pk, course_run_ids, program_uuids: get_enterprise_customer_from_catalog_id(pk))
     # pylint: disable=invalid-name,unused-argument
     def contains_content_items(self, request, pk, course_run_ids, program_uuids):
         """

--- a/enterprise/api_client/discovery.py
+++ b/enterprise/api_client/discovery.py
@@ -136,11 +136,6 @@ class CourseCatalogApiClient(object):
             dict: Paginated response or all the records.
         """
         query_params = query_params or {}
-        response = {
-            'next': None,
-            'previous': None,
-            'results': [],
-        }
 
         try:
             endpoint = getattr(self.client, self.SEARCH_ALL_ENDPOINT)
@@ -150,9 +145,16 @@ class CourseCatalogApiClient(object):
                 response['next'] = response['previous'] = None
         except Exception as ex:  # pylint: disable=broad-except
             LOGGER.exception(
+                'Attempted to call course-discovery search/all/ endpoint with the following parameters: '
+                'content_filter_query: %s, query_params: %s, traverse_pagination: %s. '
                 'Failed to retrieve data from the catalog API. content -- [%s]',
+                content_filter_query,
+                query_params,
+                traverse_pagination,
                 getattr(ex, 'content', '')
             )
+            # We need to bubble up failures when we encounter them instead of masking them!
+            raise ex
 
         return response
 

--- a/tests/test_enterprise/api_client/test_discovery.py
+++ b/tests/test_enterprise/api_client/test_discovery.py
@@ -619,15 +619,14 @@ class TestCourseCatalogApi(CourseDiscoveryApiTestMixin, unittest.TestCase):
         logger = logging.getLogger('enterprise.api_client.discovery')
         handler = MockLoggingHandler(level="ERROR")
         logger.addHandler(handler)
-        assert self.api.get_catalog_results(
-            content_filter_query='query',
-            query_params={'page': 2}
-        ) == {
-            'next': None,
-            'previous': None,
-            'results': [],
-        }
-        expected_message = 'Failed to retrieve data from the catalog API. content -- [boom]'
+        with self.assertRaises(HttpClientError):
+            self.api.get_catalog_results(
+                content_filter_query='query',
+                query_params={u'page': 2}
+            )
+        expected_message = ('Attempted to call course-discovery search/all/ endpoint with the following parameters: '
+                            'content_filter_query: query, query_params: {}, traverse_pagination: False. '
+                            'Failed to retrieve data from the catalog API. content -- [boom]').format({u'page': 2})
         assert handler.messages['error'][0] == expected_message
 
 


### PR DESCRIPTION
**Description:** In trying to get better debugging information for WL-1911, it seems that this endpoint might be behaving in unexpected ways. In particular, I noticed that it returns false for the contains_content_items call when an error occurs in calling the discovery service, and thus the error is masked from the client. We need this to be surfaced so that we can understand the failures better.

I also removed the new style permission decorator for the endpoint because it is an endpoint called by internal services, and I'd like to derisk it from any further issues.

**JIRA:** Link to JIRA ticket

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happend instead - check failed.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
