### PR TITLE
ENT-2428: Updated image url field for cornerstone and degreed

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,11 @@ Change Log
 
 Unreleased
 ----------
+[2.0.9] - 2019-10-28
+---------------------
+
+* Updated image url field in content metadata export for cornerstone and degreed
+
 [2.0.8] - 2019-10-22
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "2.0.8"
+__version__ = "2.0.9"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/cornerstone/exporters/content_metadata.py
+++ b/integrated_channels/cornerstone/exporters/content_metadata.py
@@ -15,6 +15,7 @@ from django.apps import apps
 
 from enterprise.utils import get_closest_course_run, get_language_code
 from integrated_channels.integrated_channel.exporters.content_metadata import ContentMetadataExporter
+from integrated_channels.utils import get_image_url
 
 LOGGER = getLogger(__name__)
 
@@ -33,7 +34,7 @@ class CornerstoneContentMetadataExporter(ContentMetadataExporter):  # pylint: di
         'ID': 'key',
         'Title': 'title',
         'Description': 'description',
-        'Thumbnail': 'card_image_url',
+        'Thumbnail': 'image',
         'URL': 'enrollment_url',
         'IsActive': 'is_active',
         'LastModifiedUTC': 'modified',
@@ -97,6 +98,12 @@ class CornerstoneContentMetadataExporter(ContentMetadataExporter):  # pylint: di
                 duration = "{hours}:{minutes}:00".format(hours=hours, minutes=minutes)
 
         return duration
+
+    def transform_image(self, content_metadata_item):
+        """
+        Return the image URI of the content item.
+        """
+        return get_image_url(content_metadata_item)
 
     def transform_languages(self, content_metadata_item):
         """

--- a/integrated_channels/degreed/exporters/content_metadata.py
+++ b/integrated_channels/degreed/exporters/content_metadata.py
@@ -9,7 +9,7 @@ from logging import getLogger
 
 from enterprise.utils import get_closest_course_run, get_course_run_duration_info
 from integrated_channels.integrated_channel.exporters.content_metadata import ContentMetadataExporter
-from integrated_channels.utils import strip_html_tags
+from integrated_channels.utils import get_image_url, strip_html_tags
 
 LOGGER = getLogger(__name__)
 
@@ -78,13 +78,7 @@ class DegreedContentMetadataExporter(ContentMetadataExporter):  # pylint: disabl
         """
         Return the image URI of the content item.
         """
-        image_url = ''
-        if content_metadata_item['content_type'] in ['course', 'program']:
-            image_url = content_metadata_item.get('card_image_url')
-        elif content_metadata_item['content_type'] == 'courserun':
-            image_url = content_metadata_item.get('image_url')
-
-        return image_url
+        return get_image_url(content_metadata_item)
 
     def transform_program_key(self, content_metadata_item):
         """

--- a/integrated_channels/sap_success_factors/exporters/content_metadata.py
+++ b/integrated_channels/sap_success_factors/exporters/content_metadata.py
@@ -21,6 +21,7 @@ from integrated_channels.utils import (
     UNIX_MAX_DATE_STRING,
     UNIX_MIN_DATE_STRING,
     current_time_is_in_interval,
+    get_image_url,
     parse_datetime_to_epoch_millis,
 )
 
@@ -112,13 +113,7 @@ class SapSuccessFactorsContentMetadataExporter(ContentMetadataExporter):  # pyli
         """
         Return the image URI of the content item.
         """
