### PR TITLE
ENT-1289 | Removing enterprise entitlement logic from codebase

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[2.0.0] - 2019-10-02
+---------------------
+
+* Removing EnterpriseCustomerEntitlement code
+
 [1.11.0] - 2019-10-02
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.11.0"
+__version__ = "2.0.0"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/admin/__init__.py
+++ b/enterprise/admin/__init__.py
@@ -45,7 +45,6 @@ from enterprise.models import (
     EnterpriseCustomer,
     EnterpriseCustomerBrandingConfiguration,
     EnterpriseCustomerCatalog,
-    EnterpriseCustomerEntitlement,
     EnterpriseCustomerIdentityProvider,
     EnterpriseCustomerReportingConfiguration,
     EnterpriseCustomerType,
@@ -85,35 +84,6 @@ class EnterpriseCustomerIdentityProviderInline(admin.StackedInline):
 
     model = EnterpriseCustomerIdentityProvider
     form = EnterpriseCustomerIdentityProviderAdminForm
-
-
-class EnterpriseCustomerEntitlementInline(admin.StackedInline):
-    """
-    Django admin model for EnterpriseCustomerEntitlement.
-    The admin interface has the ability to edit models on the same page as a parent model. These are called inlines.
-    https://docs.djangoproject.com/en/1.8/ref/contrib/admin/#django.contrib.admin.StackedInline
-    """
-
-    model = EnterpriseCustomerEntitlement
-    extra = 0
-    can_delete = True
-    fields = ('enterprise_customer', 'entitlement_id', 'ecommerce_coupon_url',)
-
-    def ecommerce_coupon_url(self, instance):
-        """
-        Instance is EnterpriseCustomer. Return e-commerce coupon urls.
-        """
-        if not instance.entitlement_id:
-            return "N/A"
-
-        return format_html(
-            '<a href="{base_url}/coupons/{id}" target="_blank">View coupon "{id}" details</a>',
-            base_url=settings.ECOMMERCE_PUBLIC_URL_ROOT, id=instance.entitlement_id
-        )
-
-    readonly_fields = ('ecommerce_coupon_url',)
-    ecommerce_coupon_url.allow_tags = True
-    ecommerce_coupon_url.short_description = 'Seat Entitlement URL'
 
 
 class EnterpriseCustomerCatalogInline(admin.TabularInline):
@@ -165,7 +135,6 @@ class EnterpriseCustomerAdmin(DjangoObjectActions, SimpleHistoryAdmin):
         'has_logo',
         'enable_dsc',
         'has_identity_provider',
-        'has_ecommerce_coupons',
         'uuid',
     )
 
@@ -175,7 +144,6 @@ class EnterpriseCustomerAdmin(DjangoObjectActions, SimpleHistoryAdmin):
     inlines = [
         EnterpriseCustomerBrandingConfigurationInline,
         EnterpriseCustomerIdentityProviderInline,
-        EnterpriseCustomerEntitlementInline,
         EnterpriseCustomerCatalogInline,
     ]
 
@@ -191,18 +159,6 @@ class EnterpriseCustomerAdmin(DjangoObjectActions, SimpleHistoryAdmin):
 
     class Meta(object):
         model = EnterpriseCustomer
-
-    def has_ecommerce_coupons(self, instance):
-        """
-        Return True if provded enterprise customer has ecommerce coupons.
-
-        Arguments:
-            instance (enterprise.models.EnterpriseCustomer): `EnterpriseCustomer` model instance
-        """
-        return instance.enterprise_customer_entitlements.exists()
-
-    has_ecommerce_coupons.boolean = True
-    has_ecommerce_coupons.short_description = 'Ecommerce coupons'
 
     def get_form(self, request, obj=None, **kwargs):
         """

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -96,18 +96,6 @@ class EnterpriseCustomerBrandingConfigurationSerializer(serializers.ModelSeriali
         return obj.enterprise_customer.slug
 
 
-class EnterpriseCustomerEntitlementSerializer(serializers.ModelSerializer):
-    """
-    Serializer for EnterpriseCustomerEntitlement model.
-    """
-
-    class Meta:
-        model = models.EnterpriseCustomerEntitlement
-        fields = (
-            'enterprise_customer', 'entitlement_id'
-        )
-
-
 class EnterpriseCustomerSerializer(serializers.ModelSerializer):
     """
     Serializer for EnterpriseCustomer model.
