### PR TITLE
ENT-2009: Improved logging of unlink_inactive_sap_learners command and match social auth user by `uid` field

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[1.6.13] - 2019-06-17
+---------------------
+
+* Improved logging of `unlink_inactive_sap_learners` command and matching social auth user by `uid` field
+
 [1.6.12] - 2019-06-14
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.6.12"
+__version__ = "1.6.13"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/sap_success_factors/client.py
+++ b/integrated_channels/sap_success_factors/client.py
@@ -322,8 +322,17 @@ class SAPSuccessFactorsAPIClient(IntegratedChannelApiClient):  # pylint: disable
             return None
 
         new_page_start_at = page_size + start_at
-        all_inactive_learners += sap_inactive_learners['value']
-        if sap_inactive_learners['@odata.count'] > new_page_start_at:
+        total_inactive_learners = sap_inactive_learners['@odata.count']
+        inactive_learners_on_page = sap_inactive_learners['value']
+        LOGGER.info(
+            'SAP SF searchStudent API returned [%d] inactive learners of total [%d] starting from [%d] for '
+            'enterprise customer [%s]',
+            len(inactive_learners_on_page), total_inactive_learners, start_at,
+            self.enterprise_configuration.enterprise_customer.name
+        )
+
+        all_inactive_learners += inactive_learners_on_page
+        if total_inactive_learners > new_page_start_at:
             return self._call_search_students_recursively(
                 sap_search_student_url,
                 all_inactive_learners,


### PR DESCRIPTION
**Description:** Improved logging of unlink_inactive_sap_learners command
Matching social_auth user with uid field insteand of username field

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
