### PR TITLE
create ecommerce order data upon successful manual learner course enrollment

### DIFF
--- a/enterprise/api_client/ecommerce.py
+++ b/enterprise/api_client/ecommerce.py
@@ -5,6 +5,7 @@ Client for communicating with the E-Commerce API.
 from __future__ import absolute_import, unicode_literals
 
 import logging
+from functools import reduce  # pylint: disable=redefined-builtin
 
 from requests.exceptions import ConnectionError, Timeout  # pylint: disable=redefined-builtin
 from slumber.exceptions import SlumberBaseException
@@ -102,5 +103,24 @@ class EcommerceApiClient(object):
                 enrolled_learner_email,
                 enrolled_course_run_key,
                 exc
+            )
+            raise exc
+
+    def fail_order_for_manual_course_enrollment(self, order_id):
+        """
+        Fail an existing completed ecommerce order.
+        """
+        resource = 'manual_course_enrollment_order'
+        path = [resource, str(order_id)]
+        order = reduce(getattr, path, self.client)
+
+        try:
+            return order.fail.put({
+                'reason': "Learner's manual course enrollment failed"
+            })
+        except (SlumberBaseException, ConnectionError, Timeout) as exc:
+            LOGGER.exception(
+                '[Enterprise Manual Course Enrollment] Failed to update ecommerce order. Exception occurred: '
+                'OrderId: %s, Exception: %s', order_id, exc
             )
             raise exc

--- a/enterprise/api_client/lms.py
+++ b/enterprise/api_client/lms.py
@@ -209,7 +209,33 @@ class EnrollmentApiClient(LmsApiClient):
         course_modes = self.get_course_modes(course_run_id)
         return any(course_mode for course_mode in course_modes if course_mode['slug'] == mode)
 
