### PR TITLE
Upgrade DRF to 3.7.7 to match edx-platform

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -34,7 +34,7 @@ django==1.11.21
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4bc70c03de308a277197c#egg=djangorestframework-oauth==1.1.1
 djangorestframework-xml==1.3.0
-git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc86856441bbf0bd9cb#egg=djangorestframework==3.6.3
+djangorestframework==3.7.7
 edx-django-oauth2-provider==1.3.5
 edx-django-utils==1.0.5
 edx-drf-extensions==2.3.1
@@ -51,7 +51,7 @@ jsondiff==1.1.1
 jsonfield==2.0.2
 kombu==3.0.37             # via celery
 markupsafe==1.1.1         # via jinja2
-newrelic==4.20.0.120      # via edx-django-utils
+newrelic==4.20.1.121      # via edx-django-utils
 path.py==8.2.1
 pbr==5.3.1                # via stevedore
 pillow==5.4.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -50,7 +50,7 @@ django==1.11.21
 djangorestframework-jwt==1.11.0
 git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4bc70c03de308a277197c#egg=djangorestframework-oauth==1.1.1
 djangorestframework-xml==1.3.0
-git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc86856441bbf0bd9cb#egg=djangorestframework==3.6.3
+djangorestframework==3.7.7
 doc8==0.8.0
 docutils==0.14
 edx-django-oauth2-provider==1.3.5
@@ -66,7 +66,7 @@ enum34==1.1.6
 factory-boy==2.12.0
 faker==1.0.7
 filelock==3.0.12          # via tox
-flaky==3.5.3
+flaky==3.6.0
 freezegun==0.3.12
 funcsigs==1.0.2
 future==0.17.1
@@ -88,10 +88,10 @@ markupsafe==1.1.1
 mccabe==0.6.1             # via pylint
 mock==3.0.5
 more-itertools==5.0.0
-newrelic==4.20.0.120
+newrelic==4.20.1.121
 packaging==19.0
 path.py==8.2.1
-pathlib2==2.3.3
+pathlib2==2.3.4
 pbr==5.3.1
 pillow==5.4.1
 pip-tools==3.8.0
@@ -144,7 +144,7 @@ testfixtures==6.10.0
 text-unidecode==1.2
 toml==0.10.0              # via tox
 tox-battery==0.5.1
-tox==3.12.1
+tox==3.13.0
 tqdm==4.32.2              # via twine
 twine==1.11.0
 typing==3.7.4
@@ -158,4 +158,4 @@ wrapt==1.11.2             # via astroid
 zipp==0.5.1
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.0.1        # via caniusepython3, sphinx, tox, twine
+# setuptools==41.0.1        # via caniusepython3, sphinx, twine

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -36,7 +36,7 @@ django==1.11.21
 djangorestframework-jwt==1.11.0
 git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4bc70c03de308a277197c#egg=djangorestframework-oauth==1.1.1
 djangorestframework-xml==1.3.0
-git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc86856441bbf0bd9cb#egg=djangorestframework==3.6.3
+djangorestframework==3.7.7
 doc8==0.8.0
 docutils==0.14
 edx-django-oauth2-provider==1.3.5
@@ -57,7 +57,7 @@ jsondiff==1.1.1
 jsonfield==2.0.2
 kombu==3.0.37
 markupsafe==1.1.1
-newrelic==4.20.0.120
+newrelic==4.20.1.121
 packaging==19.0           # via sphinx
 path.py==8.2.1
 pbr==5.3.1

--- a/requirements/edx-platform-constraints.txt
+++ b/requirements/edx-platform-constraints.txt
@@ -27,8 +27,8 @@ certifi==2019.6.16
 cffi==1.12.3
 chardet==3.0.4
 click==7.0                # via user-util
-coreapi==2.3.3            # via django-rest-swagger, openapi-codec
-coreschema==0.0.4         # via coreapi
+coreapi==2.3.3            # via drf-yasg
+coreschema==0.0.4         # via coreapi, drf-yasg
 git+https://github.com/edx/crowdsourcehinter.git@518605f0a95190949fe77bd39158450639e2e1dc#egg=crowdsourcehinter-xblock==0.1
 cryptography==2.7
 cssutils==1.0.2           # via pynliner
