### PR TITLE
Upgrading edx-drf-extensions to latest version

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[1.6.4] - 2019-06-05
+--------------------
+
+* Upgrade packages to get latest edx-drf-extensions version.
+
 [1.6.3] - 2019-06-04
 --------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.6.3"
+__version__ = "1.6.4"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/cornerstone/models.py
+++ b/integrated_channels/cornerstone/models.py
@@ -25,6 +25,7 @@ from integrated_channels.integrated_channel.models import EnterpriseCustomerPlug
 LOGGER = getLogger(__name__)
 
 
+# pylint: disable=feature-toggle-needs-doc
 @python_2_unicode_compatible
 class CornerstoneGlobalConfiguration(ConfigurationModel):
     """

--- a/integrated_channels/degreed/models.py
+++ b/integrated_channels/degreed/models.py
@@ -23,6 +23,7 @@ from integrated_channels.integrated_channel.models import EnterpriseCustomerPlug
 LOGGER = getLogger(__name__)
 
 
+# pylint: disable=feature-toggle-needs-doc
 @python_2_unicode_compatible
 class DegreedGlobalConfiguration(ConfigurationModel):
     """

--- a/integrated_channels/sap_success_factors/models.py
+++ b/integrated_channels/sap_success_factors/models.py
@@ -28,6 +28,7 @@ from integrated_channels.sap_success_factors.transmitters.learner_data import Sa
 LOGGER = getLogger(__name__)
 
 
