### PR TITLE
Resolving conflicts in make upgrade

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[1.7.0] - 2019-07-15
+--------------------
+
+* Pin certain constraints from edx-platform so that edx-enterprise will install properly there.
+
 [1.6.23] - 2019-07-15
 ---------------------
 

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ check_pins: ## check that our local copy of edx-platform pins is accurate
 	echo "### DON'T edit this file, it's copied from edx-platform. See make upgrade" > $(LOCAL_EDX_PINS)
 	curl -fsSL https://raw.githubusercontent.com/edx/edx-platform/master/requirements/edx/base.txt | grep -v '^-e' >> $(LOCAL_EDX_PINS)
 	python requirements/check_pins.py requirements/test-master.in $(LOCAL_EDX_PINS)
+	python requirements/check_pins.py requirements/base.txt $(LOCAL_EDX_PINS)
 
 upgrade: export CUSTOM_COMPILE_COMMAND=make upgrade
 upgrade: check_pins	## update the requirements/*.txt files with the latest packages satisfying requirements/*.in

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.6.23"
+__version__ = "1.7.0"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -18,7 +18,7 @@ chardet==3.0.4            # via requests
 click==7.0                # via code-annotations
 code-annotations==0.3.1
 cryptography==2.7
-defusedxml==0.6.0         # via djangorestframework-xml
+defusedxml==0.5.0
 django-config-models==1.0.1
 django-countries==4.6.1
 django-crum==0.7.3        # via edx-rbac
@@ -30,7 +30,7 @@ django-multi-email-field==0.5.1
 django-object-actions==0.10.0
 django-simple-history==2.7.0
 django-waffle==0.12.0
-django==1.11.21
+django==1.11.22
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4bc70c03de308a277197c#egg=djangorestframework-oauth==1.1.1
 djangorestframework-xml==1.3.0
@@ -54,15 +54,15 @@ markupsafe==1.1.1         # via jinja2
 newrelic==4.20.1.121      # via edx-django-utils
 path.py==8.2.1
 pbr==5.4.0                # via stevedore
-pillow==5.4.1
+pillow==6.1.0
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 pycparser==2.19           # via cffi
-pycryptodomex==3.8.2      # via pyjwkest
+pycryptodomex==3.4.7
 pyjwkest==1.3.2           # via edx-drf-extensions
-pyjwt==1.7.1              # via djangorestframework-jwt, edx-rest-api-client
-pymongo==3.8.0            # via edx-opaque-keys
+pyjwt==1.5.2
+pymongo==2.9.1
 python-dateutil==2.4.0
-python-slugify==3.0.2     # via code-annotations
+python-slugify==1.2.6
 pytz==2019.1
 pyyaml==5.1.1             # via code-annotations
 requests==2.22.0
@@ -70,11 +70,11 @@ rest-condition==1.0.3     # via edx-drf-extensions
 rules==2.0.1
 semantic-version==2.6.0   # via edx-drf-extensions
 shortuuid==0.5.0          # via edx-django-oauth2-provider
-six==1.12.0               # via bleach, cryptography, edx-drf-extensions, edx-opaque-keys, edx-rbac, html5lib, pyjwkest, python-dateutil, stevedore
+six==1.11.0
 slumber==0.7.1            # via edx-rest-api-client
 stevedore==1.30.1         # via code-annotations, edx-opaque-keys
 testfixtures==6.10.0
-text-unidecode==1.2       # via python-slugify
 unicodecsv==0.14.1
-urllib3==1.25.3           # via requests
+unidecode==1.1.1          # via python-slugify
+urllib3==1.23
 webencodings==0.5.1       # via html5lib

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -32,7 +32,7 @@ cookies==2.2.1
 coverage==4.5.3
 cryptography==2.7
 ddt==1.2.1
-defusedxml==0.6.0
+defusedxml==0.5.0
 diff-cover==2.3.0
 distlib==0.2.9.post0      # via caniusepython3
 django-config-models==1.0.1
