### PR TITLE
Feanil/update requiremets

### DIFF
--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.10.0"
+__version__ = "1.10.1"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -7,7 +7,7 @@
 -e git+https://github.com/edx/TinCanPython.git@0.0.5.py.35#egg=tincan==0.0.5.py.35
 alabaster==0.7.12
 amqp==1.4.9
-aniso8601==7.0.0
+aniso8601==8.0.0
 anyjson==0.3.3
 argparse==1.4.0           # via caniusepython3
 asn1crypto==0.24.0
@@ -20,13 +20,13 @@ billiard==3.3.0.23
 bleach==2.1.4
 caniusepython3==7.1.0
 celery==3.1.25
-certifi==2019.6.16
+certifi==2019.9.11
 cffi==1.12.3
 chardet==3.0.4
 click-log==0.3.2          # via edx-lint
 click==7.0
 code-annotations==0.3.2
-configparser==3.8.1
+configparser==4.0.2
 contextlib2==0.5.5
 cookies==2.2.1
 coverage==4.5.4
@@ -46,7 +46,7 @@ django-multi-email-field==0.5.1
 django-object-actions==1.1.0
 django-simple-history==2.7.3
 django-waffle==0.12.0
-django==1.11.23
+django==1.11.24
 djangorestframework-jwt==1.11.0
 djangorestframework-xml==1.4.0
 djangorestframework==3.7.7
@@ -56,8 +56,8 @@ edx-django-utils==2.0.0
 edx-drf-extensions==2.4.0
 edx-i18n-tools==0.4.8
 edx-lint==1.3.0
-edx-opaque-keys==1.0.1
-edx-rbac==1.0.2
+edx-opaque-keys[django]==2.0.0
+edx-rbac==1.0.3
 edx-rest-api-client==1.9.2
 edx-sphinx-theme==1.5.0
 enum34==1.1.6
@@ -72,7 +72,7 @@ futures==3.3.0 ; python_version == "2.7"
 html5lib==1.0.1
 idna==2.8
 imagesize==1.1.0
-importlib-metadata==0.19
+importlib-metadata==0.23
 inflect==2.1.0
 ipaddress==1.0.22
 isort==4.3.21
@@ -90,11 +90,11 @@ newrelic==5.0.2.126
 packaging==19.1
 path.py==8.2.1
 pathlib2==2.3.4
-pbr==5.4.2
+pbr==5.4.3
 pillow==6.1.0
 pip-tools==4.1.0
 pkginfo==1.5.0.1          # via twine
-pluggy==0.12.0
+pluggy==0.13.0
 pockets==0.7.2
 polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1
@@ -128,26 +128,26 @@ rest-condition==1.0.3
 restructuredtext-lint==1.3.0
 rules==2.1
 scandir==1.10.0
-semantic-version==2.6.0
+semantic-version==2.8.2
 singledispatch==3.4.0.3   # via astroid, pylint
 six==1.12.0
 slumber==0.7.1
-snowballstemmer==1.9.0
+snowballstemmer==1.9.1
 sphinx==1.8.5
 sphinxcontrib-napoleon==0.6.1
 sphinxcontrib-websupport==1.1.2
-stevedore==1.30.1
+stevedore==1.31.0
 testfixtures==6.10.0
 text-unidecode==1.2
 toml==0.10.0              # via tox
 tox-battery==0.5.1
-tox==3.13.2
+tox==3.14.0
 tqdm==4.35.0              # via twine
 twine==1.11.0
 typing==3.7.4.1
 unicodecsv==0.14.1
 urllib3==1.25.3
-virtualenv==16.7.4        # via tox
+virtualenv==16.7.5        # via tox
 wcwidth==0.1.7
 webencodings==0.5.1
 wheel==0.33.6

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -7,7 +7,7 @@
 -e git+https://github.com/edx/TinCanPython.git@0.0.5.py.35#egg=tincan==0.0.5.py.35
 alabaster==0.7.12         # via sphinx
 amqp==1.4.9               # via kombu
-aniso8601==7.0.0
+aniso8601==8.0.0
 anyjson==0.3.3            # via kombu
 asn1crypto==0.24.0
 attrs==19.1.0             # via packaging
@@ -15,7 +15,7 @@ babel==2.7.0              # via sphinx
 billiard==3.3.0.23
 bleach==2.1.4
 celery==3.1.25
-certifi==2019.6.16
+certifi==2019.9.11
 cffi==1.12.3
 chardet==3.0.4
 click==7.0
@@ -33,7 +33,7 @@ django-multi-email-field==0.5.1
 django-object-actions==1.1.0
 django-simple-history==2.7.3
 django-waffle==0.12.0
