### PR TITLE
ARCH-727 Adding sync_learner_profile_data flag to data returned by enterprise-learner endpoint.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[1.5.0] - 2019-05-08
+--------------------
+
+* Add sync_learner_profile_data flag to data returned by enterprise-learner endpoint
+
 [1.4.10] - 2019-05-08
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.4.10"
+__version__ = "1.5.0"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -117,7 +117,7 @@ class EnterpriseCustomerSerializer(serializers.ModelSerializer):
             'uuid', 'name', 'slug', 'catalog', 'active', 'site', 'enable_data_sharing_consent',
             'enforce_data_sharing_consent', 'branding_configuration', 'enterprise_customer_entitlements',
             'identity_provider', 'enable_audit_enrollment', 'replace_sensitive_sso_username',
-            'enable_portal_code_management_screen',
+            'enable_portal_code_management_screen', 'sync_learner_profile_data',
         )
 
     site = SiteSerializer()

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -267,6 +267,21 @@ class EnterpriseCustomer(TimeStampedModel):
         except ObjectDoesNotExist:
             return None
 
+    @property
+    def sync_learner_profile_data(self):
+        """
+        Return the sync_learner_profile data flag for the identity provider associated with this enterprise customer.
+
+        Returns False if enterprise customer does not have any identity provider.
+        """
+        try:
+            return (
+                self.enterprise_customer_identity_provider and
+                self.enterprise_customer_identity_provider.sync_learner_profile_data
+            )
+        except ObjectDoesNotExist:
+            return False
+
     def __str__(self):
         """
         Return human-readable string representation.
@@ -1016,12 +1031,28 @@ class EnterpriseCustomerIdentityProvider(TimeStampedModel):
         return self.__str__()
 
     @property
+    def identity_provider(self):
+        """
+        Associated identity provider instance.
+        """
+        identity_provider = utils.get_identity_provider(self.provider_id)
+        return identity_provider
+
+    @property
     def provider_name(self):
         """
         Readable name for the identity provider.
         """
-        identity_provider = utils.get_identity_provider(self.provider_id)
+        identity_provider = self.identity_provider
         return identity_provider and identity_provider.name
+
+    @property
+    def sync_learner_profile_data(self):
+        """
+        Return bool indicating if data received from the identity provider shoudl be synced to the edX profile.
+        """
+        identity_provider = self.identity_provider
+        return identity_provider is not None and identity_provider.sync_learner_profile_data
 
 
 @python_2_unicode_compatible

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -711,6 +711,7 @@ class TestEnterpriseAPIViews(APITest):
                 'site': {
                     'domain': 'example.com', 'name': 'example.com'
                 },
+                'sync_learner_profile_data': False,
             }],
         ),
         (
@@ -740,6 +741,7 @@ class TestEnterpriseAPIViews(APITest):
                     'site': {
                         'domain': 'example.com', 'name': 'example.com'
                     },
+                    'sync_learner_profile_data': False,
                 }
             }],
         ),
@@ -794,6 +796,7 @@ class TestEnterpriseAPIViews(APITest):
                 'site': {
                     'domain': 'example.com', 'name': 'example.com'
                 },
+                'sync_learner_profile_data': False,
             }],
         ),
         (
@@ -962,6 +965,7 @@ class TestEnterpriseAPIViews(APITest):
                 'site': {
                     'domain': 'example.com', 'name': 'example.com'
                 },
+                'sync_learner_profile_data': False,
             }
         else:
             assert response == expected_error


### PR DESCRIPTION
The new account settings MFE needs access to the sync_learner_profile_data flag in order to determine which fields should be editable/visible on the account settings form.