### PR TITLE
ENT-2009: Changed page size of inactive user results from 500 to 1000

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[1.6.18] - 2019-06-24
+---------------------
+
+* Changed page size of SAPSF inactive user results from 500 to 1000
+
 [1.6.17] - 2019-06-20
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.6.17"
+__version__ = "1.6.18"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/sap_success_factors/client.py
+++ b/integrated_channels/sap_success_factors/client.py
@@ -284,7 +284,7 @@ class SAPSuccessFactorsAPIClient(IntegratedChannelApiClient):  # pylint: disable
         all_inactive_learners = self._call_search_students_recursively(
             sap_search_student_url,
             all_inactive_learners=[],
-            page_size=500,
+            page_size=1000,
             start_at=0
         )
         return all_inactive_learners

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -872,7 +872,7 @@ class TestUnlinkSAPLearnersManagementCommand(unittest.TestCase, EnterpriseMockMi
         self.search_student_paginated_url = '{sap_search_student_url}&{pagination_criterion}'.format(
             sap_search_student_url=self.sap_search_student_url,
             pagination_criterion='$count=true&$top={page_size}&$skip={start_at}'.format(
-                page_size=500,
+                page_size=1000,
                 start_at=0,
             ),
         )
@@ -954,13 +954,13 @@ class TestUnlinkSAPLearnersManagementCommand(unittest.TestCase, EnterpriseMockMi
             search_student_paginated_url = '{sap_search_student_url}&{pagination_criterion}'.format(
                 sap_search_student_url=self.sap_search_student_url,
                 pagination_criterion='$count=true&$top={page_size}&$skip={start_at}'.format(
-                    page_size=500,
-                    start_at=500 * response_page,
+                    page_size=1000,
+                    start_at=1000 * response_page,
                 )
             )
             sapsf_search_student_response = {
                 u'@odata.metadataEtag': u'W/"17090d86-20fa-49c8-8de0-de1d308c8b55"',
-                u"@odata.count": 500 * len(inactive_sap_learners),
+                u"@odata.count": 1000 * len(inactive_sap_learners),
                 u'value': [{'studentID': inactive_learner}]
             }
             responses.add(
@@ -973,11 +973,11 @@ class TestUnlinkSAPLearnersManagementCommand(unittest.TestCase, EnterpriseMockMi
 
         expected_messages = [
             'Processing learners to unlink inactive users using configuration: [{}]'.format(self.sapsf),
-            'SAP SF searchStudent API returned [1] inactive learners of total [1500] starting from [0] for '
+            'SAP SF searchStudent API returned [1] inactive learners of total [3000] starting from [0] for '
             'enterprise customer [{}]'.format(self.enterprise_customer.name),
-            'SAP SF searchStudent API returned [1] inactive learners of total [1500] starting from [500] for '
+            'SAP SF searchStudent API returned [1] inactive learners of total [3000] starting from [1000] for '
             'enterprise customer [{}]'.format(self.enterprise_customer.name),
-            'SAP SF searchStudent API returned [1] inactive learners of total [1500] starting from [1000] for '
+            'SAP SF searchStudent API returned [1] inactive learners of total [3000] starting from [2000] for '
             'enterprise customer [{}]'.format(self.enterprise_customer.name),
             'Found [{}] SAP inactive learners for enterprise customer [{}]'.format(
                 len(inactive_sap_learners), self.enterprise_customer.name


### PR DESCRIPTION
Changed page size of inactive user results from 500 to 1000 to avoid timeouts for those customers who has large number of in-active users.

**JIRA:** https://openedx.atlassian.net/browse/ENT-2009


**Merge checklist:**

- [ ] Check that the versions of the requirements in the `platform-master.in` file match edx-platform.
- [ ] New requirements are in the right place (`base.in` if only used in enterprise; in the correct `platform-****.in` files if they're hosted in edx-platform)
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
