### PR TITLE
update catalog preview url

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[1.6.20] - 2019-07-10
+---------------------
+
+* Updated catalog preview URL on enterprise customer catalog admin list display
+
 [1.6.19] - 2019-07-09
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.6.19"
+__version__ = "1.6.20"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name


### PR DESCRIPTION
**Description:** This will change the catalog preview url on [Enterprise Catalogs admin page](https://mammar.sandbox.edx.org/admin/enterprise/enterprisecustomercatalog/). Instead of calling the discovery `search/all` endpoint to get a catalog details, we will hit the `enterprise_catalogs` endpoint. We need this because discovery `search/all` GET endpoint cannot handle very large catalog queries.

**JIRA:** https://openedx.atlassian.net/browse/ENT-1295

**Testing:** This PR is deployed to sandbox

1. Login to https://mammar.sandbox.edx.org/admin
2. Goto https://mammar.sandbox.edx.org/admin/enterprise/enterprisecustomercatalog/
3. The Preview links should point to `enterprise_catalogs` endpoint
4. Upon click on a Preview link, it should show the catalog details.