### PR TITLE
remove success url validation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+[2.0.21] - 2019-11-14
+---------------------
+
+* Remove success url validation for select enterprise page.
+
 [2.0.20] - 2019-11-13
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "2.0.20"
+__version__ = "2.0.21"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/forms.py
+++ b/enterprise/forms.py
@@ -5,7 +5,6 @@ User-facing forms for the Enterprise app.
 from __future__ import absolute_import, unicode_literals
 
 from django import forms
-from django.urls import Resolver404, resolve
 from django.utils.translation import ugettext as _
 
 from enterprise.models import EnterpriseCustomer, EnterpriseCustomerUser
@@ -49,11 +48,5 @@ class EnterpriseSelectionForm(forms.Form):
         # verify that learner is really a member of selected enterprise
         if not EnterpriseCustomerUser.objects.filter(enterprise_customer=enterprise, user_id=self._user_id).exists():
             raise forms.ValidationError(_("Wrong Enterprise"))
-
-        try:
-            # validate if path is a valid
-            resolve(cleaned_data['success_url'])
-        except Resolver404:
-            raise forms.ValidationError(_("Incorrect success url"))
 
         return cleaned_data

--- a/enterprise/static/enterprise/js/enterprise_selection_page.js
+++ b/enterprise/static/enterprise/js/enterprise_selection_page.js
@@ -6,7 +6,6 @@ function setupFormSubmit() {
     $('#select-enterprise-form').submit(function(event){
         event.preventDefault();
         var selectedEnterpriseUUID = $("#id_enterprise").val();
-        var successURL = $("#id_success_url").val();
 
         $("#activate-progress-icon").removeClass("is-hidden");
         $("#select-enterprise-submit").attr("disabled", true);
@@ -14,16 +13,17 @@ function setupFormSubmit() {
         $.ajax({
             url : "/enterprise/select/active",
             method : "POST",
+
             beforeSend: function (xhr) {
                 xhr.setRequestHeader("X-CSRFToken", $.cookie("csrftoken"));
             },
+
             data : {
-                enterprise : selectedEnterpriseUUID,
-                success_url: successURL
+                enterprise : selectedEnterpriseUUID
             },
 
-            success: function(xhr) {
-                redirectToURL(xhr.success_url);
+            success: function() {
+                redirectToURL($("#id_success_url").val());
             },
 
             error : function(xhr) {

--- a/enterprise/templates/enterprise/enterprise_customer_select_form.html
+++ b/enterprise/templates/enterprise/enterprise_customer_select_form.html
@@ -39,7 +39,6 @@
 
             {% for hidden_field in form.hidden_fields %}
               <div>
-              {{ hidden_field.errors }}
               {{ hidden_field }}
               </div>
             {% endfor %}

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -839,6 +839,10 @@ class EnterpriseSelectionView(FormView):
             'success_url': self.request.GET.get('success_url'),
             'user_id': self.request.user.id
         })
+        LOGGER.info(
+            '[Enterprise Selection Page] Request recieved. SuccessURL: %s',
+            self.request.GET.get('success_url')
+        )
         return initial
 
     def get_context_data(self, **kwargs):
@@ -849,7 +853,6 @@ class EnterpriseSelectionView(FormView):
             'select_enterprise_message_title': _(u'Select an organization'),
             'select_enterprise_message_subtitle': ENTERPRISE_SELECT_SUBTITLE,
         })
-        context_data.update(get_global_context(self.request, None))
         return context_data
 
     def form_invalid(self, form):
@@ -862,7 +865,7 @@ class EnterpriseSelectionView(FormView):
 
     def form_valid(self, form):
         """
-        If the form is valid, activate the selected enterprise and return `success_url`.
+        If the form is valid, activate the selected enterprise.
         """
         enterprise_customer = form.cleaned_data['enterprise']
         serializer = EnterpriseCustomerUserWriteSerializer(data={
@@ -874,10 +877,10 @@ class EnterpriseSelectionView(FormView):
             serializer.save()
             LOGGER.info(
                 '[Enterprise Selection Page] Learner activated an enterprise. User: %s, EnterpriseCustomer: %s',
+                self.request.user.username,
                 enterprise_customer,
-                self.request.user.username
             )
-            return JsonResponse({'success_url': form.cleaned_data['success_url']})
+            return JsonResponse({})
 
 
 class HandleConsentEnrollment(View):

--- a/spec/javascripts/enterprise_select_spec.js
+++ b/spec/javascripts/enterprise_select_spec.js
@@ -39,15 +39,12 @@ describe('Enterprise Selection Page', function () {
         });
 
         it('works expected on correct post data', function () {
-            var response = {
-                'success_url': '/dashboard'
-            };
             var redirectSpy = spyOn(window, 'redirectToURL');
 
             jasmine.Ajax
             .stubRequest('/enterprise/select/active')
             .andReturn({
-                responseText: JSON.stringify(response)
+                responseText: JSON.stringify({})
             });
 
             $( '#select-enterprise-submit' ).trigger( 'click' );
@@ -56,14 +53,13 @@ describe('Enterprise Selection Page', function () {
             expect(request.url).toBe('/enterprise/select/active');
             expect(request.method).toBe('POST');
             expect(request.data().enterprise).toEqual(['6ae013d4-c5c4-474d-8da9-0e559b2448e2']);
-            expect(request.data().success_url).toEqual(['/dashboard']);
             expect(redirectSpy.calls.count()).toEqual(1);
             expect(redirectSpy.calls.first().args).toEqual(['/dashboard']);
         });
 
         it('works expected on incorrect post data', function () {
             var response = {
-                'errors': ['Incorrect success url']
+                'errors': ['Enterprise not found']
             };
 
             jasmine.Ajax
@@ -73,16 +69,11 @@ describe('Enterprise Selection Page', function () {
                 responseText: JSON.stringify(response)
             });
 
-            // remove success url value from hidden input
-            $('#id_success_url').removeAttr('value');
-
             $( '#select-enterprise-submit' ).trigger( 'click' );
 
             var request = jasmine.Ajax.requests.mostRecent();
             expect(request.url).toBe('/enterprise/select/active');
             expect(request.method).toBe('POST');
-            expect(request.data().enterprise).toEqual(['6ae013d4-c5c4-474d-8da9-0e559b2448e2']);
-            expect(request.data().success_url).toEqual(['']);
 
             expect($('#select-enterprise-form-error').text().trim()).toEqual(response.errors[0]);
         });


### PR DESCRIPTION
**Description:** Initially we have added validation on `success_url` with the assumption that it will always be a platform url and also the url will not raise `Resolver404` if we apply `django.urls.resolve` function but it turns out this is not the case, for example, When we sign in through Google, the `success_url` is set to `/auth/complete/google-oauth2/?` and  `django.urls.resolve` function raises `Resolver404 ` on such a url due to `?` in the end. So we have decided to remove the validation on `success_url`.

**Testing:** Now both the below urls will work fine. 
1. https://mammar.sandbox.edx.org/enterprise/select/active?success_url=/dashboard/?
2. https://mammar.sandbox.edx.org/enterprise/select/active?success_url=/dashboard


**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
