### PR TITLE
new throttling for enterprise-learner endpoint for non-service users

### DIFF
--- a/enterprise/api/throttles.py
+++ b/enterprise/api/throttles.py
@@ -9,6 +9,7 @@ from rest_framework.throttling import UserRateThrottle
 from enterprise.api.utils import get_service_usernames
 
 SERVICE_USER_SCOPE = 'service_user'
+ENTERPRISE_LEARNER_USER_SCOPE = 'enterprise_learner_user'
 
 
 class ServiceUserThrottle(UserRateThrottle):
@@ -52,3 +53,22 @@ class ServiceUserThrottle(UserRateThrottle):
         self.scope = SERVICE_USER_SCOPE
         self.rate = self.get_rate()
         self.num_requests, self.duration = self.parse_rate(self.rate)
+
+
+class EnterpriseCustomerUserThrottle(UserRateThrottle):
+    """
+    Throttle to override rate limiting for `/enterprise/api/v1/enterprise-learner/` endpoint.
+    """
+
+    def allow_request(self, request, view):
+        """
+        Modify throttling limit for non service users.
+        """
+        service_users = get_service_usernames()
+
+        if request.user.username not in service_users:
+            self.scope = ENTERPRISE_LEARNER_USER_SCOPE
+            self.rate = self.get_rate()
+            self.num_requests, self.duration = self.parse_rate(self.rate)
+
+        return super(EnterpriseCustomerUserThrottle, self).allow_request(request, view)

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -31,7 +31,7 @@ from django.utils.translation import ugettext as _
 
 from enterprise import models
 from enterprise.api.filters import EnterpriseCustomerUserFilterBackend, UserFilterBackend
-from enterprise.api.throttles import ServiceUserThrottle
+from enterprise.api.throttles import EnterpriseCustomerUserThrottle, ServiceUserThrottle
 from enterprise.api.utils import (
     create_message_body,
     get_ent_cust_from_report_config_uuid,
@@ -253,6 +253,7 @@ class EnterpriseCustomerUserViewSet(EnterpriseReadWriteModelViewSet):
 
     queryset = models.EnterpriseCustomerUser.objects.all()
     filter_backends = (filters.OrderingFilter, DjangoFilterBackend, EnterpriseCustomerUserFilterBackend)
+    throttle_classes = [EnterpriseCustomerUserThrottle]
 
     FIELDS = (
         'enterprise_customer', 'user_id', 'active',

--- a/enterprise/settings/test.py
+++ b/enterprise/settings/test.py
@@ -149,6 +149,7 @@ DEFAULT_FROM_EMAIL = 'course_staff@example.com'
 
 USER_THROTTLE_RATE = '90/minute'
 SERVICE_USER_THROTTLE_RATE = '100/minute'
+ENTERPRISE_LEARNER_USER_THROTTLE_RATE = '120/minute'
 REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
     'PAGE_SIZE': 10,
@@ -159,6 +160,7 @@ REST_FRAMEWORK = {
     'DEFAULT_THROTTLE_RATES': {
         'user': USER_THROTTLE_RATE,
         'service_user': SERVICE_USER_THROTTLE_RATE,
+        'enterprise_learner_user': ENTERPRISE_LEARNER_USER_THROTTLE_RATE,
     },
     'DATETIME_FORMAT': '%Y-%m-%dT%H:%M:%SZ',
 }


### PR DESCRIPTION
ENT-2466

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
