### PR TITLE
Commenting out new course enrollment signal code as it seems to be no…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[2.0.1] - 2019-10-07
+--------------------
+
+* Commenting out code while troubleshooting signal issue in the LMS
+
 [2.0.0] - 2019-10-02
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/signals.py
+++ b/enterprise/signals.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, unicode_literals
 
 from logging import getLogger
 
-#from django.core.exceptions import ObjectDoesNotExist
+# from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
@@ -20,7 +20,7 @@ from enterprise.models import (
     SystemWideEnterpriseRole,
     SystemWideEnterpriseUserRoleAssignment,
 )
-#from enterprise.tasks import create_enterprise_enrollment
+# from enterprise.tasks import create_enterprise_enrollment
 from enterprise.utils import get_default_catalog_content_filter, track_enrollment
 
 # try:

--- a/enterprise/signals.py
+++ b/enterprise/signals.py
@@ -124,31 +124,32 @@ def delete_enterprise_learner_role_assignment(sender, instance, **kwargs):     #
             # Do nothing if no role assignment is present for the enterprise customer user.
             pass
 
+# TODO: investigating error around this receiver. will uncomment when resolved
 
-def create_enterprise_enrollment_receiver(sender, instance, **kwargs):     # pylint: disable=unused-argument
-    """
-    Watches for post_save signal for creates on the CourseEnrollment table.
+# def create_enterprise_enrollment_receiver(sender, instance, **kwargs):     # pylint: disable=unused-argument
+#     """
+#     Watches for post_save signal for creates on the CourseEnrollment table.
 
-    Spin off an async task to generate an EnterpriseCourseEnrollment if appropriate.
-    """
-    if kwargs.get('created') and instance.user:
-        user_id = instance.user.id
-        try:
-            ecu = EnterpriseCustomerUser.objects.get(user_id=user_id)
-        except ObjectDoesNotExist:
-            return
-        logger.info((
-            "User %s is an EnterpriseCustomerUser. "
-            "Spinning off task to check if course is within User's "
-            "Enterprise's EnterpriseCustomerCatalog."
-        ), user_id)
+#     Spin off an async task to generate an EnterpriseCourseEnrollment if appropriate.
+#     """
+#     if kwargs.get('created') and instance.user:
+#         user_id = instance.user.id
+#         try:
+#             ecu = EnterpriseCustomerUser.objects.get(user_id=user_id)
+#         except ObjectDoesNotExist:
+#             return
+#         logger.info((
+#             "User %s is an EnterpriseCustomerUser. "
+#             "Spinning off task to check if course is within User's "
+#             "Enterprise's EnterpriseCustomerCatalog."
+#         ), user_id)
 
-        create_enterprise_enrollment.delay(
-            instance.course_id,
-            ecu,
-        )
+#         create_enterprise_enrollment.delay(
+#             instance.course_id,
+#             ecu,
+#         )
 
 
 # Don't connect this receiver if we dont have access to CourseEnrollment model
-if CourseEnrollment is not None:
-    post_save.connect(create_enterprise_enrollment_receiver, sender=CourseEnrollment)
+# if CourseEnrollment is not None:
+#     post_save.connect(create_enterprise_enrollment_receiver, sender=CourseEnrollment)

--- a/enterprise/signals.py
+++ b/enterprise/signals.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, unicode_literals
 
 from logging import getLogger
 
-from django.core.exceptions import ObjectDoesNotExist
+#from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
@@ -20,13 +20,13 @@ from enterprise.models import (
     SystemWideEnterpriseRole,
     SystemWideEnterpriseUserRoleAssignment,
 )
-from enterprise.tasks import create_enterprise_enrollment
+#from enterprise.tasks import create_enterprise_enrollment
 from enterprise.utils import get_default_catalog_content_filter, track_enrollment
 
-try:
-    from student.models import CourseEnrollment
-except ImportError:
-    CourseEnrollment = None
+# try:
+#     from student.models import CourseEnrollment
+# except ImportError:
+#     CourseEnrollment = None
 
 logger = getLogger(__name__)  # pylint: disable=invalid-name
 

--- a/tests/test_enterprise/test_signals.py
+++ b/tests/test_enterprise/test_signals.py
@@ -467,68 +467,68 @@ class TestEnterpriseLearnerRoleSignals(unittest.TestCase):
         self.assertFalse(learner_role_assignment.exists())
 
 
-@mark.django_db
-class TestCourseEnrollmentSignals(unittest.TestCase):
-    """
-    Tests signals associated with CourseEnrollments (that are found in edx-platform).
-    """
-    def setUp(self):
-        """
-        Setup for `TestCourseEnrollmentSignals` test.
-        """
-        self.user = UserFactory(id=2, email='user@example.com')
-        self.enterprise_customer = EnterpriseCustomerFactory(
-            name='Team Titans',
-        )
-        self.enterprise_customer_user = EnterpriseCustomerUserFactory(
-            user_id=self.user.id,
-            enterprise_customer=self.enterprise_customer,
-        )
-        self.non_enterprise_user = UserFactory(id=999, email='user999@example.com')
-        super(TestCourseEnrollmentSignals, self).setUp()
+# @mark.django_db
+# class TestCourseEnrollmentSignals(unittest.TestCase):
+#     """
+#     Tests signals associated with CourseEnrollments (that are found in edx-platform).
+#     """
+#     def setUp(self):
+#         """
+#         Setup for `TestCourseEnrollmentSignals` test.
+#         """
+#         self.user = UserFactory(id=2, email='user@example.com')
+#         self.enterprise_customer = EnterpriseCustomerFactory(
+#             name='Team Titans',
+#         )
+#         self.enterprise_customer_user = EnterpriseCustomerUserFactory(
+#             user_id=self.user.id,
+#             enterprise_customer=self.enterprise_customer,
+#         )
+#         self.non_enterprise_user = UserFactory(id=999, email='user999@example.com')
+#         super(TestCourseEnrollmentSignals, self).setUp()
 
