### PR TITLE
ENT-1878 | Automate catalog query when updating enterprise customer catalog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,13 @@ Change Log
 
 Unreleased
 ----------
+
+[2.0.4] - 2019-10-10
+--------------------
+
+* Added preview button for EnterpriseCustomerCatalogs in EnterpriseCustomer admin page
+
+
 [2.0.3] - 2019-10-09
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "2.0.3"
+__version__ = "2.0.4"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/admin/__init__.py
+++ b/enterprise/admin/__init__.py
@@ -26,6 +26,7 @@ from django.utils.translation import ugettext as _
 from enterprise.admin.actions import export_as_csv_action
 from enterprise.admin.forms import (
     EnterpriseCustomerAdminForm,
+    EnterpriseCustomerCatalogAdminForm,
     EnterpriseCustomerIdentityProviderAdminForm,
     EnterpriseCustomerReportingConfigAdminForm,
     EnterpriseFeatureUserRoleAssignmentForm,
@@ -94,6 +95,7 @@ class EnterpriseCustomerCatalogInline(admin.TabularInline):
     """
 
     model = EnterpriseCustomerCatalog
+    form = EnterpriseCustomerCatalogAdminForm
     extra = 0
     can_delete = False
 
@@ -159,6 +161,18 @@ class EnterpriseCustomerAdmin(DjangoObjectActions, SimpleHistoryAdmin):
 
     class Meta(object):
         model = EnterpriseCustomer
+
+    def change_view(self, request, object_id, form_url='', extra_context=None):
+        preview_content_filter = EnterpriseCustomerCatalogAdminForm.get_clicked_preview_content_filter(request.POST)
+        if preview_content_filter:
+            discovery_url = discovery_query_url(preview_content_filter, html_format=False)
+            return HttpResponseRedirect(discovery_url)
+        return super(EnterpriseCustomerAdmin, self).change_view(
+            request,
+            object_id,
+            form_url,
+            extra_context=extra_context
+        )
 
     def get_form(self, request, obj=None, **kwargs):
         """

--- a/enterprise/admin/widgets.py
+++ b/enterprise/admin/widgets.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+"""
+Widgets to be used in the enterprise djangoapp.
+"""
+from __future__ import absolute_import, unicode_literals
+
+from django.forms.widgets import Input
+
+
+class SubmitInput(Input):
+    """
+    Widget for input type field
+    """
+    input_type = 'submit'
+    template_name = 'django/forms/widgets/text.html'

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -988,7 +988,7 @@ def get_enterprise_worker_user():
         return None
 
 
-def discovery_query_url(content_filter):
+def discovery_query_url(content_filter, html_format=True):
     """
     Return discovery url for preview.
     """
@@ -1005,7 +1005,9 @@ def discovery_query_url(content_filter):
         search_all_endpoint='search/all/',
         query_string=urlencode(content_filter, doseq=True)
     )
-    return format_html(
-        '<a href="{url}" target="_blank">Preview</a>',
-        url=disc_url
-    )
+    if html_format:
+        return format_html(
+            '<a href="{url}" target="_blank">Preview</a>',
+            url=disc_url
+        )
+    return disc_url

--- a/tests/test_admin/test_forms.py
+++ b/tests/test_admin/test_forms.py
@@ -4,6 +4,7 @@ Tests for the `edx-enterprise` admin forms module.
 """
 from __future__ import absolute_import, unicode_literals
 
+import json
 import unittest
 
 import ddt
@@ -15,6 +16,7 @@ from pytest import mark
 from django.core.files import File
 
 from enterprise.admin.forms import (
+    EnterpriseCustomerCatalogAdminForm,
     EnterpriseCustomerIdentityProviderAdminForm,
     EnterpriseCustomerReportingConfigAdminForm,
     ManageLearnersForm,
@@ -635,3 +637,68 @@ class TestEnterpriseCustomerReportingConfigAdminForm(unittest.TestCase):
             data=self.form_data,
         )
         assert not form.is_valid()
+
+
+@ddt.ddt
+class EnterpriseCustomerCatalogAdminFormTest(unittest.TestCase):
+    """
+    Tests Different type of utilities methods.
+    """
+    dummy_content_filter_data = {
+        'field': 'value'
+    }
+    form = EnterpriseCustomerCatalogAdminForm
+    @ddt.unpack
+    @ddt.data(
+        (
+            {
+                'enterprise_customer_catalogs-1-preview_button': 'Preview',
+                'enterprise_customer_catalogs-0-content_filter': json.dumps({'field_0': 'value_0'}),
+                'enterprise_customer_catalogs-1-content_filter': json.dumps(dummy_content_filter_data),
+                'enterprise_customer_catalogs-2-content_filter': json.dumps({'field_2': 'value_2'}),
+            },
+            'enterprise_customer_catalogs-1-preview_button'
+        ),
+        (
+            {
+                'enterprise_customer_catalogs-0-content_filter': json.dumps({'field_0': 'value_0'}),
+                'enterprise_customer_catalogs-1-content_filter': json.dumps(dummy_content_filter_data),
+                'enterprise_customer_catalogs-2-content_filter': json.dumps({'field_2': 'value_2'}),
+            },
+            None
+        ),
+    )
+    def test_get_enterprise_customer_catalog_preview_button(self, post_data, catalog_preview_button):
+        assert self.form.get_enterprise_customer_catalog_preview_button(post_data) == catalog_preview_button
+
+    @ddt.unpack
+    @ddt.data(
+        (
+            {
+                'enterprise_customer_catalogs-1-preview_button': 'Preview',
+                'enterprise_customer_catalogs-0-content_filter': json.dumps({'field_0': 'value_0'}),
+                'enterprise_customer_catalogs-1-content_filter': json.dumps(dummy_content_filter_data),
+                'enterprise_customer_catalogs-2-content_filter': json.dumps({'field_2': 'value_2'}),
+            },
+            dummy_content_filter_data
+        ),
+        # not clicked catalog_preview_button
+        (
+            {
+                'enterprise_customer_catalogs-0-content_filter': json.dumps({'field_0': 'value_0'}),
+                'enterprise_customer_catalogs-1-content_filter': json.dumps(dummy_content_filter_data),
+                'enterprise_customer_catalogs-2-content_filter': json.dumps({'field_2': 'value_2'}),
+            },
+            None
+        ),
+        # missing content filter
+        (
+            {
+                'enterprise_customer_catalogs-1-preview_button': 'Preview',
+            },
+            None
+        )
+
+    )
+    def test_get_preview_content_filter(self, post_data, content_filter):
+        assert self.form.get_clicked_preview_content_filter(post_data) == content_filter

--- a/tests/test_enterprise/views/test_router_view.py
+++ b/tests/test_enterprise/views/test_router_view.py
@@ -45,7 +45,7 @@ class TestRouterView(TestCase):
             'enterprise_course_run_enrollment_page',
             args=[self.enterprise_customer.uuid, self.course_run_id]
         ))
-        self.request.user.id = 1  # pylint: disable=invalid-name
+        self.request.user.id = 1   # pylint: disable=invalid-name
         self.kwargs = {
             'enterprise_uuid': str(self.enterprise_customer.uuid),
             'course_id': self.course_run_id,


### PR DESCRIPTION
added preview button for catalogs in enterprise customer admin page

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
