### PR TITLE
Upgrade django-config-models to unblock DRF upgrades

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,17 +74,20 @@ docs: ## generate Sphinx HTML documentation, including API docs
 	tox -e docs
 	$(BROWSER) docs/_build/html/index.html
 
+# Define PIP_COMPILE_OPTS=-v to get more information during make upgrade.
+PIP_COMPILE = pip-compile --upgrade $(PIP_COMPILE_OPTS)
+
 upgrade: ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
 	pip install -q pip-tools
-	pip-compile --upgrade -o requirements/dev.txt requirements/base.in requirements/test-$(TARGET_PLATFORM).in requirements/dev.in requirements/quality.in
-	pip-compile --upgrade -o requirements/doc.txt requirements/base.in requirements/test-$(TARGET_PLATFORM).in requirements/doc.in
-	pip-compile --upgrade -o requirements/quality.txt requirements/base.in requirements/test-$(TARGET_PLATFORM).in requirements/dev.in requirements/quality.in requirements/doc.in requirements/test.in
-	pip-compile --upgrade -o requirements/travis.txt requirements/travis.in
-	pip-compile --upgrade -o requirements/js_test.txt requirements/js_test.in
-	pip-compile --upgrade -o requirements/test.txt requirements/base.in requirements/test-$(TARGET_PLATFORM).in requirements/test.in
+	$(PIP_COMPILE) -o requirements/dev.txt requirements/base.in requirements/test-$(TARGET_PLATFORM).in requirements/dev.in requirements/quality.in
+	$(PIP_COMPILE) -o requirements/doc.txt requirements/base.in requirements/test-$(TARGET_PLATFORM).in requirements/doc.in
+	$(PIP_COMPILE) -o requirements/quality.txt requirements/base.in requirements/test-$(TARGET_PLATFORM).in requirements/dev.in requirements/quality.in requirements/doc.in requirements/test.in
+	$(PIP_COMPILE) -o requirements/travis.txt requirements/travis.in
+	$(PIP_COMPILE) -o requirements/js_test.txt requirements/js_test.in
+	$(PIP_COMPILE) -o requirements/test.txt requirements/base.in requirements/test-$(TARGET_PLATFORM).in requirements/test.in
 
 	for platform in $(ALL_PLATFORMS) ; do \
-		pip-compile --upgrade -o requirements/test-$$platform.txt requirements/base.in requirements/test-$$platform.in requirements/test.in ; \
+		$(PIP_COMPILE) -o requirements/test-$$platform.txt requirements/base.in requirements/test-$$platform.in requirements/test.in ; \
 	done
 
 requirements.js: ## install JS requirements for local development

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 enterprise
-=============================
+==========
 
 .. image:: https://img.shields.io/pypi/v/edx-enterprise.svg
     :target: https://pypi.python.org/pypi/edx-enterprise/
@@ -29,13 +29,6 @@ The ``Open edx Enterprise Service`` app provides enterprise features to the Open
 edX platform.  The majority of these features are structured around the concept
 of an ``Enterprise Customer``, which is an organization or a group of people
 that "consumes" courses published on the Open edX platform.
-
-Overview
---------
-
-The ``README.rst`` file should then provide an overview of the code in this
-repository, including the main components and useful entry points for starting
-to understand the code in more detail.
 
 Documentation
 -------------

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,7 +2,6 @@
 
 django-object-actions==0.10.0           # Object actions in Django admin
 djangorestframework-xml==1.3.0
-django-filter
 django-multi-email-field==0.5.1         # Multi email input field in Django admin
 jsondiff==1.1.1                         # Used to detect content metadata changes
 django-countries==4.6.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -28,7 +28,7 @@ cryptography==2.4.2
 defusedxml==0.6.0         # via djangorestframework-xml
 diff-cover==0.9.8
 distlib==0.2.9.post0      # via caniusepython3
-django-config-models==0.2.2
+django-config-models==1.0.1
 django-countries==4.6.1
 django-crum==0.7.3        # via edx-rbac
 django-fernet-fields==0.5

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -22,7 +22,7 @@ code-annotations==0.3.1
 cryptography==2.4.2
 defusedxml==0.6.0         # via djangorestframework-xml
 diff-cover==0.9.8
-django-config-models==0.2.2
+django-config-models==1.0.1
 django-countries==4.6.1
 django-crum==0.7.3        # via edx-rbac
 django-fernet-fields==0.5

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -35,7 +35,7 @@ ddt==1.2.1
 defusedxml==0.6.0         # via djangorestframework-xml
 diff-cover==0.9.8
 distlib==0.2.9.post0      # via caniusepython3
-django-config-models==0.2.2
+django-config-models==1.0.1
 django-countries==4.6.1
 django-crum==0.7.3        # via edx-rbac
 django-fernet-fields==0.5

--- a/requirements/test-master.in
+++ b/requirements/test-master.in
@@ -17,7 +17,7 @@ unicodecsv==0.14.1                      # Allows exporting CSV with unicode supp
 Pillow==5.4.1                           # Image manipulation module, required to use ImageField
 django-simple-history==2.7.0            # History for Django models
 edx-rest-api-client==1.9.2              # For accessing the Enrollment API (and possibly other edX APIs)
-django-config-models==0.2.2
+django-config-models==1.0.1
 requests==2.21.0                        # Required for SAPSuccessFactorsAPIClient
 django-waffle==0.12.0                   # Allows ability to add and control flags and switches for features
 testfixtures                            # Mock objects for unit tests and doc tests

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -27,7 +27,7 @@ cryptography==2.4.2
 ddt==1.2.1
 defusedxml==0.6.0         # via djangorestframework-xml
 diff-cover==0.9.8
-django-config-models==0.2.2
+django-config-models==1.0.1
 django-countries==4.6.1
 django-crum==0.7.3        # via edx-rbac
 django-fernet-fields==0.5

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -27,7 +27,7 @@ cryptography==2.4.2
 ddt==1.2.1
 defusedxml==0.6.0         # via djangorestframework-xml
 diff-cover==0.9.8
-django-config-models==0.2.2
+django-config-models==1.0.1
 django-countries==4.6.1
 django-crum==0.7.3        # via edx-rbac
 django-fernet-fields==0.5


### PR DESCRIPTION
**Description:** 

We are trying to upgrade Django REST Framework in edx-platform.  This is needed to make it possible.

I also made "make upgrade" more flexible, and cleaned up the README a tad.
**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)
