### PR TITLE
ENT-1783: Fallback to request.auth if JWT cookies are not found.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[1.6.1] - 2019-05-30
+--------------------
+
+* Fallback to request.auth if JWT cookies are not found.
+
 [1.6.0] - 2019-05-29
 --------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.6.0"
+__version__ = "1.6.1"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/rules.py
+++ b/enterprise/rules.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, unicode_literals
 import crum
 import rules
 from edx_rbac.utils import request_user_has_implicit_access_via_jwt, user_has_access_via_database
+from edx_rest_framework_extensions.auth.jwt.authentication import get_decoded_jwt_from_auth
 from edx_rest_framework_extensions.auth.jwt.cookies import get_decoded_jwt
 
 from enterprise.constants import (
@@ -25,7 +26,7 @@ def has_implicit_access_to_dashboard(user, obj):  # pylint: disable=unused-argum
         boolean: whether the request user has access or not
     """
     request = crum.get_current_request()
-    decoded_jwt = get_decoded_jwt(request)
+    decoded_jwt = get_decoded_jwt(request) or get_decoded_jwt_from_auth(request)
     return request_user_has_implicit_access_via_jwt(decoded_jwt, ENTERPRISE_DASHBOARD_ADMIN_ROLE)
 
 
@@ -53,7 +54,7 @@ def has_implicit_access_to_catalog(user, obj):  # pylint: disable=unused-argumen
         boolean: whether the request user has access or not
     """
     request = crum.get_current_request()
-    decoded_jwt = get_decoded_jwt(request)
+    decoded_jwt = get_decoded_jwt(request) or get_decoded_jwt_from_auth(request)
     return request_user_has_implicit_access_via_jwt(decoded_jwt, ENTERPRISE_CATALOG_ADMIN_ROLE, obj)
 
 
@@ -82,7 +83,7 @@ def has_implicit_access_to_enrollment_api(user, obj):  # pylint: disable=unused-
         boolean: whether the request user has access or not
     """
     request = crum.get_current_request()
-    decoded_jwt = get_decoded_jwt(request)
+    decoded_jwt = get_decoded_jwt(request) or get_decoded_jwt_from_auth(request)
     return request_user_has_implicit_access_via_jwt(decoded_jwt, ENTERPRISE_ENROLLMENT_API_ADMIN_ROLE, obj)
 
 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -7,5 +7,5 @@ jsondiff==1.1.1                         # Used to detect content metadata change
 django-countries==4.6.1
 -e git+https://github.com/edx/TinCanPython.git@0.0.5.py.35#egg=tincan==0.0.5.py.35
 django-simple-history==2.7.0
-edx-rbac==0.2.1
-edx-drf-extensions==2.2.1
+edx-rbac==1.0.1
+edx-drf-extensions==2.3.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -22,7 +22,8 @@ chardet==3.0.4            # via requests
 click-log==0.3.2          # via edx-lint
 click==7.0                # via click-log, code-annotations, edx-lint, pip-tools
 code-annotations==0.3.1
-configparser==3.7.4       # via pydocstyle, pylint
+configparser==3.7.4       # via importlib-metadata, pydocstyle, pylint
+contextlib2==0.5.5        # via importlib-metadata
 cryptography==2.4.2
 defusedxml==0.6.0         # via djangorestframework-xml
 diff-cover==0.9.8
@@ -45,11 +46,11 @@ djangorestframework-xml==1.3.0
 djangorestframework==3.6.3
 edx-django-oauth2-provider==1.3.5
 edx-django-utils==1.0.3   # via edx-drf-extensions
-edx-drf-extensions==2.2.1
+edx-drf-extensions==2.3.0
 edx-i18n-tools==0.4.8
-edx-lint==1.2.0
+edx-lint==1.2.1
 edx-opaque-keys==0.4.4
-edx-rbac==0.2.1
+edx-rbac==1.0.1
 edx-rest-api-client==1.9.2
 enum34==1.1.6             # via astroid, cryptography
 filelock==3.0.12          # via tox
@@ -58,6 +59,7 @@ future==0.17.1            # via pyjwkest
 futures==3.1.1
 html5lib==1.0.1
 idna==2.8                 # via cryptography, requests
+importlib-metadata==0.15  # via pluggy
 inflect==2.1.0            # via jinja2-pluralize
 ipaddress==1.0.22         # via cryptography
 isort==4.3.20
@@ -69,14 +71,15 @@ kombu==3.0.37             # via celery
 lazy-object-proxy==1.4.1  # via astroid
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via pylint
-newrelic==4.18.0.118      # via edx-django-utils
+newrelic==4.20.0.120      # via edx-django-utils
 packaging==19.0           # via caniusepython3
 path.py==8.2.1
+pathlib2==2.3.3           # via importlib-metadata
 pbr==5.2.0                # via stevedore
 pillow==5.4.1
 pip-tools==3.7.0
 pkginfo==1.5.0.1          # via twine
-pluggy==0.11.0            # via tox
+pluggy==0.12.0            # via tox
 polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 py==1.8.0                 # via tox
@@ -84,7 +87,7 @@ pycodestyle==2.5.0
 pycparser==2.19           # via cffi
 pycryptodomex==3.8.1      # via pyjwkest
 pydocstyle==3.0.0
-pygments==2.4.0           # via diff-cover
+pygments==2.4.2           # via diff-cover
 pyjwkest==1.3.2           # via edx-drf-extensions
 pyjwt==1.7.1              # via djangorestframework-jwt, edx-rest-api-client
 pylint-celery==0.3        # via edx-lint
@@ -101,10 +104,11 @@ requests-toolbelt==0.9.1  # via twine
 requests==2.21.0
 rest-condition==1.0.3     # via edx-drf-extensions
 rules==2.0.1
+scandir==1.10.0           # via pathlib2
 semantic-version==2.6.0   # via edx-drf-extensions
 shortuuid==0.5.0          # via edx-django-oauth2-provider
 singledispatch==3.4.0.3   # via astroid, pylint
-six==1.12.0               # via astroid, bleach, cryptography, diff-cover, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-rbac, html5lib, packaging, pip-tools, pydocstyle, pyjwkest, pylint, python-dateutil, singledispatch, stevedore, tox
+six==1.12.0               # via astroid, bleach, cryptography, diff-cover, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-rbac, html5lib, packaging, pathlib2, pip-tools, pydocstyle, pyjwkest, pylint, python-dateutil, singledispatch, stevedore, tox
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==1.2.1    # via pydocstyle
 stevedore==1.30.1         # via code-annotations, edx-opaque-keys
@@ -112,7 +116,7 @@ testfixtures==6.8.2
 text-unidecode==1.2       # via python-slugify
 toml==0.10.0              # via tox
 tox-battery==0.5.1
-tox==3.11.1
+tox==3.12.1
 tqdm==4.32.1              # via twine
 twine==1.11.0
 unicodecsv==0.14.1
@@ -121,3 +125,4 @@ virtualenv==16.6.0        # via tox
 webencodings==0.5.1       # via html5lib
 wheel==0.33.4
 wrapt==1.11.1             # via astroid
+zipp==0.5.1               # via importlib-metadata

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -10,7 +10,7 @@ amqp==1.4.9               # via kombu
 aniso8601==6.0.0
 anyjson==0.3.3            # via kombu
 asn1crypto==0.24.0        # via cryptography
-babel==2.6.0              # via sphinx
+babel==2.7.0              # via sphinx
 billiard==3.3.0.23        # via celery
 bleach==2.1.4
 celery==3.1.25
@@ -42,9 +42,9 @@ doc8==0.8.0
 docutils==0.14
 edx-django-oauth2-provider==1.3.5
 edx-django-utils==1.0.3   # via edx-drf-extensions
-edx-drf-extensions==2.2.1
+edx-drf-extensions==2.3.0
 edx-opaque-keys==0.4.4
-edx-rbac==0.2.1
+edx-rbac==1.0.1
 edx-rest-api-client==1.9.2
 edx-sphinx-theme==1.4.0
 enum34==1.1.6             # via cryptography
@@ -61,7 +61,7 @@ jsondiff==1.1.1
 jsonfield==2.0.2
 kombu==3.0.37             # via celery
 markupsafe==1.1.1         # via jinja2
-newrelic==4.18.0.118      # via edx-django-utils
+newrelic==4.20.0.120      # via edx-django-utils
 packaging==19.0           # via sphinx
 path.py==8.2.1
 pbr==5.2.0                # via stevedore
@@ -70,7 +70,7 @@ pockets==0.7.2            # via sphinxcontrib-napoleon
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 pycparser==2.19           # via cffi
 pycryptodomex==3.8.1      # via pyjwkest
-pygments==2.4.0           # via diff-cover, readme-renderer, sphinx
+pygments==2.4.2           # via diff-cover, readme-renderer, sphinx
 pyjwkest==1.3.2           # via edx-drf-extensions
 pyjwt==1.7.1              # via djangorestframework-jwt, edx-rest-api-client
 pymongo==3.8.0            # via edx-opaque-keys

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -14,7 +14,7 @@ asn1crypto==0.24.0        # via cryptography
 astroid==1.5.3            # via pylint, pylint-celery
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
-babel==2.6.0              # via sphinx
+babel==2.7.0              # via sphinx
 backports.functools-lru-cache==1.5  # via astroid, caniusepython3, isort, pylint
 billiard==3.3.0.23        # via celery
 bleach==2.1.4
@@ -26,7 +26,8 @@ chardet==3.0.4            # via doc8, requests
 click-log==0.3.2          # via edx-lint
 click==7.0                # via click-log, code-annotations, edx-lint, pip-tools
 code-annotations==0.3.1
-configparser==3.7.4       # via pydocstyle, pylint
+configparser==3.7.4       # via importlib-metadata, pydocstyle, pylint
+contextlib2==0.5.5        # via importlib-metadata
 cookies==2.2.1            # via responses
 coverage==4.5.3           # via pytest-cov
 cryptography==2.4.2
@@ -54,11 +55,11 @@ doc8==0.8.0
 docutils==0.14
 edx-django-oauth2-provider==1.3.5
 edx-django-utils==1.0.3   # via edx-drf-extensions
-edx-drf-extensions==2.2.1
+edx-drf-extensions==2.3.0
 edx-i18n-tools==0.4.8
-edx-lint==1.2.0
+edx-lint==1.2.1
 edx-opaque-keys==0.4.4
-edx-rbac==0.2.1
+edx-rbac==1.0.1
 edx-rest-api-client==1.9.2
 edx-sphinx-theme==1.4.0
 enum34==1.1.6             # via astroid, cryptography
@@ -73,6 +74,7 @@ futures==3.1.1
 html5lib==1.0.1
 idna==2.8                 # via cryptography, requests
 imagesize==1.1.0          # via sphinx
+importlib-metadata==0.15  # via pluggy
 inflect==2.1.0            # via jinja2-pluralize
 ipaddress==1.0.22         # via cryptography, faker
 isort==4.3.20
@@ -86,15 +88,15 @@ markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via pylint
 mock==3.0.5
 more-itertools==5.0.0     # via pytest
-newrelic==4.18.0.118      # via edx-django-utils
+newrelic==4.20.0.120      # via edx-django-utils
 packaging==19.0           # via caniusepython3, sphinx
 path.py==8.2.1
-pathlib2==2.3.3           # via pytest, pytest-django
+pathlib2==2.3.3           # via importlib-metadata, pytest, pytest-django
 pbr==5.2.0                # via stevedore
 pillow==5.4.1
 pip-tools==3.7.0
 pkginfo==1.5.0.1          # via twine
-pluggy==0.11.0            # via pytest, tox
+pluggy==0.12.0            # via pytest, tox
 pockets==0.7.2            # via sphinxcontrib-napoleon
 polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
@@ -103,7 +105,7 @@ pycodestyle==2.5.0
 pycparser==2.19           # via cffi
 pycryptodomex==3.8.1      # via pyjwkest
 pydocstyle==3.0.0
-pygments==2.4.0           # via diff-cover, readme-renderer, sphinx
+pygments==2.4.2           # via diff-cover, readme-renderer, sphinx
 pyjwkest==1.3.2           # via edx-drf-extensions
 pyjwt==1.7.1              # via djangorestframework-jwt, edx-rest-api-client
 pylint-celery==0.3        # via edx-lint
@@ -142,7 +144,7 @@ testfixtures==6.8.2
 text-unidecode==1.2       # via faker, python-slugify
 toml==0.10.0              # via tox
 tox-battery==0.5.1
-tox==3.11.1
+tox==3.12.1
 tqdm==4.32.1              # via twine
 twine==1.11.0
 typing==3.6.6             # via sphinx
@@ -153,3 +155,4 @@ wcwidth==0.1.7            # via pytest
 webencodings==0.5.1       # via html5lib
 wheel==0.33.4
 wrapt==1.11.1             # via astroid
+zipp==0.5.1               # via importlib-metadata

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -19,6 +19,8 @@ cffi==1.12.3              # via cryptography
 chardet==3.0.4            # via requests
 click==7.0                # via code-annotations
 code-annotations==0.3.1
+configparser==3.7.4       # via importlib-metadata
+contextlib2==0.5.5        # via importlib-metadata
 cookies==2.2.1            # via responses
 coverage==4.5.3           # via pytest-cov
 cryptography==2.4.2
@@ -43,9 +45,9 @@ djangorestframework-xml==1.3.0
 djangorestframework==3.6.3
 edx-django-oauth2-provider==1.3.5
 edx-django-utils==1.0.3   # via edx-drf-extensions
-edx-drf-extensions==2.2.1
+edx-drf-extensions==2.3.0
 edx-opaque-keys==0.4.4
-edx-rbac==0.2.1
+edx-rbac==1.0.1
 edx-rest-api-client==1.9.2
 enum34==1.1.6             # via cryptography
 factory-boy==2.12.0
@@ -56,6 +58,7 @@ funcsigs==1.0.2           # via mock, pytest
 future==0.17.1            # via pyjwkest
 html5lib==1.0.1
 idna==2.8                 # via cryptography, requests
+importlib-metadata==0.15  # via pluggy
 inflect==2.1.0            # via jinja2-pluralize
 ipaddress==1.0.22         # via cryptography, faker
 jinja2-pluralize==0.3.0   # via diff-cover
@@ -66,17 +69,17 @@ kombu==3.0.37             # via celery
 markupsafe==1.1.1         # via jinja2
 mock==3.0.5
 more-itertools==5.0.0     # via pytest
-newrelic==4.18.0.118      # via edx-django-utils
+newrelic==4.20.0.120      # via edx-django-utils
 path.py==8.2.1
-pathlib2==2.3.3           # via pytest, pytest-django
+pathlib2==2.3.3           # via importlib-metadata, pytest, pytest-django
 pbr==5.2.0                # via stevedore
 pillow==5.4.1
-pluggy==0.11.0            # via pytest
+pluggy==0.12.0            # via pytest
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 py==1.8.0                 # via pytest, pytest-catchlog
 pycparser==2.19           # via cffi
 pycryptodomex==3.8.1      # via pyjwkest
-pygments==2.4.0           # via diff-cover
+pygments==2.4.2           # via diff-cover
 pyjwkest==1.3.2           # via edx-drf-extensions
 pyjwt==1.7.1              # via djangorestframework-jwt, edx-rest-api-client
 pymongo==3.8.0            # via edx-opaque-keys
@@ -104,3 +107,4 @@ unicodecsv==0.14.1
 urllib3==1.24.3           # via requests
 wcwidth==0.1.7            # via pytest
 webencodings==0.5.1       # via html5lib
+zipp==0.5.1               # via importlib-metadata

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -19,6 +19,8 @@ cffi==1.12.3              # via cryptography
 chardet==3.0.4            # via requests
 click==7.0                # via code-annotations
 code-annotations==0.3.1
+configparser==3.7.4       # via importlib-metadata
+contextlib2==0.5.5        # via importlib-metadata
 cookies==2.2.1            # via responses
 coverage==4.5.3           # via pytest-cov
 cryptography==2.4.2
@@ -43,9 +45,9 @@ djangorestframework-xml==1.3.0
 djangorestframework==3.6.3
 edx-django-oauth2-provider==1.3.5
 edx-django-utils==1.0.3   # via edx-drf-extensions
-edx-drf-extensions==2.2.1
+edx-drf-extensions==2.3.0
 edx-opaque-keys==0.4.4
-edx-rbac==0.2.1
+edx-rbac==1.0.1
 edx-rest-api-client==1.9.2
 enum34==1.1.6             # via cryptography
 factory-boy==2.12.0
@@ -56,6 +58,7 @@ funcsigs==1.0.2           # via mock, pytest
 future==0.17.1            # via pyjwkest
 html5lib==1.0.1
 idna==2.8                 # via cryptography, requests
+importlib-metadata==0.15  # via pluggy
 inflect==2.1.0            # via jinja2-pluralize
 ipaddress==1.0.22         # via cryptography, faker
 jinja2-pluralize==0.3.0   # via diff-cover
@@ -66,17 +69,17 @@ kombu==3.0.37             # via celery
 markupsafe==1.1.1         # via jinja2
 mock==3.0.5
 more-itertools==5.0.0     # via pytest
-newrelic==4.18.0.118      # via edx-django-utils
+newrelic==4.20.0.120      # via edx-django-utils
 path.py==8.2.1
-pathlib2==2.3.3           # via pytest, pytest-django
+pathlib2==2.3.3           # via importlib-metadata, pytest, pytest-django
 pbr==5.2.0                # via stevedore
 pillow==5.4.1
-pluggy==0.11.0            # via pytest
+pluggy==0.12.0            # via pytest
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 py==1.8.0                 # via pytest, pytest-catchlog
 pycparser==2.19           # via cffi
 pycryptodomex==3.8.1      # via pyjwkest
-pygments==2.4.0           # via diff-cover
+pygments==2.4.2           # via diff-cover
 pyjwkest==1.3.2           # via edx-drf-extensions
 pyjwt==1.7.1              # via djangorestframework-jwt, edx-rest-api-client
 pymongo==3.8.0            # via edx-opaque-keys
@@ -104,3 +107,4 @@ unicodecsv==0.14.1
 urllib3==1.24.3           # via requests
 wcwidth==0.1.7            # via pytest
 webencodings==0.5.1       # via html5lib
+zipp==0.5.1               # via importlib-metadata

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -7,15 +7,21 @@
 certifi==2019.3.9         # via requests
 chardet==3.0.4            # via requests
 codecov==2.0.15
+configparser==3.7.4       # via importlib-metadata
+contextlib2==0.5.5        # via importlib-metadata
 coverage==4.5.3           # via codecov
 filelock==3.0.12          # via tox
 idna==2.8                 # via requests
-pluggy==0.11.0            # via tox
+importlib-metadata==0.15  # via pluggy
+pathlib2==2.3.3           # via importlib-metadata
+pluggy==0.12.0            # via tox
 py==1.8.0                 # via tox
 requests==2.22.0          # via codecov
-six==1.12.0               # via tox
+scandir==1.10.0           # via pathlib2
+six==1.12.0               # via pathlib2, tox
 toml==0.10.0              # via tox
 tox-battery==0.5.1
-tox==3.11.1
-urllib3==1.25.2           # via requests
+tox==3.12.1
+urllib3==1.25.3           # via requests
 virtualenv==16.6.0        # via tox
+zipp==0.5.1               # via importlib-metadata


### PR DESCRIPTION
**Description:** 
This PR updates the logic to get JWT data falls back to `request.auth` if JWT cookies are not present

**Installation instructions:** Simply install `edx-enterprise` using this branch.

**Merge checklist:**

- [x] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [x] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [x] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [x] Called `make static` for webpack bundling if any static content was updated.
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [x] Translations are updated
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)
