### PR TITLE
WL-1941: Changes to return language code instead of language name

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[1.6.14] - 2019-06-18
+---------------------
+
+* Pass language code instead of language name in languages field of course-list API for cornerstone
+
 [1.6.13] - 2019-06-17
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.6.13"
+__version__ = "1.6.14"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -878,6 +878,83 @@ def get_default_catalog_content_filter():
     return settings.ENTERPRISE_CUSTOMER_CATALOG_DEFAULT_CONTENT_FILTER or DEFAULT_CATALOG_CONTENT_FILTER
 
 
+def get_language_code(language):
+    """
+    Return IETF language tag of given language name.
+
+    - if language is not found in the language map then `en-US` is returned.
+
+    Args:
+        language (str): string language name
+
+    Returns: a language tag (two-letter language code - two letter country code if applicable)
+    """
+    language_map = {
+        "Afrikaans": "af",
+        "Arabic": "ar-SA",
+        "Azeri": "az-AZ",
+        "Belarusian": "be",
+        "Bulgarian": "bg",
+        "Catalan": "ca",
+        "Czech": "cs",
+        "Danish": "da",
+        "German": "de-DE",
+        "Greek": "el",
+        "English": "en-US",
+        "Spanish": "es-ES",
+        "Estonian": "et",
+        "Basque (Basque)": "eu",
+        "Farsi": "fa",
+        "Finnish": "fi",
+        "French": "fr-FR",
+        "Hebrew": "he",
+        "Hindi": "hi",
+        "Croatian": "hr",
+        "Hungarian": "hu",
+        "Indonesian": "id",
+        "Icelandic": "is",
+        "Italian": "it-IT",
+        "Japanese": "ja",
+        "Korean": "ko",
+        "Lithuanian": "lt",
+        "Malay": "ms-MY",
+        "Maltese": "mt",
+        "Dutch": "nl-NL",
+        "Norwegian": "nn-NO",
+        "Polish": "pl",
+        "Portuguese": "pt-BR",
+        "Romanian": "ro",
+        "Russian": "ru",
+        "Sanskrit": "sa",
+        "Sorbian": "sb",
+        "Slovak": "sk",
+        "Slovenian": "sl",
+        "Swedish": "sv-SE",
+        "Swahili": "sw",
+        "Tamil": "ta",
+        "Thai": "th",
+        "Turkish": "tr",
+        "Tsonga": "ts",
+        "Tatar": "tt",
+        "Ukrainian": "uk",
+        "Urdu": "ur",
+        "Uzbek": "uz-UZ",
+        "Vietnamese": "vi",
+        "Xhosa": "xh",
+        "Yiddish": "yi",
+        "Chinese - Mandarin": "zh-CMN",
+        "Chinese - China": "zh-CN",
+        "Chinese - Simplified": "zh-Hans",
+        "Chinese - Traditional": "zh-Hant",
+        "Chinese - Hong Kong SAR": "zh-HK",
+        "Chinese - Macau SAR": "zh-MO",
+        "Chinese - Singapore": "zh-SG",
+        "Chinese - Taiwan": "zh-TW",
+        "Zulu": "zu",
+    }
+    return language_map.get(language, "en-US")
+
+
 def get_enterprise_worker_user():
     """
     Return the user object of enterprise worker user.

--- a/integrated_channels/cornerstone/exporters/content_metadata.py
+++ b/integrated_channels/cornerstone/exporters/content_metadata.py
@@ -13,7 +13,7 @@ import pytz
 
 from django.apps import apps
 
-from enterprise.utils import get_closest_course_run
+from enterprise.utils import get_closest_course_run, get_language_code
 from integrated_channels.integrated_channel.exporters.content_metadata import ContentMetadataExporter
 
 LOGGER = getLogger(__name__)
@@ -96,7 +96,8 @@ class CornerstoneContentMetadataExporter(ContentMetadataExporter):  # pylint: di
         """
         Return the languages supported by course or `English` as default if no languages found.
         """
-        return content_metadata_item.get('languages', ['English'])
+        languages = content_metadata_item.get('languages', ['English'])
+        return [get_language_code(language) for language in languages]
 
     def transform_description(self, content_metadata_item):
         """

--- a/tests/test_integrated_channels/test_cornerstone/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_cornerstone/test_exporters/test_content_metadata.py
@@ -424,15 +424,15 @@ class TestCornerstoneContentMetadataExporter(unittest.TestCase, EnterpriseMockMi
     @ddt.data(
         (
             {'languages': ['English']},
-            ['English'],
+            ['en-US'],
         ),
         (
             {'languages': 'undefined'},
-            ['English'],
+            ['en-US'],
         ),
         (
-            {'languages': ['Spanish', 'English']},
-            ['Spanish', 'English'],
+            {'languages': ['Spanish', 'English', 'Japanese']},
+            ['es-ES', 'en-US', 'ja'],
         ),
     )
     @responses.activate


### PR DESCRIPTION
This PR has changes to return language code instead of language name in `languages` field of course-list API in cornerstone integrated channel.

**JIRA:** https://openedx.atlassian.net/browse/WL-1941


**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
