### PR TITLE
ENT-2468 | Better handle when Integrated Channels return unexpected results

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,13 @@ Change Log
 Unreleased
 ----------
 
+
+[2.0.18] - 2019-11-13
+---------------------
+
+* Better handling when Integrated Channels return unexpected results
+
+
 [2.0.17] - 2019-11-08
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "2.0.17"
+__version__ = "2.0.18"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/degreed/client.py
+++ b/integrated_channels/degreed/client.py
@@ -241,9 +241,9 @@ class DegreedAPIClient(IntegratedChannelApiClient):
         )
 
         response.raise_for_status()
-        data = response.json()
         try:
+            data = response.json()
             expires_at = data['expires_in'] + int(time.time())
             return data['access_token'], datetime.datetime.utcfromtimestamp(expires_at)
-        except KeyError:
+        except (KeyError, ValueError):
             raise requests.RequestException(response=response)

--- a/integrated_channels/integrated_channel/transmitters/content_metadata.py
+++ b/integrated_channels/integrated_channel/transmitters/content_metadata.py
@@ -126,9 +126,9 @@ class ContentMetadataTransmitter(Transmitter):
                     'Failed to update [%s] content metadata items for integrated channel [%s] [%s]',
                     len(chunk),
                     self.enterprise_configuration.enterprise_customer.name,
-                    self.enterprise_configuration.channel_code,
+                    self.enterprise_configuration.channel_code(),
                 )
-                LOGGER.error(exc)
+                LOGGER.exception(exc)
             else:
                 self._create_transmissions(chunk)
 
@@ -145,9 +145,9 @@ class ContentMetadataTransmitter(Transmitter):
                     'Failed to update [%s] content metadata items for integrated channel [%s] [%s]',
                     len(chunk),
                     self.enterprise_configuration.enterprise_customer.name,
-                    self.enterprise_configuration.channel_code,
+                    self.enterprise_configuration.channel_code(),
                 )
-                LOGGER.error(exc)
+                LOGGER.exception(exc)
             else:
                 self._update_transmissions(chunk, transmission_map)
 
@@ -164,9 +164,9 @@ class ContentMetadataTransmitter(Transmitter):
                     'Failed to delete [%s] content metadata items for integrated channel [%s] [%s]',
                     len(chunk),
                     self.enterprise_configuration.enterprise_customer.name,
-                    self.enterprise_configuration.channel_code,
+                    self.enterprise_configuration.channel_code(),
                 )
-                LOGGER.error(exc)
+                LOGGER.exception(exc)
             else:
                 self._delete_transmissions(chunk.keys())
 

--- a/integrated_channels/integrated_channel/transmitters/learner_data.py
+++ b/integrated_channels/integrated_channel/transmitters/learner_data.py
@@ -103,7 +103,7 @@ class LearnerTransmitter(Transmitter):
             sys_msg = request_exception.response.content
         except AttributeError:
             sys_msg = 'Not available'
-        LOGGER.error(
+        LOGGER.exception(
             (
                 'Failed to send completion status call for enterprise enrollment %s'
                 'with payload %s'

--- a/integrated_channels/sap_success_factors/models.py
+++ b/integrated_channels/sap_success_factors/models.py
@@ -14,6 +14,7 @@ from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
+from integrated_channels.exceptions import ClientError
 from integrated_channels.integrated_channel.models import EnterpriseCustomerPluginConfiguration
 from integrated_channels.sap_success_factors.exporters.content_metadata import SapSuccessFactorsContentMetadataExporter
 from integrated_channels.sap_success_factors.exporters.learner_data import (
@@ -201,7 +202,15 @@ class SAPSuccessFactorsEnterpriseCustomerConfiguration(EnterpriseCustomerPluginC
         Unlink inactive SAP learners form their related enterprises
         """
         sap_learner_manager = self.get_learner_manger()
-        sap_learner_manager.unlink_learners()
+        try:
+            sap_learner_manager.unlink_learners()
+        except ClientError as exc:
+            LOGGER.exception(
+                'Failed to unlink learners for integrated channel [%s] [%s] \nError: [%s]',
+                self.enterprise_customer.name,
+                self.channel_code(),
+                str(exc)
+            )
 
 
 @python_2_unicode_compatible

--- a/integrated_channels/sap_success_factors/transmitters/content_metadata.py
+++ b/integrated_channels/sap_success_factors/transmitters/content_metadata.py
@@ -57,9 +57,9 @@ class SapSuccessFactorsContentMetadataTransmitter(ContentMetadataTransmitter):
                         'Failed to update [%s] content metadata items for integrated channel [%s] [%s]',
                         len(chunked_items),
                         self.enterprise_configuration.enterprise_customer.name,
-                        self.enterprise_configuration.channel_code,
+                        self.enterprise_configuration.channel_code(),
                     )
-                    LOGGER.error(exc)
+                    LOGGER.exception(exc)
 
                     # Remove the failed items from the create/update/delete dictionaries,
                     # so ContentMetadataItemTransmission objects are not synchronized for

--- a/tests/test_integrated_channels/test_degreed/test_client.py
+++ b/tests/test_integrated_channels/test_degreed/test_client.py
@@ -64,6 +64,23 @@ class TestDegreedApiClient(unittest.TestCase):
         )
 
     @responses.activate
+    def test_oauth_with_non_json_response(self):
+        """ Test  _get_oauth_access_token with non json type response"""
+        with pytest.raises(requests.RequestException):
+            responses.add(
+                responses.POST,
+                self.oauth_url,
+            )
+            client = DegreedAPIClient(self.enterprise_config)
+            client._get_oauth_access_token(  # pylint: disable=protected-access
+                self.client_id,
+                self.client_secret,
+                self.user_id,
+                self.user_pass,
+                DegreedAPIClient.COMPLETION_PROVIDER_SCOPE
+            )
+
+    @responses.activate
     def test_create_course_completion(self):
         """
         ``create_course_completion`` should use the appropriate URLs for transmission.


### PR DESCRIPTION
whenever an integrated channel returns non-json type of content, raising
RequestException and handling it with other RequestException handlers.

ENT-2468

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
