### PR TITLE
WL-1952 | Handle corner cases for default values in CornerstoneCourseListAPI.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ----------
 
+[1.8.8] - 2019-08-01
+--------------------
+
+* For CornerstoneCourseListAPI handled corner cases for default values.
+
+
 [1.8.7] - 2019-07-31
 --------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.8.7"
+__version__ = "1.8.8"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/cornerstone/exporters/content_metadata.py
+++ b/integrated_channels/cornerstone/exporters/content_metadata.py
@@ -25,6 +25,7 @@ class CornerstoneContentMetadataExporter(ContentMetadataExporter):  # pylint: di
     """
     LONG_STRING_LIMIT = 10000
     DEFAULT_SUBJECT = "Industry Specific"
+    DEFAULT_LANGUAGE = "English"
     DEFAULT_OWNER = {
         "Name": "edX: edX Inc"
     }
@@ -47,9 +48,10 @@ class CornerstoneContentMetadataExporter(ContentMetadataExporter):  # pylint: di
         """
         Return the transformed version of the course organizations
         by converting each organization into cornerstone course owner object.
+        or default Onwer if no owner found
         """
         owners = []
-        for org in content_metadata_item.get('organizations', []):
+        for org in content_metadata_item.get('organizations') or []:
             org_name = org[:500] if org else ''
             owners.append({"Name": org_name})
         return owners or [self.DEFAULT_OWNER]
@@ -100,7 +102,7 @@ class CornerstoneContentMetadataExporter(ContentMetadataExporter):  # pylint: di
         """
         Return the languages supported by course or `English` as default if no languages found.
         """
-        languages = content_metadata_item.get('languages', ['English'])
+        languages = content_metadata_item.get('languages') or [self.DEFAULT_LANGUAGE]
         return [get_language_code(language) for language in languages]
 
     def transform_description(self, content_metadata_item):
@@ -117,10 +119,10 @@ class CornerstoneContentMetadataExporter(ContentMetadataExporter):  # pylint: di
 
     def transform_subjects(self, content_metadata_item):
         """
-        Return the transformed version of the course subject list.
+        Return the transformed version of the course subject list or default value if no subject found.
         """
         subjects = []
-        course_subjects = content_metadata_item.get('subjects', [])
+        course_subjects = content_metadata_item.get('subjects') or []
         CornerstoneGlobalConfiguration = apps.get_model(  # pylint: disable=invalid-name
             'cornerstone',
             'CornerstoneGlobalConfiguration'

--- a/tests/test_integrated_channels/test_cornerstone/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_cornerstone/test_exporters/test_content_metadata.py
@@ -430,7 +430,15 @@ class TestCornerstoneContentMetadataExporter(unittest.TestCase, EnterpriseMockMi
             ['en-US'],
         ),
         (
+            {'languages': []},
+            ['en-US'],
+        ),
+        (
             {'languages': 'undefined'},
+            ['en-US'],
+        ),
+        (
+            {'languages': None},
             ['en-US'],
         ),
         (
@@ -455,6 +463,10 @@ class TestCornerstoneContentMetadataExporter(unittest.TestCase, EnterpriseMockMi
         ),
         (
             {'organizations': 'undefined'},
+            [DEFAULT_OWNER],
+        ),
+        (
+            {'organizations': None},
             [DEFAULT_OWNER],
         ),
         (
@@ -496,6 +508,12 @@ class TestCornerstoneContentMetadataExporter(unittest.TestCase, EnterpriseMockMi
         (
             {
                 'subjects': []
+            },
+            ["Industry Specific"]
+        ),
+        (
+            {
+                'subjects': None
             },
             ["Industry Specific"]
         ),


### PR DESCRIPTION
**Description:** Handle corner cases for default values in CornerstoneCourseListAPI.

**JIRA:** https://openedx.atlassian.net/browse/WL-1952
**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Merge checklist:**

- [ ] New requirements are in the right place
    - `base.in` if needed in production, but edx-platform doesn't install it.
    - `test-master.in` if edx-platform pins it, with a matching version.
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