-        image_url = ''
-        if content_metadata_item['content_type'] == 'program':
-            image_url = content_metadata_item.get('card_image_url')
-        elif content_metadata_item['content_type'] in ['course', 'courserun']:
-            image_url = content_metadata_item.get('image_url')
-
-        return image_url
+        return get_image_url(content_metadata_item)
 
     def transform_launch_points(self, content_metadata_item):
         """

--- a/integrated_channels/utils.py
+++ b/integrated_channels/utils.py
@@ -136,3 +136,16 @@ def strfdelta(tdelta, fmt='{D:02}d {H:02}h {M:02}m {S:02}s', input_type='timedel
             values[field], remainder = divmod(remainder, constants[field])
 
     return f.format(fmt, **values)
+
+
+def get_image_url(content_metadata_item):
+    """
+    Return the image URI of the content item.
+    """
+    image_url = ''
+    if content_metadata_item['content_type'] == 'program':
+        image_url = content_metadata_item.get('card_image_url')
+    elif content_metadata_item['content_type'] in ['course', 'courserun']:
+        image_url = content_metadata_item.get('image_url')
+
+    return image_url

--- a/tests/test_integrated_channels/test_cornerstone/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_cornerstone/test_exporters/test_content_metadata.py
@@ -536,3 +536,64 @@ class TestCornerstoneContentMetadataExporter(unittest.TestCase, EnterpriseMockMi
         item_content_metadata = self._merge_dicts(FAKE_SEARCH_ALL_COURSE_RESULT_3, item_subjects)
         exporter = CornerstoneContentMetadataExporter('fake-user', self.config)
         assert sorted(exporter.transform_subjects(item_content_metadata)) == sorted(expected_subjects)
+
+    @ddt.data(
+        (
+            {
+                'aggregation_key': 'course:edX+DemoX',
+                'title': 'edX Demonstration Course',
+                'key': 'edX+DemoX',
+                'content_type': 'course',
+                'image_url': 'https://edx.devstack.lms:18000/'
+                             'asset-v1:edX+DemoX+Demo_Course+type@asset+block@images_course_image.jpg',
+                'short_description': 'Some short description.',
+                'full_description': 'Detailed description of edx demo course.',
+            },
+            'https://edx.devstack.lms:18000/asset-v1:edX+DemoX+Demo_Course+type@asset+block@images_course_image.jpg'
+        ),
+        (
+            {
+                'number': 'DemoX',
+                'org': 'edX',
+                'seat_types': ['verified', 'audit'],
+                'key': 'course-v1:edX+DemoX+Demo_Course',
+                'availability': 'Current',
+                'title': 'edX Demonstration Course',
+                'content_type': 'courserun',
+                'image_url': 'https://edx.devstack.lms:18000/'
+                             'asset-v1:edX+DemoX+Demo_Course+type@asset+block@images_course_image.jpg',
+            },
+            'https://edx.devstack.lms:18000/asset-v1:edX+DemoX+Demo_Course+type@asset+block@images_course_image.jpg'
+        ),
+        (
+            {
+
+                'uuid': '5742ec8d-25ce-43b7-a158-6dad82034ca2',
+                'title': 'edX Demonstration program',
+                'published': True,
+                'language': [],
+                'type': 'Verified Certificate',
+                'status': 'active',
+                'content_type': 'program',
+                'card_image_url': 'https://edx.devstack.discovery/'
+                                  'media/programs/banner_images/5742ec8d-25ce-43b7-a158-6dad82034ca2.jpg',
+            },
+            'https://edx.devstack.discovery/media/programs/banner_images/5742ec8d-25ce-43b7-a158-6dad82034ca2.jpg',
+        ),
+        (
+            {
+                'title': 'INVALID COURSE',
+                'content_type': 'INVALID-CONTENT_TYPE',
+            },
+            '',
+        ),
+    )
+    @responses.activate
+    @ddt.unpack
+    def test_transform_image(self, content_metadata_item, expected_thumbnail_url):
+        """
+        Transforming a image gives back the thumbnail URI by checking the
+        content type of the provided `content_metadata_item`.
+        """
+        exporter = CornerstoneContentMetadataExporter('fake-user', self.config)
+        assert exporter.transform_image(content_metadata_item) == expected_thumbnail_url

--- a/tests/test_integrated_channels/test_degreed/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_degreed/test_exporters/test_content_metadata.py
@@ -59,8 +59,8 @@ class TestDegreedContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin)
                 'title': 'edX Demonstration Course',
                 'key': 'edX+DemoX',
                 'content_type': 'course',
-                'card_image_url': 'https://edx.devstack.lms:18000/'
-                                  'asset-v1:edX+DemoX+Demo_Course+type@asset+block@images_course_image.jpg',
+                'image_url': 'https://edx.devstack.lms:18000/'
+                             'asset-v1:edX+DemoX+Demo_Course+type@asset+block@images_course_image.jpg',
                 'short_description': 'Some short description.',
                 'full_description': 'Detailed description of edx demo course.',
             },


### PR DESCRIPTION
JIRA: https://openedx.atlassian.net/browse/ENT-2428

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
