### PR TITLE
ENT-1990 updated duration based on effort and weeks-to-complete

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ Change Log
 
 Unreleased
 ----------
+[1.6.11] - 2019-06-14
+---------------------
+
+* Update the format of course_duration in xAPI payload data.
 
 [1.6.10] - 2019-06-13
 ---------------------

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.6.10"
+__version__ = "1.6.11"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/xapi/utils.py
+++ b/integrated_channels/xapi/utils.py
@@ -21,7 +21,10 @@ def send_course_enrollment_statement(lrs_configuration, course_enrollment):
          course_enrollment (CourseEnrollment): Course enrollment object.
     """
     user_details = LearnerInfoSerializer(course_enrollment.user)
-    course_details = CourseInfoSerializer(course_enrollment.course)
+    course_details = CourseInfoSerializer(
+        course_enrollment.course,
+        context={'site': lrs_configuration.enterprise_customer.site}
+    )
 
     statement = LearnerCourseEnrollmentStatement(
         course_enrollment.user,
@@ -43,7 +46,10 @@ def send_course_completion_statement(lrs_configuration, user, course_overview, c
          course_grade (CourseGrade): course grade object.
     """
     user_details = LearnerInfoSerializer(user)
-    course_details = CourseInfoSerializer(course_overview)
+    course_details = CourseInfoSerializer(
+        course_overview,
+        context={'site': lrs_configuration.enterprise_customer.site}
+    )
 
     statement = LearnerCourseCompletionStatement(
         user,

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -8,4 +8,5 @@ django-countries==4.6.1
 -e git+https://github.com/edx/TinCanPython.git@0.0.5.py.35#egg=tincan==0.0.5.py.35
 django-simple-history==2.7.0
 edx-rbac==0.2.1
+edx-django-utils
 edx-drf-extensions==2.3.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -45,7 +45,7 @@ djangorestframework-oauth==1.1.0
 djangorestframework-xml==1.3.0
 djangorestframework==3.6.3
 edx-django-oauth2-provider==1.3.5
-edx-django-utils==1.0.5   # via edx-drf-extensions
+edx-django-utils==1.0.5
 edx-drf-extensions==2.3.1
 edx-i18n-tools==0.4.8
 edx-lint==1.3.0
@@ -75,7 +75,7 @@ newrelic==4.20.0.120      # via edx-django-utils
 packaging==19.0           # via caniusepython3
 path.py==8.2.1
 pathlib2==2.3.3           # via importlib-metadata
-pbr==5.2.1                # via stevedore
+pbr==5.3.0                # via stevedore
 pillow==5.4.1
 pip-tools==3.8.0
 pkginfo==1.5.0.1          # via twine
@@ -126,6 +126,3 @@ webencodings==0.5.1       # via html5lib
 wheel==0.33.4
 wrapt==1.11.1             # via astroid
 zipp==0.5.1               # via importlib-metadata
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.0.1        # via caniusepython3, tox, twine

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -41,7 +41,7 @@ djangorestframework==3.6.3
 doc8==0.8.0
 docutils==0.14
 edx-django-oauth2-provider==1.3.5
-edx-django-utils==1.0.5   # via edx-drf-extensions
+edx-django-utils==1.0.5
 edx-drf-extensions==2.3.1
 edx-opaque-keys==0.4.4
 edx-rbac==0.2.1
@@ -64,7 +64,7 @@ markupsafe==1.1.1         # via jinja2
 newrelic==4.20.0.120      # via edx-django-utils
 packaging==19.0           # via sphinx
 path.py==8.2.1
-pbr==5.2.1                # via stevedore
+pbr==5.3.0                # via stevedore
 pillow==5.4.1
 pockets==0.7.2            # via sphinxcontrib-napoleon
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
@@ -99,6 +99,3 @@ typing==3.6.6             # via sphinx
 unicodecsv==0.14.1
 urllib3==1.24.3           # via requests
 webencodings==0.5.1       # via html5lib
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.0.1        # via sphinx

--- a/requirements/js_test.txt
+++ b/requirements/js_test.txt
@@ -24,6 +24,3 @@ selenium==3.6.0           # via jasmine
 six==1.12.0               # via cheroot, cherrypy, jasmine, more-itertools, tempora
 tempora==1.14.1           # via portend
 zc.lockfile==1.4          # via cherrypy
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.0.1        # via zc.lockfile

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -54,7 +54,7 @@ djangorestframework==3.6.3
 doc8==0.8.0
 docutils==0.14
 edx-django-oauth2-provider==1.3.5
-edx-django-utils==1.0.5   # via edx-drf-extensions
+edx-django-utils==1.0.5
 edx-drf-extensions==2.3.1
 edx-i18n-tools==0.4.8
 edx-lint==1.3.0
@@ -92,7 +92,7 @@ newrelic==4.20.0.120      # via edx-django-utils
 packaging==19.0           # via caniusepython3, pytest, sphinx
 path.py==8.2.1
 pathlib2==2.3.3           # via importlib-metadata, pytest, pytest-django
-pbr==5.2.1                # via stevedore
+pbr==5.3.0                # via stevedore
 pillow==5.4.1
 pip-tools==3.8.0
 pkginfo==1.5.0.1          # via twine
@@ -156,6 +156,3 @@ webencodings==0.5.1       # via html5lib
 wheel==0.33.4
 wrapt==1.11.1             # via astroid
 zipp==0.5.1               # via importlib-metadata
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.0.1        # via caniusepython3, sphinx, tox, twine

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -44,7 +44,7 @@ djangorestframework-oauth==1.1.0
 djangorestframework-xml==1.3.0
 djangorestframework==3.6.3
 edx-django-oauth2-provider==1.3.5
-edx-django-utils==1.0.5   # via edx-drf-extensions
+edx-django-utils==1.0.5
 edx-drf-extensions==2.3.1
 edx-opaque-keys==0.4.4
 edx-rbac==0.2.1
@@ -73,7 +73,7 @@ newrelic==4.20.0.120      # via edx-django-utils
 packaging==19.0           # via pytest
 path.py==8.2.1
 pathlib2==2.3.3           # via importlib-metadata, pytest, pytest-django
-pbr==5.2.1                # via stevedore
+pbr==5.3.0                # via stevedore
 pillow==5.4.1
 pluggy==0.12.0            # via pytest
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -44,7 +44,7 @@ djangorestframework-oauth==1.1.0
 djangorestframework-xml==1.3.0
 djangorestframework==3.6.3
 edx-django-oauth2-provider==1.3.5
-edx-django-utils==1.0.5   # via edx-drf-extensions
+edx-django-utils==1.0.5
 edx-drf-extensions==2.3.1
 edx-opaque-keys==0.4.4
 edx-rbac==0.2.1
@@ -73,7 +73,7 @@ newrelic==4.20.0.120      # via edx-django-utils
 packaging==19.0           # via pytest
 path.py==8.2.1
 pathlib2==2.3.3           # via importlib-metadata, pytest, pytest-django
-pbr==5.2.1                # via stevedore
+pbr==5.3.0                # via stevedore
 pillow==5.4.1
 pluggy==0.12.0            # via pytest
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -25,6 +25,3 @@ tox==3.12.1
 urllib3==1.25.3           # via requests
 virtualenv==16.6.0        # via tox
 zipp==0.5.1               # via importlib-metadata
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.0.1        # via tox

--- a/tests/test_integrated_channels/test_xapi/test_utils.py
+++ b/tests/test_integrated_channels/test_xapi/test_utils.py
@@ -50,19 +50,29 @@ class TestUtils(unittest.TestCase):
         self.x_api_client = EnterpriseXAPIClient(self.x_api_lrs_config)
 
     @mock.patch('integrated_channels.xapi.client.RemoteLRS', mock.MagicMock())
-    def test_send_course_enrollment_statement(self):
+    @mock.patch('enterprise.api_client.discovery.JwtBuilder')
+    @mock.patch('enterprise.api_client.discovery.get_edx_api_data')
+    @mock.patch('enterprise.api_client.discovery.CatalogIntegration')
+    def test_send_course_enrollment_statement(self, mock_catalog_integration, *args):  # pylint: disable=unused-argument
         """
         Verify that send_course_enrollment_statement sends xAPI statement to LRS.
         """
+        mock_integration_config = mock.Mock(enabled=True)
+        mock_catalog_integration.current.return_value = mock_integration_config
         send_course_enrollment_statement(self.x_api_lrs_config, self.course_enrollment)
 
         self.x_api_client.lrs.save_statement.assert_called()  # pylint: disable=no-member
 
     @mock.patch('integrated_channels.xapi.client.RemoteLRS', mock.MagicMock())
-    def test_send_course_completion_statement(self):
+    @mock.patch('enterprise.api_client.discovery.JwtBuilder')
+    @mock.patch('enterprise.api_client.discovery.get_edx_api_data')
+    @mock.patch('enterprise.api_client.discovery.CatalogIntegration')
+    def test_send_course_completion_statement(self, mock_catalog_integration, *args):  # pylint: disable=unused-argument
         """
         Verify that send_course_completion_statement sends xAPI statement to LRS.
         """
+        mock_integration_config = mock.Mock(enabled=True)
+        mock_catalog_integration.current.return_value = mock_integration_config
         send_course_completion_statement(
             self.x_api_lrs_config,
             self.user,


### PR DESCRIPTION
**Description:** This PR updates the xapi course_duration based on effort and weeks-to-complete

**JIRA:** https://openedx.atlassian.net/browse/ENT-1990

**Testing instructions:**

- Create an account at https://cloud.scorm.com

- Use the Sandbox endpoint

![image](https://user-images.githubusercontent.com/34648393/59360401-736a8300-8d49-11e9-8a62-1eb02ba991d5.png)

- Copy the key and secret from the Activity Providers tab to a new configuration in the  Enterprise xAPI Integration › Xapilrs configurations in LMS Admin.
![image](https://user-images.githubusercontent.com/34648393/59360734-14f1d480-8d4a-11e9-86e8-22c1161033ec.png)

- Setup the Catalog Integration and associated service user
![image](https://user-images.githubusercontent.com/34648393/59360885-571b1600-8d4a-11e9-802a-e688e4cd0bfe.png)

- Setup course_metadata in the discovery admin to have values for weeks_to_complete and max_effort

![image](https://user-images.githubusercontent.com/34648393/59361076-b7aa5300-8d4a-11e9-8725-459211d95a6b.png)

- Run the management command /integrated_channels/xapi/management/commands/send_course_enrollments.py

- Verify that the course_duration is being correctly populated in the SCORM cloud LRS viewer

![image](https://user-images.githubusercontent.com/34648393/59361390-356e5e80-8d4b-11e9-9ea2-197c9a6f2cd4.png)


**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [x] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)
