### PR TITLE
Exclude ended/expired course runs from endpoint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ Change Log
 
 Unreleased
 ----------
+[2.0.6] - 2019-10-18
+---------------------
+
+* Add query_param to remove expired course runs from /enterprise/api/v1/enterprise_catalogs/UUID/ endpoint
 
 [2.0.5] - 2019-10-15
 ---------------------

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "2.0.5"
+__version__ = "2.0.6"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -1269,7 +1269,7 @@ class EnterpriseCustomerCatalog(TimeStampedModel):
 
     def get_paginated_content(self, query_parameters):
         """
-        Return paginated discovery service search results withoutexpired course runs.
+        Return paginated discovery service search results without expired course runs.
 
         Arguments:
             query_parameters (dict): Additional query parameters to add to the search API call, e.g. page.
@@ -1277,8 +1277,8 @@ class EnterpriseCustomerCatalog(TimeStampedModel):
             dict: The paginated discovery service search results.
         """
         query_params = query_parameters.copy()
-        # exclude_expire_course_run query_param is added to remove the expired course run
-        query_params["exclude_expire_course_run"] = True
+        # exclude_expired_course_run query_param is added to remove the expired course run
+        query_params["exclude_expired_course_run"] = True
         results = []
         content_filter_query = self.content_filter.copy()
         catalog_client = get_course_catalog_api_service_client(self.enterprise_customer.site)

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -1269,17 +1269,20 @@ class EnterpriseCustomerCatalog(TimeStampedModel):
 
     def get_paginated_content(self, query_parameters):
         """
-        Return paginated discovery service search results.
+        Return paginated discovery service search results withoutexpired course runs.
 
         Arguments:
             query_parameters (dict): Additional query parameters to add to the search API call, e.g. page.
         Returns:
             dict: The paginated discovery service search results.
         """
+        query_params = query_parameters.copy()
+        # exclude_expire_course_run query_param is added to remove the expired course run
+        query_params["exclude_expire_course_run"] = True
         results = []
         content_filter_query = self.content_filter.copy()
         catalog_client = get_course_catalog_api_service_client(self.enterprise_customer.site)
-        search_results = catalog_client.get_catalog_results(content_filter_query, query_parameters.dict())
+        search_results = catalog_client.get_catalog_results(content_filter_query, query_params.dict())
         for content in search_results['results']:
             if content['content_type'] == 'courserun' and content['has_enrollable_seats']:
                 results.append(content)

--- a/tests/test_enterprise/views/test_router_view.py
+++ b/tests/test_enterprise/views/test_router_view.py
@@ -45,7 +45,7 @@ class TestRouterView(TestCase):
             'enterprise_course_run_enrollment_page',
             args=[self.enterprise_customer.uuid, self.course_run_id]
         ))
-        self.request.user.id = 1   # pylint: disable=invalid-name
+        self.request.user.id = 1  # pylint: disable=invalid-name
         self.kwargs = {
             'enterprise_uuid': str(self.enterprise_customer.uuid),
             'course_id': self.course_run_id,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -918,6 +918,21 @@ class TestEnterpriseCustomerCatalog(unittest.TestCase):
         assert response['count'] == 129381  # Previously this would have been 1
 
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
+    def test_exclude_expired_course_run_in_api_query_param(self, mock_catalog_api_class):
+        """
+        Test EnterpriseCustomerCatalog.get_paginated_content should pass the exclude_expired_course_runs query param to
+        the discovery service API
+        """
+        mock_catalog_api = mock_catalog_api_class.return_value
+        enterprise_catalog = factories.EnterpriseCustomerCatalogFactory()
+        enterprise_catalog.get_paginated_content(QueryDict())
+        mock_catalog_api.get_catalog_results.assert_called_with({
+            u'partner': u'edx',
+            u'level_type': [u'Introductory', u'Intermediate', u'Advanced'],
+            u'availability': [u'Current', u'Starting Soon', u'Upcoming'],
+            u'content_type': u'course'}, {"exclude_expired_course_run": True})
+
+    @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     def test_contains_programs(self, mock_catalog_api_class):
         """
         Test EnterpriseCustomerCatalog.contains_programs.


### PR DESCRIPTION
This Pr code aimed to remove the Ended/Expired Course Runs from the following endpoint
**enterprise/api/v1/enterprise_catalogs/UUID/**

This Pr is dependent on [Course-Discovery PR](https://github.com/edx/course-discovery/pull/2211)

PRE-PR Results:
All course runs will be visible in results.
POST-PR Results:
Course runs which are expired will not be visible in results.

[ENT-1470](https://openedx.atlassian.net/browse/ENT-1470)

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
