### PR TITLE
ENT-1054: Fix enrollment page course key issues

### DIFF
--- a/consent/helpers.py
+++ b/consent/helpers.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, unicode_literals
 from django.apps import apps
 
 from consent.models import ProxyDataSharingConsent
-from enterprise.api_client.discovery import CourseCatalogApiServiceClient
+from enterprise.api_client.discovery import get_course_catalog_api_service_client
 from enterprise.utils import get_enterprise_customer
 
 
@@ -59,7 +59,7 @@ def get_program_data_sharing_consent(username, program_uuid, enterprise_customer
     :return: The data sharing consent object
     """
     enterprise_customer = get_enterprise_customer(enterprise_customer_uuid)
-    discovery_client = CourseCatalogApiServiceClient(enterprise_customer.site)
+    discovery_client = get_course_catalog_api_service_client(enterprise_customer.site)
     course_ids = discovery_client.get_program_course_keys(program_uuid)
     child_consents = (
         get_data_sharing_consent(username, enterprise_customer_uuid, course_id=individual_course_id)

--- a/consent/models.py
+++ b/consent/models.py
@@ -46,6 +46,7 @@ class DataSharingConsentQuerySet(models.query.QuerySet):
         This customizes the queryset to return an instance of ``ProxyDataSharingConsent`` when
         the searched-for ``DataSharingConsent`` instance does not exist.
         """
+        # TODO: ENT-2010
         original_kwargs = kwargs.copy()
         if 'course_id' in kwargs:
             try:

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -12,11 +12,9 @@ from uuid import UUID
 
 import bleach
 import pytz
-from opaque_keys import InvalidKeyError
-from opaque_keys.edx.keys import CourseKey
 from six import iteritems  # pylint: disable=ungrouped-imports
-# pylint: disable=import-error
-from six.moves.urllib.parse import parse_qs, quote_plus, urlencode, urlparse, urlsplit, urlunsplit
+# pylint: disable=import-error,wrong-import-order,ungrouped-imports
+from six.moves.urllib.parse import parse_qs, urlencode, urlparse, urlsplit, urlunsplit
 
 from django.apps import apps
 from django.conf import settings
@@ -825,19 +823,6 @@ def strip_html_tags(text, allowed_tags=None):
     if allowed_tags is None:
         allowed_tags = ALLOWED_TAGS
     return bleach.clean(text, tags=allowed_tags, attributes=['id', 'class', 'style', 'href', 'title'], strip=True)
-
-
-def parse_course_key(course_identifier):
-    """
-    Return the serialized course key given either a course run ID or course key.
-    """
-    try:
-        course_run_key = CourseKey.from_string(course_identifier)
-    except InvalidKeyError:
-        # Assume we already have a course key.
-        return course_identifier
-
-    return quote_plus(' '.join([course_run_key.org, course_run_key.course]))
 
 
 def get_content_metadata_item_id(content_metadata_item):

--- a/integrated_channels/degreed/exporters/learner_data.py
+++ b/integrated_channels/degreed/exporters/learner_data.py
@@ -11,7 +11,7 @@ from logging import getLogger
 
 from django.apps import apps
 
-from enterprise.utils import parse_course_key
+from enterprise.api_client.discovery import get_course_catalog_api_service_client
 from integrated_channels.integrated_channel.exporters.learner_data import LearnerExporter
 
 LOGGER = getLogger(__name__)
@@ -45,11 +45,14 @@ class DegreedLearnerExporter(LearnerExporter):
             )
             # We return two records here, one with the course key and one with the course run id, to account for
             # uncertainty about the type of content (course vs. course run) that was sent to the integrated channel.
+            course_catalog_client = get_course_catalog_api_service_client(
+                site=enterprise_enrollment.enterprise_customer_user.enterprise_customer.site
+            )
             return [
                 DegreedLearnerDataTransmissionAudit(
                     enterprise_course_enrollment_id=enterprise_enrollment.id,
                     degreed_user_email=enterprise_enrollment.enterprise_customer_user.user_email,
-                    course_id=parse_course_key(enterprise_enrollment.course_id),
+                    course_id=course_catalog_client.get_course_id(enterprise_enrollment.course_id),
                     course_completed=completed_date is not None and is_passing,
                     completed_timestamp=completed_timestamp,
                 ),

--- a/integrated_channels/sap_success_factors/exporters/learner_data.py
+++ b/integrated_channels/sap_success_factors/exporters/learner_data.py
@@ -10,9 +10,10 @@ from logging import getLogger
 
 from django.apps import apps
 
+from enterprise.api_client.discovery import get_course_catalog_api_service_client
 from enterprise.models import EnterpriseCustomerUser, PendingEnterpriseCustomerUser
 from enterprise.tpa_pipeline import get_user_from_social_auth
-from enterprise.utils import get_identity_provider, parse_course_key
+from enterprise.utils import get_identity_provider
 from integrated_channels.integrated_channel.exporters.learner_data import LearnerExporter
 from integrated_channels.sap_success_factors.client import SAPSuccessFactorsAPIClient
 from integrated_channels.utils import parse_datetime_to_epoch_millis
@@ -48,11 +49,14 @@ class SapSuccessFactorsLearnerExporter(LearnerExporter):
             )
             # We return two records here, one with the course key and one with the course run id, to account for
             # uncertainty about the type of content (course vs. course run) that was sent to the integrated channel.
