### PR TITLE
Add mgmt command for seeding enterprise data on devstack

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[2.0.11] - 2019-11-06
+---------------------
+
+* Add management command to populate sample enterprise data in the LMS within devstack
+
 [2.0.10] - 2019-10-29
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "2.0.10"
+__version__ = "2.0.11"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -500,7 +500,7 @@ class CatalogQueryView(APIView):
 
     def get(self, request, catalog_query_id):
         """
-        API endpoint for fetching a enterprise catalog query.
+        API endpoint for fetching an enterprise catalog query.
         """
         try:
             catalog_query = models.EnterpriseCatalogQuery.objects.get(pk=catalog_query_id)

--- a/enterprise/management/commands/seed_enterprise_devstack_data.py
+++ b/enterprise/management/commands/seed_enterprise_devstack_data.py
@@ -125,11 +125,12 @@ class Command(BaseCommand):
 
     def _add_user_to_groups(self, user, role):
         """ Adds a user with a given role to the appropriate groups """
-        if role != ENTERPRISE_LEARNER_ROLE:
-            data_api_group = Group.objects.get(name=ENTERPRISE_DATA_API_ACCESS_GROUP)
-            data_api_group.user_set.add(user)
-            enrollment_api_group = Group.objects.get(name=ENTERPRISE_ENROLLMENT_API_ACCESS_GROUP)
-            enrollment_api_group.user_set.add(user)
+        if role == ENTERPRISE_LEARNER_ROLE:
+            return
+        data_api_group = Group.objects.get(name=ENTERPRISE_DATA_API_ACCESS_GROUP)
+        data_api_group.user_set.add(user)
+        enrollment_api_group = Group.objects.get(name=ENTERPRISE_ENROLLMENT_API_ACCESS_GROUP)
+        enrollment_api_group.user_set.add(user)
 
     def _create_system_wide_role_assignment(self, user, role):
         """
@@ -145,23 +146,24 @@ class Command(BaseCommand):
         """
         Gets or creates a feature role assignment for the specified user and role
         """
-        if role != ENTERPRISE_LEARNER_ROLE:
-            feature_roles = [
-                ENTERPRISE_CATALOG_ADMIN_ROLE,
-                ENTERPRISE_DASHBOARD_ADMIN_ROLE,
-                ENTERPRISE_ENROLLMENT_API_ADMIN_ROLE,
-                ENTERPRISE_REPORTING_CONFIG_ADMIN_ROLE,
-            ]
-            for feature_role in feature_roles:
-                feature_role_obj, __ = EnterpriseFeatureRole.objects.get_or_create(name=feature_role)
-                EnterpriseFeatureUserRoleAssignment.objects.get_or_create(
-                    user=user,
-                    role=feature_role_obj,
-                )
+        if role == ENTERPRISE_LEARNER_ROLE:
+            return
+        feature_roles = [
+            ENTERPRISE_CATALOG_ADMIN_ROLE,
+            ENTERPRISE_DASHBOARD_ADMIN_ROLE,
+            ENTERPRISE_ENROLLMENT_API_ADMIN_ROLE,
+            ENTERPRISE_REPORTING_CONFIG_ADMIN_ROLE,
+        ]
+        for feature_role in feature_roles:
+            feature_role_obj, __ = EnterpriseFeatureRole.objects.get_or_create(name=feature_role)
+            EnterpriseFeatureUserRoleAssignment.objects.get_or_create(
+                user=user,
+                role=feature_role_obj,
+            )
 
     def _create_enterprise_customer_user(self, username, enterprise_customer):
         """
-        Gets or creates a EnterpriseCustomerUser associated with an EnterpriseCustomer
+        Gets or creates an EnterpriseCustomerUser associated with an EnterpriseCustomer
         """
         user, __ = User.objects.get_or_create(username=username)
         enterprise_customer_user, __ = EnterpriseCustomerUser.objects.get_or_create(
@@ -172,7 +174,7 @@ class Command(BaseCommand):
 
     def _create_enterprise(self, enterprise_users):
         """
