### PR TITLE
ENT-2352: Removed flaky package and flakiness in unit test

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -27,7 +27,7 @@ click-log==0.3.2          # via edx-lint
 click==7.0
 code-annotations==0.3.2
 configparser==4.0.2
-contextlib2==0.5.5
+contextlib2==0.6.0
 cookies==2.2.1
 coverage==4.5.4
 cryptography==2.7
@@ -62,9 +62,8 @@ edx-rest-api-client==1.9.2
 edx-sphinx-theme==1.5.0
 enum34==1.1.6
 factory-boy==2.12.0
-faker==2.0.1
+faker==2.0.2
 filelock==3.0.12          # via tox
-flaky==3.6.1
 freezegun==0.3.12
 funcsigs==1.0.2
 future==0.17.1
@@ -87,7 +86,7 @@ mccabe==0.6.1             # via pylint
 mock==3.0.5
 more-itertools==5.0.0
 newrelic==5.0.2.126
-packaging==19.1
+packaging==19.2
 path.py==8.2.1
 pathlib2==2.3.4
 pbr==5.4.3
@@ -117,7 +116,7 @@ pytest-cov==2.7.1
 pytest-django==3.5.1
 pytest==4.6.5
 python-dateutil==2.4.0
-python-slugify==3.0.3
+python-slugify==3.0.4
 pytz==2019.2
 pyyaml==5.1.2
 readme-renderer==24.0
@@ -138,21 +137,18 @@ sphinxcontrib-napoleon==0.6.1
 sphinxcontrib-websupport==1.1.2
 stevedore==1.31.0
 testfixtures==6.10.0
-text-unidecode==1.2
+text-unidecode==1.3
 toml==0.10.0              # via tox
 tox-battery==0.5.1
 tox==3.14.0
-tqdm==4.35.0              # via twine
+tqdm==4.36.1              # via twine
 twine==1.11.0
 typing==3.7.4.1
 unicodecsv==0.14.1
-urllib3==1.25.3
+urllib3==1.25.5
 virtualenv==16.7.5        # via tox
 wcwidth==0.1.7
 webencodings==0.5.1
 wheel==0.33.6
 wrapt==1.11.2             # via astroid
 zipp==0.6.0
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.2.0        # via caniusepython3, sphinx, twine

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -10,7 +10,6 @@ amqp==1.4.9               # via kombu
 aniso8601==8.0.0
 anyjson==0.3.3            # via kombu
 asn1crypto==0.24.0
-attrs==19.1.0             # via packaging
 babel==2.7.0              # via sphinx
 billiard==3.3.0.23
 bleach==2.1.4
@@ -57,7 +56,7 @@ jsonfield==2.0.2
 kombu==3.0.37
 markupsafe==1.1.1         # via jinja2
 newrelic==5.0.2.126
-packaging==19.1           # via sphinx
+packaging==19.2           # via sphinx
 path.py==8.2.1
 pbr==5.4.3
 pillow==6.1.0
@@ -71,7 +70,7 @@ pyjwt==1.5.2
 pymongo==2.9.1
 pyparsing==2.4.2          # via packaging
 python-dateutil==2.4.0
-python-slugify==3.0.3
+python-slugify==3.0.4
 pytz==2019.2
 pyyaml==5.1.2
 readme-renderer==24.0
@@ -88,11 +87,8 @@ sphinxcontrib-napoleon==0.6.1
 sphinxcontrib-websupport==1.1.2  # via sphinx
 stevedore==1.31.0
 testfixtures==6.10.0
-text-unidecode==1.2       # via python-slugify
+text-unidecode==1.3       # via python-slugify
 typing==3.7.4.1           # via sphinx
 unicodecsv==0.14.1
-urllib3==1.25.3
+urllib3==1.25.5
 webencodings==0.5.1       # via html5lib
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.2.0        # via sphinx

--- a/requirements/edx-platform-constraints.txt
+++ b/requirements/edx-platform-constraints.txt
@@ -30,7 +30,7 @@ chardet==3.0.4
 git+https://github.com/edx/openedx-chem.git@ff4e3a03d3c7610e47a9af08eb648d8aabe2eb18#egg=chem==1.0.0
 click==7.0                # via code-annotations, user-util
 code-annotations==0.3.2   # via edx-enterprise
