### PR TITLE
WL-1938 | Capture user attributes sent by cornerstone

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[1.6.16] - 2019-06-20
+---------------------
+
+* Capture user attributes sent by cornerstone
+
 [1.6.15] - 2019-06-18
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.6.15"
+__version__ = "1.6.16"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -54,6 +54,7 @@ from enterprise.utils import (
     track_enrollment,
     ungettext_min_max,
 )
+from integrated_channels.cornerstone.utils import create_cornerstone_learner_data
 
 try:
     from openedx.core.djangoapps.catalog.utils import get_localized_price_text
@@ -1805,6 +1806,10 @@ class RouterView(NonAtomicView):
                 )
                 return render_page_with_error_code_message(request, context_data, error_code, log_message)
             kwargs['course_id'] = course_run_id
+
+        # Enrollments through Cornerstone have some params in querystring, need to store those params if exists.
+        if course_key:
+            create_cornerstone_learner_data(request, course_key)
 
         # Ensure that the link is saved to the database prior to making some call in a downstream view
         # which may need to know that the user belongs to an enterprise customer.

--- a/integrated_channels/cornerstone/utils.py
+++ b/integrated_channels/cornerstone/utils.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+"""
+Utilities for Cornerstone integrated channels.
+"""
+
+from __future__ import absolute_import, unicode_literals, with_statement
+
+from logging import getLogger
+
+from integrated_channels.cornerstone.models import CornerstoneLearnerDataTransmissionAudit
+
+LOGGER = getLogger(__name__)
+
+
+def create_cornerstone_learner_data(request, course_id):
+    """
+        updates or creates CornerstoneLearnerDataTransmissionAudit
+    """
+    try:
+        defaults = {
+            'user_guid': request.GET['userGuid'],
+            'session_token': request.GET['sessionToken'],
+            'callback_url': request.GET['callbackUrl'],
+            'subdomain': request.GET['subdomain'],
+        }
+        CornerstoneLearnerDataTransmissionAudit.objects.update_or_create(
+            user_id=request.user.id,
+            course_id=course_id,
+            defaults=defaults
+        )
+    except KeyError:
+        # if we couldn't find a key, it means we don't want to save data. just skip it by doing nothing.
+        pass
+    except Exception as ex:  # pylint: disable=broad-except
+        LOGGER.error('Unable to Create/Update CornerstoneLearnerDataTransmissionAudit. {ex}'.format(ex=ex))

--- a/tests/test_integrated_channels/test_cornerstone/test_utils.py
+++ b/tests/test_integrated_channels/test_cornerstone/test_utils.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for the utilities used by Cornerstone integration channel.
+"""
+
+from __future__ import absolute_import, unicode_literals, with_statement
+
+import unittest
+
+import ddt
+from pytest import mark
+
+from django.test import RequestFactory
+
+from integrated_channels.cornerstone.models import CornerstoneLearnerDataTransmissionAudit
+from integrated_channels.cornerstone.utils import create_cornerstone_learner_data
+from test_utils.factories import UserFactory
+
+
+@ddt.ddt
+class TestCornerstoneUtils(unittest.TestCase):
+    """
+    Test utility functions used by Cornerstone integration channel.
+    """
+    @staticmethod
+    def _assert_learner_data_transmission_audit(transmission_audit, user, course_id, querystring):
+        """ Asserts CornerstoneLearnerDataTransmissionAudit values"""
+        assert transmission_audit.user == user
+        assert transmission_audit.course_id == course_id
+        assert transmission_audit.user_guid == querystring['userGuid']
+        assert transmission_audit.session_token == querystring['sessionToken']
+        assert transmission_audit.callback_url == querystring['callbackUrl']
+        assert transmission_audit.subdomain == querystring['subdomain']
+
+    @staticmethod
+    def _get_request(querystring, user=None):
+        """ returns mocked request """
+        request = RequestFactory().get(path='/', data=querystring)
+        request.user = user if user else UserFactory()
+        return request
+
+    @ddt.data(
+        (
+            {
+                'userGuid': 'dummy_id',
+                'sessionToken': 'dummySessionToken',
+                'callbackUrl': 'dummy_callbackUrl',
+                'subdomain': 'dummy_subdomain',
+            },
+            'dummy_courseId',
+            True,
+        ),
+        (
+            {
+                'callbackUrl': 'dummy_callbackUrl',
+                'subdomain': 'dummy_subdomain',
+            },
+            'dummy_courseId',
+            False,
+        ),
+        (
+            {},
+            None,
+            False,
+        ),
+    )
+    @ddt.unpack
+    @mark.django_db
+    def test_update_cornerstone_learner_data_transmission_audit(self, querystring, course_id, expected_result):
+        """ test creating records """
+        request = self._get_request(querystring)
+        create_cornerstone_learner_data(request, course_id)
+        actual_result = request.user.cornerstone_transmission_audit.filter(course_id=course_id).exists()
+        assert actual_result == expected_result
+
+    @mark.django_db
+    def test_update_cornerstone_learner_data_transmission_audit_with_existing_data(self):
+        """ test updating audit records """
+        user = UserFactory()
+        course_id = 'dummy_courseId'
+        querystring = {
+            'userGuid': 'dummy_id',
+            'sessionToken': 'dummy_session_token',
+            'callbackUrl': 'dummy_callbackUrl',
+            'subdomain': 'dummy_subdomain',
+        }
+
+        # creating data for first time
+        request = self._get_request(querystring, user)
+        create_cornerstone_learner_data(request, course_id)
+        records = CornerstoneLearnerDataTransmissionAudit.objects.all()
+        assert records.count() == 1
+        self._assert_learner_data_transmission_audit(records.first(), user, course_id, querystring)
+
+        # Updating just sessionToken Should NOT create new records, instead update old one.
+        querystring['sessionToken'] = 'updated_dummy_session_token'
+        request = self._get_request(querystring, user)
+        create_cornerstone_learner_data(request, course_id)
+        records = CornerstoneLearnerDataTransmissionAudit.objects.all()
+        assert records.count() == 1
+        self._assert_learner_data_transmission_audit(records.first(), user, course_id, querystring)
+
+        # But updating courseId Should create fresh record.
+        course_id = 'updated_dummy_courseId'
+        request = self._get_request(querystring, user)
+        create_cornerstone_learner_data(request, course_id)
+        records = CornerstoneLearnerDataTransmissionAudit.objects.all()
+        assert records.count() == 2
+        self._assert_learner_data_transmission_audit(records[1], user, course_id, querystring)


### PR DESCRIPTION
**Description:** 
added create_cornerstone_learner_data_transmission_audit util to create records
called that utility from RouterView
added unit tests

**JIRA:** https://openedx.atlassian.net/browse/WL-1938

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happend instead - check failed.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [x] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
