### PR TITLE
Add order creation to the enterprise customer manual enroll tool

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[2.0.13] - 2019-11-07
+---------------------
+
+* Add manual order creation to enterprise manual enrollment admin form
+
 [2.0.12] - 2019-11-06
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "2.0.12"
+__version__ = "2.0.13"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/package-lock.json
+++ b/package-lock.json
@@ -1794,7 +1794,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1815,12 +1816,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1835,17 +1838,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1962,7 +1968,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1974,6 +1981,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1988,6 +1996,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1995,12 +2004,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2019,6 +2030,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2099,7 +2111,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2111,6 +2124,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2196,7 +2210,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2232,6 +2247,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2251,6 +2267,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2294,12 +2311,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/tests/test_admin/test_view.py
+++ b/tests/test_admin/test_view.py
@@ -590,13 +590,14 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
             # Allow us to send forms involving pending users
             email_or_username = getattr(user, 'username', getattr(user, 'user_email', None))
 
-        response = self.client.post(self.view_url, data={
-            ManageLearnersForm.Fields.EMAIL_OR_USERNAME: email_or_username,
-            ManageLearnersForm.Fields.COURSE_MODE: mode,
-            ManageLearnersForm.Fields.COURSE: course_id,
-            ManageLearnersForm.Fields.PROGRAM: program_id,
-            ManageLearnersForm.Fields.NOTIFY: notify
-        })
+        with mock.patch("enterprise.api_client.ecommerce.ecommerce_api_client"):
+            response = self.client.post(self.view_url, data={
+                ManageLearnersForm.Fields.EMAIL_OR_USERNAME: email_or_username,
+                ManageLearnersForm.Fields.COURSE_MODE: mode,
+                ManageLearnersForm.Fields.COURSE: course_id,
+                ManageLearnersForm.Fields.PROGRAM: program_id,
+                ManageLearnersForm.Fields.NOTIFY: notify
+            })
         return response
 
     @mock.patch("enterprise.admin.views.track_enrollment")
@@ -725,7 +726,13 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
     @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.admin.views.EnrollmentApiClient")
     @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
-    def test_post_multi_enroll_user(self, forms_client, views_client, course_catalog_client, track_enrollment):
+    def test_post_multi_enroll_user(
+            self,
+            forms_client,
+            views_client,
+            course_catalog_client,
+            track_enrollment,
+    ):
         """
         Test that an existing learner can be enrolled in multiple courses.
         """
@@ -735,7 +742,13 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
     @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.admin.views.EnrollmentApiClient")
     @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
-    def test_post_multi_enroll_pending_user(self, forms_client, views_client, course_catalog_client, track_enrollment):
+    def test_post_multi_enroll_pending_user(
+            self,
+            forms_client,
+            views_client,
+            course_catalog_client,
+            track_enrollment,
+    ):
         """
         Test that a pending learner can be enrolled in multiple courses.
         """
@@ -745,7 +758,13 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
     @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.admin.views.EnrollmentApiClient")
     @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
-    def test_post_enroll_no_course_detail(self, forms_client, views_client, course_catalog_client, track_enrollment):
+    def test_post_enroll_no_course_detail(
+            self,
+            forms_client,
+            views_client,
+            course_catalog_client,
+            track_enrollment,
+    ):
         catalog_instance = course_catalog_client.return_value
         catalog_instance.get_course_run.return_value = {}
         views_instance = views_client.return_value
@@ -780,7 +799,11 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
     @mock.patch("enterprise.admin.views.EnrollmentApiClient")
     @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
     def test_post_enroll_course_when_enrollment_closed(
-            self, forms_client, views_client, course_catalog_client, track_enrollment
+            self,
+            forms_client,
+            views_client,
+            course_catalog_client,
+            track_enrollment,
     ):
         """
         Tests scenario when user being enrolled has already SCE(student CourseEnrollment) record
@@ -943,7 +966,13 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
     @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.admin.views.EnrollmentApiClient")
     @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
-    def test_post_enrollment_error(self, forms_client, views_client, course_catalog_client, reverse_mock):
+    def test_post_enrollment_error(
+            self,
+            forms_client,
+            views_client,
+            course_catalog_client,
+            reverse_mock,
+    ):
         reverse_mock.return_value = '/courses/course-v1:HarvardX+CoolScience+2016'
         catalog_instance = course_catalog_client.return_value
         catalog_instance.get_course_run.return_value = {
@@ -975,7 +1004,7 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
             views_client,
             course_catalog_client,
             reverse_mock,
-            logging_mock
+            logging_mock,
     ):
         reverse_mock.return_value = '/courses/course-v1:HarvardX+CoolScience+2016'
         catalog_instance = course_catalog_client.return_value
@@ -1059,7 +1088,7 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
             self,
             catalog_client,
             views_client,
-            views_catalog_client
+            views_catalog_client,
     ):
         views_catalog_instance = views_catalog_client.return_value
         views_catalog_instance.get_program_by_uuid.side_effect = fake_catalog_api.get_program_by_uuid
@@ -1140,7 +1169,8 @@ class TestEnterpriseCustomerManageLearnersViewPostBulkUpload(BaseTestEnterpriseC
                 post_data[ManageLearnersForm.Fields.COURSE_MODE] = course_mode
             post_data[ManageLearnersForm.Fields.NOTIFY] = 'by_email' if notify else 'do_not_notify'
             post_data['enterprise_customer'] = self.enterprise_customer
-            response = self.client.post(self.view_url, data=post_data)
+            with mock.patch("enterprise.api_client.ecommerce.ecommerce_api_client"):
+                response = self.client.post(self.view_url, data=post_data)
         return response
 
     def test_post_not_logged_in(self):
@@ -1287,7 +1317,13 @@ class TestEnterpriseCustomerManageLearnersViewPostBulkUpload(BaseTestEnterpriseC
     @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.admin.views.EnrollmentApiClient")
     @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
-    def test_post_link_and_enroll(self, forms_client, views_client, course_catalog_client, track_enrollment):
+    def test_post_link_and_enroll(
+            self,
+            forms_client,
+            views_client,
+            course_catalog_client,
+            track_enrollment,
+    ):
         """
         Test bulk upload with linking and enrolling
         """


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [X] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [X] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