-        Creates a enterprise and its associated data, including the
+        Creates an enterprise and its associated data, including the
         EnterpriseCustomer, an enterprise catalog, and initial users of
         varying roles.
         """

--- a/enterprise/management/commands/seed_enterprise_devstack_data.py
+++ b/enterprise/management/commands/seed_enterprise_devstack_data.py
@@ -6,10 +6,10 @@ from __future__ import absolute_import, unicode_literals
 import logging
 
 from django.contrib.auth.models import User, Group
-from django.core.management.base import BaseCommand
 from django.contrib.sites.models import Site
-from django.utils.text import slugify
+from django.core.management.base import BaseCommand
 from django.db.utils import IntegrityError
+from django.utils.text import slugify
 
 from enterprise.constants import (
     ENTERPRISE_DATA_API_ACCESS_GROUP,

--- a/enterprise/management/commands/seed_enterprise_devstack_data.py
+++ b/enterprise/management/commands/seed_enterprise_devstack_data.py
@@ -58,7 +58,7 @@ class Command(BaseCommand):
     def _create_enterprise_customer(self, site):
         """ TODO """
         customer_name = 'Test Enterprise'
-        enterprise_customer, __ = EnterpriseCustomer.objects.get_or_create(
+        enterprise_customer, __ = EnterpriseCustomer.objects.get_or_create(  # pylint: disable=no-member
             name=customer_name,
             site_id=site.id,
             country='US',

--- a/enterprise/management/commands/seed_enterprise_devstack_data.py
+++ b/enterprise/management/commands/seed_enterprise_devstack_data.py
@@ -1,0 +1,232 @@
+"""
+Management command for assigning enterprise roles to existing enterprise users.
+"""
+from __future__ import absolute_import, unicode_literals
+
+import logging
+
+from django.contrib.auth.models import User, Group
+from django.core.management.base import BaseCommand
+from django.contrib.sites.models import Site
+from django.utils.text import slugify
+from django.db.utils import IntegrityError
+
+from enterprise.constants import (
+    ENTERPRISE_DATA_API_ACCESS_GROUP,
+    ENTERPRISE_ENROLLMENT_API_ACCESS_GROUP,
+    ENTERPRISE_LEARNER_ROLE,
+    ENTERPRISE_ADMIN_ROLE,
+    ENTERPRISE_OPERATOR_ROLE,
+    ENTERPRISE_CATALOG_ADMIN_ROLE,
+    ENTERPRISE_DASHBOARD_ADMIN_ROLE,
+    ENTERPRISE_ENROLLMENT_API_ADMIN_ROLE,
+    ENTERPRISE_REPORTING_CONFIG_ADMIN_ROLE,
+)
+from enterprise.models import (
+    EnterpriseCustomer,
+    EnterpriseCustomerCatalog,
+    EnterpriseCustomerUser,
+    EnterpriseFeatureRole,
+    EnterpriseFeatureUserRoleAssignment,
+    SystemWideEnterpriseRole,
+    SystemWideEnterpriseUserRoleAssignment,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+CATALOG_CONTENT_FILTER = {
+    'content_type': 'courserun',
+}
+
+class Command(BaseCommand):
+    """
+    Management command for populating Devstack with initial data for enterprise.
+
+    Example usage:
+        $ ./manage.py lms create_enterprise_devstack_data
+    """
+    help = 'Seeds an enterprise customer, users of various roles and permissions initial data in devstack for related Enterprise models'
+
+    def _get_default_site(self):
+        """ TODO """
+        site = Site.objects.get_or_create(name='example.com')
+        return site
+
+    def _create_enterprise_customer(self, site):
+        """ TODO """
+        customer_name = 'Test Enterprise'
+        enterprise_customer, __ = EnterpriseCustomer.objects.get_or_create(
+            name=customer_name,
+            site_id=site.id,
+            country='US',
+            slug=slugify(customer_name),
+            enable_data_sharing_consent=True,
+            enable_portal_code_management_screen=True,
+            enable_portal_reporting_config_screen=True,
+        )
+        return enterprise_customer
+
+    def _create_catalog_for_enterprise(self, enterprise_customer):
+        """ TODO """
+        catalog, __ = EnterpriseCustomerCatalog.objects.get_or_create(
+            title='All Course Runs',
+            enterprise_customer=enterprise_customer,
+            content_filter=CATALOG_CONTENT_FILTER,
+        )
+        return catalog
+
+    def _create_enterprise_data_api_group(self):
+        """ TODO """
+        Group.objects.get_or_create(name=ENTERPRISE_DATA_API_ACCESS_GROUP)
+
+    def _create_enterprise_enrollment_api_group(self):
+        """ TODO """
+        Group.objects.get_or_create(name=ENTERPRISE_ENROLLMENT_API_ACCESS_GROUP)
+
+    def _create_enterprise_user(self, username, role):
+        """ TODO """
+        valid_roles = [
+            ENTERPRISE_LEARNER_ROLE,
+            ENTERPRISE_ADMIN_ROLE,
+            ENTERPRISE_OPERATOR_ROLE,
+        ]
+        if role in valid_roles:
+            is_staff = True if role == ENTERPRISE_OPERATOR_ROLE else False
+            try:
+                user = User.objects.create_user(
+                    email='{username}@example.com'.format(username=username),
+                    username=username,
+                    password='edx',
+                    is_staff=is_staff,
+                )
+            except IntegrityError:
+                # If a user we attempt to create in this method already exists but with
+                # slightly different parameters, we will attempt to use the existing user.
+                user = User.objects.get(username=username)
+            if user:
+                self._add_user_to_groups(user=user, role=role)
+                self._create_system_wide_role_assignment(user=user, role=role)
+                self._create_feature_role_assignments(user=user, role=role)
+                return {
+                    "user": user,
+                    "role": role,
+                }
+        else:
+            LOGGER.warning('\nUser not created. Role %s not recognized.', role)
+        return None
+
+    def _add_user_to_groups(self, user, role):
+        """ TODO """
+        if role != ENTERPRISE_LEARNER_ROLE:
+            data_api_group = Group.objects.get(name=ENTERPRISE_DATA_API_ACCESS_GROUP)
+            data_api_group.user_set.add(user)
+            enrollment_api_group = Group.objects.get(name=ENTERPRISE_ENROLLMENT_API_ACCESS_GROUP)
+            enrollment_api_group.user_set.add(user)
+
+    def _create_system_wide_role_assignment(self, user, role):
+        """ TODO """
+        system_role, __ = SystemWideEnterpriseRole.objects.get_or_create(name=role)
+        SystemWideEnterpriseUserRoleAssignment.objects.get_or_create(
+            user=user,
+            role=system_role,
+        )
+
+    def _create_feature_role_assignments(self, user, role):
+        """ TODO """
+        if role != ENTERPRISE_LEARNER_ROLE:
+            feature_roles = [
+                ENTERPRISE_CATALOG_ADMIN_ROLE,
+                ENTERPRISE_DASHBOARD_ADMIN_ROLE,
+                ENTERPRISE_ENROLLMENT_API_ADMIN_ROLE,
+                ENTERPRISE_REPORTING_CONFIG_ADMIN_ROLE,
+            ]
+            for feature_role in feature_roles:
+                feature_role_obj, __ = EnterpriseFeatureRole.objects.get_or_create(name=feature_role)
+                EnterpriseFeatureUserRoleAssignment.objects.get_or_create(
+                    user=user,
+                    role=feature_role_obj,
+                )
+
+    def _create_enterprise_customer_user(self, username, enterprise_customer):
+        """ TODO """
+        user, __ = User.objects.get_or_create(username=username)
+        enterprise_customer_user, __ = EnterpriseCustomerUser.objects.get_or_create(
+            user_id=user.pk,
+            enterprise_customer=enterprise_customer,
+        )
+        return enterprise_customer_user
+
+    def _create_enterprise(self, enterprise_users):
+        """ TODO """
+        site, __ = self._get_default_site()
+        enterprise_customer = self._create_enterprise_customer(site=site)
+        enterprise_catalog = self._create_catalog_for_enterprise(
+            enterprise_customer=enterprise_customer
+        )
+        enterprise_linked_users = []
+        for enterprise_user in enterprise_users:
+            enterprise_user_obj = self._create_enterprise_customer_user(
+                username=enterprise_user['user'].username,
+                enterprise_customer=enterprise_customer,
+            )
+            enterprise_linked_users.append({
+                "enterprise_user": enterprise_user_obj,
+                "enterprise_role": enterprise_user['role'],
+            })
+
+        return {
+            "enterprise_customer": enterprise_customer,
+            "enterprise_catalog": enterprise_catalog,
+            "enterprise_linked_users": enterprise_linked_users,
+        }
+
+    def handle(self, *args, **options):
+        """
+        Entry point for managment command execution.
+        """
+        LOGGER.info(
+            '\nEnsuring enterprise-related Django groups (%s, %s) exist...',
+            ENTERPRISE_DATA_API_ACCESS_GROUP,
+            ENTERPRISE_ENROLLMENT_API_ACCESS_GROUP,
+        )
+        self._create_enterprise_data_api_group()
+        self._create_enterprise_enrollment_api_group()
+
+        LOGGER.info('\nCreating enterprise users and assigning roles...')
+        # Create one of each enterprise user type (i.e., learner, admin, operator)
+        enterprise_users = [
+            self._create_enterprise_user(
+                username=ENTERPRISE_LEARNER_ROLE,
+                role=ENTERPRISE_LEARNER_ROLE,
+            ),
+            self._create_enterprise_user(
+                username=ENTERPRISE_ADMIN_ROLE,
+                role=ENTERPRISE_ADMIN_ROLE,
+            ),
+            self._create_enterprise_user(
+                username=ENTERPRISE_OPERATOR_ROLE,
+                role=ENTERPRISE_OPERATOR_ROLE
+            ),
+        ]
+        # Add a couple more learners!
+        for i in range(2):
+            enterprise_users.append(self._create_enterprise_user(
+                username='{role}_{index}'.format(
+                    role=ENTERPRISE_LEARNER_ROLE,
+                    index=i+1,
+                ),
+                role=ENTERPRISE_LEARNER_ROLE
+            ))
+
+        LOGGER.info('\nCreating a new enterprise...')
+        enterprise = self._create_enterprise(enterprise_users=enterprise_users)
+        LOGGER.info(
+            '\nSuccessfully created a new enterprise with the following data:' +
+            '\n|    Enterprise Customer: %s' +
+            '\n|    Enterprise Catalog: %s' +
+            '\n|    Enterprise Users (%d): %s',
+            enterprise['enterprise_customer'],
+            enterprise['enterprise_catalog'],
+            len(enterprise['enterprise_linked_users']),
+            enterprise['enterprise_linked_users'],
+        )

--- a/enterprise/management/commands/seed_enterprise_devstack_data.py
+++ b/enterprise/management/commands/seed_enterprise_devstack_data.py
@@ -5,21 +5,21 @@ from __future__ import absolute_import, unicode_literals
 
 import logging
 
-from django.contrib.auth.models import User, Group
+from django.contrib.auth.models import Group, User
 from django.contrib.sites.models import Site
 from django.core.management.base import BaseCommand
 from django.db.utils import IntegrityError
 from django.utils.text import slugify
 
 from enterprise.constants import (
-    ENTERPRISE_DATA_API_ACCESS_GROUP,
-    ENTERPRISE_ENROLLMENT_API_ACCESS_GROUP,
-    ENTERPRISE_LEARNER_ROLE,
     ENTERPRISE_ADMIN_ROLE,
-    ENTERPRISE_OPERATOR_ROLE,
     ENTERPRISE_CATALOG_ADMIN_ROLE,
     ENTERPRISE_DASHBOARD_ADMIN_ROLE,
+    ENTERPRISE_DATA_API_ACCESS_GROUP,
+    ENTERPRISE_ENROLLMENT_API_ACCESS_GROUP,
     ENTERPRISE_ENROLLMENT_API_ADMIN_ROLE,
+    ENTERPRISE_LEARNER_ROLE,
+    ENTERPRISE_OPERATOR_ROLE,
     ENTERPRISE_REPORTING_CONFIG_ADMIN_ROLE,
 )
 from enterprise.models import (

--- a/enterprise/management/commands/seed_enterprise_devstack_data.py
+++ b/enterprise/management/commands/seed_enterprise_devstack_data.py
@@ -45,7 +45,10 @@ class Command(BaseCommand):
     Example usage:
         $ ./manage.py lms seed_enterprise_devstack_data
     """
