### PR TITLE
ENT-2431:Added support to activate/deactivate learner's enterprise

### DIFF
--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -255,7 +255,7 @@ class EnterpriseCustomerUserViewSet(EnterpriseReadWriteModelViewSet):
     filter_backends = (filters.OrderingFilter, DjangoFilterBackend, EnterpriseCustomerUserFilterBackend)
 
     FIELDS = (
-        'enterprise_customer', 'user_id',
+        'enterprise_customer', 'user_id', 'active',
     )
     filter_fields = FIELDS
     ordering_fields = FIELDS

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -631,7 +631,7 @@ class EnterpriseCustomerUser(TimeStampedModel):
         verbose_name = _("Enterprise Customer Learner")
         verbose_name_plural = _("Enterprise Customer Learners")
         unique_together = (("enterprise_customer", "user_id"),)
-        ordering = ['created']
+        ordering = ['active', '-modified']
 
     @property
     def user(self):

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -388,6 +388,7 @@ class TestEnterpriseAPIViews(APITest):
         response = self.load_json(response.content)
 
         if status_code == 201:
+            data.update({'active': True})
             self.assertDictEqual(data, response)
 
     def test_post_enterprise_customer_user_logged_out(self):
@@ -454,7 +455,7 @@ class TestEnterpriseAPIViews(APITest):
 
             }],
             [{
-                'id': 1, 'user_id': 0, 'user': None, 'data_sharing_consent_records': [], 'groups': [],
+                'id': 1, 'user_id': 0, 'user': None, 'active': True, 'data_sharing_consent_records': [], 'groups': [],
                 'enterprise_customer': {
                     'uuid': FAKE_UUIDS[0], 'name': 'Test Enterprise Customer', 'slug': TEST_SLUG,
                     'active': True, 'enable_data_sharing_consent': True,


### PR DESCRIPTION
Added support to activate/deactivate learner's enterprise

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
