### PR TITLE
ENT-2419 | Create ecommerce orders during user reg. from pending enrollments

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[2.0.12] - 2019-11-06
+---------------------
+
+* Update 'EnterpriseCustomerUser' model. Add 'create_order_for_enrollment'. Called during 'enroll'. Will create an ecommerce order for pending course enrollments.
+
 [2.0.11] - 2019-11-06
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "2.0.11"
+__version__ = "2.0.12"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -982,8 +982,22 @@ def get_enterprise_worker_user():
     """
     Return the user object of enterprise worker user.
     """
+    return _get_service_worker(settings.ENTERPRISE_SERVICE_WORKER_USERNAME)
+
+
+def get_ecommerce_worker_user():
+    """
+    Return the user object of ecommerce worker user.
+    """
+    return _get_service_worker(settings.ECOMMERCE_SERVICE_WORKER_USERNAME)
+
+
+def _get_service_worker(service_worker_username):
+    """
+    Retrieve the specified service worker object. If user cannot be found then returns None.
+    """
     try:
-        return User.objects.get(username=settings.ENTERPRISE_SERVICE_WORKER_USERNAME)
+        return User.objects.get(username=service_worker_username)
     except User.DoesNotExist:
         return None
 


### PR DESCRIPTION
[ENT-2419]
- Update 'EnterpriseCustomerUser' model. During the 'enroll' call we will use EcommerceApiClient to create an order for any enrollments pending for user.
- Added method to retrieve ecommerce worker in 'utils.py' used when creating an instance of the EcommerceApiClient. 

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)


[ENT-2419]: https://openedx.atlassian.net/browse/ENT-2419