-    help = 'Seeds an enterprise customer, users of various roles and permissions initial data in devstack for related Enterprise models'
+    help = '''
+    Seeds an enterprise customer, users of various roles and permissions initial 
+    data in devstack for related Enterprise models.
+    '''
 
     def _get_default_site(self):
         """ TODO """
@@ -222,11 +225,13 @@ class Command(BaseCommand):
         enterprise = self._create_enterprise(enterprise_users=enterprise_users)
         LOGGER.info(
             '\nSuccessfully created a new enterprise with the following data:' +
-            '\n|    Enterprise Customer: %s' +
-            '\n|    Enterprise Catalog: %s' +
+            '\n|    Enterprise Customer: %s (%s)' +
+            '\n|    Enterprise Catalog: %s (%s)' +
             '\n|    Enterprise Users (%d): %s',
-            enterprise['enterprise_customer'],
-            enterprise['enterprise_catalog'],
+            enterprise['enterprise_customer'].name,
+            enterprise['enterprise_customer'].uuid,
+            enterprise['enterprise_catalog'].title,
+            enterprise['enterprise_catalog'].uuid,
             len(enterprise['enterprise_linked_users']),
             enterprise['enterprise_linked_users'],
         )

--- a/enterprise/management/commands/seed_enterprise_devstack_data.py
+++ b/enterprise/management/commands/seed_enterprise_devstack_data.py
@@ -51,12 +51,12 @@ class Command(BaseCommand):
     '''
 
     def _get_default_site(self):
-        """ TODO """
+        """ Gets or creates the default devstack site example.com """
         site = Site.objects.get_or_create(name='example.com')
         return site
 
     def _create_enterprise_customer(self, site):
-        """ TODO """
+        """ Gets or creates an EnterpriseCustomer """
         customer_name = 'Test Enterprise'
         enterprise_customer, __ = EnterpriseCustomer.objects.get_or_create(  # pylint: disable=no-member
             name=customer_name,
@@ -70,7 +70,7 @@ class Command(BaseCommand):
         return enterprise_customer
 
     def _create_catalog_for_enterprise(self, enterprise_customer):
-        """ TODO """
+        """ Gets or creates a catalog for an EnterpriseCustomer """
         catalog, __ = EnterpriseCustomerCatalog.objects.get_or_create(
             title='All Course Runs',
             enterprise_customer=enterprise_customer,
@@ -79,15 +79,20 @@ class Command(BaseCommand):
         return catalog
 
     def _create_enterprise_data_api_group(self):
-        """ TODO """
+        """ Ensures the `ENTERPRISE_DATA_API_ACCESS_GROUP` is created """
         Group.objects.get_or_create(name=ENTERPRISE_DATA_API_ACCESS_GROUP)
 
     def _create_enterprise_enrollment_api_group(self):
-        """ TODO """
+        """ Ensures the `ENTERPRISE_ENROLLMENT_API_ACCESS_GROUP` is created """
         Group.objects.get_or_create(name=ENTERPRISE_ENROLLMENT_API_ACCESS_GROUP)
 
     def _create_enterprise_user(self, username, role):
-        """ TODO """
+        """ 
+        Creates a new user with the specified `username` and `role` (e.g., 
+        'enterprise_learner'). The newly created user is added to the 
+        appropriate Django groups (e.g., data api access) and creates 
+        system-wide and feature role assignments.
+        """
         valid_roles = [
             ENTERPRISE_LEARNER_ROLE,
             ENTERPRISE_ADMIN_ROLE,
@@ -119,7 +124,7 @@ class Command(BaseCommand):
         return None
 
     def _add_user_to_groups(self, user, role):
-        """ TODO """
+        """ Adds a user with a given role to the appropriate groups """
         if role != ENTERPRISE_LEARNER_ROLE:
             data_api_group = Group.objects.get(name=ENTERPRISE_DATA_API_ACCESS_GROUP)
             data_api_group.user_set.add(user)
@@ -127,7 +132,9 @@ class Command(BaseCommand):
             enrollment_api_group.user_set.add(user)
 
     def _create_system_wide_role_assignment(self, user, role):
-        """ TODO """
+        """ 
+        Gets or creates a system-wide role assignment for the specified user and role 
+        """
         system_role, __ = SystemWideEnterpriseRole.objects.get_or_create(name=role)
         SystemWideEnterpriseUserRoleAssignment.objects.get_or_create(
             user=user,
@@ -135,7 +142,9 @@ class Command(BaseCommand):
         )
 
     def _create_feature_role_assignments(self, user, role):
-        """ TODO """
+        """ 
+        Gets or creates a feature role assignment for the specified user and role 
+        """
         if role != ENTERPRISE_LEARNER_ROLE:
             feature_roles = [
                 ENTERPRISE_CATALOG_ADMIN_ROLE,
@@ -151,7 +160,9 @@ class Command(BaseCommand):
                 )
 
     def _create_enterprise_customer_user(self, username, enterprise_customer):
-        """ TODO """
+        """
+        Gets or creates a EnterpriseCustomerUser associated with an EnterpriseCustomer 
+        """
         user, __ = User.objects.get_or_create(username=username)
         enterprise_customer_user, __ = EnterpriseCustomerUser.objects.get_or_create(
             user_id=user.pk,
@@ -160,7 +171,11 @@ class Command(BaseCommand):
         return enterprise_customer_user
 
     def _create_enterprise(self, enterprise_users):
-        """ TODO """
+        """
+        Creates a enterprise and its associated data, including the 
+        EnterpriseCustomer, an enterprise catalog, and initial users of 
+        varying roles.
+        """
         site, __ = self._get_default_site()
         enterprise_customer = self._create_enterprise_customer(site=site)
         enterprise_catalog = self._create_catalog_for_enterprise(

--- a/enterprise/management/commands/seed_enterprise_devstack_data.py
+++ b/enterprise/management/commands/seed_enterprise_devstack_data.py
@@ -43,7 +43,7 @@ class Command(BaseCommand):
     Management command for populating Devstack with initial data for enterprise.
 
     Example usage:
-        $ ./manage.py lms create_enterprise_devstack_data
+        $ ./manage.py lms seed_enterprise_devstack_data
     """
     help = 'Seeds an enterprise customer, users of various roles and permissions initial data in devstack for related Enterprise models'
 

--- a/enterprise/management/commands/seed_enterprise_devstack_data.py
+++ b/enterprise/management/commands/seed_enterprise_devstack_data.py
@@ -38,6 +38,7 @@ CATALOG_CONTENT_FILTER = {
     'content_type': 'courserun',
 }
 
+
 class Command(BaseCommand):
     """
     Management command for populating Devstack with initial data for enterprise.
@@ -46,7 +47,7 @@ class Command(BaseCommand):
         $ ./manage.py lms seed_enterprise_devstack_data
     """
     help = '''
