### PR TITLE
ENT-2390 | Adding logging to search/all/ endpoint in discovery api cl…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,11 @@ Change Log
 
 Unreleased
 ----------
+[2.0.8] - 2019-10-22
+---------------------
+
+* Adding logging to search/all/ endpoint in discovery api client
+
 [2.0.7] - 2019-10-21
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "2.0.7"
+__version__ = "2.0.8"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api_client/discovery.py
+++ b/enterprise/api_client/discovery.py
@@ -153,6 +153,12 @@ class CourseCatalogApiClient(object):
             )
             response = cache.get(cache_key)
             if not response:
+                LOGGER.info(
+                    'ENT-2390-1 | Calling discovery service for search/all/ '
+                    'data with content_filter_query %s and query_params %s',
+                    content_filter_query,
+                    query_params,
+                )
                 # Response is not cached, so make a call.
                 response = self.get_catalog_results_from_discovery(
                     content_filter_query,
@@ -160,6 +166,13 @@ class CourseCatalogApiClient(object):
                     traverse_pagination
                 )
                 cache.set(cache_key, response, settings.ENTERPRISE_API_CACHE_TIMEOUT)
+            else:
+                LOGGER.info(
+                    'ENT-2390-2 | Got search/all/ data from the cache with '
+                    'content_filter_query %s and query_params %s',
+                    content_filter_query,
+                    query_params,
+                )
         except Exception as ex:  # pylint: disable=broad-except
             LOGGER.exception(
                 'Attempted to call course-discovery search/all/ endpoint with the following parameters: '


### PR DESCRIPTION
…ient

My goal here will be to use the ENT text I place in the logs in combination with splunk to compare instances of each getting called (the ticket text seemed like it would be a good choice to make a unique text search)

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