-contextlib2==0.5.5
+contextlib2==0.6.0
 coreapi==2.3.3            # via drf-yasg
 coreschema==0.0.4         # via coreapi, drf-yasg
 git+https://github.com/edx/crowdsourcehinter.git@a7ffc85b134b7d8909bf1fefd23dbdb8eb28e467#egg=crowdsourcehinter-xblock==0.2
@@ -83,7 +83,7 @@ docutils==0.15.2          # via botocore
 drf-yasg==1.16
 edx-ace==0.1.10
 edx-analytics-data-api-client==0.15.3
-edx-bulk-grades==0.6.0
+edx-bulk-grades==0.6.4
 edx-ccx-keys==1.0.0
 edx-celeryutils==0.3.0
 edx-completion==2.0.0
@@ -92,21 +92,21 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==2.0.0
 edx-drf-extensions==2.4.0
-edx-enterprise==1.9.12
+edx-enterprise==1.10.4
 edx-i18n-tools==0.4.8
 edx-milestones==0.2.3
-edx-oauth2-provider==1.3.0
+edx-oauth2-provider==1.3.1
 edx-opaque-keys[django]==2.0.0
 edx-organizations==2.1.0
 edx-proctoring-proctortrack==1.0.5
-edx-proctoring==2.0.8
+edx-proctoring==2.0.9
 edx-rbac==1.0.3           # via edx-enterprise
 edx-rest-api-client==1.9.2
 edx-search==1.2.2
 git+https://github.com/mitodl/edx-sga.git@3828ba9e413080a81b907a3381e5ffa05e063f81#egg=edx-sga==0.8.3
 edx-submissions==3.0.1
-edx-user-state-client==1.1.1
-edx-when==0.3
+edx-user-state-client==1.1.2
+edx-when==0.4
 edxval==1.1.27
 elasticsearch==1.9.0      # via edx-search
 enum34==1.1.6
@@ -114,6 +114,7 @@ event-tracking==0.2.9
 feedparser==5.1.3
 fs-s3fs==0.1.8
 fs==2.0.18
+funcsigs==1.0.2
 future==0.17.1            # via edx-celeryutils, edx-enterprise, pyjwkest
 futures==3.3.0 ; python_version == "2.7"  # via django-pipeline, python-swiftclient, s3transfer, xblock-utils
 geoip2==2.9.0
@@ -145,7 +146,7 @@ markdown==2.6.11
 markey==0.8               # via django-babel-underscore
 markupsafe==1.1.1
 maxminddb==1.4.1          # via geoip2
-mock==1.0.1
+mock==3.0.5
 git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a#egg=MongoDBProxy==0.1.0+edx.2
 mongoengine==0.10.0
 mpmath==1.1.0             # via sympy
@@ -186,15 +187,15 @@ python-dateutil==2.4.0
 python-levenshtein==0.12.0
 python-memcached==1.59
 python-openid==2.2.5 ; python_version == "2.7"  # via social-auth-core
-python-slugify==3.0.3     # via code-annotations
-python-swiftclient==3.8.0
+python-slugify==3.0.4     # via code-annotations
+python-swiftclient==3.8.1
 python3-saml==1.5.0
 pytz==2019.2
 pyuca==1.1
 pyyaml==5.1.2
-git+https://github.com/edx/RecommenderXBlock.git@1.4.1#egg=recommender-xblock==1.4.1
+recommender-xblock==1.4.4
 redis==2.10.6
-reportlab==3.5.23
+reportlab==3.5.26
 requests-oauthlib==1.1.0
 requests==2.22.0
 rest-condition==1.0.3
@@ -221,14 +222,14 @@ soupsieve==1.9.3          # via beautifulsoup4
 sqlparse==0.3.0
 staff-graded-xblock==0.5
 stevedore==1.31.0
-super-csv==0.9.1
+super-csv==0.9.4
 sympy==1.4
 testfixtures==6.10.0      # via edx-enterprise
