### PR TITLE
WL-1927: Using OAuth2AuthenticationAllowInactiveUser as oauth2 authentication class

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[1.6.6] - 2019-06-10
+--------------------
+
+* Use OAuth2AuthenticationAllowInactiveUser as oauth2 authentication instead of BearerAuthentication for course-list API.
+
 [1.6.5] - 2019-06-06
 --------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.6.5"
+__version__ = "1.6.6"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -166,6 +166,19 @@ def get_all_field_names(model, excluded=None):
     return [f.name for f in model._meta.get_fields() if f.name not in excluded_fields]
 
 
+def get_oauth2authentication_class():
+    """
+    Return oauth2 authentication class to authenticate REST APIs with Bearer token.
+    """
+    try:
+        from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser as OAuth2Authentication
+    except ImportError:
+        from edx_rest_framework_extensions.auth.bearer.authentication import BearerAuthentication \
+            as OAuth2Authentication
+
+    return OAuth2Authentication
+
+
 def get_catalog_admin_url(catalog_id):
     """
     Get url to catalog details admin page.

--- a/integrated_channels/cornerstone/views.py
+++ b/integrated_channels/cornerstone/views.py
@@ -3,14 +3,13 @@ Views containing APIs for cornerstone integrated channel
 """
 from __future__ import absolute_import, unicode_literals
 
-from edx_rest_framework_extensions.auth.bearer.authentication import BearerAuthentication
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from rest_framework import generics, permissions, renderers, status
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.response import Response
 
 from enterprise.api.throttles import ServiceUserThrottle
-from enterprise.utils import get_enterprise_customer, get_enterprise_worker_user
+from enterprise.utils import get_enterprise_customer, get_enterprise_worker_user, get_oauth2authentication_class
 from integrated_channels.cornerstone.models import CornerstoneEnterpriseCustomerConfiguration
 
 
@@ -74,7 +73,7 @@ class CornerstoneCoursesListView(generics.ListAPIView):
 
     """
     permission_classes = (permissions.IsAuthenticated,)
-    authentication_classes = (JwtAuthentication, BearerAuthentication, SessionAuthentication,)
+    authentication_classes = (JwtAuthentication, get_oauth2authentication_class(), SessionAuthentication,)
     throttle_classes = (ServiceUserThrottle,)
     renderer_classes = [renderers.JSONRenderer]
 


### PR DESCRIPTION
This PR has changes to use `OAuth2AuthenticationAllowInactiveUser` as oauth2 authentication instead of `BearerAuthentication` because `BearerAuthentication` requires `OAUTH2_USER_INFO_URL` settings which we don't have in LMS.
**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
