### PR TITLE
Don't use pinned requirements

### DIFF
--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.6.23"
+__version__ = "1.6.24"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ base_path = os.path.dirname(__file__)
 
 README = open(os.path.join(base_path, "README.rst")).read()
 CHANGELOG = open(os.path.join(base_path, "CHANGELOG.rst")).read()
-REQUIREMENTS, DEPENDENCY_LINKS = get_requirements(os.path.join(base_path, 'requirements', 'base.txt'))
+REQUIREMENTS, DEPENDENCY_LINKS = get_requirements(os.path.join(base_path, 'requirements', 'base.in'))
 
 setup(
     name="edx-enterprise",


### PR DESCRIPTION
The strict requirements in base.txt are causing edx-platform's `make upgrade` to fail. This changes the requirements to use base.in, instead.