### PR TITLE
WL-1946: Added ability to skip keys if their value is None for content exporter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[1.6.19] - 2019-07-09
+---------------------
+
+* Added ability to skip keys if their value is None for content exporter
+
 [1.6.18] - 2019-06-24
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.6.18"
+__version__ = "1.6.19"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/cornerstone/exporters/content_metadata.py
+++ b/integrated_channels/cornerstone/exporters/content_metadata.py
@@ -38,6 +38,7 @@ class CornerstoneContentMetadataExporter(ContentMetadataExporter):  # pylint: di
         'Languages': 'languages',
         'Subjects': 'subjects',
     }
+    SKIP_KEY_IF_NONE = True
 
     def transform_organizations(self, content_metadata_item):
         """

--- a/integrated_channels/integrated_channel/exporters/content_metadata.py
+++ b/integrated_channels/integrated_channel/exporters/content_metadata.py
@@ -62,6 +62,7 @@ class ContentMetadataExporter(Exporter):
     #
     # TODO: Move this to the EnterpriseCustomerPluginConfiguration model as a JSONField.
     DATA_TRANSFORM_MAPPING = {}
+    SKIP_KEY_IF_NONE = False
 
     def __init__(self, user, enterprise_configuration):
         """
@@ -116,12 +117,12 @@ class ContentMetadataExporter(Exporter):
                 )
             )
             if transformer:
-                transformed_item[integrated_channel_schema_key] = transformer(content_metadata_item)
+                transformed_value = transformer(content_metadata_item)
             else:
                 # The concrete subclass does not define an override for the given field,
                 # so just use the data key to index the content metadata item dictionary.
                 try:
-                    transformed_item[integrated_channel_schema_key] = content_metadata_item[edx_data_schema_key]
+                    transformed_value = content_metadata_item[edx_data_schema_key]
                 except KeyError:
                     # There may be a problem with the DATA_TRANSFORM_MAPPING on
                     # the concrete subclass or the concrete subclass does not implement
@@ -132,6 +133,12 @@ class ContentMetadataExporter(Exporter):
                         self.enterprise_customer.name,
                         content_metadata_item,
                     )
+                    continue
+
+            if transformed_value is None and self.SKIP_KEY_IF_NONE:
+                continue
+            else:
+                transformed_item[integrated_channel_schema_key] = transformed_value
 
         return transformed_item
 


### PR DESCRIPTION
Added ability to skip keys in content exporter if their value is None.

**Merge checklist:**

- [ ] New requirements are in the right place
    - `base.in` if needed in production, but edx-platform doesn't install it.
    - `test-master.in` if edx-platform pins it, with a matching version.
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
