### PR TITLE
ENT-2294 | Updating enterprise_learner_portal LMS API calls to refer …

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ----------
 
+[1.10.5] - 2019-09-23
+---------------------
+
+* Updating enterprise_learner_portal LMS API calls to refer to new function locations in the LMS.
+
+
 [1.10.4] - 2019-09-05
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.10.4"
+__version__ = "1.10.5"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise_learner_portal/api/v1/serializers.py
+++ b/enterprise_learner_portal/api/v1/serializers.py
@@ -12,11 +12,11 @@ from enterprise.utils import NotConnectedToOpenEdX
 from enterprise_learner_portal.utils import get_course_run_status
 
 try:
+    from lms.djangoapps.bulk_email.api import get_emails_enabled
     from lms.djangoapps.certificates.api import get_certificate_for_user
-    from lms.djangoapps.program_enrollments.api.api import (
+    from lms.djangoapps.course_api.api import (
         get_due_dates,
         get_course_run_url,
-        get_emails_enabled,
     )
 except ImportError:
     get_certificate_for_user = None


### PR DESCRIPTION
…to new function locations

NOTE: This cannot be merged and deployed before: https://github.com/edx/edx-platform/pull/21752/files

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