@@ -61,7 +61,6 @@ django-pyfs==2.0
 django-ratelimit-backend==1.1.1
 django-ratelimit==2.0.0
 django-require==1.0.11
-django-rest-swagger==2.2.0
 django-sekizai==1.0.0
 django-ses==0.8.4
 django-simple-history==2.7.0
@@ -75,9 +74,10 @@ django==1.11.21
 djangorestframework-jwt==1.11.0
 git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4bc70c03de308a277197c#egg=djangorestframework-oauth==1.1.1
 djangorestframework-xml==1.3.0  # via edx-enterprise
-git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc86856441bbf0bd9cb#egg=djangorestframework==3.6.3
+djangorestframework==3.7.7
 docopt==0.6.2
 docutils==0.14            # via botocore
+drf-yasg==1.16.0
 edx-ace==0.1.10
 edx-analytics-data-api-client==0.15.3
 git+https://github.com/edx/edx-bulk-grades@f58f9fa01d95c01211fc94ebb92f0fb1a04bf32b#egg=edx-bulk-grades==0.1.1
@@ -89,7 +89,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.5
 edx-drf-extensions==2.3.1
-edx-enterprise==1.6.15
+edx-enterprise==1.6.17
 edx-i18n-tools==0.4.8
 edx-milestones==0.2.3
 edx-oauth2-provider==1.2.2
@@ -107,7 +107,7 @@ edx-when==0.1.6
 edxval==1.1.25
 elasticsearch==1.9.0      # via edx-search
 enum34==1.1.6
-event-tracking==0.2.8
+event-tracking==0.2.9
 feedparser==5.1.3
 firebase-token-generator==1.3.2
 fs-s3fs==0.1.8
@@ -116,11 +116,12 @@ future==0.17.1            # via pyjwkest
 futures==3.2.0 ; python_version == "2.7"  # via django-pipeline, python-swiftclient, s3transfer, xblock-utils
 geoip2==2.9.0
 glob2==0.7
-gunicorn==19.5.0
+gunicorn==19.9.0
 help-tokens==1.0.4
 html5lib==1.0.1
 httplib2==0.13.0          # via oauth2, zendesk
 idna==2.8
+inflection==0.3.1         # via drf-yasg
 ipaddress==1.0.22
 isodate==0.6.0            # via python3-saml
 itypes==1.1.0             # via coreapi
@@ -153,7 +154,6 @@ nodeenv==1.1.1
 numpy==1.16.4
 oauth2==1.9.0.post1
 oauthlib==2.1.0
-openapi-codec==1.3.2      # via django-rest-swagger
 git+https://github.com/edx/edx-ora2.git@2.2.3#egg=ora2==2.2.3
 path.py==8.2.1
 pathtools==0.1.2
@@ -195,6 +195,8 @@ requests-oauthlib==1.1.0
 requests==2.22.0
 rest-condition==1.0.3
 rfc6266-parser==0.0.5.post2
+ruamel.ordereddict==0.4.13  # via ruamel.yaml
+ruamel.yaml==0.15.97      # via drf-yasg
 rules==2.0.1
 s3transfer==0.1.13        # via boto3
 sailthru-client==2.2.3
@@ -202,7 +204,7 @@ scipy==1.2.1
 semantic-version==2.6.0   # via edx-drf-extensions
 shapely==1.6.4.post2
 shortuuid==0.5.0          # via edx-django-oauth2-provider
-simplejson==3.16.0        # via django-rest-swagger, mailsnake, sailthru-client, zendesk
+simplejson==3.16.0        # via mailsnake, sailthru-client, zendesk
 singledispatch==3.4.0.3
 six==1.11.0
 slumber==0.7.1            # via edx-rest-api-client
@@ -218,7 +220,7 @@ git+https://github.com/edx/super-csv@1a9dcc89eb65c3ed434b509b84062f8fcabd901b#eg
 sympy==1.4
 tincan==0.0.5             # via edx-enterprise
 unicodecsv==0.14.1