-django==1.11.23
+django==1.11.24
 djangorestframework-jwt==1.11.0
 djangorestframework-xml==1.4.0
 djangorestframework==3.7.7
@@ -41,8 +41,8 @@ doc8==0.8.0
 docutils==0.15.2
 edx-django-utils==2.0.0
 edx-drf-extensions==2.4.0
-edx-opaque-keys==1.0.1
-edx-rbac==1.0.2
+edx-opaque-keys[django]==2.0.0
+edx-rbac==1.0.3
 edx-rest-api-client==1.9.2
 edx-sphinx-theme==1.5.0
 enum34==1.1.6
@@ -59,7 +59,7 @@ markupsafe==1.1.1         # via jinja2
 newrelic==5.0.2.126
 packaging==19.1           # via sphinx
 path.py==8.2.1
-pbr==5.4.2
+pbr==5.4.3
 pillow==6.1.0
 pockets==0.7.2            # via sphinxcontrib-napoleon
 psutil==1.2.1
@@ -79,14 +79,14 @@ requests==2.22.0
 rest-condition==1.0.3
 restructuredtext-lint==1.3.0  # via doc8
 rules==2.1
-semantic-version==2.6.0
+semantic-version==2.8.2
 six==1.12.0
 slumber==0.7.1
-snowballstemmer==1.9.0    # via sphinx
+snowballstemmer==1.9.1    # via sphinx
 sphinx==1.8.5
 sphinxcontrib-napoleon==0.6.1
 sphinxcontrib-websupport==1.1.2  # via sphinx
-stevedore==1.30.1
+stevedore==1.31.0
 testfixtures==6.10.0
 text-unidecode==1.2       # via python-slugify
 typing==3.7.4.1           # via sphinx

--- a/requirements/edx-platform-constraints.txt
+++ b/requirements/edx-platform-constraints.txt
@@ -7,7 +7,7 @@
 #
 amqp==1.4.9               # via kombu
 analytics-python==1.2.9
-aniso8601==7.0.0          # via tincan
+aniso8601==8.0.0          # via tincan
 anyjson==0.3.3            # via kombu
 appdirs==1.4.3            # via fs
 argh==0.26.2
@@ -24,7 +24,7 @@ botocore==1.8.17
 git+https://github.com/edx/bridgekeeper.git@4e34894e4ac5d0467ed1901811a81fd87ee01937#egg=bridgekeeper==0.0
 git+https://github.com/edx/openedx-calc.git@e9b698c85ad1152002bc0868f475f153dce88952#egg=calc==0.4
 celery==3.1.25
-certifi==2019.6.16
+certifi==2019.9.11
 cffi==1.12.3
 chardet==3.0.4
 git+https://github.com/edx/openedx-chem.git@ff4e3a03d3c7610e47a9af08eb648d8aabe2eb18#egg=chem==1.0.0
@@ -70,10 +70,10 @@ django-simple-history==2.7.3
 django-splash==0.2.2
 django-statici18n==1.4.0
 django-storages==1.4.1
-django-user-tasks==0.1.9
+django-user-tasks==0.2.0
 django-waffle==0.12.0
 django-webpack-loader==0.6.0
-django==1.11.23
+django==1.11.24
 djangorestframework-jwt==1.11.0
 git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4bc70c03de308a277197c#egg=djangorestframework-oauth==1.1.1
 djangorestframework-xml==1.4.0  # via edx-enterprise
@@ -83,8 +83,8 @@ docutils==0.15.2          # via botocore
 drf-yasg==1.16
 edx-ace==0.1.10
 edx-analytics-data-api-client==0.15.3
-edx-bulk-grades==0.5.9
-edx-ccx-keys==0.2.2
+edx-bulk-grades==0.6.0
+edx-ccx-keys==1.0.0
 edx-celeryutils==0.3.0
 edx-completion==2.0.0
 edx-django-oauth2-provider==1.3.5
@@ -92,22 +92,22 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==2.0.0
 edx-drf-extensions==2.4.0
-edx-enterprise==1.9.6
+edx-enterprise==1.9.12
 edx-i18n-tools==0.4.8
 edx-milestones==0.2.3
 edx-oauth2-provider==1.3.0
-edx-opaque-keys[django]==1.0.1
+edx-opaque-keys[django]==2.0.0
 edx-organizations==2.1.0
 edx-proctoring-proctortrack==1.0.5
-edx-proctoring==2.0.7
-edx-rbac==1.0.2           # via edx-enterprise
+edx-proctoring==2.0.8
+edx-rbac==1.0.3           # via edx-enterprise
 edx-rest-api-client==1.9.2
 edx-search==1.2.2
 git+https://github.com/mitodl/edx-sga.git@3828ba9e413080a81b907a3381e5ffa05e063f81#egg=edx-sga==0.8.3
 edx-submissions==3.0.1
 edx-user-state-client==1.1.1
 edx-when==0.3
