### PR TITLE
ENT-1054: Fix enrollment page course key issues

### DIFF
--- a/consent/models.py
+++ b/consent/models.py
@@ -58,7 +58,18 @@ class DataSharingConsentQuerySet(models.query.QuerySet):
                 except DataSharingConsent.DoesNotExist:
                     # A record for the course run didn't exist, so modify the query
                     # parameters to look for just a course record on the second pass.
-                    kwargs['course_id'] = parse_course_key(course_run_key)
+
+                    site = None
+                    if 'enterprise_customer' in kwargs:
+                        site = kwargs['enterprise_customer'].site
+
+                    try:
+                        course_id = get_course_catalog_api_service_client(site=site).get_course_id(
+                            course_identifier=course_run_key
+                        )
+                        kwargs['course_id'] = course_id
+                    except ImproperlyConfigured:
+                        LOGGER.warning('CourseCatalogApiServiceClient is improperly configured.')
 
         try:
             return self.get(*args, **kwargs)

--- a/enterprise/api_client/discovery.py
+++ b/enterprise/api_client/discovery.py
@@ -235,30 +235,29 @@ class CourseCatalogApiClient(object):
 
     def get_course_id(self, course_identifier):
         """
-        Return the course key for the given course identifier.  The `course_identifier` may be a course key or a course
-        run id; in either case the course key will be returned.
+        Return the course id for the given course identifier.  The `course_identifier` may be a course id or a course
+        run id; in either case the course id will be returned.
 
-        The 'course key' is the identifier for a course (ex. edX+DemoX)
+        The 'course id' is the identifier for a course (ex. edX+DemoX)
         The 'course run id' is the identifier for a run of a course (ex. edX+DemoX+demo_run)
 
         Arguments:
-            course_identifier (str): The course key or course run id
+            course_identifier (str): The course id or course run id
 
         Returns:
-            (str): course key
+            (str): course id
         """
-        # TODO: go through comments and make sure this all makes sense
         try:
             CourseKey.from_string(course_identifier)
         except InvalidKeyError:
-            # An `InvalidKeyError` is thrown if `course_identifier` is not in the proper format for a course run id
-            # `course_identifier` cannot be a course run id. Assume `course_identifier` is the  course key (course id).
+            # An `InvalidKeyError` is thrown if `course_identifier` is not in the proper format for a course run id.
+            # Since `course_identifier` is not a course run id we assume `course_identifier` is the  course id.
             return course_identifier
 
-        # `course_identifier` must be a course run id.  We cannot use `CourseKey.from_string` to find the course key
-        # because that method assumes the course key is always a substring of the course run id and this is not always
-        # the case.  The only reliable way to determine which courses are associated with a given course run id is by
-        # by calling the discovery service.
+        # If here, `course_identifier` must be a course run id.
+        # We cannot use `CourseKey.from_string` to find the course id because that method assumes the course id is
+        # always a substring of the course run id and this is not always the case.  The only reliable way to determine
+        # which courses are associated with a given course run id is by by calling the discovery service.
         course_run_data = self.get_course_run(course_identifier)
         if 'course' in course_run_data:
             return course_run_data['course']

--- a/enterprise/api_client/discovery.py
+++ b/enterprise/api_client/discovery.py
@@ -233,6 +233,38 @@ class CourseCatalogApiClient(object):
             default=[]
         )
 
+    def get_course_id(self, course_identifier):
+        """
+        Return the course key for the given course identifier.  The `course_identifier` may be a course key or a course
+        run id; in either case the course key will be returned.
+
+        The 'course key' is the identifier for a course (ex. edX+DemoX)
+        The 'course run id' is the identifier for a run of a course (ex. edX+DemoX+demo_run)
+
+        Arguments:
+            course_identifier (str): The course key or course run id
+
+        Returns:
+            (str): course key
+        """
+        # TODO: go through comments and make sure this all makes sense
+        try:
+            CourseKey.from_string(course_identifier)
+        except InvalidKeyError:
+            # An `InvalidKeyError` is thrown if `course_identifier` is not in the proper format for a course run id
+            # `course_identifier` cannot be a course run id. Assume `course_identifier` is the  course key (course id).
+            return course_identifier
+
+        # `course_identifier` must be a course run id.  We cannot use `CourseKey.from_string` to find the course key
+        # because that method assumes the course key is always a substring of the course run id and this is not always
+        # the case.  The only reliable way to determine which courses are associated with a given course run id is by
+        # by calling the discovery service.
+        course_run_data = self.get_course_run(course_identifier)
+        if 'course' in course_run_data:
+            return course_run_data['course']
+
+        return None
+
     def get_course_and_course_run(self, course_run_id):
         """
         Return the course and course run metadata for the given course run ID.

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -1331,7 +1331,8 @@ class EnterpriseCustomerCatalog(TimeStampedModel):
         and/or course run ids.
         """
         # Translate any provided course run IDs to course keys.
-        course_keys = {parse_course_key(k) for k in content_ids}
+        catalog_client = get_course_catalog_api_service_client()
+        course_keys = {catalog_client.get_course_id(k) for k in content_ids}
 
         content_ids_in_catalog = self.content_filter_ids
         if not content_ids_in_catalog:


### PR DESCRIPTION
The enterprise enrollment page (```enterprise/<enterprise-customer-id>/course/<course-id>/enroll/```) is failing in certain edge cases where the ```course_run_id``` and the ```course_id``` don't follow the expected format.

*Some back story to clarify the problem*:  Traditionally ```course_id```s have been substrings of ```course_run_id```s.  For example, for the course ```edX+DemoX``` has a course run ```course-v1:edX+DemoX+Demonstration_Course```.  However, ```course_id```s do not have to be substrings of their ```course_run_id```s.  You may have a course ```edX+DemoX``` with a course run ```course-v1:edX+DemoY+run_Y```.  Unfortunately, the ```edx-enterprise``` code assumes that ```course_id```s are always substrings of ```course_run_id```s.  Let's say a user tries to enroll in the course run ```course-v1:edX+DemoY+run_Y``` through the enterprise enrollment URL.  In order to populate that page we need to get data on the course associated with that course run.  The code tries to find that course by calling ```parse_course_key()``` and gets ```edX+DemoY```.  That course does not exist and causes problems.

*The solution*:  The discovery service understands the relationship between courses and course runs.  To fix this issue, instead of calling ```parse_course_key()``` we need to makea  call to the discovery service.  Specifically, the ```course_runs``` endpoint which takes a ```course_run_id``` and in the JSON blob it returns the ```course_id```.

Disclaimer: I know that ```course_id``` and ```course_run_id``` are not the way we reference those concepts in other parts of the code, but it is the way it's referenced in most of ```edx-enterprsie``` repo and I didn't want to change it

*Additionally*: When this change was originially rolled out to prod it there was a bug in the enterprise-catalogs api. This happened because I didn't not initially handle every case that ```parse_course_key()``` handled correctly.  Specifically, when ```parse_course_key()``` gets a course id as an argument it just returns it.  In my initial implementation, ```parse_course_key()``` returned ```None``` when given a course id.  This has now been fixed.

**Description:** Describe in a couple of sentence what this PR adds

**JIRA:** Link to JIRA ticket

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happend instead - check failed.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
