### PR TITLE
[MICROBA-56] Added Source to the EnterpriseEnrollments for Enterprise APIs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[2.0.20] - 2019-11-13
+---------------------
+
+* Added Source to Enterprise API Enrollments.
+
 [2.0.19] - 2019-13-08
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "2.0.19"
+__version__ = "2.0.20"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -565,7 +565,12 @@ class EnterpriseCustomerCourseEnrollmentsSerializer(serializers.Serializer):
             validated_data['enterprise_customer_user'] = enterprise_customer_user
             try:
                 if is_active:
-                    enterprise_customer_user.enroll(course_run_id, course_mode, cohort=cohort)
+                    enterprise_customer_user.enroll(
+                        course_run_id,
+                        course_mode,
+                        cohort=cohort,
+                        source_slug=models.EnterpriseEnrollmentSource.API
+                    )
                 else:
                     enterprise_customer_user.unenroll(course_run_id)
             except (CourseEnrollmentDowngradeError, CourseEnrollmentPermissionError, HttpClientError) as exc:
@@ -594,7 +599,10 @@ class EnterpriseCustomerCourseEnrollmentsSerializer(serializers.Serializer):
                     user_email,
                     course_mode,
                     course_run_id,
-                    cohort=cohort
+                    cohort=cohort,
+                    enrollment_source=models.EnterpriseEnrollmentSource.get_source(
+                        models.EnterpriseEnrollmentSource.API
+                    )
                 )
             else:
                 enterprise_customer.clear_pending_registration(user_email, course_run_id)


### PR DESCRIPTION
[ENT-2082]

Now [MICROBA-56]

This PR adds the Source to Enterprise CourseEnrollments and Pending
Enrollments that are made through the EnterpriseCustomer
Enrollment API.

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [x] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)


[MICROBA-56]: https://openedx.atlassian.net/browse/MICROBA-56