-edxval==1.1.26
+edxval==1.1.27
 elasticsearch==1.9.0      # via edx-search
 enum34==1.1.6
 event-tracking==0.2.9
@@ -157,11 +157,11 @@ nodeenv==1.1.1
 numpy==1.16.5
 git+https://github.com/joestump/python-oauth2.git@b94f69b1ad195513547924e380d9265133e995fa#egg=oauth2
 oauthlib==2.1.0
-git+https://github.com/edx/edx-ora2.git@2.2.7#egg=ora2==2.2.7
+git+https://github.com/edx/edx-ora2.git@2.3.1#egg=ora2==2.3.1
 path.py==8.2.1
 pathtools==0.1.2
 paver==1.3.4
-pbr==5.4.2
+pbr==5.4.3
 pdfminer.six==20181108
 piexif==1.0.2
 pillow==6.1.0
@@ -206,7 +206,7 @@ rules==2.1
 s3transfer==0.1.13        # via boto3
 sailthru-client==2.2.3
 scipy==1.2.1
-semantic-version==2.6.0   # via edx-drf-extensions
+semantic-version==2.8.2   # via edx-drf-extensions
 shapely==1.6.4.post2
 shortuuid==0.5.0          # via edx-django-oauth2-provider
 simplejson==3.16.0        # via mailsnake, sailthru-client
@@ -220,7 +220,7 @@ sortedcontainers==2.1.0
 soupsieve==1.9.3          # via beautifulsoup4
 sqlparse==0.3.0
 staff-graded-xblock==0.5
-stevedore==1.30.1
+stevedore==1.31.0
 super-csv==0.9.1
 sympy==1.4
 testfixtures==6.10.0      # via edx-enterprise

--- a/requirements/js_test.txt
+++ b/requirements/js_test.txt
@@ -6,7 +6,7 @@
 #
 argparse==1.4.0           # via jasmine
 backports.functools-lru-cache==1.5  # via cheroot, jaraco.functools
-cheroot==6.5.6            # via cherrypy
+cheroot==6.5.8            # via cherrypy
 cherrypy==17.3.0
 contextlib2==0.5.5        # via cherrypy
 glob2==0.7                # via jasmine-core

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -5,12 +5,12 @@
 #    make upgrade
 #
 -e git+https://github.com/edx/TinCanPython.git@0.0.5.py.35#egg=tincan==0.0.5.py.35
-aniso8601==7.0.0
+aniso8601==8.0.0
 asn1crypto==0.24.0        # via cryptography
 billiard==3.3.0.23        # via celery
 bleach==2.1.4
 celery==3.1.25
-certifi==2019.6.16        # via requests
+certifi==2019.9.11        # via requests
 cffi==1.12.3              # via cryptography
 chardet==3.0.4            # via requests
 click==7.0                # via code-annotations
@@ -28,14 +28,14 @@ django-multi-email-field==0.5.1
 django-object-actions==1.1.0
 django-simple-history==2.7.3
 django-waffle==0.12.0
-django==1.11.23
+django==1.11.24
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework-xml==1.4.0
 djangorestframework==3.7.7
 edx-django-utils==2.0.0
 edx-drf-extensions==2.4.0
-edx-opaque-keys==1.0.1
-edx-rbac==1.0.2
+edx-opaque-keys[django]==2.0.0
+edx-rbac==1.0.3
 edx-rest-api-client==1.9.2
 enum34==1.1.6             # via cryptography
 future==0.17.1
@@ -48,7 +48,7 @@ jsonfield==2.0.2
 kombu==3.0.37             # via celery
 newrelic==5.0.2.126       # via edx-django-utils
 path.py==8.2.1
-pbr==5.4.2                # via stevedore
+pbr==5.4.3                # via stevedore
 pillow==6.1.0
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 pyjwkest==1.3.2           # via edx-drf-extensions
@@ -61,10 +61,10 @@ pyyaml==5.1.2             # via code-annotations
 requests==2.22.0
 rest-condition==1.0.3     # via edx-drf-extensions
 rules==2.1
-semantic-version==2.6.0   # via edx-drf-extensions
+semantic-version==2.8.2   # via edx-drf-extensions
 six==1.12.0
 slumber==0.7.1
-stevedore==1.30.1
+stevedore==1.31.0
 testfixtures==6.10.0
 unicodecsv==0.14.1
 urllib3==1.25.3           # via requests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,7 +6,7 @@
 #
 -e git+https://github.com/edx/TinCanPython.git@0.0.5.py.35#egg=tincan==0.0.5.py.35
 amqp==1.4.9               # via kombu