-text-unidecode==1.2       # via python-slugify
+text-unidecode==1.3       # via python-slugify
 tincan==0.0.5             # via edx-enterprise
 unicodecsv==0.14.1
 uritemplate==3.0.0        # via coreapi, drf-yasg
-urllib3==1.25.3
+urllib3==1.25.5
 user-util==0.1.5
 voluptuous==0.11.7
 watchdog==0.9.0
@@ -239,7 +240,7 @@ wrapt==1.10.5
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.4#egg=xblock-drag-and-drop-v2==2.2.4
 git+https://github.com/open-craft/xblock-poll@add89e14558c30f3c8dc7431e5cd6536fff6d941#egg=xblock-poll==1.5.1
 xblock-utils==1.2.2
-xblock==1.2.4
+xblock==1.2.5
 xmlsec==1.3.3             # via python3-saml
 xss-utils==0.1.1
 

--- a/requirements/js_test.txt
+++ b/requirements/js_test.txt
@@ -8,7 +8,7 @@ argparse==1.4.0           # via jasmine
 backports.functools-lru-cache==1.5  # via cheroot, jaraco.functools
 cheroot==6.5.8            # via cherrypy
 cherrypy==17.3.0
-contextlib2==0.5.5        # via cherrypy
+contextlib2==0.6.0        # via cherrypy
 glob2==0.7                # via jasmine-core
 jaraco.functools==2.0     # via tempora
 jasmine-core==2.99.1      # via jasmine
@@ -24,6 +24,3 @@ selenium==3.6.0           # via jasmine
 six==1.12.0               # via cheroot, cherrypy, jasmine, more-itertools, tempora
 tempora==1.14.1           # via portend
 zc.lockfile==2.0          # via cherrypy
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.2.0        # via zc.lockfile

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -55,7 +55,7 @@ pyjwkest==1.3.2           # via edx-drf-extensions
 pyjwt==1.5.2              # via edx-rest-api-client
 pymongo==2.9.1            # via edx-opaque-keys
 python-dateutil==2.4.0
-python-slugify==3.0.3     # via code-annotations
+python-slugify==3.0.4     # via code-annotations
 pytz==2019.2
 pyyaml==5.1.2             # via code-annotations
 requests==2.22.0
@@ -67,4 +67,4 @@ slumber==0.7.1
 stevedore==1.31.0
 testfixtures==6.10.0
 unicodecsv==0.14.1
-urllib3==1.25.3           # via requests
+urllib3==1.25.5           # via requests

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -6,7 +6,6 @@ ddt                       # data-driven tests
 diff-cover
 django-model-utils        # Provides TimeStampedModel abstract base class
 factory_boy               # Test factory framework
-flaky                     # rerun flaky tests automatically if they fail, up to a limit
 freezegun                 # Time freezing library
 mock                      # mocking library
 pytest-catchlog           # Show log output for test failures
@@ -14,4 +13,3 @@ pytest-cov                # pytest extension for code coverage statistics
 pytest-django             # pytest extension for better Django support
 responses                 # utility library for mocking out the requests library
 testfixtures              # Mock objects for unit tests and doc tests
-flaky                     # Rerun flaky tests automatically if they fail, up to a limit

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,7 +10,7 @@ aniso8601==8.0.0
 anyjson==0.3.3            # via kombu
 asn1crypto==0.24.0
 atomicwrites==1.3.0       # via pytest
-attrs==19.1.0             # via packaging, pytest
+attrs==19.1.0             # via pytest
 billiard==3.3.0.23
 bleach==2.1.4
 celery==3.1.25
@@ -20,7 +20,7 @@ chardet==3.0.4
 click==7.0
 code-annotations==0.3.2
 configparser==4.0.2       # via importlib-metadata
-contextlib2==0.5.5        # via importlib-metadata
+contextlib2==0.6.0        # via importlib-metadata
 cookies==2.2.1            # via responses
 coverage==4.5.4           # via pytest-cov
 cryptography==2.7
@@ -49,8 +49,7 @@ edx-rbac==1.0.3
 edx-rest-api-client==1.9.2
 enum34==1.1.6
 factory-boy==2.12.0