@@ -117,7 +105,7 @@ class EnterpriseCustomerSerializer(serializers.ModelSerializer):
         model = models.EnterpriseCustomer
         fields = (
             'uuid', 'name', 'slug', 'active', 'site', 'enable_data_sharing_consent',
-            'enforce_data_sharing_consent', 'branding_configuration', 'enterprise_customer_entitlements',
+            'enforce_data_sharing_consent', 'branding_configuration',
             'identity_provider', 'enable_audit_enrollment', 'replace_sensitive_sso_username',
             'enable_portal_code_management_screen', 'sync_learner_profile_data', 'enable_audit_data_reporting',
             'enable_learner_portal', 'learner_portal_hostname', 'enable_portal_reporting_config_screen'
@@ -125,9 +113,6 @@ class EnterpriseCustomerSerializer(serializers.ModelSerializer):
 
     site = SiteSerializer()
     branding_configuration = EnterpriseCustomerBrandingConfigurationSerializer()
-    enterprise_customer_entitlements = EnterpriseCustomerEntitlementSerializer(  # pylint: disable=invalid-name
-        many=True,
-    )
 
 
 class EnterpriseCustomerBasicSerializer(serializers.ModelSerializer):
@@ -351,22 +336,6 @@ class EnterpriseCustomerUserWriteSerializer(serializers.ModelSerializer):
             enterprise_customer=enterprise_customer,
         )
         ecu.save()
-
-
-class EnterpriseCustomerUserEntitlementSerializer(ImmutableStateSerializer):
-    """
-    Serializer for the entitlements of EnterpriseCustomerUser.
-
-    This Serializer is for read only endpoint of enterprise learner's entitlements
-    It will ignore any state changing requests like POST, PUT and PATCH.
-    """
-
-    entitlements = serializers.ListField(
-        child=serializers.DictField()
-    )
-
-    user = UserSerializer(read_only=True)
-    enterprise_customer = EnterpriseCustomerSerializer(read_only=True)
 
 
 class CourseDetailSerializer(ImmutableStateSerializer):

