### PR TITLE
use edx-drf-extensions jwt utils

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[1.8.0] - 2019-07-22
+--------------------
+
+* Replce edx-rbac jwt utils with edx-drf-extensions jwt utils
+
 [1.7.3] - 2019-07-19
 --------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.7.3"
+__version__ = "1.8.0"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/rules.py
+++ b/enterprise/rules.py
@@ -5,11 +5,9 @@ from __future__ import absolute_import, unicode_literals
 
 import crum
 import rules
-from edx_rbac.utils import (
-    get_decoded_jwt_from_request,
-    request_user_has_implicit_access_via_jwt,
-    user_has_access_via_database,
-)
+from edx_rbac.utils import request_user_has_implicit_access_via_jwt, user_has_access_via_database
+from edx_rest_framework_extensions.auth.jwt.authentication import get_decoded_jwt_from_auth
+from edx_rest_framework_extensions.auth.jwt.cookies import get_decoded_jwt
 
 from enterprise.constants import (
     ENTERPRISE_CATALOG_ADMIN_ROLE,
@@ -28,7 +26,7 @@ def has_implicit_access_to_dashboard(user, obj):  # pylint: disable=unused-argum
         boolean: whether the request user has access or not
     """
     request = crum.get_current_request()
-    decoded_jwt = get_decoded_jwt_from_request(request)
+    decoded_jwt = get_decoded_jwt(request) or get_decoded_jwt_from_auth(request)
     return request_user_has_implicit_access_via_jwt(decoded_jwt, ENTERPRISE_DASHBOARD_ADMIN_ROLE)
 
 
@@ -56,7 +54,7 @@ def has_implicit_access_to_catalog(user, obj):  # pylint: disable=unused-argumen
         boolean: whether the request user has access or not
     """
     request = crum.get_current_request()
-    decoded_jwt = get_decoded_jwt_from_request(request)
+    decoded_jwt = get_decoded_jwt(request) or get_decoded_jwt_from_auth(request)
     return request_user_has_implicit_access_via_jwt(decoded_jwt, ENTERPRISE_CATALOG_ADMIN_ROLE, obj)
 
 
@@ -85,7 +83,7 @@ def has_implicit_access_to_enrollment_api(user, obj):  # pylint: disable=unused-
         boolean: whether the request user has access or not
     """
     request = crum.get_current_request()
-    decoded_jwt = get_decoded_jwt_from_request(request)
+    decoded_jwt = get_decoded_jwt(request) or get_decoded_jwt_from_auth(request)
     return request_user_has_implicit_access_via_jwt(decoded_jwt, ENTERPRISE_ENROLLMENT_API_ADMIN_ROLE, obj)
 
 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -27,6 +27,7 @@ edx-django-utils
 edx-drf-extensions
 edx-opaque-keys[django]
 edx-rest-api-client
+edx-rbac
 future
 jsondiff
 jsonfield
@@ -43,4 +44,3 @@ testfixtures
 unicodecsv
 
 # Explicitly pinned packages. Anything pinned here must match edx-platform's pinned packages.
-edx-rbac==0.2.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -25,7 +25,7 @@ cffi==1.12.3
 chardet==3.0.4
 click-log==0.3.2          # via edx-lint
 click==7.0
-code-annotations==0.3.1
+code-annotations==0.3.2
 configparser==3.7.4
 contextlib2==0.5.5
 cookies==2.2.1
@@ -43,17 +43,17 @@ django-filter==1.0.4
 django-ipware==2.1.0
 django-model-utils==3.0.0
 django-multi-email-field==0.5.1
-django-object-actions==0.10.0
-django-simple-history==2.7.0
+django-object-actions==1.1.0
+django-simple-history==2.7.3
 django-waffle==0.12.0
 django==1.11.22
 djangorestframework-jwt==1.11.0
-djangorestframework-xml==1.3.0
+djangorestframework-xml==1.4.0
 djangorestframework==3.7.7
 doc8==0.8.0
-docutils==0.14
+docutils==0.15
 edx-django-utils==2.0.0
-edx-drf-extensions==2.3.1
+edx-drf-extensions==2.3.5
 edx-i18n-tools==0.4.8
 edx-lint==1.3.0
 edx-opaque-keys[django]==1.0.1
@@ -78,7 +78,7 @@ ipaddress==1.0.22
 isort==4.3.21
 jinja2-pluralize==0.3.0
 jinja2==2.10.1
-jsondiff==1.1.1
+jsondiff==1.2.0
 jsonfield==2.0.2
 kombu==3.0.37
 lazy-object-proxy==1.4.1  # via astroid
@@ -90,9 +90,9 @@ newrelic==4.20.1.121
 packaging==19.0
 path.py==8.2.1
 pathlib2==2.3.4
-pbr==5.4.0
+pbr==5.4.1
 pillow==6.1.0
-pip-tools==3.8.0
+pip-tools==3.9.0
 pkginfo==1.5.0.1          # via twine
 pluggy==0.12.0
 pockets==0.7.2
@@ -111,7 +111,7 @@ pylint-django==0.7.2      # via edx-lint
 pylint-plugin-utils==0.5  # via pylint-celery, pylint-django
 pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==2.9.1
-pyparsing==2.4.0
+pyparsing==2.4.1
 pytest-catchlog==1.2.2
 pytest-cov==2.7.1
 pytest-django==3.5.1

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -18,7 +18,7 @@ certifi==2019.6.16
 cffi==1.12.3
 chardet==3.0.4
 click==7.0
-code-annotations==0.3.1
+code-annotations==0.3.2
 cryptography==2.7
 defusedxml==0.5.0
 django-config-models==1.0.1
@@ -29,17 +29,17 @@ django-filter==1.0.4
 django-ipware==2.1.0
 django-model-utils==3.0.0
 django-multi-email-field==0.5.1
-django-object-actions==0.10.0
-django-simple-history==2.7.0
+django-object-actions==1.1.0
+django-simple-history==2.7.3
 django-waffle==0.12.0
 django==1.11.22
 djangorestframework-jwt==1.11.0
-djangorestframework-xml==1.3.0
+djangorestframework-xml==1.4.0
 djangorestframework==3.7.7
 doc8==0.8.0
-docutils==0.14
+docutils==0.15
 edx-django-utils==2.0.0
-edx-drf-extensions==2.3.1
+edx-drf-extensions==2.3.5
 edx-opaque-keys[django]==1.0.1
 edx-rbac==0.2.1
 edx-rest-api-client==1.9.2
@@ -51,14 +51,14 @@ idna==2.8
 imagesize==1.1.0          # via sphinx
 ipaddress==1.0.22
 jinja2==2.10.1
-jsondiff==1.1.1
+jsondiff==1.2.0
 jsonfield==2.0.2
 kombu==3.0.37
 markupsafe==1.1.1         # via jinja2
 newrelic==4.20.1.121
 packaging==19.0           # via sphinx
 path.py==8.2.1
-pbr==5.4.0
+pbr==5.4.1
 pillow==6.1.0
 pockets==0.7.2            # via sphinxcontrib-napoleon
 psutil==1.2.1
@@ -68,7 +68,7 @@ pygments==2.4.2           # via readme-renderer, sphinx
 pyjwkest==1.3.2
 pyjwt==1.5.2
 pymongo==2.9.1
-pyparsing==2.4.0          # via packaging
+pyparsing==2.4.1          # via packaging
 python-dateutil==2.4.0
 python-slugify==1.2.6
 pytz==2019.1

--- a/requirements/edx-platform-constraints.txt
+++ b/requirements/edx-platform-constraints.txt
@@ -5,10 +5,10 @@
 #
 #    make upgrade
 #
-amqp==1.4.9               # via edx-enterprise, kombu
+amqp==1.4.9               # via kombu
 analytics-python==1.2.9
-aniso8601==7.0.0          # via edx-enterprise, tincan
-anyjson==0.3.3            # via edx-enterprise, kombu
+aniso8601==7.0.0          # via tincan
+anyjson==0.3.3            # via kombu
 appdirs==1.4.3            # via fs
 argh==0.26.2
 asn1crypto==0.24.0
@@ -16,7 +16,7 @@ attrs==17.4.0
 babel==1.3
 backports.functools-lru-cache==1.5  # via soupsieve
 beautifulsoup4==4.7.1     # via pynliner
-billiard==3.3.0.23        # via celery, edx-enterprise
+billiard==3.3.0.23        # via celery
 bleach==2.1.4
 boto3==1.4.8
 boto==2.39.0
@@ -27,8 +27,8 @@ certifi==2019.6.16
 cffi==1.12.3
 chardet==3.0.4
 git+https://github.com/edx/openedx-chem.git@ff4e3a03d3c7610e47a9af08eb648d8aabe2eb18#egg=chem==1.0.0
-click==7.0                # via code-annotations, edx-enterprise, user-util
-code-annotations==0.3.1   # via edx-enterprise
+click==7.0                # via code-annotations, user-util
+code-annotations==0.3.2   # via edx-enterprise
 coreapi==2.3.3            # via drf-yasg
 coreschema==0.0.4         # via coreapi, drf-yasg
 git+https://github.com/edx/crowdsourcehinter.git@518605f0a95190949fe77bd39158450639e2e1dc#egg=crowdsourcehinter-xblock==0.1
@@ -56,7 +56,7 @@ django-multi-email-field==0.5.1  # via edx-enterprise
 django-mysql==2.4.1
 git+https://github.com/edx/django-oauth-plus.git@01ec2a161dfc3465f9d35b9211ae790177418316#egg=django-oauth-plus==2.2.9.edx-1
 django-oauth-toolkit==1.1.3
-django-object-actions==0.10.0  # via edx-enterprise
+django-object-actions==1.1.0  # via edx-enterprise
 git+https://github.com/edx/django-openid-auth.git@0.15.1#egg=django-openid-auth==0.15.1
 django-pipeline==1.6.14
 django-pyfs==2.0
@@ -65,7 +65,7 @@ django-ratelimit==2.0.0
 django-require==1.0.11
 django-sekizai==1.0.0
 django-ses==0.8.4
-django-simple-history==2.7.0
+django-simple-history==2.7.3
 django-splash==0.2.2
 django-statici18n==1.4.0
 django-storages==1.4.1
@@ -75,11 +75,11 @@ django-webpack-loader==0.6.0
 django==1.11.22
 djangorestframework-jwt==1.11.0
 git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4bc70c03de308a277197c#egg=djangorestframework-oauth==1.1.1
-djangorestframework-xml==1.3.0  # via edx-enterprise
+djangorestframework-xml==1.4.0  # via edx-enterprise
 djangorestframework==3.7.7
 docopt==0.6.2
 docutils==0.14            # via botocore
-drf-yasg==1.16.0
+drf-yasg==1.16
 edx-ace==0.1.10
 edx-analytics-data-api-client==0.15.3
 edx-bulk-grades==0.1.5
@@ -90,13 +90,13 @@ edx-django-oauth2-provider==1.3.5
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==2.0.0
-edx-drf-extensions==2.3.1
-edx-enterprise==1.7.0
+edx-drf-extensions==2.3.5
+edx-enterprise==1.7.3
 edx-i18n-tools==0.4.8
 edx-milestones==0.2.3
-edx-oauth2-provider==1.2.2
+edx-oauth2-provider==1.2.3
 edx-opaque-keys[django]==1.0.1
-edx-organizations==2.0.3
+edx-organizations==2.1.0
 edx-proctoring-proctortrack==1.0.5
 edx-proctoring==2.0.6
 edx-rbac==0.2.1           # via edx-enterprise
@@ -127,11 +127,11 @@ inflection==0.3.1         # via drf-yasg
 ipaddress==1.0.22
 isodate==0.6.0            # via python3-saml
 itypes==1.1.0             # via coreapi
-jinja2==2.10.1            # via code-annotations, coreschema, edx-enterprise
+jinja2==2.10.1            # via code-annotations, coreschema
 jmespath==0.9.4           # via boto3, botocore
-jsondiff==1.1.1           # via edx-enterprise
+jsondiff==1.2.0           # via edx-enterprise
 jsonfield==2.0.2
-kombu==3.0.37             # via celery, edx-enterprise
+kombu==3.0.37             # via celery
 lazy==1.1
 lepl==5.1.3               # via rfc6266-parser
 libsass==0.10.0
@@ -160,7 +160,7 @@ git+https://github.com/edx/edx-ora2.git@2.2.3#egg=ora2==2.2.3
 path.py==8.2.1
 pathtools==0.1.2
 paver==1.3.4
-pbr==5.4.0
+pbr==5.4.1
 pdfminer.six==20181108
 piexif==1.0.2
 pillow==6.1.0
@@ -185,7 +185,7 @@ python-dateutil==2.4.0
 python-levenshtein==0.12.0
 python-memcached==1.59
 python-openid==2.2.5 ; python_version == "2.7"  # via social-auth-core
-python-slugify==1.2.6     # via code-annotations, edx-enterprise
+python-slugify==1.2.6     # via code-annotations
 python-swiftclient==3.8.0
 python3-saml==1.5.0
 pytz==2019.1
@@ -199,14 +199,14 @@ requests==2.22.0
 rest-condition==1.0.3
 rfc6266-parser==0.0.5.post2
 ruamel.ordereddict==0.4.13 ; python_version == "2.7"  # via ruamel.yaml
-ruamel.yaml==0.15.99      # via drf-yasg
+ruamel.yaml==0.15.100     # via drf-yasg
 rules==2.0.1
 s3transfer==0.1.13        # via boto3
 sailthru-client==2.2.3
 scipy==1.2.1
-semantic-version==2.6.0   # via edx-drf-extensions, edx-enterprise
+semantic-version==2.6.0   # via edx-drf-extensions
 shapely==1.6.4.post2
-shortuuid==0.5.0          # via edx-django-oauth2-provider, edx-enterprise
+shortuuid==0.5.0          # via edx-django-oauth2-provider
 simplejson==3.16.0        # via mailsnake, sailthru-client, zendesk
 singledispatch==3.4.0.3
 six==1.11.0
@@ -219,19 +219,18 @@ soupsieve==1.9.2          # via beautifulsoup4
 sqlparse==0.3.0
 staff-graded-xblock==0.3
 stevedore==1.30.1
-super-csv==0.6
+super-csv==0.7
 sympy==1.4
 testfixtures==6.10.0      # via edx-enterprise
 tincan==0.0.5             # via edx-enterprise
 unicodecsv==0.14.1
-unidecode==1.1.1          # via edx-enterprise
 uritemplate==3.0.0        # via coreapi, drf-yasg
 urllib3==1.23
 user-util==0.1.5
 voluptuous==0.11.5
 watchdog==0.9.0
 web-fragments==0.3.0
-webencodings==0.5.1       # via edx-enterprise, html5lib
+webencodings==0.5.1       # via html5lib
 webob==1.8.5              # via xblock
 wrapt==1.10.5
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.1#egg=xblock-drag-and-drop-v2==2.2.1

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -14,7 +14,7 @@ certifi==2019.6.16        # via requests
 cffi==1.12.3              # via cryptography
 chardet==3.0.4            # via requests
 click==7.0                # via code-annotations
-code-annotations==0.3.1
+code-annotations==0.3.2
 cryptography==2.7
 defusedxml==0.5.0         # via djangorestframework-xml
 django-config-models==1.0.1
@@ -25,15 +25,15 @@ django-filter==1.0.4
 django-ipware==2.1.0
 django-model-utils==3.0.0
 django-multi-email-field==0.5.1
-django-object-actions==0.10.0
-django-simple-history==2.7.0
+django-object-actions==1.1.0
+django-simple-history==2.7.3
 django-waffle==0.12.0
 django==1.11.22
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
-djangorestframework-xml==1.3.0
+djangorestframework-xml==1.4.0
 djangorestframework==3.7.7
 edx-django-utils==2.0.0
-edx-drf-extensions==2.3.1
+edx-drf-extensions==2.3.5
 edx-opaque-keys[django]==1.0.1
 edx-rbac==0.2.1
 edx-rest-api-client==1.9.2
@@ -43,12 +43,12 @@ html5lib==1.0.1           # via bleach
 idna==2.8                 # via requests
 ipaddress==1.0.22         # via cryptography
 jinja2==2.10.1            # via code-annotations
-jsondiff==1.1.1
+jsondiff==1.2.0
 jsonfield==2.0.2
 kombu==3.0.37             # via celery
 newrelic==4.20.1.121      # via edx-django-utils
 path.py==8.2.1
-pbr==5.4.0                # via stevedore
+pbr==5.4.1                # via stevedore
 pillow==6.1.0
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 pyjwkest==1.3.2           # via edx-drf-extensions

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -18,7 +18,7 @@ certifi==2019.6.16
 cffi==1.12.3
 chardet==3.0.4
 click==7.0
-code-annotations==0.3.1
+code-annotations==0.3.2
 configparser==3.7.4       # via importlib-metadata
 contextlib2==0.5.5        # via importlib-metadata
 cookies==2.2.1            # via responses
@@ -35,15 +35,15 @@ django-filter==1.0.4
 django-ipware==2.1.0
 django-model-utils==3.0.0
 django-multi-email-field==0.5.1
-django-object-actions==0.10.0
-django-simple-history==2.7.0
+django-object-actions==1.1.0
+django-simple-history==2.7.3
 django-waffle==0.12.0
 django==1.11.22
 djangorestframework-jwt==1.11.0
-djangorestframework-xml==1.3.0
+djangorestframework-xml==1.4.0
 djangorestframework==3.7.7
 edx-django-utils==2.0.0
-edx-drf-extensions==2.3.1
+edx-drf-extensions==2.3.5
 edx-opaque-keys[django]==1.0.1
 edx-rbac==0.2.1
 edx-rest-api-client==1.9.2
@@ -61,7 +61,7 @@ inflect==2.1.0            # via jinja2-pluralize
 ipaddress==1.0.22
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.10.1
-jsondiff==1.1.1
+jsondiff==1.2.0
 jsonfield==2.0.2
 kombu==3.0.37
 markupsafe==1.1.1         # via jinja2
@@ -71,7 +71,7 @@ newrelic==4.20.1.121
 packaging==19.0           # via pytest
 path.py==8.2.1
 pathlib2==2.3.4           # via importlib-metadata, pytest, pytest-django
-pbr==5.4.0
+pbr==5.4.1
 pillow==6.1.0
 pluggy==0.12.0            # via pytest
 psutil==1.2.1
@@ -82,7 +82,7 @@ pygments==2.4.2           # via diff-cover
 pyjwkest==1.3.2
 pyjwt==1.5.2
 pymongo==2.9.1
-pyparsing==2.4.0          # via packaging
+pyparsing==2.4.1          # via packaging
 pytest-catchlog==1.2.2
 pytest-cov==2.7.1
 pytest-django==3.5.1

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -17,7 +17,7 @@ packaging==19.0           # via tox
 pathlib2==2.3.4           # via importlib-metadata
 pluggy==0.12.0            # via tox
 py==1.8.0                 # via tox
-pyparsing==2.4.0          # via packaging
+pyparsing==2.4.1          # via packaging
 requests==2.22.0          # via codecov
 scandir==1.10.0           # via pathlib2
 six==1.12.0               # via packaging, pathlib2, tox


### PR DESCRIPTION
**Description:** This upgrades the edx-rbac to latest version and as a result of this upgrade we are using jwt utils from edx-drf-extensions package because those jwt utils are now removed from edx-rbac.
 
**JIRA:** [ENT-2002](https://openedx.atlassian.net/browse/ENT-2002)