-    @mock.patch('enterprise.tasks.create_enterprise_enrollment.delay')
-    def test_receiver_calls_task_if_ecu_exists(self, mock_task):
-        """
-        Receiver should call a task
-        if user tied to the CourseEnrollment that is handed into the function
-        is an EnterpriseCustomerUser
-        """
-        sender = mock.Mock()  # This would be a CourseEnrollment class
-        instance = mock.Mock()  # This would be a CourseEnrollment instance
-        instance.user = self.user
-        instance.course_id = "fake:course_id"
-        # Signal metadata (note: 'signal' would be an actual object, but we dont need it here)
-        kwargs = {
-            'update_fields': None,
-            'raw': False,
-            'signal': '<django.db.models.signals.ModelSignal object at 0x7fcfc38b5e90>',
-            'using': 'default',
-            'created': True,
-        }
+#     @mock.patch('enterprise.tasks.create_enterprise_enrollment.delay')
+#     def test_receiver_calls_task_if_ecu_exists(self, mock_task):
+#         """
+#         Receiver should call a task
+#         if user tied to the CourseEnrollment that is handed into the function
+#         is an EnterpriseCustomerUser
+#         """
+#         sender = mock.Mock()  # This would be a CourseEnrollment class
+#         instance = mock.Mock()  # This would be a CourseEnrollment instance
+#         instance.user = self.user
+#         instance.course_id = "fake:course_id"
+#         # Signal metadata (note: 'signal' would be an actual object, but we dont need it here)
+#         kwargs = {
+#             'update_fields': None,
+#             'raw': False,
+#             'signal': '<django.db.models.signals.ModelSignal object at 0x7fcfc38b5e90>',
+#             'using': 'default',
+#             'created': True,
+#         }
 
-        create_enterprise_enrollment_receiver(sender, instance, **kwargs)
-        mock_task.assert_called_once_with(instance.course_id, self.enterprise_customer_user)
+#         create_enterprise_enrollment_receiver(sender, instance, **kwargs)
+#         mock_task.assert_called_once_with(instance.course_id, self.enterprise_customer_user)
 
-    @mock.patch('enterprise.tasks.create_enterprise_enrollment.delay')
-    def test_receiver_does_not_call_task_if_ecu_not_exists(self, mock_task):
-        """
-        Receiver should NOT call a task
-        if user tied to the CourseEnrollment that is handed into the function
-        is NOT an EnterpriseCustomerUser
-        """
-        sender = mock.Mock()  # This would be a CourseEnrollment class
-        instance = mock.Mock()  # This would be a CourseEnrollment instance
-        instance.user = self.non_enterprise_user
-        instance.course_id = "fake:course_id"
-        # Signal metadata (note: 'signal' would be an actual object, but we dont need it here)
-        kwargs = {
-            'update_fields': None,
-            'raw': False,
-            'signal': '<django.db.models.signals.ModelSignal object at 0x7fcfc38b5e90>',
-            'using': 'default',
-            'created': True,
-        }
+#     @mock.patch('enterprise.tasks.create_enterprise_enrollment.delay')
+#     def test_receiver_does_not_call_task_if_ecu_not_exists(self, mock_task):
+#         """
+#         Receiver should NOT call a task
+#         if user tied to the CourseEnrollment that is handed into the function
+#         is NOT an EnterpriseCustomerUser
+#         """
+#         sender = mock.Mock()  # This would be a CourseEnrollment class
+#         instance = mock.Mock()  # This would be a CourseEnrollment instance
+#         instance.user = self.non_enterprise_user
+#         instance.course_id = "fake:course_id"
+#         # Signal metadata (note: 'signal' would be an actual object, but we dont need it here)
+#         kwargs = {
+#             'update_fields': None,
+#             'raw': False,
+#             'signal': '<django.db.models.signals.ModelSignal object at 0x7fcfc38b5e90>',
+#             'using': 'default',
+#             'created': True,
+#         }
 
-        create_enterprise_enrollment_receiver(sender, instance, **kwargs)
-        mock_task.assert_not_called()
+#         create_enterprise_enrollment_receiver(sender, instance, **kwargs)
+#         mock_task.assert_not_called()

--- a/tests/test_enterprise/test_signals.py
+++ b/tests/test_enterprise/test_signals.py
@@ -23,7 +23,7 @@ from enterprise.models import (
     SystemWideEnterpriseRole,
     SystemWideEnterpriseUserRoleAssignment,
 )
-from enterprise.signals import create_enterprise_enrollment_receiver, handle_user_post_save
+#from enterprise.signals import create_enterprise_enrollment_receiver, handle_user_post_save
 from test_utils.factories import (
     EnterpriseCustomerCatalogFactory,
     EnterpriseCustomerFactory,

--- a/tests/test_enterprise/test_signals.py
+++ b/tests/test_enterprise/test_signals.py
@@ -23,7 +23,7 @@ from enterprise.models import (
     SystemWideEnterpriseRole,
     SystemWideEnterpriseUserRoleAssignment,
 )
-#from enterprise.signals import create_enterprise_enrollment_receiver, handle_user_post_save
+from enterprise.signals import handle_user_post_save
 from test_utils.factories import (
     EnterpriseCustomerCatalogFactory,
     EnterpriseCustomerFactory,


### PR DESCRIPTION
…t playing nicely on stage

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