-    def enroll_user_in_course(self, username, course_id, mode, cohort=None):
+    def enroll_user_in_course(self, username, course_id, mode, cohort=None, enrollment_attributes=None):
+        """
+        Call the enrollment API to enroll the user in the course specified by course_id.
+
+        Args:
+            username (str): The username by which the user goes on the OpenEdX platform
+            course_id (str): The string value of the course's unique identifier
+            mode (str): The enrollment mode which should be used for the enrollment
+            cohort (str): Add the user to this named cohort
+            enrollment_attrs: List that contains enrollment attributes for course enrollment
+
+        Returns:
+            dict: A dictionary containing details of the enrollment, including course details, mode, username, etc.
+
+        """
+        data = {
+            'user': username,
+            'course_details': {'course_id': course_id},
+            'mode': mode,
+            'cohort': cohort,
+        }
+        if enrollment_attributes:
+            data['enrollment_attributes'] = enrollment_attributes
+
+        return self.client.enrollment.post(data)
+
+    def update_course_enrollment(self, username, course_id, mode, attrs):
         """
         Call the enrollment API to enroll the user in the course specified by course_id.
 
@@ -228,7 +254,7 @@ class EnrollmentApiClient(LmsApiClient):
                 'user': username,
                 'course_details': {'course_id': course_id},
                 'mode': mode,
-                'cohort': cohort,
+                'enrollment_attributes': attrs,
             }
         )
 

--- a/tests/test_admin/test_view.py
+++ b/tests/test_admin/test_view.py
@@ -27,7 +27,6 @@ from enterprise.admin import (
 )
 from enterprise.admin.forms import ManageLearnersForm, TransmitEnterpriseCoursesForm
 from enterprise.admin.utils import ValidationMessages, get_course_runs_from_program
-from enterprise.api_client.ecommerce import EcommerceApiClient
 from enterprise.constants import PAGE_SIZE
 from enterprise.django_compatibility import reverse
 from enterprise.models import (
@@ -175,7 +174,7 @@ class BaseTestEnterpriseCustomerManageLearnersView(TestCase):
         self.ecommerce_service_user = UserFactory(username=settings.ECOMMERCE_SERVICE_WORKER_USERNAME)
 
         patcher = mock.patch.multiple(
-            'enterprise.admin.views',
+            'enterprise.utils',
             CourseEnrollment=mock.DEFAULT,
             CourseEnrollmentAttribute=mock.DEFAULT
         )
@@ -1132,25 +1131,6 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
         self._assert_django_messages(response, set([
             (messages.ERROR, "The following learners could not be enrolled in Program2: {}".format(user.email)),
         ]))
-
-    @ddt.unpack
-    @ddt.data(
-        {'ecomm_response': {u'order_number': u'EDX-100100'}, 'view_util_response': True},
-        {'ecomm_response': {}, 'view_util_response': False},
-    )
-    @mock.patch("enterprise.api_client.ecommerce.ecommerce_api_client")
-    def test_create_order_data_for_learner_enrollment(
-            self, mock_ecommerce_api_client, ecomm_response, view_util_response
-    ):
-        """
-        Tests that `create_order_data_for_learner_enrollment` works as expected.
-        """
-        self._mock_ecommerce_api_client(client_mock=mock_ecommerce_api_client, return_value=ecomm_response)
-        result = EnterpriseCustomerManageLearnersView().create_order_data_for_learner_enrollment(
-            EcommerceApiClient(), self.user, 'course-v1:TestX+Test100+2019_T1'
-        )
-
-        assert result == view_util_response
 
     @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.api_client.ecommerce.ecommerce_api_client")

--- a/tests/test_enterprise/api_client/test_ecommerce.py
+++ b/tests/test_enterprise/api_client/test_ecommerce.py
@@ -10,7 +10,9 @@ import unittest
 import ddt
 import mock
 from pytest import mark, raises
+from requests.exceptions import Timeout
 
+from django.conf import settings
 from django.contrib.auth.models import User
 
 from enterprise.api_client.ecommerce import EcommerceApiClient
@@ -39,13 +41,14 @@ class TestEcommerceApiClient(unittest.TestCase):
     def setUp(self):
         super(TestEcommerceApiClient, self).setUp()
         self.user = factories.UserFactory()
+        self.ecommerce_service_user = factories.UserFactory(username=settings.ECOMMERCE_SERVICE_WORKER_USERNAME)
 
-    def _setup_ecommerce_api_client(self, client_mock, method_name, return_value):
+    def _setup_ecommerce_api_client(self, client_mock, method_name, return_value, side_effect=None):
         """
         Sets up the E-Commerce API client
         """
         mocked_attributes = {
-            method_name: mock.MagicMock(return_value=return_value),
+            method_name: mock.MagicMock(return_value=return_value, side_effect=side_effect),
         }
         api_mock = mock.MagicMock(**mocked_attributes)
 
@@ -66,3 +69,34 @@ class TestEcommerceApiClient(unittest.TestCase):
             }
         )
         assert EcommerceApiClient(self.user).get_course_final_price(mode) == '$100'
+
+    @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
+    def test_create_ecommerce_order_for_manual_course_enrollment_post_success(self, ecommerce_api_client_mock):
+        """
+        Test that `create_ecommerce_order_for_manual_course_enrollment` returns expected response in case of success.
+        """
+        return_value = {'order_number': 'EDX-100100'}
+        self._setup_ecommerce_api_client(
+            client_mock=ecommerce_api_client_mock,
+            method_name='manual_course_enrollment_order.post',
+            return_value=return_value
+        )
+        assert EcommerceApiClient().create_ecommerce_order_for_manual_course_enrollment(1, '', '', '') == return_value
+
+    @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
+    def test_create_ecommerce_order_for_manual_course_enrollment_post_fail(self, ecommerce_api_client_mock):
+        """
+        Test that `create_ecommerce_order_for_manual_course_enrollment` returns expected response in case of exception.
+        """
+        self._setup_ecommerce_api_client(
+            client_mock=ecommerce_api_client_mock,
+            method_name='manual_course_enrollment_order.post',
+            return_value={},
+            side_effect=Timeout()
+        )
+
+        with mock.patch('enterprise.api_client.ecommerce.LOGGER.exception') as mock_logger:
+            assert EcommerceApiClient().create_ecommerce_order_for_manual_course_enrollment(
+                1, 'bat', 'bat@example.com', 'course-v1:HarvardX+CoolScience+2016'
+            ) is None
+            assert mock_logger.called


### PR DESCRIPTION
**Description:** Create ecommerce order record for successful enrollment of a learner through the `manage_learners` admin page.

**JIRA:** https://openedx.atlassian.net/browse/ENT-2081

**Dependencies:** https://github.com/edx/ecommerce/pull/2520

**Sandbox:**
- [Manage Learners Admin Page](https://mammar.sandbox.edx.org/admin/enterprise/enterprisecustomer/cc8a0260-36d0-4520-8e1a-154d0431aa9c/change/)
- [Ecommerce Order Page](https://ecommerce-mammar.sandbox.edx.org/dashboard/orders/)

**Testing:**
1. Go to manage learners page
2. Enroll single or multiple learners. Enrollment should be successful.
3. Go to ecommerce orders page.
4. You should see an order with correct data for the learner enrolled.

**Single Enrollment Order Creation Failure Message**
<img width="1439" alt="Screenshot 2019-08-21 at 4 45 08 PM" src="https://user-images.githubusercontent.com/6767924/63429640-10c1f180-c434-11e9-8abf-479710278de0.png">


**Bulk Enrollment Order Creation Failure Message**
<img width="1440" alt="Screenshot 2019-08-21 at 4 48 17 PM" src="https://user-images.githubusercontent.com/6767924/63429655-1c151d00-c434-11e9-9c9f-80bc2773d228.png">
