### PR TITLE
WL-1943 | Server Error on enterprise course enroll url

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[1.6.17] - 2019-06-20
+---------------------
+
+* Fixed Server Error on enterprise course enroll url caused by week_to_complete None value
+
 [1.6.16] - 2019-06-20
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.6.16"
+__version__ = "1.6.17"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -800,7 +800,8 @@ def is_course_run_about_to_end(current_course_run):
     now = datetime.datetime.now(pytz.UTC)
     if current_course_run:
         end_date = parse_datetime_handle_invalid(current_course_run.get('end'))
-        if end_date and (end_date - now).days > current_course_run.get('weeks_to_complete', 0) * 7:
+        weeks_to_complete = current_course_run.get('weeks_to_complete') or 0
+        if end_date and (end_date - now).days > weeks_to_complete * 7:
             about_to_end = False
     return about_to_end
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1168,6 +1168,13 @@ class TestEnterpriseUtils(unittest.TestCase):
             ),
             False,
         ),
+        (
+            fake_catalog_api.create_course_run_dict(
+                end=DATETIME_NOW + datetime.timedelta(days=20),
+                weeks_to_complete=None
+            ),
+            False,
+        ),
     )
     @ddt.unpack
     def test_is_course_run_about_to_end(self, course_run, expected_boolean):


### PR DESCRIPTION
**Description:** converting course week_to_complete default None to 0 in is_course_run_about_to_end util

**JIRA:** 
https://openedx.atlassian.net/browse/WL-1943

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happend instead - check failed.

**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