-uritemplate==3.0.0        # via coreapi
+uritemplate==3.0.0        # via coreapi, drf-yasg
 urllib3==1.23
 user-util==0.1.5
 voluptuous==0.11.5
@@ -231,7 +233,7 @@ git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.1#egg=xblock-d
 git+https://github.com/open-craft/xblock-poll@add89e14558c30f3c8dc7431e5cd6536fff6d941#egg=xblock-poll==1.5.1
 xblock-utils==1.2.1
 xblock==1.2.2
-xmlsec==1.3.3             # via python3-saml
+xss-utils==0.1.0
 zendesk==1.1.1
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/test-master.in
+++ b/requirements/test-master.in
@@ -4,8 +4,7 @@
 celery==3.1.25                          # Run task workers in other locations
 cryptography==2.7                       # For random password generation
 django==1.11.21                         # Application server
-git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc86856441bbf0bd9cb#egg=djangorestframework==3.6.3
-                                        # REST API extensions for Django
+djangorestframework==3.7.7              # REST API extensions for Django
 git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4bc70c03de308a277197c#egg=djangorestframework-oauth==1.1.1
                                         # For enterprise REST API endpoint
 django-fernet-fields==0.6               # Fernet symmetric encryption for Django model fields, using the cryptography library.

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -42,7 +42,7 @@ django==1.11.21
 djangorestframework-jwt==1.11.0
 git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4bc70c03de308a277197c#egg=djangorestframework-oauth==1.1.1
 djangorestframework-xml==1.3.0
-git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc86856441bbf0bd9cb#egg=djangorestframework==3.6.3
+djangorestframework==3.7.7
 edx-django-oauth2-provider==1.3.5
 edx-django-utils==1.0.5
 edx-drf-extensions==2.3.1
@@ -52,7 +52,7 @@ edx-rest-api-client==1.9.2
 enum34==1.1.6
 factory-boy==2.12.0
 faker==1.0.7              # via factory-boy
-flaky==3.5.3
+flaky==3.6.0
 freezegun==0.3.12
 funcsigs==1.0.2           # via mock, pytest
 future==0.17.1
@@ -69,10 +69,10 @@ kombu==3.0.37
 markupsafe==1.1.1
 mock==3.0.5
 more-itertools==5.0.0     # via pytest
-newrelic==4.20.0.120
+newrelic==4.20.1.121
 packaging==19.0           # via pytest
 path.py==8.2.1
-pathlib2==2.3.3           # via importlib-metadata, pytest, pytest-django
+pathlib2==2.3.4           # via importlib-metadata, pytest, pytest-django
 pbr==5.3.1
 pillow==5.4.1
 pluggy==0.12.0            # via pytest

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -12,19 +12,18 @@ contextlib2==0.5.5        # via importlib-metadata
 coverage==4.5.3           # via codecov
 filelock==3.0.12          # via tox
 idna==2.8                 # via requests
-importlib-metadata==0.18  # via pluggy
-pathlib2==2.3.3           # via importlib-metadata
+importlib-metadata==0.18  # via pluggy, tox
+packaging==19.0           # via tox
+pathlib2==2.3.4           # via importlib-metadata
 pluggy==0.12.0            # via tox
 py==1.8.0                 # via tox
+pyparsing==2.4.0          # via packaging
 requests==2.22.0          # via codecov
 scandir==1.10.0           # via pathlib2
-six==1.12.0               # via pathlib2, tox
+six==1.12.0               # via packaging, pathlib2, tox
 toml==0.10.0              # via tox
 tox-battery==0.5.1
-tox==3.12.1
+tox==3.13.0
 urllib3==1.25.3           # via requests
 virtualenv==16.6.1        # via tox
 zipp==0.5.1               # via importlib-metadata
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.0.1        # via tox


### PR DESCRIPTION
- [x] New requirements are in the right place
    - `base.in` if needed in production, but edx-platform doesn't install it.
    - `test-master.in` if edx-platform pins it, with a matching version.
- [x] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)
