### PR TITLE
WL-1952 | Cornerstone consumer expects course list API to have default values for all required fields

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,12 @@ Change Log
 
 Unreleased
 ----------
+
+[1.8.7] - 2019-07-31
+--------------------
+
 * Added history models for PendingEnrollment and PendingEnterpriseCustomerUser.
+* Sending default values for required fields in Cornerstone Course List API
 
 [1.8.6] - 2019-07-25
 --------------------

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.8.6"
+__version__ = "1.8.7"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/cornerstone/exporters/content_metadata.py
+++ b/integrated_channels/cornerstone/exporters/content_metadata.py
@@ -25,6 +25,9 @@ class CornerstoneContentMetadataExporter(ContentMetadataExporter):  # pylint: di
     """
     LONG_STRING_LIMIT = 10000
     DEFAULT_SUBJECT = "Industry Specific"
+    DEFAULT_OWNER = {
+        "Name": "edX: edX Inc"
+    }
     DATA_TRANSFORM_MAPPING = {
         'ID': 'key',
         'Title': 'title',
@@ -49,7 +52,7 @@ class CornerstoneContentMetadataExporter(ContentMetadataExporter):  # pylint: di
         for org in content_metadata_item.get('organizations', []):
             org_name = org[:500] if org else ''
             owners.append({"Name": org_name})
-        return owners
+        return owners or [self.DEFAULT_OWNER]
 
     def transform_is_active(self, content_metadata_item):
         """
@@ -127,4 +130,4 @@ class CornerstoneContentMetadataExporter(ContentMetadataExporter):  # pylint: di
             for cornerstone_subject, edx_subjects in subjects_mapping_dict.items():
                 if subject.lower() in [edx_subject.lower() for edx_subject in edx_subjects]:
                     subjects.append(cornerstone_subject)
-        return list(set(subjects)) or [self.DEFAULT_SUBJECT] if course_subjects else []
+        return list(set(subjects)) or [self.DEFAULT_SUBJECT]

--- a/tests/test_integrated_channels/test_cornerstone/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_cornerstone/test_exporters/test_content_metadata.py
@@ -22,6 +22,9 @@ from test_utils.fake_catalog_api import FAKE_SEARCH_ALL_COURSE_RESULT_3
 from test_utils.fake_enterprise_api import EnterpriseMockMixin
 
 NOW = datetime.datetime.now(pytz.UTC)
+DEFAULT_OWNER = {
+    "Name": "edX: edX Inc"
+}
 LONG_ORG_NAME = "Very long org name, Very long org name, Very long org name, Very long org name, " \
                 "Very long org name, Very long org name, Very long org name, Very long org name, " \
                 "Very long org name, Very long org name, Very long org name, Very long org name, " \
@@ -448,11 +451,11 @@ class TestCornerstoneContentMetadataExporter(unittest.TestCase, EnterpriseMockMi
     @ddt.data(
         (
             {'organizations': []},
-            [],
+            [DEFAULT_OWNER],
         ),
         (
             {'organizations': 'undefined'},
-            [],
+            [DEFAULT_OWNER],
         ),
         (
             None,
@@ -494,7 +497,7 @@ class TestCornerstoneContentMetadataExporter(unittest.TestCase, EnterpriseMockMi
             {
                 'subjects': []
             },
-            []
+            ["Industry Specific"]
         ),
     )
     @responses.activate

--- a/tests/test_integrated_channels/test_cornerstone/test_views.py
+++ b/tests/test_integrated_channels/test_cornerstone/test_views.py
@@ -103,3 +103,9 @@ class TestCornerstoneCoursesListView(APITest, EnterpriseMockMixin):
         ]
         for key in expected_keys:
             self.assertIn(key, keys)
+
+        # required fields should not be empty
+        required_keys = ["Owners", "Languages", "Subjects"]
+        for item in response.data:
+            for key in required_keys:
+                self.assertTrue(item[key])


### PR DESCRIPTION

**Description:** Describe in a couple of sentence what this PR adds

Cornerstone consumer was expecting course list API to have default values for all required fields
Now we are returning default values for required fields in Cornerstone Course List API

**JIRA:** https://openedx.atlassian.net/browse/WL-1952

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Merge checklist:**

- [ ] New requirements are in the right place
    - `base.in` if needed in production, but edx-platform doesn't install it.
    - `test-master.in` if edx-platform pins it, with a matching version.
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
