### PR TITLE
ENT-2203 Update learner portal enterprise enrollments endpoint to filter on enterprise_id

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[1.9.9] - 2019-08-29
+--------------------
+
+* Updated learner portal enrollments endpoint to require an enterprise id.
+
 [1.9.8] - 2019-08-29
 --------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.9.8"
+__version__ = "1.9.9"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise_learner_portal/api/v1/views.py
+++ b/enterprise_learner_portal/api/v1/views.py
@@ -9,6 +9,7 @@ from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthenticat
 from rest_framework import permissions
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.response import Response
+from rest_framework.status import HTTP_400_BAD_REQUEST
 from rest_framework.views import APIView
 
 from django.shortcuts import get_object_or_404
@@ -42,9 +43,17 @@ class EnterpriseCourseEnrollmentView(APIView):
             )
 
         user = request.user
+        enterprise_customer_id = request.query_params.get('enterprise_id', None)
+        if not enterprise_customer_id:
+            return Response(
+                {'error': 'enterprise_id must be provided as a query parameter'},
+                status=HTTP_400_BAD_REQUEST
+            )
+
         enterprise_customer_user = get_object_or_404(
             EnterpriseCustomerUser,
-            user_id=user.id
+            user_id=user.id,
+            enterprise_customer__uuid=enterprise_customer_id,
         )
         course_ids_for_ent_enrollments = EnterpriseCourseEnrollment.objects.filter(
             enterprise_customer_user=enterprise_customer_user

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -26,10 +26,10 @@ chardet==3.0.4
 click-log==0.3.2          # via edx-lint
 click==7.0
 code-annotations==0.3.2
-configparser==3.7.4
+configparser==3.8.1
 contextlib2==0.5.5
 cookies==2.2.1
-coverage==4.5.3
+coverage==4.5.4
 cryptography==2.7
 ddt==1.2.1
 defusedxml==0.5.0
@@ -46,14 +46,14 @@ django-multi-email-field==0.5.1
 django-object-actions==1.1.0
 django-simple-history==2.7.3
 django-waffle==0.12.0
-django==1.11.22
+django==1.11.23
 djangorestframework-jwt==1.11.0
 djangorestframework-xml==1.4.0
 djangorestframework==3.7.7
 doc8==0.8.0
-docutils==0.15.1.post1
+docutils==0.15.2
 edx-django-utils==2.0.0
-edx-drf-extensions==2.3.7
+edx-drf-extensions==2.4.0
 edx-i18n-tools==0.4.8
 edx-lint==1.3.0
 edx-opaque-keys==1.0.1
@@ -62,9 +62,9 @@ edx-rest-api-client==1.9.2
 edx-sphinx-theme==1.5.0
 enum34==1.1.6
 factory-boy==2.12.0
-faker==2.0.0
+faker==2.0.1
 filelock==3.0.12          # via tox
-flaky==3.6.0
+flaky==3.6.1
 freezegun==0.3.12
 funcsigs==1.0.2
 future==0.17.1
@@ -72,27 +72,27 @@ futures==3.3.0 ; python_version == "2.7"
 html5lib==1.0.1
 idna==2.8
 imagesize==1.1.0
-importlib-metadata==0.18
+importlib-metadata==0.19
 inflect==2.1.0
 ipaddress==1.0.22
 isort==4.3.21
 jinja2-pluralize==0.3.0
 jinja2==2.10.1
-jsondiff==1.2.0
+jsondiff==1.1.1
 jsonfield==2.0.2
 kombu==3.0.37
-lazy-object-proxy==1.4.1  # via astroid
+lazy-object-proxy==1.4.2  # via astroid
 markupsafe==1.1.1
 mccabe==0.6.1             # via pylint
 mock==3.0.5
 more-itertools==5.0.0
-newrelic==4.20.1.121
-packaging==19.0
+newrelic==5.0.2.126
+packaging==19.1
 path.py==8.2.1
 pathlib2==2.3.4
-pbr==5.4.1
+pbr==5.4.2
 pillow==6.1.0
-pip-tools==3.9.0
+pip-tools==4.1.0
 pkginfo==1.5.0.1          # via twine
 pluggy==0.12.0
 pockets==0.7.2
@@ -101,7 +101,7 @@ psutil==1.2.1
 py==1.8.0
 pycodestyle==2.5.0
 pycparser==2.19
-pycryptodomex==3.8.2
+pycryptodomex==3.9.0
 pydocstyle==3.0.0
 pygments==2.4.2
 pyjwkest==1.3.2
@@ -111,26 +111,26 @@ pylint-django==0.7.2      # via edx-lint
 pylint-plugin-utils==0.5  # via pylint-celery, pylint-django
 pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==2.9.1
-pyparsing==2.4.1.1
+pyparsing==2.4.2
 pytest-catchlog==1.2.2
 pytest-cov==2.7.1
 pytest-django==3.5.1
-pytest==4.6.4
+pytest==4.6.5
 python-dateutil==2.4.0
-python-slugify==1.2.6
-pytz==2019.1
-pyyaml==5.1.1
+python-slugify==3.0.3
+pytz==2019.2
+pyyaml==5.1.2
 readme-renderer==24.0
 requests-toolbelt==0.9.1  # via twine
 requests==2.22.0
 responses==0.10.6
 rest-condition==1.0.3
 restructuredtext-lint==1.3.0
-rules==2.0.1
+rules==2.1
 scandir==1.10.0
 semantic-version==2.6.0
 singledispatch==3.4.0.3   # via astroid, pylint
-six==1.11.0
+six==1.12.0
 slumber==0.7.1
 snowballstemmer==1.9.0
 sphinx==1.8.5
@@ -142,18 +142,17 @@ text-unidecode==1.2
 toml==0.10.0              # via tox
 tox-battery==0.5.1
 tox==3.13.2
-tqdm==4.32.2              # via twine
+tqdm==4.35.0              # via twine
 twine==1.11.0
-typing==3.7.4
+typing==3.7.4.1
 unicodecsv==0.14.1
-unidecode==1.1.1
-urllib3==1.23
-virtualenv==16.7.1        # via tox
+urllib3==1.25.3
+virtualenv==16.7.4        # via tox
 wcwidth==0.1.7
 webencodings==0.5.1
-wheel==0.33.4
+wheel==0.33.6
 wrapt==1.11.2             # via astroid
-zipp==0.5.2
+zipp==0.6.0
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.0.1        # via caniusepython3, sphinx, twine
+# setuptools==41.2.0        # via caniusepython3, sphinx, twine

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -10,6 +10,7 @@ amqp==1.4.9               # via kombu
 aniso8601==7.0.0
 anyjson==0.3.3            # via kombu
 asn1crypto==0.24.0
+attrs==19.1.0             # via packaging
 babel==2.7.0              # via sphinx
 billiard==3.3.0.23
 bleach==2.1.4
@@ -32,14 +33,14 @@ django-multi-email-field==0.5.1
 django-object-actions==1.1.0
 django-simple-history==2.7.3
 django-waffle==0.12.0
-django==1.11.22
+django==1.11.23
 djangorestframework-jwt==1.11.0
 djangorestframework-xml==1.4.0
 djangorestframework==3.7.7
 doc8==0.8.0
-docutils==0.15.1.post1
+docutils==0.15.2
 edx-django-utils==2.0.0
-edx-drf-extensions==2.3.7
+edx-drf-extensions==2.4.0
 edx-opaque-keys==1.0.1
 edx-rbac==1.0.2
 edx-rest-api-client==1.9.2
@@ -51,35 +52,35 @@ idna==2.8
 imagesize==1.1.0          # via sphinx
 ipaddress==1.0.22
 jinja2==2.10.1
-jsondiff==1.2.0
+jsondiff==1.1.1
 jsonfield==2.0.2
 kombu==3.0.37
 markupsafe==1.1.1         # via jinja2
-newrelic==4.20.1.121
-packaging==19.0           # via sphinx
+newrelic==5.0.2.126
+packaging==19.1           # via sphinx
 path.py==8.2.1
-pbr==5.4.1
+pbr==5.4.2
 pillow==6.1.0
 pockets==0.7.2            # via sphinxcontrib-napoleon
 psutil==1.2.1
 pycparser==2.19           # via cffi
-pycryptodomex==3.8.2      # via pyjwkest
+pycryptodomex==3.9.0      # via pyjwkest
 pygments==2.4.2           # via readme-renderer, sphinx
 pyjwkest==1.3.2
 pyjwt==1.5.2
 pymongo==2.9.1
-pyparsing==2.4.1.1        # via packaging
+pyparsing==2.4.2          # via packaging
 python-dateutil==2.4.0
-python-slugify==1.2.6
-pytz==2019.1
-pyyaml==5.1.1
+python-slugify==3.0.3
+pytz==2019.2
+pyyaml==5.1.2
 readme-renderer==24.0
 requests==2.22.0
 rest-condition==1.0.3
 restructuredtext-lint==1.3.0  # via doc8
-rules==2.0.1
+rules==2.1
 semantic-version==2.6.0
-six==1.11.0
+six==1.12.0
 slumber==0.7.1
 snowballstemmer==1.9.0    # via sphinx
 sphinx==1.8.5
@@ -87,11 +88,11 @@ sphinxcontrib-napoleon==0.6.1
 sphinxcontrib-websupport==1.1.2  # via sphinx
 stevedore==1.30.1
 testfixtures==6.10.0
-typing==3.7.4             # via sphinx
+text-unidecode==1.2       # via python-slugify
+typing==3.7.4.1           # via sphinx
 unicodecsv==0.14.1
-unidecode==1.1.1          # via python-slugify
-urllib3==1.23
+urllib3==1.25.3
 webencodings==0.5.1       # via html5lib
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.0.1        # via sphinx
+# setuptools==41.2.0        # via sphinx

--- a/requirements/edx-platform-constraints.txt
+++ b/requirements/edx-platform-constraints.txt
@@ -21,6 +21,7 @@ bleach==2.1.4
 boto3==1.4.8
 boto==2.39.0
 botocore==1.8.17
+git+https://github.com/edx/bridgekeeper.git@4e34894e4ac5d0467ed1901811a81fd87ee01937#egg=bridgekeeper==0.0
 git+https://github.com/edx/openedx-calc.git@e9b698c85ad1152002bc0868f475f153dce88952#egg=calc==0.4
 celery==3.1.25
 certifi==2019.6.16
@@ -29,9 +30,10 @@ chardet==3.0.4
 git+https://github.com/edx/openedx-chem.git@ff4e3a03d3c7610e47a9af08eb648d8aabe2eb18#egg=chem==1.0.0
 click==7.0                # via code-annotations, user-util
 code-annotations==0.3.2   # via edx-enterprise
+contextlib2==0.5.5
 coreapi==2.3.3            # via drf-yasg
 coreschema==0.0.4         # via coreapi, drf-yasg
-git+https://github.com/edx/crowdsourcehinter.git@518605f0a95190949fe77bd39158450639e2e1dc#egg=crowdsourcehinter-xblock==0.1
+git+https://github.com/edx/crowdsourcehinter.git@a7ffc85b134b7d8909bf1fefd23dbdb8eb28e467#egg=crowdsourcehinter-xblock==0.2
 cryptography==2.7
 cssutils==1.0.2           # via pynliner
 ddt==1.2.1
@@ -54,10 +56,9 @@ django-model-utils==3.0.0
 django-mptt==0.8.7
 django-multi-email-field==0.5.1  # via edx-enterprise
 django-mysql==2.4.1
-git+https://github.com/edx/django-oauth-plus.git@01ec2a161dfc3465f9d35b9211ae790177418316#egg=django-oauth-plus==2.2.9.edx-1
+git+https://github.com/edx/django-oauth-plus.git@66155b545b23ebc01ec438849d303077e8198dfd#egg=django-oauth-plus==2.2.9.edx-3
 django-oauth-toolkit==1.1.3
 django-object-actions==1.1.0  # via edx-enterprise
-git+https://github.com/edx/django-openid-auth.git@0.15.1#egg=django-openid-auth==0.15.1
 django-pipeline==1.6.14
 django-pyfs==2.0
 django-ratelimit-backend==1.1.1
@@ -69,20 +70,20 @@ django-simple-history==2.7.3
 django-splash==0.2.2
 django-statici18n==1.4.0
 django-storages==1.4.1
-django-user-tasks==0.1.7
+django-user-tasks==0.1.9
 django-waffle==0.12.0
 django-webpack-loader==0.6.0
-django==1.11.22
+django==1.11.23
 djangorestframework-jwt==1.11.0
 git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4bc70c03de308a277197c#egg=djangorestframework-oauth==1.1.1
 djangorestframework-xml==1.4.0  # via edx-enterprise
 djangorestframework==3.7.7
 docopt==0.6.2
-docutils==0.15.1          # via botocore
+docutils==0.15.2          # via botocore
 drf-yasg==1.16
 edx-ace==0.1.10
 edx-analytics-data-api-client==0.15.3
-edx-bulk-grades==0.2
+edx-bulk-grades==0.5.9
 edx-ccx-keys==0.2.2
 edx-celeryutils==0.3.0
 edx-completion==2.0.0
@@ -90,28 +91,27 @@ edx-django-oauth2-provider==1.3.5
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==2.0.0
-edx-drf-extensions==2.3.7
-edx-enterprise==1.8.4
+edx-drf-extensions==2.4.0
+edx-enterprise==1.9.6
 edx-i18n-tools==0.4.8
 edx-milestones==0.2.3
-edx-oauth2-provider==1.2.3
+edx-oauth2-provider==1.3.0
 edx-opaque-keys[django]==1.0.1
 edx-organizations==2.1.0
 edx-proctoring-proctortrack==1.0.5
-edx-proctoring==2.0.6
+edx-proctoring==2.0.7
 edx-rbac==1.0.2           # via edx-enterprise
 edx-rest-api-client==1.9.2
 edx-search==1.2.2
 git+https://github.com/mitodl/edx-sga.git@3828ba9e413080a81b907a3381e5ffa05e063f81#egg=edx-sga==0.8.3
-edx-submissions==2.1.1
+edx-submissions==3.0.1
 edx-user-state-client==1.1.1
-edx-when==0.1.6
-edxval==1.1.25
+edx-when==0.3
+edxval==1.1.26
 elasticsearch==1.9.0      # via edx-search
 enum34==1.1.6
 event-tracking==0.2.9
 feedparser==5.1.3
-firebase-token-generator==1.3.2
 fs-s3fs==0.1.8
 fs==2.0.18
 future==0.17.1            # via edx-celeryutils, edx-enterprise, pyjwkest
@@ -121,7 +121,7 @@ glob2==0.7
 gunicorn==19.9.0
 help-tokens==1.0.4
 html5lib==1.0.1
-httplib2==0.13.0          # via oauth2, zendesk
+httplib2==0.13.1
 idna==2.8
 inflection==0.3.1         # via drf-yasg
 ipaddress==1.0.22
@@ -129,9 +129,10 @@ isodate==0.6.0            # via python3-saml
 itypes==1.1.0             # via coreapi
 jinja2==2.10.1            # via code-annotations, coreschema
 jmespath==0.9.4           # via boto3, botocore
-jsondiff==1.2.0           # via edx-enterprise
+jsondiff==1.1.1           # via edx-enterprise
 jsonfield==2.0.2
 kombu==3.0.37             # via celery
+laboratory==1.0.2
 lazy==1.1
 lepl==5.1.3               # via rfc6266-parser
 libsass==0.10.0
@@ -145,22 +146,22 @@ markey==0.8               # via django-babel-underscore
 markupsafe==1.1.1
 maxminddb==1.4.1          # via geoip2
 mock==1.0.1
-git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
+git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a#egg=MongoDBProxy==0.1.0+edx.2
 mongoengine==0.10.0
 mpmath==1.1.0             # via sympy
-mysqlclient==1.4.2.post1
+mysqlclient==1.4.4
 networkx==1.7
-newrelic==4.20.1.121
-nltk==3.4.4
+newrelic==5.0.2.126
+nltk==3.4.5
 nodeenv==1.1.1
-numpy==1.16.4
-oauth2==1.9.0.post1
+numpy==1.16.5
+git+https://github.com/joestump/python-oauth2.git@b94f69b1ad195513547924e380d9265133e995fa#egg=oauth2
 oauthlib==2.1.0
-git+https://github.com/edx/edx-ora2.git@2.2.6#egg=ora2==2.2.6
+git+https://github.com/edx/edx-ora2.git@2.2.7#egg=ora2==2.2.7
 path.py==8.2.1
 pathtools==0.1.2
 paver==1.3.4
-pbr==5.4.1
+pbr==5.4.2
 pdfminer.six==20181108
 piexif==1.0.2
 pillow==6.1.0
@@ -169,9 +170,9 @@ polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1
 py2neo==3.1.2
 pycontracts==1.7.1
-pycountry==19.7.15
+pycountry==19.8.18
 pycparser==2.19
-pycryptodome==3.8.2       # via pdfminer.six
+pycryptodome==3.9.0       # via pdfminer.six
 pycryptodomex==3.4.7
 pygments==2.4.2
 pygraphviz==1.5
@@ -185,61 +186,62 @@ python-dateutil==2.4.0
 python-levenshtein==0.12.0
 python-memcached==1.59
 python-openid==2.2.5 ; python_version == "2.7"  # via social-auth-core
-python-slugify==1.2.6     # via code-annotations
+python-slugify==3.0.3     # via code-annotations
 python-swiftclient==3.8.0
 python3-saml==1.5.0
-pytz==2019.1
+pytz==2019.2
 pyuca==1.1
-pyyaml==5.1.1
-git+https://github.com/edx/RecommenderXBlock.git@1.4.0#egg=recommender-xblock==1.4.0
+pyyaml==5.1.2
+git+https://github.com/edx/RecommenderXBlock.git@1.4.1#egg=recommender-xblock==1.4.1
 redis==2.10.6
 reportlab==3.5.23
 requests-oauthlib==1.1.0
 requests==2.22.0
 rest-condition==1.0.3
 rfc6266-parser==0.0.5.post2
-ruamel.ordereddict==0.4.13 ; python_version == "2.7"  # via ruamel.yaml
-ruamel.yaml==0.15.100     # via drf-yasg
-rules==2.0.1
+ruamel.ordereddict==0.4.14 ; python_version == "2.7"  # via ruamel.yaml
+ruamel.yaml.clib==0.1.2   # via ruamel.yaml
+ruamel.yaml==0.16.5       # via drf-yasg
+rules==2.1
 s3transfer==0.1.13        # via boto3
 sailthru-client==2.2.3
 scipy==1.2.1
 semantic-version==2.6.0   # via edx-drf-extensions
 shapely==1.6.4.post2
 shortuuid==0.5.0          # via edx-django-oauth2-provider
-simplejson==3.16.0        # via mailsnake, sailthru-client, zendesk
+simplejson==3.16.0        # via mailsnake, sailthru-client
 singledispatch==3.4.0.3
-six==1.11.0
-slumber==0.7.1            # via edx-enterprise, edx-rest-api-client
+six==1.12.0
+slumber==0.7.1            # via edx-bulk-grades, edx-enterprise, edx-rest-api-client
 social-auth-app-django==2.1.0
 social-auth-core==1.7.0
 sorl-thumbnail==12.3
 sortedcontainers==2.1.0
-soupsieve==1.9.2          # via beautifulsoup4
+soupsieve==1.9.3          # via beautifulsoup4
 sqlparse==0.3.0
-staff-graded-xblock==0.3
+staff-graded-xblock==0.5
 stevedore==1.30.1
-super-csv==0.8
+super-csv==0.9.1
 sympy==1.4
 testfixtures==6.10.0      # via edx-enterprise
+text-unidecode==1.2       # via python-slugify
 tincan==0.0.5             # via edx-enterprise
 unicodecsv==0.14.1
 uritemplate==3.0.0        # via coreapi, drf-yasg
-urllib3==1.23
+urllib3==1.25.3
 user-util==0.1.5
-voluptuous==0.11.5
+voluptuous==0.11.7
 watchdog==0.9.0
 web-fragments==0.3.0
 webencodings==0.5.1       # via html5lib
 webob==1.8.5              # via xblock
 wrapt==1.10.5
-git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.1#egg=xblock-drag-and-drop-v2==2.2.1
+git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.4#egg=xblock-drag-and-drop-v2==2.2.4
 git+https://github.com/open-craft/xblock-poll@add89e14558c30f3c8dc7431e5cd6536fff6d941#egg=xblock-poll==1.5.1
-xblock-utils==1.2.1
-xblock==1.2.2
+xblock-utils==1.2.2
+xblock==1.2.4
 xmlsec==1.3.3             # via python3-saml
 xss-utils==0.1.1
-zendesk==1.1.1
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.0.1        # via fs, lazy, python-levenshtein
+# setuptools==41.2.0        # via fs, lazy, python-levenshtein

--- a/requirements/js_test.txt
+++ b/requirements/js_test.txt
@@ -6,7 +6,7 @@
 #
 argparse==1.4.0           # via jasmine
 backports.functools-lru-cache==1.5  # via cheroot, jaraco.functools
-cheroot==6.5.5            # via cherrypy
+cheroot==6.5.6            # via cherrypy
 cherrypy==17.3.0
 contextlib2==0.5.5        # via cherrypy
 glob2==0.7                # via jasmine-core
@@ -18,12 +18,12 @@ markupsafe==1.1.1         # via jinja2
 more-itertools==5.0.0     # via cheroot, cherrypy, jaraco.functools
 ordereddict==1.1          # via jasmine-core
 portend==2.5              # via cherrypy
-pytz==2019.1              # via tempora
+pytz==2019.2              # via tempora
 pyyaml==3.10              # via jasmine
 selenium==3.6.0           # via jasmine
 six==1.12.0               # via cheroot, cherrypy, jasmine, more-itertools, tempora
 tempora==1.14.1           # via portend
-zc.lockfile==1.4          # via cherrypy
+zc.lockfile==2.0          # via cherrypy
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.0.1        # via zc.lockfile
+# setuptools==41.2.0        # via zc.lockfile

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -28,12 +28,12 @@ django-multi-email-field==0.5.1
 django-object-actions==1.1.0
 django-simple-history==2.7.3
 django-waffle==0.12.0
-django==1.11.22
+django==1.11.23
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework-xml==1.4.0
 djangorestframework==3.7.7
 edx-django-utils==2.0.0
-edx-drf-extensions==2.3.7
+edx-drf-extensions==2.4.0
 edx-opaque-keys==1.0.1
 edx-rbac==1.0.2
 edx-rest-api-client==1.9.2
@@ -43,28 +43,28 @@ html5lib==1.0.1           # via bleach
 idna==2.8                 # via requests
 ipaddress==1.0.22         # via cryptography
 jinja2==2.10.1            # via code-annotations
-jsondiff==1.2.0
+jsondiff==1.1.1
 jsonfield==2.0.2
 kombu==3.0.37             # via celery
-newrelic==4.20.1.121      # via edx-django-utils
+newrelic==5.0.2.126       # via edx-django-utils
 path.py==8.2.1
-pbr==5.4.1                # via stevedore
+pbr==5.4.2                # via stevedore
 pillow==6.1.0
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 pyjwkest==1.3.2           # via edx-drf-extensions
 pyjwt==1.5.2              # via edx-rest-api-client
 pymongo==2.9.1            # via edx-opaque-keys
 python-dateutil==2.4.0
-python-slugify==1.2.6     # via code-annotations
-pytz==2019.1
-pyyaml==5.1.1             # via code-annotations
+python-slugify==3.0.3     # via code-annotations
+pytz==2019.2
+pyyaml==5.1.2             # via code-annotations
 requests==2.22.0
 rest-condition==1.0.3     # via edx-drf-extensions
-rules==2.0.1
+rules==2.1
 semantic-version==2.6.0   # via edx-drf-extensions
-six==1.11.0
+six==1.12.0
 slumber==0.7.1
 stevedore==1.30.1
 testfixtures==6.10.0
 unicodecsv==0.14.1
-urllib3==1.23             # via requests
+urllib3==1.25.3           # via requests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,7 +10,7 @@ aniso8601==7.0.0
 anyjson==0.3.3            # via kombu
 asn1crypto==0.24.0
 atomicwrites==1.3.0       # via pytest
-attrs==19.1.0             # via pytest
+attrs==19.1.0             # via packaging, pytest
 billiard==3.3.0.23
 bleach==2.1.4
 celery==3.1.25
@@ -19,10 +19,10 @@ cffi==1.12.3
 chardet==3.0.4
 click==7.0
 code-annotations==0.3.2
-configparser==3.7.4       # via importlib-metadata
+configparser==3.8.1       # via importlib-metadata
 contextlib2==0.5.5        # via importlib-metadata
 cookies==2.2.1            # via responses
-coverage==4.5.3           # via pytest-cov
+coverage==4.5.4           # via pytest-cov
 cryptography==2.7
 ddt==1.2.1
 defusedxml==0.5.0
@@ -38,73 +38,72 @@ django-multi-email-field==0.5.1
 django-object-actions==1.1.0
 django-simple-history==2.7.3
 django-waffle==0.12.0
-django==1.11.22
+django==1.11.23
 djangorestframework-jwt==1.11.0
 djangorestframework-xml==1.4.0
 djangorestframework==3.7.7
 edx-django-utils==2.0.0
-edx-drf-extensions==2.3.7
+edx-drf-extensions==2.4.0
 edx-opaque-keys==1.0.1
 edx-rbac==1.0.2
 edx-rest-api-client==1.9.2
 enum34==1.1.6
 factory-boy==2.12.0
-faker==2.0.0              # via factory-boy
-flaky==3.6.0
+faker==2.0.1              # via factory-boy
+flaky==3.6.1
 freezegun==0.3.12
 funcsigs==1.0.2           # via mock, pytest
 future==0.17.1
 html5lib==1.0.1
 idna==2.8
-importlib-metadata==0.18  # via pluggy, pytest
+importlib-metadata==0.19  # via pluggy, pytest
 inflect==2.1.0            # via jinja2-pluralize
 ipaddress==1.0.22
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.10.1
-jsondiff==1.2.0
+jsondiff==1.1.1
 jsonfield==2.0.2
 kombu==3.0.37
 markupsafe==1.1.1         # via jinja2
 mock==3.0.5
-more-itertools==5.0.0     # via pytest
-newrelic==4.20.1.121
-packaging==19.0           # via pytest
+more-itertools==5.0.0     # via pytest, zipp
+newrelic==5.0.2.126
+packaging==19.1           # via pytest
 path.py==8.2.1
 pathlib2==2.3.4           # via importlib-metadata, pytest, pytest-django
-pbr==5.4.1
+pbr==5.4.2
 pillow==6.1.0
 pluggy==0.12.0            # via pytest
 psutil==1.2.1
 py==1.8.0                 # via pytest, pytest-catchlog
 pycparser==2.19           # via cffi
-pycryptodomex==3.8.2      # via pyjwkest
+pycryptodomex==3.9.0      # via pyjwkest
 pygments==2.4.2           # via diff-cover
 pyjwkest==1.3.2
 pyjwt==1.5.2
 pymongo==2.9.1
-pyparsing==2.4.1.1        # via packaging
+pyparsing==2.4.2          # via packaging
 pytest-catchlog==1.2.2
 pytest-cov==2.7.1
 pytest-django==3.5.1
-pytest==4.6.4             # via pytest-catchlog, pytest-cov, pytest-django
+pytest==4.6.5             # via pytest-catchlog, pytest-cov, pytest-django
 python-dateutil==2.4.0
-python-slugify==1.2.6
-pytz==2019.1
-pyyaml==5.1.1
+python-slugify==3.0.3
+pytz==2019.2
+pyyaml==5.1.2
 requests==2.22.0
 responses==0.10.6
 rest-condition==1.0.3
-rules==2.0.1
+rules==2.1
 scandir==1.10.0           # via pathlib2
 semantic-version==2.6.0
-six==1.11.0
+six==1.12.0
 slumber==0.7.1
 stevedore==1.30.1
 testfixtures==6.10.0
-text-unidecode==1.2       # via faker
+text-unidecode==1.2       # via faker, python-slugify
 unicodecsv==0.14.1
-unidecode==1.1.1          # via python-slugify
-urllib3==1.23
+urllib3==1.25.3
 wcwidth==0.1.7            # via pytest
 webencodings==0.5.1       # via html5lib
-zipp==0.5.2               # via importlib-metadata
+zipp==0.6.0               # via importlib-metadata

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -4,26 +4,28 @@
 #
 #    make upgrade
 #
+attrs==19.1.0             # via packaging
 certifi==2019.6.16        # via requests
 chardet==3.0.4            # via requests
 codecov==2.0.15
-configparser==3.7.4       # via importlib-metadata
+configparser==3.8.1       # via importlib-metadata
 contextlib2==0.5.5        # via importlib-metadata
-coverage==4.5.3           # via codecov
+coverage==4.5.4           # via codecov
 filelock==3.0.12          # via tox
 idna==2.8                 # via requests
-importlib-metadata==0.18  # via pluggy, tox
-packaging==19.0           # via tox
+importlib-metadata==0.19  # via pluggy, tox
+more-itertools==5.0.0     # via zipp
+packaging==19.1           # via tox
 pathlib2==2.3.4           # via importlib-metadata
 pluggy==0.12.0            # via tox
 py==1.8.0                 # via tox
-pyparsing==2.4.1.1        # via packaging
+pyparsing==2.4.2          # via packaging
 requests==2.22.0          # via codecov
 scandir==1.10.0           # via pathlib2
-six==1.12.0               # via packaging, pathlib2, tox
+six==1.12.0               # via more-itertools, packaging, pathlib2, tox
 toml==0.10.0              # via tox
 tox-battery==0.5.1
 tox==3.13.2
 urllib3==1.25.3           # via requests
-virtualenv==16.7.1        # via tox
-zipp==0.5.2               # via importlib-metadata
+virtualenv==16.7.4        # via tox
+zipp==0.6.0               # via importlib-metadata

--- a/tests/test_enterprise_learner_portal/api/test_views.py
+++ b/tests/test_enterprise_learner_portal/api/test_views.py
@@ -5,9 +5,12 @@ Tests for the EnterpriseCourseEnrollmentview of the enterprise_learner_portal ap
 
 from __future__ import absolute_import, unicode_literals
 
+import uuid
+
 import mock
 from pytest import mark
 
+from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.test import Client, TestCase
 
@@ -22,10 +25,18 @@ class TestEnterpriseCourseEnrollmentView(TestCase):
     EnterpriseCourseEnrollmentView tests.
     """
 
+    class MockSerializer(object):
+        """ Returns obj with data property. """
+
+        @property
+        def data(self):
+            """ Return fake serialized data. """
+            return {'hooray': 'here is the data'}
+
     def setUp(self):
         super(TestEnterpriseCourseEnrollmentView, self).setUp()
 
-        enterprise_customer = factories.EnterpriseCustomerFactory()
+        self.enterprise_customer = factories.EnterpriseCustomerFactory()
 
         # Create our user we will enroll in a course
         self.user = factories.UserFactory.create(is_staff=True, is_active=True)
@@ -33,7 +44,7 @@ class TestEnterpriseCourseEnrollmentView(TestCase):
         self.user.save()
         enrolled_ent_customer_user = factories.EnterpriseCustomerUserFactory(
             user_id=self.user.id,
-            enterprise_customer=enterprise_customer,
+            enterprise_customer=self.enterprise_customer,
         )
         course_run_id = 'course-v1:edX+DemoX+Demo_Course'
         EnterpriseCourseEnrollment.objects.create(
@@ -47,7 +58,7 @@ class TestEnterpriseCourseEnrollmentView(TestCase):
         )
         factories.EnterpriseCustomerUserFactory(
             user_id=not_enrolled_user.id,
-            enterprise_customer=enterprise_customer,
+            enterprise_customer=self.enterprise_customer,
         )
 
         self.client = Client()
@@ -60,25 +71,66 @@ class TestEnterpriseCourseEnrollmentView(TestCase):
         View should return data created by EnterpriseCourseEnrollmentSerializer
         (which we mock in this case)
         """
-        class MockSerializer(object):
-            """ Returns obj with data property. """
-            @property
-            def data(self):
-                """ Return fake serialized data. """
-                return {'hooray': 'here is the data'}
 
         mock_get_overviews.return_value = {'overview_info': 'this would be a larger dict'}
-        mock_serializer.return_value = MockSerializer()
+        mock_serializer.return_value = self.MockSerializer()
 
-        url = reverse('enterprise-learner-portal-course-enrollment-list')
-        resp = self.client.get(url)
+        resp = self.client.get(
+            '{host}{path}?enterprise_id={enterprise_id}'.format(
+                host=settings.TEST_SERVER,
+                path=reverse('enterprise-learner-portal-course-enrollment-list'),
+                enterprise_id=str(self.enterprise_customer.uuid)
+            )
+        )
         assert resp.status_code == 200
         assert resp.json() == {'hooray': 'here is the data'}
+
+    @mock.patch('enterprise_learner_portal.api.v1.views.EnterpriseCourseEnrollmentSerializer')
+    @mock.patch('enterprise_learner_portal.api.v1.views.get_course_overviews')
+    def test_view_returns_bad_request_without_enterprise(self, mock_get_overviews, mock_serializer):
+        """
+        View should return a 400 because of the missing enterprise_id parameter.
+        """
+        mock_get_overviews.return_value = {'overview_info': 'this would be a larger dict'}
+        mock_serializer.return_value = self.MockSerializer()
+
+        resp = self.client.get(
+            '{host}{path}'.format(
+                host=settings.TEST_SERVER,
+                path=reverse('enterprise-learner-portal-course-enrollment-list')
+            )
+        )
+        assert resp.status_code == 400
+        assert resp.json() == {'error': 'enterprise_id must be provided as a query parameter'}
+
+    @mock.patch('enterprise_learner_portal.api.v1.views.EnterpriseCourseEnrollmentSerializer')
+    @mock.patch('enterprise_learner_portal.api.v1.views.get_course_overviews')
+    def test_view_returns_not_found_unlinked_enterprise(self, mock_get_overviews, mock_serializer):
+        """
+        View should return a 404 because the user is not linked to the enterprise.
+        """
+        mock_get_overviews.return_value = {'overview_info': 'this would be a larger dict'}
+        mock_serializer.return_value = self.MockSerializer()
+
+        resp = self.client.get(
+            '{host}{path}?enterprise_id={enterprise_id}'.format(
+                host=settings.TEST_SERVER,
+                path=reverse('enterprise-learner-portal-course-enrollment-list'),
+                enterprise_id=str(uuid.uuid4()),
+            )
+        )
+        assert resp.status_code == 404
+        assert resp.json() == {'detail': 'Not found.'}
 
     def test_view_requires_openedx_installation(self):
         """
         View should raise error if imports to helper methods fail.
         """
-        url = reverse('enterprise-learner-portal-course-enrollment-list')
         with self.assertRaises(NotConnectedToOpenEdX):
-            self.client.get(url)
+            self.client.get(
+                '{host}{path}?enterprise_id={enterprise_id}'.format(
+                    host=settings.TEST_SERVER,
+                    path=reverse('enterprise-learner-portal-course-enrollment-list'),
+                    enterprise_id=str(self.enterprise_customer.uuid)
+                )
+            )


### PR DESCRIPTION
**Description:** Since learner portals will always be tied to a specific enterprise, we need to filter a user's enrollments by that enterprise to avoid error conditions when a user is linked to many.

**JIRA:** Link to JIRA ticket

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Merge checklist:**

- [ ] New requirements are in the right place
    - `base.in` if needed in production, but edx-platform doesn't install it.
    - `test-master.in` if edx-platform pins it, with a matching version.
- [ ] Regenerate requirements with `make upgrade && make requirements` (and make sure to fix any errors).
  **DO NOT** just add dependencies to `requirements/*.txt` files.
- [ ] Called `make static` for webpack bundling if any static content was updated.
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] edx-platform PR (be sure to include edx-platform requirements upgrades that were present in this PR)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
