### PR TITLE
Added passwords for files to the API for reporting config

### DIFF
--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.10.1"
+__version__ = "1.10.2"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -449,7 +449,6 @@ class EnterpriseCustomerReportingConfigurationSerializer(serializers.ModelSerial
     """
     Serializer for EnterpriseCustomerReportingConfiguration model.
     """
-
     class Meta:
         model = models.EnterpriseCustomerReportingConfiguration
         fields = (
@@ -459,6 +458,8 @@ class EnterpriseCustomerReportingConfigurationSerializer(serializers.ModelSerial
             'pgp_encryption_key', 'enterprise_customer_catalogs', 'uuid'
         )
 
+    encrypted_password = serializers.CharField(required=False, allow_blank=False, read_only=False)
+    encrypted_sftp_password = serializers.CharField(required=False, allow_blank=False, read_only=False)
     enterprise_customer = EnterpriseCustomerSerializer(read_only=True)
     enterprise_customer_id = serializers.PrimaryKeyRelatedField(
         queryset=models.EnterpriseCustomer.objects.all(),  # pylint: disable=no-member

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -497,6 +497,12 @@ class EnterpriseCustomerReportingConfigurationViewSet(EnterpriseReadWriteModelVi
     def partial_update(self, request, *args, **kwargs):
         return super(EnterpriseCustomerReportingConfigurationViewSet, self).partial_update(request, *args, **kwargs)
 
+    @permission_required(
+        'enterprise.can_manage_reporting_config',
+        fn=lambda request, *args, **kwargs: get_ent_cust_from_report_config_uuid(kwargs['uuid']))
+    def destroy(self, request, *args, **kwargs):
+        return super(EnterpriseCustomerReportingConfigurationViewSet, self).destroy(request, *args, **kwargs)
+
 
 class CatalogQueryView(APIView):
     """

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -1814,6 +1814,9 @@ class EnterpriseCustomerReportingConfiguration(TimeStampedModel):
     def encrypted_password(self):
         """
         Return encrypted password as a string.
+
+        The data is encrypted in the DB at rest, but is unencrypted in the app when retrieved through the
+        decrypted_password field. This method will encrypt the password again before sending.
         """
         if self.decrypted_password:
             return force_text(
@@ -1823,10 +1826,20 @@ class EnterpriseCustomerReportingConfiguration(TimeStampedModel):
             )
         return self.decrypted_password
 
+    @encrypted_password.setter
+    def encrypted_password(self, value):
+        """
+        Set the encrypted password.
+        """
+        self.decrypted_password = value
+
     @property
     def encrypted_sftp_password(self):
         """
         Return encrypted SFTP password as a string.
+
+        The data is encrypted in the DB at rest, but is unencrypted in the app when retrieved through the
+        decrypted_password field. This method will encrypt the password again before sending.
         """
         if self.decrypted_sftp_password:
             return force_text(
@@ -1835,6 +1848,13 @@ class EnterpriseCustomerReportingConfiguration(TimeStampedModel):
                 )
             )
         return self.decrypted_sftp_password
+
+    @encrypted_sftp_password.setter
+    def encrypted_sftp_password(self, value):
+        """
+        Set the encrypted SFTP password.
+        """
+        self.decrypted_sftp_password = value
 
     def __str__(self):
         """

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -2374,6 +2374,7 @@ class TestEnterpriseReportingConfigAPIViews(APITest):
             'active': 'true',
             'delivery_method': 'email',
             'email': ['test@test.com', 'foo@test.com'],
+            'encrypted_password': 'testPassword',
             'frequency': 'monthly',
             'day_of_month': 1,
             'day_of_week': 3,
@@ -2381,7 +2382,6 @@ class TestEnterpriseReportingConfigAPIViews(APITest):
             'sftp_hostname': 'null',
             'sftp_port': 22,
             'sftp_username': 'test@test.com',
-            'encrypted_sftp_password': 'null',
             'sftp_file_path': 'null',
             'data_type': 'progress',
             'report_type': 'csv',
@@ -2392,7 +2392,7 @@ class TestEnterpriseReportingConfigAPIViews(APITest):
             'active': True,
             'encrypted_sftp_password': None,
         })
-
+        expected_data.pop('encrypted_password')
         client = APIClient()
         client.login(username='test_user', password='test_password')
 
@@ -2416,6 +2416,8 @@ class TestEnterpriseReportingConfigAPIViews(APITest):
         if has_feature_role:
             response_content = self.load_json(response.content)
             assert response_content['enterprise_customer']['uuid'] == str(enterprise_customer.uuid)
+            assert response_content['encrypted_password'] != post_data['encrypted_password']
+            response_content.pop('encrypted_password')
             self._assert_config_response(expected_data, response_content)
 
     @mock.patch('enterprise.rules.crum.get_current_request')
@@ -2448,6 +2450,7 @@ class TestEnterpriseReportingConfigAPIViews(APITest):
             'active': 'true',
             'delivery_method': 'email',
             'email': ['test@test.com', 'foo@test.com'],
+            'encrypted_password': 'passwordUpdate',
             'frequency': 'monthly',
             'day_of_month': 1,
             'day_of_week': 3,
@@ -2461,6 +2464,7 @@ class TestEnterpriseReportingConfigAPIViews(APITest):
             'pgp_encryption_key': ''
         }
         expected_data = put_data.copy()
+        expected_data.pop('encrypted_password')
         expected_data.update({
             'active': True,
         })
@@ -2492,6 +2496,8 @@ class TestEnterpriseReportingConfigAPIViews(APITest):
             response_content = self.load_json(response.content)
             assert response_content['enterprise_customer']['uuid'] == str(enterprise_customer.uuid)
             response_content.pop('enterprise_customer')
+            assert response_content['encrypted_password'] is not None
+            response_content.pop('encrypted_password')
             for key, value in expected_data.items():
                 assert response_content[key] == value
 
@@ -2528,6 +2534,9 @@ class TestEnterpriseReportingConfigAPIViews(APITest):
         }
         expected_data = patch_data.copy()
         expected_data.pop('enterprise_customer_id')
+        patch_data['encrypted_password'] = 'newPassword'
+        patch_data['encrypted_sftp_password'] = 'newSFTPPassword'
+
         test_config = factories.EnterpriseCustomerReportingConfigFactory.create(**model_item)
 
         client = APIClient()


### PR DESCRIPTION
[ENT-2321]

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [x] Translations updated

**Post merge:**
- [x] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [x] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [x] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
