### PR TITLE
ENT-2272 | Added endpoint to get list of enterprise customer with search support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[1.10.4] - 2019-09-05
+---------------------
+
+* Added new endpoint basic_list to EnterpriseEnrollment.
+
 [1.10.3] - 2019-09-19
 ---------------------
 * Add enable_portal_reoprting_config_screen field to EnterpriseCustomer model.

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.10.3"
+__version__ = "1.10.4"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -130,6 +130,18 @@ class EnterpriseCustomerSerializer(serializers.ModelSerializer):
     )
 
 
+class EnterpriseCustomerBasicSerializer(serializers.ModelSerializer):
+    """
+    Serializer for EnterpriseCustomer model only for name and id fields.
+    """
+
+    class Meta:
+        model = models.EnterpriseCustomer
+        fields = ('id', 'name')
+
+    id = serializers.CharField(source='uuid')  # pylint: disable=invalid-name
+
+
 class EnterpriseCourseEnrollmentReadOnlySerializer(serializers.ModelSerializer):
     """
     Serializer for EnterpriseCourseEnrollment model.

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -116,6 +116,21 @@ class EnterpriseCustomerViewSet(EnterpriseReadWriteModelViewSet):
     filter_fields = FIELDS
     ordering_fields = FIELDS
 
+    def get_serializer_class(self):
+        if self.action == 'basic_list':
+            return serializers.EnterpriseCustomerBasicSerializer
+        return self.serializer_class
+
+    @list_route()
+    # pylint: disable=invalid-name,unused-argument
+    def basic_list(self, request, *arg, **kwargs):
+        """
+            Enterprise Customer's Basic data list without pagination
+        """
+        queryset = self.get_queryset().order_by('name')
+        serializer = self.get_serializer(queryset, many=True)
+        return Response(serializer.data)
+
     @method_decorator(require_at_least_one_query_parameter('course_run_ids', 'program_uuids'))
     @detail_route()
     @permission_required('enterprise.can_view_catalog', fn=lambda request, pk, course_run_ids, program_uuids: pk)


### PR DESCRIPTION
add a new endpoint to get a list of enterprise customer with basic data only with search capability

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