-aniso8601==7.0.0
+aniso8601==8.0.0
 anyjson==0.3.3            # via kombu
 asn1crypto==0.24.0
 atomicwrites==1.3.0       # via pytest
@@ -14,12 +14,12 @@ attrs==19.1.0             # via packaging, pytest
 billiard==3.3.0.23
 bleach==2.1.4
 celery==3.1.25
-certifi==2019.6.16
+certifi==2019.9.11
 cffi==1.12.3
 chardet==3.0.4
 click==7.0
 code-annotations==0.3.2
-configparser==3.8.1       # via importlib-metadata
+configparser==4.0.2       # via importlib-metadata
 contextlib2==0.5.5        # via importlib-metadata
 cookies==2.2.1            # via responses
 coverage==4.5.4           # via pytest-cov
@@ -38,14 +38,14 @@ django-multi-email-field==0.5.1
 django-object-actions==1.1.0
 django-simple-history==2.7.3
 django-waffle==0.12.0
-django==1.11.23
+django==1.11.24
 djangorestframework-jwt==1.11.0
 djangorestframework-xml==1.4.0
 djangorestframework==3.7.7
 edx-django-utils==2.0.0
 edx-drf-extensions==2.4.0
-edx-opaque-keys==1.0.1
-edx-rbac==1.0.2
+edx-opaque-keys[django]==2.0.0
+edx-rbac==1.0.3
 edx-rest-api-client==1.9.2
 enum34==1.1.6
 factory-boy==2.12.0
@@ -56,7 +56,7 @@ funcsigs==1.0.2           # via mock, pytest
 future==0.17.1
 html5lib==1.0.1
 idna==2.8
-importlib-metadata==0.19  # via pluggy, pytest
+importlib-metadata==0.23  # via pluggy, pytest
 inflect==2.1.0            # via jinja2-pluralize
 ipaddress==1.0.22
 jinja2-pluralize==0.3.0   # via diff-cover
@@ -71,9 +71,9 @@ newrelic==5.0.2.126
 packaging==19.1           # via pytest
 path.py==8.2.1
 pathlib2==2.3.4           # via importlib-metadata, pytest, pytest-django
-pbr==5.4.2
+pbr==5.4.3
 pillow==6.1.0
-pluggy==0.12.0            # via pytest
+pluggy==0.13.0            # via pytest
 psutil==1.2.1
 py==1.8.0                 # via pytest, pytest-catchlog
 pycparser==2.19           # via cffi
@@ -96,10 +96,10 @@ responses==0.10.6
 rest-condition==1.0.3
 rules==2.1
 scandir==1.10.0           # via pathlib2
-semantic-version==2.6.0
+semantic-version==2.8.2
 six==1.12.0
 slumber==0.7.1
-stevedore==1.30.1
+stevedore==1.31.0
 testfixtures==6.10.0
 text-unidecode==1.2       # via faker, python-slugify
 unicodecsv==0.14.1

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -5,19 +5,19 @@
 #    make upgrade
 #
 attrs==19.1.0             # via packaging
-certifi==2019.6.16        # via requests
+certifi==2019.9.11        # via requests
 chardet==3.0.4            # via requests
 codecov==2.0.15
-configparser==3.8.1       # via importlib-metadata
+configparser==4.0.2       # via importlib-metadata
 contextlib2==0.5.5        # via importlib-metadata
 coverage==4.5.4           # via codecov
 filelock==3.0.12          # via tox
 idna==2.8                 # via requests
-importlib-metadata==0.19  # via pluggy, tox
+importlib-metadata==0.23  # via pluggy, tox
 more-itertools==5.0.0     # via zipp
 packaging==19.1           # via tox
 pathlib2==2.3.4           # via importlib-metadata
-pluggy==0.12.0            # via tox
+pluggy==0.13.0            # via tox
 py==1.8.0                 # via tox
 pyparsing==2.4.2          # via packaging
 requests==2.22.0          # via codecov
@@ -25,7 +25,7 @@ scandir==1.10.0           # via pathlib2
 six==1.12.0               # via more-itertools, packaging, pathlib2, tox
 toml==0.10.0              # via tox
 tox-battery==0.5.1
-tox==3.13.2
+tox==3.14.0
 urllib3==1.25.3           # via requests
-virtualenv==16.7.4        # via tox
+virtualenv==16.7.5        # via tox
 zipp==0.6.0               # via importlib-metadata


### PR DESCRIPTION
Ran this to unblock the edx-platform upgrarde of edx-opaque keys.

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