-faker==2.0.1              # via factory-boy
-flaky==3.6.1
+faker==2.0.2              # via factory-boy
 freezegun==0.3.12
 funcsigs==1.0.2           # via mock, pytest
 future==0.17.1
@@ -68,7 +67,7 @@ markupsafe==1.1.1         # via jinja2
 mock==3.0.5
 more-itertools==5.0.0     # via pytest, zipp
 newrelic==5.0.2.126
-packaging==19.1           # via pytest
+packaging==19.2           # via pytest
 path.py==8.2.1
 pathlib2==2.3.4           # via importlib-metadata, pytest, pytest-django
 pbr==5.4.3
@@ -88,7 +87,7 @@ pytest-cov==2.7.1
 pytest-django==3.5.1
 pytest==4.6.5             # via pytest-catchlog, pytest-cov, pytest-django
 python-dateutil==2.4.0
-python-slugify==3.0.3
+python-slugify==3.0.4
 pytz==2019.2
 pyyaml==5.1.2
 requests==2.22.0
@@ -101,9 +100,9 @@ six==1.12.0
 slumber==0.7.1
 stevedore==1.31.0
 testfixtures==6.10.0
-text-unidecode==1.2       # via faker, python-slugify
+text-unidecode==1.3       # via faker, python-slugify
 unicodecsv==0.14.1
-urllib3==1.25.3
+urllib3==1.25.5
 wcwidth==0.1.7            # via pytest
 webencodings==0.5.1       # via html5lib
 zipp==0.6.0               # via importlib-metadata

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -4,18 +4,17 @@
 #
 #    make upgrade
 #
-attrs==19.1.0             # via packaging
 certifi==2019.9.11        # via requests
 chardet==3.0.4            # via requests
 codecov==2.0.15
 configparser==4.0.2       # via importlib-metadata
-contextlib2==0.5.5        # via importlib-metadata
+contextlib2==0.6.0        # via importlib-metadata
 coverage==4.5.4           # via codecov
 filelock==3.0.12          # via tox
 idna==2.8                 # via requests
 importlib-metadata==0.23  # via pluggy, tox
 more-itertools==5.0.0     # via zipp
-packaging==19.1           # via tox
+packaging==19.2           # via tox
 pathlib2==2.3.4           # via importlib-metadata
 pluggy==0.13.0            # via tox
 py==1.8.0                 # via tox
@@ -26,6 +25,6 @@ six==1.12.0               # via more-itertools, packaging, pathlib2, tox
 toml==0.10.0              # via tox
 tox-battery==0.5.1
 tox==3.14.0
-urllib3==1.25.3           # via requests
+urllib3==1.25.6           # via requests
 virtualenv==16.7.5        # via tox
 zipp==0.6.0               # via importlib-metadata

--- a/tests/test_integrated_channels/test_sap_success_factors/test_client.py
+++ b/tests/test_integrated_channels/test_sap_success_factors/test_client.py
@@ -7,13 +7,12 @@ from __future__ import absolute_import, unicode_literals, with_statement
 
 import datetime
 import json
-import time
 import unittest
 
 import ddt
 import requests
 import responses
-from flaky import flaky
+from freezegun import freeze_time
 from pytest import mark, raises
 
 from integrated_channels.exceptions import ClientError
@@ -22,6 +21,8 @@ from integrated_channels.sap_success_factors.models import (
     SAPSuccessFactorsEnterpriseCustomerConfiguration,
     SAPSuccessFactorsGlobalConfiguration,
 )
+
+NOW = datetime.datetime(2017, 1, 2, 3, 4, 5)
 
 
 @ddt.ddt
@@ -75,10 +76,10 @@ class TestSAPSuccessFactorsAPIClient(unittest.TestCase):
             secret=self.client_secret
         )
 
-    @flaky(max_runs=3)
     @responses.activate
+    @freeze_time(NOW)
     def test_get_oauth_access_token(self):
-        expected_response = (self.access_token, datetime.datetime.utcfromtimestamp(self.expires_in + int(time.time())))
+        expected_response = (self.access_token, NOW + datetime.timedelta(seconds=self.expires_in))
 
         responses.add(
             responses.POST,


### PR DESCRIPTION
Removed flaky package and flakiness in unit test,
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