+# pylint: disable=feature-toggle-needs-doc
 @python_2_unicode_compatible
 class SAPSuccessFactorsGlobalConfiguration(ConfigurationModel):
     """

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -8,4 +8,4 @@ django-countries==4.6.1
 -e git+https://github.com/edx/TinCanPython.git@0.0.5.py.35#egg=tincan==0.0.5.py.35
 django-simple-history==2.7.0
 edx-rbac==1.0.1
-edx-drf-extensions==2.3.0
+edx-drf-extensions==2.3.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -46,9 +46,9 @@ djangorestframework-xml==1.3.0
 djangorestframework==3.6.3
 edx-django-oauth2-provider==1.3.5
 edx-django-utils==1.0.3   # via edx-drf-extensions
-edx-drf-extensions==2.3.0
+edx-drf-extensions==2.3.1
 edx-i18n-tools==0.4.8
-edx-lint==1.2.1
+edx-lint==1.3.0
 edx-opaque-keys==0.4.4
 edx-rbac==1.0.1
 edx-rest-api-client==1.9.2
@@ -59,7 +59,7 @@ future==0.17.1            # via pyjwkest
 futures==3.1.1
 html5lib==1.0.1
 idna==2.8                 # via cryptography, requests
-importlib-metadata==0.15  # via pluggy
+importlib-metadata==0.17  # via pluggy
 inflect==2.1.0            # via jinja2-pluralize
 ipaddress==1.0.22         # via cryptography
 isort==4.3.20
@@ -75,7 +75,7 @@ newrelic==4.20.0.120      # via edx-django-utils
 packaging==19.0           # via caniusepython3
 path.py==8.2.1
 pathlib2==2.3.3           # via importlib-metadata
-pbr==5.2.0                # via stevedore
+pbr==5.2.1                # via stevedore
 pillow==5.4.1
 pip-tools==3.7.0
 pkginfo==1.5.0.1          # via twine
@@ -85,7 +85,7 @@ psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 py==1.8.0                 # via tox
 pycodestyle==2.5.0
 pycparser==2.19           # via cffi
-pycryptodomex==3.8.1      # via pyjwkest
+pycryptodomex==3.8.2      # via pyjwkest
 pydocstyle==3.0.0
 pygments==2.4.2           # via diff-cover
 pyjwkest==1.3.2           # via edx-drf-extensions

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -42,7 +42,7 @@ doc8==0.8.0
 docutils==0.14
 edx-django-oauth2-provider==1.3.5
 edx-django-utils==1.0.3   # via edx-drf-extensions
-edx-drf-extensions==2.3.0
+edx-drf-extensions==2.3.1
 edx-opaque-keys==0.4.4
 edx-rbac==1.0.1
 edx-rest-api-client==1.9.2
@@ -64,12 +64,12 @@ markupsafe==1.1.1         # via jinja2
 newrelic==4.20.0.120      # via edx-django-utils
 packaging==19.0           # via sphinx
 path.py==8.2.1
-pbr==5.2.0                # via stevedore
+pbr==5.2.1                # via stevedore
 pillow==5.4.1
 pockets==0.7.2            # via sphinxcontrib-napoleon
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 pycparser==2.19           # via cffi
-pycryptodomex==3.8.1      # via pyjwkest
+pycryptodomex==3.8.2      # via pyjwkest
 pygments==2.4.2           # via diff-cover, readme-renderer, sphinx
 pyjwkest==1.3.2           # via edx-drf-extensions
 pyjwt==1.7.1              # via djangorestframework-jwt, edx-rest-api-client

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -55,9 +55,9 @@ doc8==0.8.0
 docutils==0.14
 edx-django-oauth2-provider==1.3.5
 edx-django-utils==1.0.3   # via edx-drf-extensions
-edx-drf-extensions==2.3.0
+edx-drf-extensions==2.3.1
 edx-i18n-tools==0.4.8
-edx-lint==1.2.1
+edx-lint==1.3.0
 edx-opaque-keys==0.4.4
 edx-rbac==1.0.1
 edx-rest-api-client==1.9.2
@@ -67,14 +67,14 @@ factory-boy==2.12.0
 faker==1.0.7              # via factory-boy
 filelock==3.0.12          # via tox
 flaky==3.5.3
-freezegun==0.3.11
+freezegun==0.3.12
 funcsigs==1.0.2           # via mock, pytest
 future==0.17.1            # via pyjwkest
 futures==3.1.1
 html5lib==1.0.1
 idna==2.8                 # via cryptography, requests
 imagesize==1.1.0          # via sphinx
-importlib-metadata==0.15  # via pluggy
+importlib-metadata==0.17  # via pluggy, pytest
 inflect==2.1.0            # via jinja2-pluralize
 ipaddress==1.0.22         # via cryptography, faker
 isort==4.3.20
@@ -89,10 +89,10 @@ mccabe==0.6.1             # via pylint
 mock==3.0.5
 more-itertools==5.0.0     # via pytest
 newrelic==4.20.0.120      # via edx-django-utils
-packaging==19.0           # via caniusepython3, sphinx
+packaging==19.0           # via caniusepython3, pytest, sphinx
 path.py==8.2.1
 pathlib2==2.3.3           # via importlib-metadata, pytest, pytest-django
-pbr==5.2.0                # via stevedore
+pbr==5.2.1                # via stevedore
 pillow==5.4.1
 pip-tools==3.7.0
 pkginfo==1.5.0.1          # via twine
@@ -103,7 +103,7 @@ psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 py==1.8.0                 # via pytest, pytest-catchlog, tox
 pycodestyle==2.5.0
 pycparser==2.19           # via cffi
-pycryptodomex==3.8.1      # via pyjwkest
+pycryptodomex==3.8.2      # via pyjwkest
 pydocstyle==3.0.0
 pygments==2.4.2           # via diff-cover, readme-renderer, sphinx
 pyjwkest==1.3.2           # via edx-drf-extensions
@@ -116,8 +116,8 @@ pymongo==3.8.0            # via edx-opaque-keys
 pyparsing==2.4.0          # via packaging
 pytest-catchlog==1.2.2
 pytest-cov==2.7.1
-pytest-django==3.4.8
-pytest==4.5.0             # via pytest-catchlog, pytest-cov, pytest-django
+pytest-django==3.5.0
+pytest==4.6.2             # via pytest-catchlog, pytest-cov, pytest-django
 python-dateutil==2.8.0
 python-slugify==3.0.2     # via code-annotations
 pytz==2019.1

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -45,7 +45,7 @@ djangorestframework-xml==1.3.0
 djangorestframework==3.6.3
 edx-django-oauth2-provider==1.3.5
 edx-django-utils==1.0.3   # via edx-drf-extensions
-edx-drf-extensions==2.3.0
+edx-drf-extensions==2.3.1
 edx-opaque-keys==0.4.4
 edx-rbac==1.0.1
 edx-rest-api-client==1.9.2
@@ -53,12 +53,12 @@ enum34==1.1.6             # via cryptography
 factory-boy==2.12.0
 faker==1.0.7              # via factory-boy
 flaky==3.5.3
-freezegun==0.3.11
+freezegun==0.3.12
 funcsigs==1.0.2           # via mock, pytest
 future==0.17.1            # via pyjwkest
 html5lib==1.0.1
 idna==2.8                 # via cryptography, requests
-importlib-metadata==0.15  # via pluggy
+importlib-metadata==0.17  # via pluggy, pytest
 inflect==2.1.0            # via jinja2-pluralize
 ipaddress==1.0.22         # via cryptography, faker
 jinja2-pluralize==0.3.0   # via diff-cover
@@ -70,23 +70,25 @@ markupsafe==1.1.1         # via jinja2
 mock==3.0.5
 more-itertools==5.0.0     # via pytest
 newrelic==4.20.0.120      # via edx-django-utils
+packaging==19.0           # via pytest
 path.py==8.2.1
 pathlib2==2.3.3           # via importlib-metadata, pytest, pytest-django
-pbr==5.2.0                # via stevedore
+pbr==5.2.1                # via stevedore
 pillow==5.4.1
 pluggy==0.12.0            # via pytest
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 py==1.8.0                 # via pytest, pytest-catchlog
 pycparser==2.19           # via cffi
-pycryptodomex==3.8.1      # via pyjwkest
+pycryptodomex==3.8.2      # via pyjwkest
 pygments==2.4.2           # via diff-cover
 pyjwkest==1.3.2           # via edx-drf-extensions
 pyjwt==1.7.1              # via djangorestframework-jwt, edx-rest-api-client
 pymongo==3.8.0            # via edx-opaque-keys
+pyparsing==2.4.0          # via packaging
 pytest-catchlog==1.2.2
 pytest-cov==2.7.1
-pytest-django==3.4.8
-pytest==4.5.0             # via pytest-catchlog, pytest-cov, pytest-django
+pytest-django==3.5.0
+pytest==4.6.2             # via pytest-catchlog, pytest-cov, pytest-django
 python-dateutil==2.8.0
 python-slugify==3.0.2     # via code-annotations
 pytz==2019.1
@@ -98,7 +100,7 @@ rules==2.0.1
 scandir==1.10.0           # via pathlib2
 semantic-version==2.6.0   # via edx-drf-extensions
 shortuuid==0.5.0          # via edx-django-oauth2-provider
-six==1.12.0               # via bleach, cryptography, diff-cover, edx-drf-extensions, edx-opaque-keys, edx-rbac, faker, freezegun, html5lib, mock, more-itertools, pathlib2, pyjwkest, pytest, python-dateutil, responses, stevedore
+six==1.12.0               # via bleach, cryptography, diff-cover, edx-drf-extensions, edx-opaque-keys, edx-rbac, faker, freezegun, html5lib, mock, more-itertools, packaging, pathlib2, pyjwkest, pytest, python-dateutil, responses, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 stevedore==1.30.1         # via code-annotations, edx-opaque-keys
 testfixtures==6.8.2

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -45,7 +45,7 @@ djangorestframework-xml==1.3.0
 djangorestframework==3.6.3
 edx-django-oauth2-provider==1.3.5
 edx-django-utils==1.0.3   # via edx-drf-extensions
-edx-drf-extensions==2.3.0
+edx-drf-extensions==2.3.1
 edx-opaque-keys==0.4.4
 edx-rbac==1.0.1
 edx-rest-api-client==1.9.2
@@ -53,12 +53,12 @@ enum34==1.1.6             # via cryptography
 factory-boy==2.12.0
 faker==1.0.7              # via factory-boy
 flaky==3.5.3
-freezegun==0.3.11
+freezegun==0.3.12
 funcsigs==1.0.2           # via mock, pytest
 future==0.17.1            # via pyjwkest
 html5lib==1.0.1
 idna==2.8                 # via cryptography, requests
-importlib-metadata==0.15  # via pluggy
+importlib-metadata==0.17  # via pluggy, pytest
 inflect==2.1.0            # via jinja2-pluralize
 ipaddress==1.0.22         # via cryptography, faker
 jinja2-pluralize==0.3.0   # via diff-cover
@@ -70,23 +70,25 @@ markupsafe==1.1.1         # via jinja2
 mock==3.0.5
 more-itertools==5.0.0     # via pytest
 newrelic==4.20.0.120      # via edx-django-utils
+packaging==19.0           # via pytest
 path.py==8.2.1
 pathlib2==2.3.3           # via importlib-metadata, pytest, pytest-django
-pbr==5.2.0                # via stevedore
+pbr==5.2.1                # via stevedore
 pillow==5.4.1
 pluggy==0.12.0            # via pytest
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 py==1.8.0                 # via pytest, pytest-catchlog
 pycparser==2.19           # via cffi
-pycryptodomex==3.8.1      # via pyjwkest
+pycryptodomex==3.8.2      # via pyjwkest
 pygments==2.4.2           # via diff-cover
 pyjwkest==1.3.2           # via edx-drf-extensions
 pyjwt==1.7.1              # via djangorestframework-jwt, edx-rest-api-client
 pymongo==3.8.0            # via edx-opaque-keys
+pyparsing==2.4.0          # via packaging
 pytest-catchlog==1.2.2
 pytest-cov==2.7.1
-pytest-django==3.4.8
-pytest==4.5.0             # via pytest-catchlog, pytest-cov, pytest-django
+pytest-django==3.5.0
+pytest==4.6.2             # via pytest-catchlog, pytest-cov, pytest-django
 python-dateutil==2.8.0
 python-slugify==3.0.2     # via code-annotations
 pytz==2019.1
@@ -98,7 +100,7 @@ rules==2.0.1
 scandir==1.10.0           # via pathlib2
 semantic-version==2.6.0   # via edx-drf-extensions
 shortuuid==0.5.0          # via edx-django-oauth2-provider
-six==1.12.0               # via bleach, cryptography, diff-cover, edx-drf-extensions, edx-opaque-keys, edx-rbac, faker, freezegun, html5lib, mock, more-itertools, pathlib2, pyjwkest, pytest, python-dateutil, responses, stevedore
+six==1.12.0               # via bleach, cryptography, diff-cover, edx-drf-extensions, edx-opaque-keys, edx-rbac, faker, freezegun, html5lib, mock, more-itertools, packaging, pathlib2, pyjwkest, pytest, python-dateutil, responses, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 stevedore==1.30.1         # via code-annotations, edx-opaque-keys
 testfixtures==6.8.2

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -12,7 +12,7 @@ contextlib2==0.5.5        # via importlib-metadata
 coverage==4.5.3           # via codecov
 filelock==3.0.12          # via tox
 idna==2.8                 # via requests
-importlib-metadata==0.15  # via pluggy
+importlib-metadata==0.17  # via pluggy
 pathlib2==2.3.3           # via importlib-metadata
 pluggy==0.12.0            # via tox
 py==1.8.0                 # via tox


### PR DESCRIPTION
**Description:** We broke our enterprise catalog endpoints because of the introduction of a call to is_jwt_authenticated in edx drf extensions when performing authz checks. This function has been fixed to resolve the error.

**JIRA:** Link to JIRA ticket

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happend instead - check failed.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
