### PR TITLE
Reduce course mode match exception log level

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[1.4.8] - 2019-04-26
+--------------------
+
+* Reduce course mode match exception log level
+
 [1.4.7] - 2019-04-17
 --------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.4.7"
+__version__ = "1.4.8"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -793,7 +793,7 @@ class CourseEnrollmentView(NonAtomicView):
             modes = [mode for mode in modes if mode['slug'] in enterprise_catalog.enabled_course_modes]
             modes.sort(key=lambda course_mode: enterprise_catalog.enabled_course_modes.index(course_mode['slug']))
             if not modes:
-                LOGGER.warning(
+                LOGGER.info(
                     'No matching course modes found for course run {course_run_id} in '
                     'EnterpriseCustomerCatalog [{enterprise_catalog_uuid}]'.format(
                         course_run_id=course_run_id,


### PR DESCRIPTION
**Description:** The exception workflow in this case is more of an expected scenario -- in some cases such as a passed verification upgrade deadline a course will no longer have a seat that matches the modes filter of a particular enterprise customer catalog.  The "warning" level associated with this exception is creating some alerting noise, so we'll drop the level to "info" in order to be able to retroactively determine the cause of the UI error state when it occurs.

**Merge deadline:** No hard deadline.

**Merge checklist:**

- [ ] ~~Check that the versions of the requirements in the `platform-master.in` file match edx-platform.~~
- [ ] ~~New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)~~
- [ ] ~~Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).~~
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] ~~Called `make static` for webpack bundling if any static content was updated.~~
- [ ] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [ ] ~~Documentation updated (not only docstrings)~~
- [ ] ~~Commits are (reasonably) squashed~~
- [ ] ~~Translations are updated~~
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
