### PR TITLE
ENT-1827 | Updated the 'contains_courses' function.

### DIFF
--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -1323,7 +1323,7 @@ class EnterpriseCustomerCatalog(TimeStampedModel):
 
     def contains_courses(self, content_ids):
         """
-        Return true if this catalog contains the given courses.
+        Return True if this catalog contains the given courses else False.
 
         The content_ids parameter should be a list containing course keys
         and/or course run ids.
@@ -1339,7 +1339,10 @@ class EnterpriseCustomerCatalog(TimeStampedModel):
         if not content_ids_in_catalog:
             content_ids_in_catalog = self._filter_members('key', list(course_keys)) if course_keys else set()
 
-        return set(content_ids).issubset(content_ids_in_catalog) or course_keys.issubset(content_ids_in_catalog)
+        return bool(
+            (content_ids and set(content_ids).issubset(content_ids_in_catalog)) or
+            (course_keys and course_keys.issubset(content_ids_in_catalog))
+        )
 
     def contains_programs(self, program_uuids):
         """
@@ -1349,7 +1352,7 @@ class EnterpriseCustomerCatalog(TimeStampedModel):
         if not content_ids_in_catalog:
             content_ids_in_catalog = self._filter_members('uuid', program_uuids)
 
-        return set(program_uuids).issubset(content_ids_in_catalog)
+        return bool(program_uuids and set(program_uuids).issubset(content_ids_in_catalog))
 
     def get_course(self, course_key):
         """

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -188,6 +188,11 @@ class TestEnterpriseCustomer(unittest.TestCase):
         mock_catalog_api.get_catalog_results.return_value = {}
         assert enterprise_customer.catalog_contains_course(fake_catalog_api.FAKE_COURSE_RUN['key']) is False
 
+        # When a key doesn't exist in discovery then get_course_id returns None.
+        mock_catalog_api.get_catalog_results.return_value = {'results': [fake_catalog_api.FAKE_COURSE_RUN]}
+        mock_catalog_api.get_course_id.return_value = None
+        assert enterprise_customer.catalog_contains_course(fake_catalog_api.FAKE_COURSE_RUN['key']) is False
+
 
 @mark.django_db
 @ddt.ddt
@@ -911,6 +916,20 @@ class TestEnterpriseCustomerCatalog(unittest.TestCase):
 
         response = enterprise_catalog.get_paginated_content(QueryDict())
         assert response['count'] == 129381  # Previously this would have been 1
+
+    @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
+    def test_contains_programs(self, mock_catalog_api_class):
+        """
+        Test EnterpriseCustomerCatalog.contains_programs.
+        """
+        mock_catalog_api = mock_catalog_api_class.return_value
+        mock_catalog_api.get_catalog_results.return_value = {'results': [fake_catalog_api.FAKE_PROGRAM_RESPONSE1]}
+
+        catalog = factories.EnterpriseCustomerCatalogFactory()
+        assert catalog.contains_programs([fake_catalog_api.FAKE_PROGRAM_RESPONSE1['uuid']]) is True
+
+        mock_catalog_api.get_catalog_results.return_value = {}
+        assert catalog.contains_programs([fake_catalog_api.FAKE_PROGRAM_RESPONSE1['uuid']]) is False
 
 
 @mark.django_db


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
