### PR TITLE
Make get_course_id fall back to the behaviour of `parse_course_key`

### DIFF
--- a/enterprise/api_client/discovery.py
+++ b/enterprise/api_client/discovery.py
@@ -11,6 +11,7 @@ from edx_rest_api_client.exceptions import SlumberBaseException
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from requests.exceptions import ConnectionError, Timeout  # pylint: disable=redefined-builtin
+from six.moves.urllib.parse import quote_plus
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured, ObjectDoesNotExist
@@ -168,7 +169,7 @@ class CourseCatalogApiClient(object):
         """
 
         try:
-            CourseKey.from_string(course_identifier)
+            course_run_key = CourseKey.from_string(course_identifier)
         except InvalidKeyError:
             # An `InvalidKeyError` is thrown if `course_identifier` is not in the proper format for a course run id.
             # Since `course_identifier` is not a course run id we assume `course_identifier` is the  course id.
@@ -182,7 +183,9 @@ class CourseCatalogApiClient(object):
         if 'course' in course_run_data:
             return course_run_data['course']
 
-        return None
+        # If none of the above methods of deriving the course key work, this will return the course id parsed from the
+        # course identifier (in the above example it would be 'edX+DemoY')
+        return quote_plus(' '.join([course_run_key.org, course_run_key.course]))
 
     def get_course_and_course_run(self, course_run_id):
         """


### PR DESCRIPTION
**Description:** Describe in a couple of sentence what this PR adds

**JIRA:** Link to JIRA ticket

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happend instead - check failed.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
