### PR TITLE
Fix Issue: Calling Search API with ```None```

### DIFF
--- a/enterprise/api_client/discovery.py
+++ b/enterprise/api_client/discovery.py
@@ -182,6 +182,9 @@ class CourseCatalogApiClient(object):
         if 'course' in course_run_data:
             return course_run_data['course']
 
+        LOGGER.info(
+            "Could not find course_key for course identifier [%s].", course_identifier
+        )
         return None
 
     def get_course_and_course_run(self, course_run_id):

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -1322,9 +1322,12 @@ class EnterpriseCustomerCatalog(TimeStampedModel):
         catalog_client = get_course_catalog_api_service_client(self.enterprise_customer.site)
         course_keys = {catalog_client.get_course_id(k) for k in content_ids}
 
+        # Remove `None` from set of course_keys if present
+        course_keys = course_keys.difference({None})
+
         content_ids_in_catalog = self.content_filter_ids
         if not content_ids_in_catalog:
-            content_ids_in_catalog = self._filter_members('key', list(course_keys))
+            content_ids_in_catalog = self._filter_members('key', list(course_keys)) if course_keys else set()
 
         return set(content_ids).issubset(content_ids_in_catalog) or course_keys.issubset(content_ids_in_catalog)
 


### PR DESCRIPTION
The ```edx-enterprise``` code could get into a state where it called the ```search/all``` endpoint in ```discovery``` with the query params ```key: [None]```.
This happened because the method ```get_course_id``` returns ```None`` when passed a ```course_identifier``` that has no valid ```course_key```.

The fix:
- Log when ```get_course_id``` cannot find a ```course_key```
- Filter out the course key ```None``` before calling discovery's search endpoint.  If ```None``` is the only course_key in the list, do not call discovery.

**Description:** Describe in a couple of sentence what this PR adds

**JIRA:** Link to JIRA ticket

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happend instead - check failed.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