--- a/enterprise/api/v1/urls.py
+++ b/enterprise/api/v1/urls.py
@@ -21,11 +21,6 @@ router.register(
     'enterprise-customer-branding',
 )
 router.register(
-    "enterprise-customer-entitlement",
-    views.EnterpriseCustomerEntitlementViewSet,
-    'enterprise-customer-entitlement',
-)
-router.register(
     "enterprise_customer_reporting",
     views.EnterpriseCustomerReportingConfigurationViewSet,
     'enterprise-customer-reporting',

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -264,25 +264,6 @@ class EnterpriseCustomerUserViewSet(EnterpriseReadWriteModelViewSet):
             return serializers.EnterpriseCustomerUserReadOnlySerializer
         return serializers.EnterpriseCustomerUserWriteSerializer
 
-    @detail_route()
-    def entitlements(self, request, pk=None):  # pylint: disable=invalid-name,unused-argument
-        """
-        Retrieve the list of entitlements available to this learner.
-
-        Only those entitlements are returned that satisfy enterprise customer's data sharing setting.
-
-        Arguments:
-            request (HttpRequest): Reference to in-progress request instance.
-            pk (Int): Primary key value of the selected enterprise learner.
-
-        Returns:
-            (HttpResponse): Response object containing a list of learner's entitlements.
-        """
-        enterprise_customer_user = self.get_object()
-        instance = {"entitlements": enterprise_customer_user.entitlements}
-        serializer = serializers.EnterpriseCustomerUserEntitlementSerializer(instance, context={'request': request})
-        return Response(serializer.data)
-
 
 class EnterpriseCustomerBrandingConfigurationViewSet(EnterpriseReadOnlyModelViewSet):
     """
@@ -299,22 +280,6 @@ class EnterpriseCustomerBrandingConfigurationViewSet(EnterpriseReadOnlyModelView
     filter_fields = FIELDS
     ordering_fields = FIELDS
     lookup_field = 'enterprise_customer__slug'
-
-
-class EnterpriseCustomerEntitlementViewSet(EnterpriseReadOnlyModelViewSet):
-    """
-    API views for the ``enterprise-customer-entitlements`` API endpoint.
-    """
-
-    queryset = models.EnterpriseCustomerEntitlement.objects.all()
-    serializer_class = serializers.EnterpriseCustomerEntitlementSerializer
-
-    USER_ID_FILTER = 'enterprise_customer__enterprise_customer_users__user_id'
-    FIELDS = (
-        'enterprise_customer', 'entitlement_id',
-    )
-    filter_fields = FIELDS
-    ordering_fields = FIELDS
 
 
 class EnterpriseCustomerCatalogViewSet(EnterpriseReadOnlyModelViewSet):

--- a/test_utils/factories.py
+++ b/test_utils/factories.py
@@ -20,7 +20,6 @@ from enterprise.models import (
     EnterpriseCustomer,
     EnterpriseCustomerBrandingConfiguration,
     EnterpriseCustomerCatalog,
-    EnterpriseCustomerEntitlement,
     EnterpriseCustomerIdentityProvider,
     EnterpriseCustomerReportingConfiguration,
     EnterpriseCustomerUser,
@@ -209,26 +208,6 @@ class PendingEnrollmentFactory(factory.django.DjangoModelFactory):
     course_mode = 'audit'
     user = factory.SubFactory(PendingEnterpriseCustomerUserFactory)
     cohort_name = None
-
-
-class EnterpriseCustomerEntitlementFactory(factory.django.DjangoModelFactory):
-    """
-    EnterpriseCustomerEntitlement factory.
-
-    Creates an instance of EnterpriseCustomerEntitlement with minimal boilerplate - uses this class' attributes as
-    default parameters for EnterpriseCustomerEntitlementFactory constructor.
-    """
-
-    class Meta(object):
-        """
-        Meta for EnterpriseCustomerEntitlementFactory.
-        """
-
-        model = EnterpriseCustomerEntitlement
-
-    id = factory.LazyAttribute(lambda x: FAKER.random_int(min=1))
-    entitlement_id = factory.LazyAttribute(lambda x: FAKER.random_int(min=1))
-    enterprise_customer = factory.SubFactory(EnterpriseCustomerFactory)
 
 
 class EnterpriseCustomerBrandingConfigurationFactory(factory.django.DjangoModelFactory):

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -38,7 +38,6 @@ from enterprise.constants import (
 from enterprise.models import (
     EnterpriseCatalogQuery,
     EnterpriseCourseEnrollment,
-    EnterpriseCustomer,
     EnterpriseCustomerUser,
     EnterpriseFeatureRole,
     EnterpriseFeatureUserRoleAssignment,
@@ -86,7 +85,6 @@ ENTERPRISE_CATALOGS_PROGRAM_ENDPOINT = reverse(
     kwargs={'pk': FAKE_UUIDS[1], 'program_uuid': FAKE_UUIDS[3]}
 )
 ENTERPRISE_COURSE_ENROLLMENT_LIST_ENDPOINT = reverse('enterprise-course-enrollment-list')
-ENTERPRISE_CUSTOMER_ENTITLEMENT_LIST_ENDPOINT = reverse('enterprise-customer-entitlement-list')
 ENTERPRISE_CUSTOMER_BRANDING_LIST_ENDPOINT = reverse('enterprise-customer-branding-list')
 ENTERPRISE_CUSTOMER_BRANDING_DETAIL_ENDPOINT = reverse('enterprise-customer-branding-detail', (TEST_SLUG,))
 ENTERPRISE_CUSTOMER_LIST_ENDPOINT = reverse('enterprise-customer-list')
@@ -97,7 +95,6 @@ ENTERPRISE_CUSTOMER_CONTAINS_CONTENT_ENDPOINT = reverse(
 )
 ENTERPRISE_CUSTOMER_COURSE_ENROLLMENTS_ENDPOINT = reverse('enterprise-customer-course-enrollments', (FAKE_UUIDS[0],))
 ENTERPRISE_CUSTOMER_REPORTING_ENDPOINT = reverse('enterprise-customer-reporting-list')
-ENTERPRISE_LEARNER_ENTITLEMENTS_ENDPOINT = reverse('enterprise-learner-entitlements', (1,))
 ENTERPRISE_LEARNER_LIST_ENDPOINT = reverse('enterprise-learner-list')
 ENTERPRISE_CUSTOMER_WITH_ACCESS_TO_ENDPOINT = reverse('enterprise-customer-with-access-to')
 
@@ -148,84 +145,6 @@ class TestEnterpriseAPIViews(APITest):
         """
         for item in items:
             factory.create(**item)
-
-    @ddt.data(
-        (
-            True, EnterpriseCustomer.AT_ENROLLMENT, True,
-            [1, 2, 3], {"entitlements": [
-                {"entitlement_id": 1, "requires_consent": False},
-                {"entitlement_id": 2, "requires_consent": False},
-                {"entitlement_id": 3, "requires_consent": False},
-            ]},
-        ),
-        (
-            True, EnterpriseCustomer.AT_ENROLLMENT, False,
-            [1, 2, 3], {"entitlements": [
-                {"entitlement_id": 1, "requires_consent": True},
-                {"entitlement_id": 2, "requires_consent": True},
-                {"entitlement_id": 3, "requires_consent": True},
-            ]},
-        ),
-        (
-            False, EnterpriseCustomer.AT_ENROLLMENT, True,
-            [1, 2, 3], {"entitlements": [
-                {"entitlement_id": 1, "requires_consent": False},
-                {"entitlement_id": 2, "requires_consent": False},
-                {"entitlement_id": 3, "requires_consent": False},
-            ]},
-        ),
-        (
-            True, EnterpriseCustomer.AT_ENROLLMENT, None,
-            [], {"entitlements": []},
-        ),
-        (
-            True, EnterpriseCustomer.EXTERNALLY_MANAGED, True,
-            [1, 2, 3],
-            {"entitlements": [
-                {"entitlement_id": 1, "requires_consent": False},
-                {"entitlement_id": 2, "requires_consent": False},
-                {"entitlement_id": 3, "requires_consent": False},
-            ]},
-        ),
-    )
-    @ddt.unpack
-    def test_enterprise_learner_entitlements(
-            self, enable_data_sharing_consent, enforce_data_sharing_consent,
-            learner_consent_state, entitlements, expected_json
-    ):
-        """
-        Test that entitlement details route on enterprise learner returns correct data.
-        This test verifies that entitlements returned by entitlement details route on enterprise learner
-        has the expected behavior as listed down.
-            1. Empty entitlements list if enterprise customer requires data sharing consent
-                (this includes enforcing data sharing consent at login and at enrollment) and enterprise learner
-                 does not consent to share data.
-            2. Full list of entitlements for all other cases.
-        """
-        user_id = self.user.id + 1
-        enterprise_customer = factories.EnterpriseCustomerFactory(
-            enable_data_sharing_consent=enable_data_sharing_consent,
-            enforce_data_sharing_consent=enforce_data_sharing_consent,
-        )
-        user = factories.UserFactory(id=user_id)
-        ecu = factories.EnterpriseCustomerUserFactory(
-            user_id=user.id,
-            enterprise_customer=enterprise_customer,
-        )
-        factories.DataSharingConsentFactory(
-            username=user.username,
-            enterprise_customer=enterprise_customer,
-            granted=learner_consent_state,
-        )
-        for entitlement in entitlements:
-            factories.EnterpriseCustomerEntitlementFactory(
-                enterprise_customer=enterprise_customer,
-                entitlement_id=entitlement,
-            )
-        url = reverse('enterprise-learner-entitlements', (ecu.id, ))
-        response = self.client.get(settings.TEST_SERVER + url)
-        response = self.load_json(response.content)
-        assert sorted(response) == sorted(expected_json)
 
     @override_settings(ECOMMERCE_SERVICE_WORKER_USERNAME=TEST_USERNAME)
     @mock.patch("enterprise.api.v1.serializers.track_enrollment")
@@ -507,7 +426,7 @@ class TestEnterpriseAPIViews(APITest):
                 'uuid': FAKE_UUIDS[0], 'name': 'Test Enterprise Customer', 'slug': TEST_SLUG,
                 'active': True, 'enable_data_sharing_consent': True,
                 'enforce_data_sharing_consent': 'at_enrollment',
-                'branding_configuration': None, 'enterprise_customer_entitlements': [],
+                'branding_configuration': None,
                 'enable_audit_enrollment': False, 'enable_audit_data_reporting': True, 'identity_provider': None,
                 'replace_sensitive_sso_username': False, 'enable_portal_code_management_screen': False,
                 'enable_portal_reporting_config_screen': False,
@@ -540,7 +459,7 @@ class TestEnterpriseAPIViews(APITest):
                     'uuid': FAKE_UUIDS[0], 'name': 'Test Enterprise Customer', 'slug': TEST_SLUG,
                     'active': True, 'enable_data_sharing_consent': True,
                     'enforce_data_sharing_consent': 'at_enrollment',
-                    'branding_configuration': None, 'enterprise_customer_entitlements': [],
+                    'branding_configuration': None,
                     'enable_audit_enrollment': False, 'identity_provider': None,
                     'replace_sensitive_sso_username': False, 'enable_portal_code_management_screen': False,
                     'enable_portal_reporting_config_screen': False,
@@ -552,19 +471,6 @@ class TestEnterpriseAPIViews(APITest):
                     'enable_learner_portal': False,
                     'learner_portal_hostname': '',
                 }
