### PR TITLE
ENT-2463 | Handle IntegrityError during course enroll in EnterpriseCustomerUser mdoel

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[2.0.16] - 2019-11-07
+---------------------
+
+* Address defect ENT-2463. Add protection within EnterpriseCustomerUser model in enroll method during coure enrollments.
+
 [2.0.15] - 2019-11-07
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "2.0.15"
+__version__ = "2.0.16"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name


### PR DESCRIPTION
[ENT-2463]
- Handle IntegrityError/Race condition that can occur in EnterpriseCustomerUser.enroll() call.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)


[ENT-2463]: https://openedx.atlassian.net/browse/ENT-2463