### PR TITLE
ENT-1321 Fix version increment

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ----------
 
+[1.9.3] - 2019-08-20
+--------------------
+
+* Fix for include course run dates and pacing type in the course description sent to SAP. Prior release (1.9.2) did
+not include bumping the version in __init__.py.
+
 [1.9.2] - 2019-08-20
 --------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,8 +17,7 @@ Unreleased
 [1.9.3] - 2019-08-20
 --------------------
 
-* Fix for include course run dates and pacing type in the course description sent to SAP. Prior release (1.9.2) did
-not include bumping the version in __init__.py.
+* Fix for include course run dates and pacing type in the course description sent to SAP. Prior release (1.9.2) did not include bumping the version in __init__.py.
 
 [1.9.2] - 2019-08-20
 --------------------

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.9.1"
+__version__ = "1.9.3"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name


### PR DESCRIPTION
**Description:** In the prior release (1.9.2) I forgot to increment the version in ___init__.py_ (or lost the increment in a rebase). Since I already tagged 1.9.2 in github, making a new release of 1.9.3 seems cleanest.

**JIRA:** https://openedx.atlassian.net/browse/ENT-1321

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Merge checklist:**

- [ ] New requirements are in the right place
    - `base.in` if needed in production, but edx-platform doesn't install it.
    - `test-master.in` if edx-platform pins it, with a matching version.
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