-            }],
-        ),
-        (
-            factories.EnterpriseCustomerEntitlementFactory,
-            ENTERPRISE_CUSTOMER_ENTITLEMENT_LIST_ENDPOINT,
-            itemgetter('enterprise_customer'),
-            [{
-                'enterprise_customer__uuid': FAKE_UUIDS[0],
-                'entitlement_id': 1
-            }],
-            [{
-                'enterprise_customer': FAKE_UUIDS[0],
-                'entitlement_id': 1
             }],
         ),
         (
@@ -599,7 +505,7 @@ class TestEnterpriseAPIViews(APITest):
                 'uuid': FAKE_UUIDS[1], 'name': 'Test Enterprise Customer', 'slug': TEST_SLUG,
                 'active': True, 'enable_data_sharing_consent': True,
                 'enforce_data_sharing_consent': 'at_enrollment',
-                'branding_configuration': None, 'enterprise_customer_entitlements': [],
+                'branding_configuration': None,
                 'enable_audit_enrollment': False, 'identity_provider': FAKE_UUIDS[0],
                 'replace_sensitive_sso_username': False, 'enable_portal_code_management_screen': False,
                 'enable_portal_reporting_config_screen': False,
@@ -753,7 +659,7 @@ class TestEnterpriseAPIViews(APITest):
                 'uuid': FAKE_UUIDS[0], 'name': 'Test Enterprise Customer', 'slug': TEST_SLUG,
                 'active': True, 'enable_data_sharing_consent': True,
                 'enforce_data_sharing_consent': 'at_enrollment',
-                'branding_configuration': None, 'enterprise_customer_entitlements': [],
+                'branding_configuration': None,
                 'enable_audit_enrollment': False, 'enable_audit_data_reporting': False, 'identity_provider': None,
                 'replace_sensitive_sso_username': False, 'enable_portal_code_management_screen': True,
                 'enable_portal_reporting_config_screen': False,

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -81,7 +81,6 @@ class TestEnterpriseUtils(unittest.TestCase):
                 "pendingenterprisecustomeruser",
                 "branding_configuration",
                 "enterprise_customer_identity_provider",
-                "enterprise_customer_entitlements",
                 "enterprise_customer_catalogs",
                 "enterprise_enrollment_template",
                 "reporting_configurations",


### PR DESCRIPTION
This needs to be merged and deployed AFTER the corresponding ecommerce  PR here: https://github.com/edx/ecommerce/pull/2612

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