-    Seeds an enterprise customer, users of various roles and permissions initial 
+    Seeds an enterprise customer, users of various roles and permissions initial
     data in devstack for related Enterprise models.
     '''
 
@@ -233,7 +234,7 @@ class Command(BaseCommand):
             enterprise_users.append(self._create_enterprise_user(
                 username='{role}_{index}'.format(
                     role=ENTERPRISE_LEARNER_ROLE,
-                    index=i+1,
+                    index=i + 1,
                 ),
                 role=ENTERPRISE_LEARNER_ROLE
             ))

--- a/enterprise/management/commands/seed_enterprise_devstack_data.py
+++ b/enterprise/management/commands/seed_enterprise_devstack_data.py
@@ -87,10 +87,10 @@ class Command(BaseCommand):
         Group.objects.get_or_create(name=ENTERPRISE_ENROLLMENT_API_ACCESS_GROUP)
 
     def _create_enterprise_user(self, username, role):
-        """ 
-        Creates a new user with the specified `username` and `role` (e.g., 
-        'enterprise_learner'). The newly created user is added to the 
-        appropriate Django groups (e.g., data api access) and creates 
+        """
+        Creates a new user with the specified `username` and `role` (e.g.,
+        'enterprise_learner'). The newly created user is added to the
+        appropriate Django groups (e.g., data api access) and creates
         system-wide and feature role assignments.
         """
         valid_roles = [
@@ -132,8 +132,8 @@ class Command(BaseCommand):
             enrollment_api_group.user_set.add(user)
 
     def _create_system_wide_role_assignment(self, user, role):
-        """ 
-        Gets or creates a system-wide role assignment for the specified user and role 
+        """
+        Gets or creates a system-wide role assignment for the specified user and role
         """
         system_role, __ = SystemWideEnterpriseRole.objects.get_or_create(name=role)
         SystemWideEnterpriseUserRoleAssignment.objects.get_or_create(
@@ -142,8 +142,8 @@ class Command(BaseCommand):
         )
 
     def _create_feature_role_assignments(self, user, role):
-        """ 
-        Gets or creates a feature role assignment for the specified user and role 
+        """
+        Gets or creates a feature role assignment for the specified user and role
         """
         if role != ENTERPRISE_LEARNER_ROLE:
             feature_roles = [
@@ -161,7 +161,7 @@ class Command(BaseCommand):
 
     def _create_enterprise_customer_user(self, username, enterprise_customer):
         """
-        Gets or creates a EnterpriseCustomerUser associated with an EnterpriseCustomer 
+        Gets or creates a EnterpriseCustomerUser associated with an EnterpriseCustomer
         """
         user, __ = User.objects.get_or_create(username=username)
         enterprise_customer_user, __ = EnterpriseCustomerUser.objects.get_or_create(
@@ -172,8 +172,8 @@ class Command(BaseCommand):
 
     def _create_enterprise(self, enterprise_users):
         """
-        Creates a enterprise and its associated data, including the 
-        EnterpriseCustomer, an enterprise catalog, and initial users of 
+        Creates a enterprise and its associated data, including the
+        EnterpriseCustomer, an enterprise catalog, and initial users of
         varying roles.
         """
         site, __ = self._get_default_site()

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -1951,7 +1951,7 @@ class EnterpriseFeatureRole(UserRole):
 @python_2_unicode_compatible
 class EnterpriseFeatureUserRoleAssignment(EnterpriseRoleAssignmentContextMixin, UserRoleAssignment):
     """
-    Model to map users to a EnterpriseFeatureRole.
+    Model to map users to an EnterpriseFeatureRole.
 
     .. no_pii:
     """

--- a/integrated_channels/cornerstone/views.py
+++ b/integrated_channels/cornerstone/views.py
@@ -17,7 +17,7 @@ class CornerstoneCoursesListView(generics.ListAPIView):
     """
         **Use Cases**
 
-            Get a list of courses to share on cornerstone filtered by a enterprise customer.
+            Get a list of courses to share on cornerstone filtered by an enterprise customer.
 
         **Example Requests**
 


### PR DESCRIPTION
A management command to seed devstack LMS enterprise models with some data. A separate management command will exist for seeding devstack Ecommerce enterprise coupon/offer models.

The result of this script from within `lms-shell` is:
![image](https://user-images.githubusercontent.com/2828721/68211578-dc2af400-ffa5-11e9-8f7d-f34c07ee1288.png)


**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