@@ -46,7 +46,7 @@ django-multi-email-field==0.5.1
 django-object-actions==0.10.0
 django-simple-history==2.7.0
 django-waffle==0.12.0
-django==1.11.21
+django==1.11.22
 djangorestframework-jwt==1.11.0
 git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4bc70c03de308a277197c#egg=djangorestframework-oauth==1.1.1
 djangorestframework-xml==1.3.0
@@ -64,7 +64,7 @@ edx-rest-api-client==1.9.2
 edx-sphinx-theme==1.5.0
 enum34==1.1.6
 factory-boy==2.12.0
-faker==1.0.7
+faker==2.0.0
 filelock==3.0.12          # via tox
 flaky==3.6.0
 freezegun==0.3.12
@@ -93,7 +93,7 @@ packaging==19.0
 path.py==8.2.1
 pathlib2==2.3.4
 pbr==5.4.0
-pillow==5.4.1
+pillow==6.1.0
 pip-tools==3.8.0
 pkginfo==1.5.0.1          # via twine
 pluggy==0.12.0
@@ -103,23 +103,23 @@ psutil==1.2.1
 py==1.8.0
 pycodestyle==2.5.0
 pycparser==2.19
-pycryptodomex==3.8.2
+pycryptodomex==3.4.7
 pydocstyle==3.0.0
 pygments==2.4.2
 pyjwkest==1.3.2
-pyjwt==1.7.1
+pyjwt==1.5.2
 pylint-celery==0.3        # via edx-lint
 pylint-django==0.7.2      # via edx-lint
 pylint-plugin-utils==0.5  # via pylint-celery, pylint-django
 pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pymongo==3.8.0
+pymongo==2.9.1
 pyparsing==2.4.0
 pytest-catchlog==1.2.2
 pytest-cov==2.7.1
 pytest-django==3.5.1
 pytest==4.6.4
 python-dateutil==2.4.0
-python-slugify==3.0.2
+python-slugify==1.2.6
 pytz==2019.1
 pyyaml==5.1.1
 readme-renderer==24.0
@@ -133,7 +133,7 @@ scandir==1.10.0
 semantic-version==2.6.0
 shortuuid==0.5.0
 singledispatch==3.4.0.3   # via astroid, pylint
-six==1.12.0
+six==1.11.0
 slumber==0.7.1
 snowballstemmer==1.9.0
 sphinx==1.8.5
@@ -149,13 +149,11 @@ tqdm==4.32.2              # via twine
 twine==1.11.0
 typing==3.7.4
 unicodecsv==0.14.1
-urllib3==1.25.3
+unidecode==1.1.1
+urllib3==1.23
 virtualenv==16.6.2        # via tox
 wcwidth==0.1.7
 webencodings==0.5.1
 wheel==0.33.4
 wrapt==1.11.2             # via astroid
 zipp==0.5.2
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.0.1        # via caniusepython3, sphinx, twine

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -20,7 +20,7 @@ chardet==3.0.4
 click==7.0
 code-annotations==0.3.1
 cryptography==2.7
-defusedxml==0.6.0
+defusedxml==0.5.0
 django-config-models==1.0.1
 django-countries==4.6.1
 django-crum==0.7.3
@@ -32,7 +32,7 @@ django-multi-email-field==0.5.1
 django-object-actions==0.10.0
 django-simple-history==2.7.0
 django-waffle==0.12.0
-django==1.11.21
+django==1.11.22
 djangorestframework-jwt==1.11.0
 git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4bc70c03de308a277197c#egg=djangorestframework-oauth==1.1.1
 djangorestframework-xml==1.3.0
@@ -61,18 +61,18 @@ newrelic==4.20.1.121
 packaging==19.0           # via sphinx
 path.py==8.2.1
 pbr==5.4.0
-pillow==5.4.1
+pillow==6.1.0
 pockets==0.7.2            # via sphinxcontrib-napoleon
 psutil==1.2.1
 pycparser==2.19
-pycryptodomex==3.8.2
+pycryptodomex==3.4.7
 pygments==2.4.2           # via readme-renderer, sphinx
 pyjwkest==1.3.2