+            course_catalog_client = get_course_catalog_api_service_client(
+                site=enterprise_enrollment.enterprise_customer_user.enterprise_customer.site
+            )
             return [
                 SapSuccessFactorsLearnerDataTransmissionAudit(
                     enterprise_course_enrollment_id=enterprise_enrollment.id,
                     sapsf_user_id=sapsf_user_id,
-                    course_id=parse_course_key(enterprise_enrollment.course_id),
+                    course_id=course_catalog_client.get_course_id(enterprise_enrollment.course_id),
                     course_completed=course_completed,
                     completed_timestamp=completed_timestamp,
                     grade=grade,

--- a/test_utils/fake_catalog_api.py
+++ b/test_utils/fake_catalog_api.py
@@ -1244,6 +1244,7 @@ def setup_course_catalog_api_client_mock(
     fake_course_run = FAKE_COURSE_RUN.copy()
     fake_program = FAKE_PROGRAM_RESPONSE3.copy()
     fake_program_type = FAKE_PROGRAM_TYPE.copy()
+    fake_search_all_course_result = FAKE_SEARCH_ALL_COURSE_RESULT.copy()
 
     # Apply overrides to default fake course catalog metadata.
     if course_overrides:
@@ -1258,10 +1259,12 @@ def setup_course_catalog_api_client_mock(
     # Mock course catalog api functions.
     client.get_course_details.return_value = fake_course
     client.get_course_run.return_value = fake_course_run
+    client.get_course_id.return_value = fake_course['key']
     client.get_course_and_course_run.return_value = (fake_course, fake_course_run)
     client.get_program_course_keys.return_value = [course['key'] for course in fake_program['courses']]
     client.get_program_by_uuid.return_value = fake_program
     client.get_program_type_by_slug.return_value = fake_program_type
+    client.get_catalog_results.return_value = {'results': [fake_search_all_course_result]}
 
 
 def create_course_run_dict(start="2014-10-14T13:11:03Z", end="3000-10-13T13:11:01Z",

--- a/tests/test_consent/api/test_permissions.py
+++ b/tests/test_consent/api/test_permissions.py
@@ -35,7 +35,7 @@ class TestConsentAPIPermissions(APITest):
         Perform operations common to all tests.
         """
         super(TestConsentAPIPermissions, self).setUp()
-        discovery_client_class = mock.patch('enterprise.models.CourseCatalogApiServiceClient')
+        discovery_client_class = mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
         self.discovery_client = discovery_client_class.start().return_value
         self.discovery_client.is_course_in_catalog.return_value = True
         self.addCleanup(discovery_client_class.stop)

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -886,7 +886,7 @@ class TestEnterpriseAPIViews(APITest):
         ),
     )
     @ddt.unpack
-    @mock.patch('enterprise.models.CourseCatalogApiServiceClient')
+    @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     @mock.patch("enterprise.utils.update_query_parameters", mock.MagicMock(side_effect=side_effect))
     def test_enterprise_customer_catalogs_detail(
             self,
@@ -930,7 +930,7 @@ class TestEnterpriseAPIViews(APITest):
 
         self.assertDictEqual(response, expected_result)
 
-    @mock.patch('enterprise.models.CourseCatalogApiServiceClient')
+    @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     @mock.patch("enterprise.utils.update_query_parameters", mock.MagicMock(side_effect=side_effect))
     def test_enterprise_customer_catalogs_detail_pagination(self, mock_catalog_api_client):
         """
@@ -969,7 +969,7 @@ class TestEnterpriseAPIViews(APITest):
 
         assert response == expected_result
 
-    @mock.patch('enterprise.models.CourseCatalogApiServiceClient')
+    @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     @mock.patch("enterprise.utils.update_query_parameters", mock.MagicMock(side_effect=side_effect))
     def test_enterprise_customer_catalogs_detail_pagination_filtering(self, mock_catalog_api_client):
         """
@@ -1041,7 +1041,7 @@ class TestEnterpriseAPIViews(APITest):
         ),
     )
     @ddt.unpack
-    @mock.patch('enterprise.models.CourseCatalogApiServiceClient')
+    @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     def test_enterprise_catalog_contains_content_items_with_search(self, contains_content_items, query_params,
                                                                    search_results, mock_catalog_api_client):
         """
@@ -1087,7 +1087,7 @@ class TestEnterpriseAPIViews(APITest):
         ),
     )
     @ddt.unpack
-    @mock.patch('enterprise.models.CourseCatalogApiServiceClient')
+    @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     def test_enterprise_catalog_contains_content_items_without_search(self, contains_content_items, query_params,
                                                                       mock_catalog_api_client):
         """
@@ -1169,7 +1169,7 @@ class TestEnterpriseAPIViews(APITest):
         ),
     )
     @ddt.unpack
-    @mock.patch('enterprise.models.CourseCatalogApiServiceClient')
+    @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     def test_enterprise_catalog_course_run_detail(self, is_staff, is_linked_to_enterprise, is_course_run_in_catalog,
                                                   mocked_course_run, expected_result, mock_catalog_api_client):
         """
@@ -1233,7 +1233,7 @@ class TestEnterpriseAPIViews(APITest):
         ),
     )
     @ddt.unpack
-    @mock.patch('enterprise.models.CourseCatalogApiServiceClient')
+    @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     def test_enterprise_catalog_course_detail(self, is_staff, is_linked_to_enterprise, is_course_in_catalog,
                                               mocked_course, expected_result, mock_catalog_api_client):
         """
@@ -1299,7 +1299,7 @@ class TestEnterpriseAPIViews(APITest):
         ),
     )
     @ddt.unpack
-    @mock.patch('enterprise.models.CourseCatalogApiServiceClient')
+    @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     def test_enterprise_catalog_program_detail(self, is_staff, is_linked_to_enterprise, has_existing_catalog,
                                                is_program_in_catalog, mocked_program, expected_result,
                                                mock_catalog_api_client):
@@ -1373,7 +1373,7 @@ class TestEnterpriseAPIViews(APITest):
         ),
     )
     @ddt.unpack
-    @mock.patch('enterprise.models.CourseCatalogApiServiceClient')
+    @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     def test_enterprise_customer_contains_content_items(self, contains_content_items, query_params, search_results,
                                                         mock_catalog_api_client):
         """

--- a/tests/test_enterprise/api_client/test_discovery.py
+++ b/tests/test_enterprise/api_client/test_discovery.py
@@ -283,28 +283,44 @@ class TestCourseCatalogApi(CourseDiscoveryApiTestMixin, unittest.TestCase):
     @ddt.data(
         (
             "course-v1:JediAcademy+AppliedTelekinesis+T1",
-            {"course_runs": [{"key": "course-v1:JediAcademy+AppliedTelekinesis+T1"}]},
+            {
+                "course": "JediAcademy+AppliedTelekinesis"
+            },
+            {
+                "course_runs": [{"key": "course-v1:JediAcademy+AppliedTelekinesis+T1"}]
+            },
             "JediAcademy+AppliedTelekinesis",
             {"key": "course-v1:JediAcademy+AppliedTelekinesis+T1"}
         ),
         (
             "course-v1:JediAcademy+AppliedTelekinesis+T1",
             {},
-            "JediAcademy+AppliedTelekinesis",
+            {},
+            None,
             None
         ),
         (
             "course-v1:JediAcademy+AppliedTelekinesis+T1",
-            {"course_runs": [
-                {"key": "course-v1:JediAcademy+AppliedTelekinesis+T222"},
-                {"key": "course-v1:JediAcademy+AppliedTelekinesis+T1"}
-            ]},
+            {
+                "course": "JediAcademy+AppliedTelekinesis"
+            },
+            {
+                "course_runs": [
+                    {"key": "course-v1:JediAcademy+AppliedTelekinesis+T222"},
+                    {"key": "course-v1:JediAcademy+AppliedTelekinesis+T1"}
+                ]
+            },
             "JediAcademy+AppliedTelekinesis",
             {"key": "course-v1:JediAcademy+AppliedTelekinesis+T1"}
         ),
         (
             "course-v1:JediAcademy+AppliedTelekinesis+T1",
-            {"course_runs": []},
+            {
+                "course": "JediAcademy+AppliedTelekinesis"
+            },
+            {
+                "course_runs": []
+            },
             "JediAcademy+AppliedTelekinesis",
             None
         )
@@ -313,19 +329,20 @@ class TestCourseCatalogApi(CourseDiscoveryApiTestMixin, unittest.TestCase):
     def test_get_course_and_course_run(
             self,
             course_run_id,
-            response_dict,
+            course_runs_endpoint_response,
+            course_endpoint_response,
             expected_resource_id,
             expected_course_run
     ):
         """
         Verify get_course_and_course_run of CourseCatalogApiClient works as expected.
         """
-        self.get_data_mock.return_value = response_dict
-        expected_result = response_dict, expected_course_run
+        self.get_data_mock.side_effect = [course_runs_endpoint_response, course_endpoint_response]
+        expected_result = course_endpoint_response, expected_course_run
 
         actual_result = self.api.get_course_and_course_run(course_run_id)
 
-        assert self.get_data_mock.call_count == 1
+        assert self.get_data_mock.call_count == 2
         resource, resource_id = self._get_important_parameters(self.get_data_mock)
 
         assert resource == CourseCatalogApiClient.COURSES_ENDPOINT

--- a/tests/test_enterprise/views/test_program_enrollment_view.py
+++ b/tests/test_enterprise/views/test_program_enrollment_view.py
@@ -162,14 +162,12 @@ class TestProgramEnrollmentView(EmbargoAPIMixin, MessagesMixin, TestCase):
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.lms.embargo_api')
-    @mock.patch('consent.helpers.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
+    @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.ProgramDataExtender')
     def test_get_program_enrollment_page(
             self,
             program_data_extender_mock,
-            course_catalog_api_client_mock_1,
-            course_catalog_api_client_mock_2,
+            course_catalog_api_client_mock,
             embargo_api_mock,
             *args
     ):  # pylint: disable=unused-argument,invalid-name
@@ -178,8 +176,7 @@ class TestProgramEnrollmentView(EmbargoAPIMixin, MessagesMixin, TestCase):
         """
         self._setup_embargo_api(embargo_api_mock)
         self._setup_program_data_extender(program_data_extender_mock)
-        setup_course_catalog_api_client_mock(course_catalog_api_client_mock_1)
-        setup_course_catalog_api_client_mock(course_catalog_api_client_mock_2)
+        setup_course_catalog_api_client_mock(course_catalog_api_client_mock)
         enterprise_customer = EnterpriseCustomerFactory(name='Starfleet Academy')
         expected_context = {
             'LMS_SEGMENT_KEY': settings.LMS_SEGMENT_KEY,
@@ -409,14 +406,12 @@ class TestProgramEnrollmentView(EmbargoAPIMixin, MessagesMixin, TestCase):
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.lms.embargo_api')
-    @mock.patch('consent.helpers.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
+    @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.ProgramDataExtender')
     def test_get_program_enrollment_page_enrolled_in_program(
             self,
             program_data_extender_mock,
-            course_catalog_api_client_mock_1,
-            course_catalog_api_client_mock_2,
+            course_catalog_api_client_mock,
             embargo_api_mock,
             *args
     ):  # pylint: disable=unused-argument,invalid-name
@@ -429,8 +424,7 @@ class TestProgramEnrollmentView(EmbargoAPIMixin, MessagesMixin, TestCase):
             "is_enrolled": True,
             "upgrade_url": None,
         })
-        setup_course_catalog_api_client_mock(course_catalog_api_client_mock_1)
-        setup_course_catalog_api_client_mock(course_catalog_api_client_mock_2)
+        setup_course_catalog_api_client_mock(course_catalog_api_client_mock)
         enterprise_customer = EnterpriseCustomerFactory(name='Starfleet Academy')
         expected_context = {
             'page_title': 'Confirm your enrollment',
@@ -567,16 +561,14 @@ class TestProgramEnrollmentView(EmbargoAPIMixin, MessagesMixin, TestCase):
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.lms.embargo_api')
-    @mock.patch('consent.helpers.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
+    @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.ProgramDataExtender')
     @ddt.data(True, False)
     def test_get_program_enrollment_page_consent_message(
             self,
             consent_granted,
             program_data_extender_mock,
-            course_catalog_api_client_mock_1,
-            course_catalog_api_client_mock_2,
+            course_catalog_api_client_mock,
             embargo_api_mock,
             *args
     ):  # pylint: disable=unused-argument,invalid-name
@@ -585,8 +577,7 @@ class TestProgramEnrollmentView(EmbargoAPIMixin, MessagesMixin, TestCase):
         """
         self._setup_embargo_api(embargo_api_mock)
         self._setup_program_data_extender(program_data_extender_mock)
-        setup_course_catalog_api_client_mock(course_catalog_api_client_mock_1)
-        setup_course_catalog_api_client_mock(course_catalog_api_client_mock_2)
+        setup_course_catalog_api_client_mock(course_catalog_api_client_mock)
         enterprise_customer = EnterpriseCustomerFactory(name='Starfleet Academy')
         enterprise_customer_user = EnterpriseCustomerUserFactory(
             enterprise_customer=enterprise_customer,
@@ -627,14 +618,12 @@ class TestProgramEnrollmentView(EmbargoAPIMixin, MessagesMixin, TestCase):
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.lms.embargo_api')
-    @mock.patch('consent.helpers.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
+    @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.ProgramDataExtender')
     def test_get_program_enrollment_page_no_price_info_found_message(
             self,
             program_data_extender_mock,
-            course_catalog_api_client_mock_1,
-            course_catalog_api_client_mock_2,
+            course_catalog_api_client_mock,
             embargo_api_mock,
             *args
     ):  # pylint: disable=unused-argument,invalid-name
@@ -644,8 +633,7 @@ class TestProgramEnrollmentView(EmbargoAPIMixin, MessagesMixin, TestCase):
         self._setup_embargo_api(embargo_api_mock)
         program_data_extender_mock = self._setup_program_data_extender(program_data_extender_mock)
         program_data_extender_mock.return_value.extend.return_value['discount_data'] = {}
-        setup_course_catalog_api_client_mock(course_catalog_api_client_mock_1)
-        setup_course_catalog_api_client_mock(course_catalog_api_client_mock_2)
+        setup_course_catalog_api_client_mock(course_catalog_api_client_mock)
         enterprise_customer = EnterpriseCustomerFactory(name='Starfleet Academy')
         program_enrollment_page_url = reverse(
             'enterprise_program_enrollment_page',
@@ -671,16 +659,14 @@ class TestProgramEnrollmentView(EmbargoAPIMixin, MessagesMixin, TestCase):
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.lms.embargo_api')
-    @mock.patch('consent.helpers.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
+    @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.ProgramDataExtender')
     @ddt.data(True, False)
     def test_get_program_enrollment_page_program_unenrollable(
             self,
             enrollable,
             program_data_extender_mock,
-            course_catalog_api_client_mock_1,
-            course_catalog_api_client_mock_2,
+            course_catalog_api_client_mock,
             embargo_api_mock,
             *args
     ):  # pylint: disable=unused-argument,invalid-name
@@ -690,8 +676,7 @@ class TestProgramEnrollmentView(EmbargoAPIMixin, MessagesMixin, TestCase):
         self._setup_embargo_api(embargo_api_mock)
         program_data_extender_mock = self._setup_program_data_extender(program_data_extender_mock).return_value
         program_data_extender_mock.extend.return_value['is_learner_eligible_for_one_click_purchase'] = enrollable
-        setup_course_catalog_api_client_mock(course_catalog_api_client_mock_1)
-        setup_course_catalog_api_client_mock(course_catalog_api_client_mock_2)
+        setup_course_catalog_api_client_mock(course_catalog_api_client_mock)
         enterprise_customer = EnterpriseCustomerFactory(name='Starfleet Academy')
         program_enrollment_page_url = reverse(
             'enterprise_program_enrollment_page',
@@ -717,7 +702,7 @@ class TestProgramEnrollmentView(EmbargoAPIMixin, MessagesMixin, TestCase):
 
     @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.views.ProgramDataExtender')
-    @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
+    @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     def test_get_program_enrollment_page_for_non_existing_program(
             self,
             course_catalog_api_client_mock,
@@ -740,7 +725,7 @@ class TestProgramEnrollmentView(EmbargoAPIMixin, MessagesMixin, TestCase):
 
     @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.views.ProgramDataExtender')
-    @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
+    @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     def test_get_program_enrollment_page_for_non_existing_program_type(
             self,
             course_catalog_api_client_mock,
@@ -827,14 +812,12 @@ class TestProgramEnrollmentView(EmbargoAPIMixin, MessagesMixin, TestCase):
         for fragment in expected_fragments:
             assert fragment in response.url
 
-    @mock.patch('consent.helpers.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
+    @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.ProgramDataExtender')
     def test_get_program_enrollment_page_for_certificate_eligible_user(
             self,
             program_data_extender_mock,
-            course_catalog_api_client_mock_1,
-            course_catalog_api_client_mock_2,
+            course_catalog_api_client_mock,
             *args
     ):  # pylint: disable=unused-argument,invalid-name
         """
@@ -846,8 +829,7 @@ class TestProgramEnrollmentView(EmbargoAPIMixin, MessagesMixin, TestCase):
                 "is_enrolled": True,
                 "upgrade_url": None,
             })
-        setup_course_catalog_api_client_mock(course_catalog_api_client_mock_1)
-        setup_course_catalog_api_client_mock(course_catalog_api_client_mock_2)
+        setup_course_catalog_api_client_mock(course_catalog_api_client_mock)
         enterprise_customer = EnterpriseCustomerFactory()
         program_enrollment_page_url = reverse(
             'enterprise_program_enrollment_page',
@@ -863,7 +845,7 @@ class TestProgramEnrollmentView(EmbargoAPIMixin, MessagesMixin, TestCase):
         )
 
     @mock.patch('enterprise.views.ProgramDataExtender')
-    @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
+    @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     def test_get_program_enrollment_page_with_discovery_error(
             self,
             course_catalog_api_client_mock,
@@ -883,12 +865,10 @@ class TestProgramEnrollmentView(EmbargoAPIMixin, MessagesMixin, TestCase):
         self._assert_get_returns_404_with_mock(program_enrollment_page_url)
 
     @mock.patch('enterprise.views.ProgramDataExtender')
-    @mock.patch('consent.helpers.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
+    @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     def test_post_program_enrollment_view_redirect_to_program_dashboard(
             self,
-            course_catalog_api_client_mock_1,
-            course_catalog_api_client_mock_2,
+            course_catalog_api_client_mock,
             program_data_extender_mock,
             *args
     ):  # pylint: disable=unused-argument,invalid-name
@@ -901,8 +881,7 @@ class TestProgramEnrollmentView(EmbargoAPIMixin, MessagesMixin, TestCase):
                 "is_enrolled": True,
                 "upgrade_url": None,
             })
-        setup_course_catalog_api_client_mock(course_catalog_api_client_mock_1)
-        setup_course_catalog_api_client_mock(course_catalog_api_client_mock_2)
+        setup_course_catalog_api_client_mock(course_catalog_api_client_mock)
         enterprise_customer = EnterpriseCustomerFactory()
         program_enrollment_page_url = reverse(
             'enterprise_program_enrollment_page',
@@ -919,7 +898,7 @@ class TestProgramEnrollmentView(EmbargoAPIMixin, MessagesMixin, TestCase):
         )
 
     @mock.patch('enterprise.views.get_data_sharing_consent')
-    @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
+    @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.ProgramDataExtender')
     def test_post_program_enrollment_view_redirect_to_dsc(
             self,
@@ -960,7 +939,7 @@ class TestProgramEnrollmentView(EmbargoAPIMixin, MessagesMixin, TestCase):
         )
 
     @mock.patch('enterprise.views.get_data_sharing_consent')
-    @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
+    @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.ProgramDataExtender')
     def test_post_program_enrollment_view_redirect_to_basket(
             self,
@@ -992,14 +971,12 @@ class TestProgramEnrollmentView(EmbargoAPIMixin, MessagesMixin, TestCase):
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.lms.embargo_api')
-    @mock.patch('consent.helpers.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
+    @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.ProgramDataExtender')
     def test_embargo_restriction(
             self,
             program_data_extender_mock,
-            course_catalog_api_client_mock_1,
-            course_catalog_api_client_mock_2,
+            course_catalog_api_client_mock,
             embargo_api_mock,
             *args
     ):  # pylint: disable=unused-argument,invalid-name
@@ -1008,8 +985,7 @@ class TestProgramEnrollmentView(EmbargoAPIMixin, MessagesMixin, TestCase):
         """
         self._setup_embargo_api(embargo_api_mock, redirect_url=self.EMBARGO_REDIRECT_URL)
         self._setup_program_data_extender(program_data_extender_mock)
-        setup_course_catalog_api_client_mock(course_catalog_api_client_mock_1)
-        setup_course_catalog_api_client_mock(course_catalog_api_client_mock_2)
+        setup_course_catalog_api_client_mock(course_catalog_api_client_mock)
         enterprise_customer = EnterpriseCustomerFactory(name='Starfleet Academy')
 
         program_enrollment_page_url = reverse(

--- a/tests/test_enterprise/views/test_router_view.py
+++ b/tests/test_enterprise/views/test_router_view.py
@@ -165,7 +165,7 @@ class TestRouterView(TestCase):
     @ddt.data(
         True, False
     )
-    @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
+    @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.EnrollmentApiClient')
     @mock.patch('enterprise.views.RouterView', new_callable=views.RouterView)
     def test_get_redirects_with_course_key(
@@ -193,7 +193,7 @@ class TestRouterView(TestCase):
         router_view_mock.redirect.assert_called_once()
 
     @mock.patch('enterprise.views.get_global_context')
-    @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
+    @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     def test_get_raises_404_with_bad_catalog_client(self, catalog_api_mock, mock_global_context):
         """
         ``get`` responds with a 404 when the catalog client is not properly configured.
@@ -211,7 +211,7 @@ class TestRouterView(TestCase):
 
     @mock.patch('enterprise.views.get_global_context')
     @mock.patch('enterprise.views.EnrollmentApiClient')
-    @mock.patch('enterprise.views.CourseCatalogApiServiceClient')
+    @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     def test_get_raises_404_with_bad_course_key(self, catalog_api_mock, enrollment_api_mock, mock_global_context):
         """
         ``get`` responds with a 404 when a course run cannot be found given the provided course key.

--- a/tests/test_integrated_channels/test_degreed/test_exporters/test_learner_data.py
+++ b/tests/test_integrated_channels/test_degreed/test_exporters/test_learner_data.py
@@ -17,6 +17,7 @@ from django.utils import timezone
 
 from integrated_channels.degreed.exporters.learner_data import DegreedLearnerExporter
 from test_utils import factories
+from test_utils.fake_catalog_api import setup_course_catalog_api_client_mock
 
 
 @mark.django_db
@@ -55,6 +56,11 @@ class TestDegreedLearnerExporter(unittest.TestCase):
         self.tpa_client = tpa_client_mock.start()
         self.tpa_client.return_value.get_remote_id.return_value = 'fake-remote-id'
         self.addCleanup(tpa_client_mock.stop)
+
+        course_catalog_api_client_mock = mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
+        self.course_catalog_client = course_catalog_api_client_mock.start()
+        setup_course_catalog_api_client_mock(self.course_catalog_client)
+        self.addCleanup(course_catalog_api_client_mock.stop)
         super(TestDegreedLearnerExporter, self).setUp()
 
     @ddt.data(

--- a/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_learner_data.py
+++ b/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_learner_data.py
@@ -145,9 +145,12 @@ class TestLearnerExporter(unittest.TestCase):
     @mock.patch('enterprise.models.EnrollmentApiClient')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CourseApiClient')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CertificatesApiClient')
+    @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     def test_learner_data_instructor_paced_no_certificate(
-            self, mock_certificate_api, mock_course_api, mock_enrollment_api
+            self, mock_course_catalog_api, mock_certificate_api, mock_course_api, mock_enrollment_api
     ):
+        mock_course_catalog_api.return_value.get_course_id.return_value = self.course_key
+
         enrollment = factories.EnterpriseCourseEnrollmentFactory(
             enterprise_customer_user=self.enterprise_customer_user,
             course_id=self.course_id,
@@ -209,9 +212,12 @@ class TestLearnerExporter(unittest.TestCase):
     @mock.patch('enterprise.models.EnrollmentApiClient')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CourseApiClient')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CertificatesApiClient')
+    @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     def test_learner_data_instructor_paced_with_certificate(
-            self, mock_certificate_api, mock_course_api, mock_enrollment_api
+            self, mock_course_catalog_api, mock_certificate_api, mock_course_api, mock_enrollment_api
     ):
+        mock_course_catalog_api.return_value.get_course_id.return_value = self.course_key
+
         enrollment = factories.EnterpriseCourseEnrollmentFactory(
             enterprise_customer_user=self.enterprise_customer_user,
             course_id=self.course_id,
@@ -253,16 +259,25 @@ class TestLearnerExporter(unittest.TestCase):
     @mock.patch('enterprise.models.EnrollmentApiClient')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.GradesApiClient')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CourseApiClient')
-    def test_learner_data_self_paced_no_grades(self, mock_course_api, mock_grades_api, mock_enrollment_api):
+    @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
+    def test_learner_data_self_paced_no_grades(
+            self,
+            mock_course_catalog_api,
+            mock_course_api,
+            mock_grades_api,
+            mock_enrollment_api,
+    ):
         enrollment = factories.EnterpriseCourseEnrollmentFactory(
             enterprise_customer_user=self.enterprise_customer_user,
             course_id=self.course_id,
         )
 
-        # Return instructor-paced course details
-        mock_course_api.return_value.get_course_details.return_value = dict(
-            pacing='self',
-        )
+        mock_course_catalog_api.return_value.get_course_id.return_value = self.course_key
+
+        # Return self-paced course details
+        mock_course_api.return_value.get_course_details.return_value = {
+            'pacing': 'self',
+        }
 
         # Mock grades data not found
         mock_grades_api.return_value.get_course_grade.side_effect = HttpNotFoundError(
@@ -303,12 +318,24 @@ class TestLearnerExporter(unittest.TestCase):
     @mock.patch('enterprise.models.EnrollmentApiClient')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.GradesApiClient')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CourseApiClient')
-    def test_learner_data_self_paced_course(self, passing, end_date, expected_completion, expected_grade,
-                                            mock_course_api, mock_grades_api, mock_enrollment_api):
+    @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
+    def test_learner_data_self_paced_course(
+            self,
+            passing,
+            end_date,
+            expected_completion,
+            expected_grade,
+            mock_course_catalog_api,
+            mock_course_api,
+            mock_grades_api,
+            mock_enrollment_api
+    ):
         enrollment = factories.EnterpriseCourseEnrollmentFactory(
             enterprise_customer_user=self.enterprise_customer_user,
             course_id=self.course_id,
         )
+
+        mock_course_catalog_api.return_value.get_course_id.return_value = self.course_key
 
         # Mock self-paced course details
         mock_course_api.return_value.get_course_details.return_value = dict(
@@ -349,9 +376,19 @@ class TestLearnerExporter(unittest.TestCase):
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CertificatesApiClient')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.GradesApiClient')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CourseApiClient')
+    @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     def test_learner_data_multiple_courses(
-            self, pacing, grade, mock_course_api, mock_grades_api, mock_certificate_api, mock_enrollment_api
+            self,
+            pacing,
+            grade,
+            mock_course_catalog_api,
+            mock_course_api,
+            mock_grades_api,
+            mock_certificate_api,
+            mock_enrollment_api
     ):
+        mock_course_catalog_api.return_value.get_course_id.return_value = self.course_key
+
         enrollment1 = factories.EnterpriseCourseEnrollmentFactory(
             enterprise_customer_user=self.enterprise_customer_user,
             course_id=self.course_id,
@@ -468,16 +505,20 @@ class TestLearnerExporter(unittest.TestCase):
     @mock.patch('enterprise.models.EnrollmentApiClient')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.GradesApiClient')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CourseApiClient')
+    @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     def test_learner_data_audit_data_reporting(
             self,
             enable_audit_enrollment,
             enable_reporting,
             mode,
             expected_data_len,
+            mock_course_catalog_api,
             mock_course_api,
             mock_grades_api,
             mock_enrollment_api
     ):
+        mock_course_catalog_api.return_value.get_course_id.return_value = self.course_key
+
         enrollment = factories.EnterpriseCourseEnrollmentFactory(
             enterprise_customer_user=self.enterprise_customer_user,
             course_id=self.course_id,

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -51,7 +51,7 @@ from integrated_channels.integrated_channel.management.commands import (
 )
 from integrated_channels.sap_success_factors.models import SAPSuccessFactorsEnterpriseCustomerConfiguration
 from test_utils import factories
-from test_utils.fake_catalog_api import CourseDiscoveryApiTestMixin
+from test_utils.fake_catalog_api import CourseDiscoveryApiTestMixin, setup_course_catalog_api_client_mock
 from test_utils.fake_enterprise_api import EnterpriseMockMixin
 
 NOW = datetime(2017, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
@@ -115,6 +115,9 @@ class TestTransmitCourseMetadataManagementCommand(unittest.TestCase, EnterpriseM
         )
         self.sapsf_global_configuration = factories.SAPSuccessFactorsGlobalConfigurationFactory()
         self.catalog_api_config_mock = self._make_patch(self._make_catalog_api_location("CatalogIntegration"))
+        self.catalog_api_client_mock = self._make_patch(
+            self._make_catalog_api_location("CourseCatalogApiServiceClient")
+        )
         super(TestTransmitCourseMetadataManagementCommand, self).setUp()
 
     def test_enterprise_customer_not_found(self):
@@ -748,6 +751,11 @@ class TestLearnerDataTransmitIntegration(unittest.TestCase):
         self.addCleanup(sapsf_create_course_completion.stop)
         # pylint: enable=invalid-name
 
+        # Course Catalog API Client
+        course_catalog_api_client_mock = mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
+        self.course_catalog_client = course_catalog_api_client_mock.start()
+        self.addCleanup(course_catalog_api_client_mock.stop)
+
     @responses.activate
     @ddt.data(
         # Certificate marks course completion
@@ -787,12 +795,25 @@ class TestLearnerDataTransmitIntegration(unittest.TestCase):
         Test the log output from a successful run of the transmit_learner_data management command,
         using all the ways we can invoke it.
         """
+
+        setup_course_catalog_api_client_mock(
+            self.course_catalog_client,
+            course_overrides={
+                'course_id': COURSE_ID,
+                'end': end_date.isoformat() if end_date else None,
+                'pacing': 'self' if self_paced else 'instructor'
+            }
+        )
         with transmit_learner_data_context(command_kwargs, certificate, self_paced, end_date, passed) as (args, kwargs):
             with LogCapture(level=logging.DEBUG) as log_capture:
                 expected_output = get_expected_output(**expected_completion)
                 call_command('transmit_learner_data', *args, **kwargs)
+                # get the list of logs just in this repo
+                enterprise_log_messages = [
+                    record.getMessage() for record in log_capture.records if 'edx-enterprise' in record.pathname
+                ]
                 for index, message in enumerate(expected_output):
-                    assert message in log_capture.records[index].getMessage()
+                    assert message in enterprise_log_messages[index]
 
 
 @mark.django_db

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -156,7 +156,7 @@ class TestEnterpriseCustomer(unittest.TestCase):
         """
         assert factories.EnterpriseCustomerFactory().identity_provider is None
 
-    @mock.patch('enterprise.models.CourseCatalogApiServiceClient')
+    @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     def test_catalog_contains_course_with_enterprise_customer_catalog(self, mock_catalog_api_class):
         """
         Test EnterpriseCustomer.catalog_contains_course with a related EnterpriseCustomerCatalog.
@@ -1029,7 +1029,7 @@ class TestEnterpriseCustomerCatalog(unittest.TestCase):
         enterprise_catalog.save()
         assert EnterpriseCustomerCatalog.objects.get(uuid=uuid).title == title
 
-    @mock.patch('enterprise.models.CourseCatalogApiServiceClient')
+    @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     def test_get_paginated_content_uses_total_count_from_response(self, mock_catalog_api_class):
         """
         Test EnterpriseCustomerCatalog.get_paginated_content should use the count value


### PR DESCRIPTION
The enterprise enrollment page (```enterprise/<enterprise-customer-id>/course/<course-id>/enroll/```) is failing in certain edge cases where the ```course_run_id``` and the ```course_id``` don't follow the expected format.

*Some back story to clarify the problem*:  Traditionally ```course_id```s have been substrings of ```course_run_id```s.  For example, for the course ```edX+DemoX``` has a course run ```course-v1:edX+DemoX+Demonstration_Course```.  However, ```course_id```s do not have to be substrings of their ```course_run_id```s.  You may have a course ```edX+DemoX``` with a course run ```course-v1:edX+DemoY+run_Y```.  Unfortunately, the ```edx-enterprise``` code assumes that ```course_id```s are always substrings of ```course_run_id```s.  Let's say a user tries to enroll in the course run ```course-v1:edX+DemoY+run_Y``` through the enterprise enrollment URL.  In order to populate that page we need to get data on the course associated with that course run.  The code tries to find that course by calling ```parse_course_key()``` and gets ```edX+DemoY```.  That course does not exist and causes problems.

*The solution*:  The discovery service understands the relationship between courses and course runs.  To fix this issue, instead of calling ```parse_course_key()``` we need to makea  call to the discovery service.  Specifically, the ```course_runs``` endpoint which takes a ```course_run_id``` and in the JSON blob it returns the ```course_id```.

Disclaimer: I know that ```course_id``` and ```course_run_id``` are not the way we reference those concepts in other parts of the code, but it is the way it's referenced in most of ```edx-enterprsie``` repo and I didn't want to change it

*Additionally*: When this change was originially rolled out to prod it there was a bug in the enterprise-catalogs api. This happened because I didn't not initially handle every case that ```parse_course_key()``` handled correctly.  Specifically, when ```parse_course_key()``` gets a course id as an argument it just returns it.  In my initial implementation, ```parse_course_key()``` returned ```None``` when given a course id.  This has now been fixed.

**Description:** Describe in a couple of sentence what this PR adds

**JIRA:** Link to JIRA ticket

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happend instead - check failed.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
