### PR TITLE
ENT-2258: Strip html tags and entities from course description for degreed

### DIFF
--- a/integrated_channels/degreed/exporters/content_metadata.py
+++ b/integrated_channels/degreed/exporters/content_metadata.py
@@ -9,6 +9,7 @@ from logging import getLogger
 
 from enterprise.utils import get_closest_course_run, get_course_run_duration_info
 from integrated_channels.integrated_channel.exporters.content_metadata import ContentMetadataExporter
+from integrated_channels.utils import strip_html_tags
 
 LOGGER = getLogger(__name__)
 
@@ -49,7 +50,7 @@ class DegreedContentMetadataExporter(ContentMetadataExporter):  # pylint: disabl
             description = content_metadata_item.get('short_description') or content_metadata_item.get('title') or ''
         if description:
             description = "{duration_info}{description}".format(duration_info=duration_info, description=description)
-        return description
+        return strip_html_tags(description)
 
     def transform_courserun_content_language(self, content_metadata_item):
         """

--- a/integrated_channels/utils.py
+++ b/integrated_channels/utils.py
@@ -6,12 +6,14 @@ Utilities common to different integrated channels.
 from __future__ import absolute_import, unicode_literals
 
 import datetime
+import re
 from itertools import islice
 from string import Formatter
 
 from six.moves import range
 
 from django.utils import timezone
+from django.utils.html import strip_tags
 
 from enterprise.api_client.lms import parse_lms_api_datetime
 
@@ -29,6 +31,20 @@ def parse_datetime_to_epoch(datestamp, magnitude=1.0):
     parsed_datetime = parse_lms_api_datetime(datestamp)
     time_since_epoch = parsed_datetime - UNIX_EPOCH
     return int(time_since_epoch.total_seconds() * magnitude)
+
+
+def strip_html_tags(text, strip_entities=True):
+    """
+    Return (str): Text without any html tags and entities.
+
+    Args:
+        text (str): text having html tags
+        strip_entities (bool): If set to True html entities are also stripped
+    """
+    text = strip_tags(text)
+    if strip_entities:
+        text = re.sub(r'&([a-zA-Z]{4,5}|#[0-9]{2,4});', '', text)
+    return text
 
 
 def parse_datetime_to_epoch_millis(datestamp):

--- a/tests/test_integrated_channels/test_degreed/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_degreed/test_exporters/test_content_metadata.py
@@ -184,6 +184,30 @@ class TestDegreedContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin)
             },
             '',
         ),
+        (
+            {
+                'title': '',
+                'short_description': '',
+                'full_description': '<p>This course is part of the '
+                                    '<a href=\"../../../../microsoft-professional-program-certficate-data-science\">'
+                                    '<em>&#8804;Professional Program Certificate in Data Science</em></a>'
+                                    '&nbsp;That doesn&rsquo;t<em> '
+                                    'only teach us how to build a cloud data science solution using Microsoft Azure '
+                                    'Machine Learning platform',
+                'course_runs': [
+                    {
+                        'start': '2018-02-05T05:00:00Z',
+                        'min_effort': 2,
+                        'max_effort': 4,
+                        'weeks_to_complete': 10
+                    }
+                ]
+            },
+
+            '2-4 hours a week for 10 weeks. '
+            'This course is part of the Professional Program Certificate in Data ScienceThat doesnt '
+            'only teach us how to build a cloud data science solution using Microsoft Azure Machine Learning platform'
+        ),
     )
     @responses.activate
     @ddt.unpack


### PR DESCRIPTION
It appears Degreed accepts only plain text in course description. These changes strip html tags and entities from course description for degreed. ENT-2258

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