-pyjwt==1.7.1
-pymongo==3.8.0
+pyjwt==1.5.2
+pymongo==2.9.1
 pyparsing==2.4.0          # via packaging
 python-dateutil==2.4.0
-python-slugify==3.0.2
+python-slugify==1.2.6
 pytz==2019.1
 pyyaml==5.1.1
 readme-renderer==24.0
@@ -82,7 +82,7 @@ restructuredtext-lint==1.3.0  # via doc8
 rules==2.0.1
 semantic-version==2.6.0
 shortuuid==0.5.0
-six==1.12.0
+six==1.11.0
 slumber==0.7.1
 snowballstemmer==1.9.0    # via sphinx
 sphinx==1.8.5
@@ -90,11 +90,8 @@ sphinxcontrib-napoleon==0.6.1
 sphinxcontrib-websupport==1.1.2  # via sphinx
 stevedore==1.30.1
 testfixtures==6.10.0
-text-unidecode==1.2
 typing==3.7.4             # via sphinx
 unicodecsv==0.14.1
-urllib3==1.25.3
+unidecode==1.1.1
+urllib3==1.23
 webencodings==0.5.1
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.0.1        # via sphinx

--- a/requirements/edx-platform-constraints.txt
+++ b/requirements/edx-platform-constraints.txt
@@ -97,7 +97,7 @@ edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==1.0.1
 edx-organizations==2.0.3
 edx-proctoring-proctortrack==1.0.5
-edx-proctoring==2.0.5
+edx-proctoring==2.0.6
 edx-rbac==0.2.1           # via edx-enterprise
 edx-rest-api-client==1.9.2
 edx-search==1.2.2

--- a/requirements/js_test.txt
+++ b/requirements/js_test.txt
@@ -24,6 +24,3 @@ selenium==3.6.0           # via jasmine
 six==1.12.0               # via cheroot, cherrypy, jasmine, more-itertools, tempora
 tempora==1.14.1           # via portend
 zc.lockfile==1.4          # via cherrypy
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.0.1        # via zc.lockfile

--- a/requirements/test-master.in
+++ b/requirements/test-master.in
@@ -3,7 +3,7 @@
 
 celery==3.1.25                          # Run task workers in other locations
 cryptography==2.7                       # For random password generation
-django==1.11.21                         # Application server
+django==1.11.22                         # Application server
 djangorestframework==3.7.7              # REST API extensions for Django
 git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4bc70c03de308a277197c#egg=djangorestframework-oauth==1.1.1
                                         # For enterprise REST API endpoint
@@ -15,7 +15,6 @@ edx-django-oauth2-provider==1.3.5       # edx Django OAuth2 provider
 edx-drf-extensions                      # edX extensions to django rest framework
 edx-opaque-keys[django]==1.0.1          # edX plugins for handling course keys
 unicodecsv==0.14.1                      # Allows exporting CSV with unicode support (a drop-in replacement for built-in csv module)
-Pillow==5.4.1                           # Image manipulation module, required to use ImageField
 django-simple-history==2.7.0            # History for Django models
 edx-rest-api-client==1.9.2              # For accessing the Enrollment API (and possibly other edX APIs)
 django-config-models==1.0.1
@@ -35,6 +34,14 @@ html5lib==1.0.1
 path.py==8.2.1
 python-dateutil==2.4.0
 pytz==2019.1
+defusedxml==0.5.0                       # Pinned because it is implicitly constrained by another package in edx-platform.
+pycryptodomex==3.4.7                    # Pinned because it is explicitly constrained in edx-platform.
+pyjwt==1.5.2                            # Pinned because it is implicitly constrained by another package in edx-platform.
+six==1.11.0                             # Pinned because it is explicitly constrained in edx-platform.
+pymongo==2.9.1                          # Pinned because it is implicitly constrained by another package in edx-platform.
+urllib3==1.23                           # Pinned because it is explicitly constrained in edx-platform.
+pillow==6.1.0                           # We used to constrain this to an earlier version, updating to match edx-platform.
+python-slugify==1.2.6                   # Pinned because it is explicitly constrained in edx-platform.
 
 # other
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -25,7 +25,7 @@ cookies==2.2.1            # via responses
 coverage==4.5.3           # via pytest-cov
 cryptography==2.7
 ddt==1.2.1
-defusedxml==0.6.0
+defusedxml==0.5.0
 diff-cover==2.3.0
 django-config-models==1.0.1
 django-countries==4.6.1
@@ -38,7 +38,7 @@ django-multi-email-field==0.5.1
 django-object-actions==0.10.0
 django-simple-history==2.7.0
 django-waffle==0.12.0
-django==1.11.21
+django==1.11.22
 djangorestframework-jwt==1.11.0
 git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4bc70c03de308a277197c#egg=djangorestframework-oauth==1.1.1
 djangorestframework-xml==1.3.0
@@ -51,7 +51,7 @@ edx-rbac==0.2.1
 edx-rest-api-client==1.9.2
 enum34==1.1.6
 factory-boy==2.12.0
-faker==1.0.7              # via factory-boy
+faker==2.0.0              # via factory-boy
 flaky==3.6.0
 freezegun==0.3.12
 funcsigs==1.0.2           # via mock, pytest
@@ -74,23 +74,23 @@ packaging==19.0           # via pytest
 path.py==8.2.1
 pathlib2==2.3.4           # via importlib-metadata, pytest, pytest-django
 pbr==5.4.0
-pillow==5.4.1
+pillow==6.1.0
 pluggy==0.12.0            # via pytest
 psutil==1.2.1
 py==1.8.0                 # via pytest, pytest-catchlog
 pycparser==2.19
-pycryptodomex==3.8.2
+pycryptodomex==3.4.7
 pygments==2.4.2           # via diff-cover
 pyjwkest==1.3.2
-pyjwt==1.7.1
-pymongo==3.8.0
+pyjwt==1.5.2
+pymongo==2.9.1
 pyparsing==2.4.0          # via packaging
 pytest-catchlog==1.2.2
 pytest-cov==2.7.1
 pytest-django==3.5.1
 pytest==4.6.4             # via pytest-catchlog, pytest-cov, pytest-django
 python-dateutil==2.4.0
-python-slugify==3.0.2
+python-slugify==1.2.6
 pytz==2019.1
 pyyaml==5.1.1
 requests==2.22.0
@@ -100,13 +100,14 @@ rules==2.0.1
 scandir==1.10.0           # via pathlib2
 semantic-version==2.6.0
 shortuuid==0.5.0
-six==1.12.0
+six==1.11.0
 slumber==0.7.1
 stevedore==1.30.1
 testfixtures==6.10.0
-text-unidecode==1.2
+text-unidecode==1.2       # via faker
 unicodecsv==0.14.1
-urllib3==1.25.3
+unidecode==1.1.1
+urllib3==1.23
 wcwidth==0.1.7            # via pytest
 webencodings==0.5.1
 zipp==0.5.2               # via importlib-metadata


### PR DESCRIPTION
**Description:**
tl;dr, we should find a way to stop pinning as many dependencies as we can to avoid update conflicts with edx-platform.

Longer:
I started by running make upgrade in edx-platform against this branch, and adding things that failed as a constraint in requirements/test-master.in, and then running make upgrade in edx-enterprise, then repeating the process. There were several issues going on, but the main problem is that we are trying to stay in sync with edx-platform, but we pin explicitly when a package is upgraded, and it may be constrained for some reason in edx-platform. It took a while to come to this, and there is a corresponding change necessary in edx-platform because of transifex-client, which we would have had to resolve anyway in edx-platform.

Here is the corresponding edx-platform branch I used to test make upgrade: https://github.com/edx/edx-platform/pull/21132

**Merge deadline:** ASAP - we are blocking make upgrade from being run without errors in edx-platform.

**Merge checklist:**

- [ ] New requirements are in the right place
    - `base.in` if needed in production, but edx-platform doesn't install it.
    - `test-master.in` if edx-platform pins it, with a matching version.
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
