### PR TITLE
ENT-2346 Overridden get in EnterpriseCustomerUser manager

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ Change Log
 
 Unreleased
 ----------
+[2.0.22] - 2019-11-18
+---------------------
+
+* Custom get function in EnterpriseCustomerUserManager to enable multiple user enterprises.
 
 [2.0.21] - 2019-11-14
 ---------------------

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "2.0.21"
+__version__ = "2.0.22"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -532,6 +532,18 @@ class EnterpriseCustomerUserManager(models.Manager):
     This class should contain methods that create, modify or query :class:`.EnterpriseCustomerUser` entities.
     """
 
+    def get(self, **kwargs):
+        """
+        Overridden get method to return the first element in case of learner with multiple enterprises.
+
+        Raises EnterpriseCustomerUser.DoesNotExist if no records are found.
+        """
+        fetched_object = super(EnterpriseCustomerUserManager, self).get_queryset().filter(**kwargs).first()
+        if fetched_object:
+            return fetched_object
+        else:
+            raise EnterpriseCustomerUser.DoesNotExist
+
     def get_link_by_email(self, user_email):
         """
         Return link by email.

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -203,6 +203,30 @@ class TestEnterpriseCustomerUserManager(unittest.TestCase):
     Tests EnterpriseCustomerUserManager.
     """
 
+    def test_get_returns_only_one_when_multiple_objects_returned(self):
+        """
+        Test that get on custom model manager returns only the active object when multiple objects found.
+        """
+        enterprise_customer1 = factories.EnterpriseCustomerFactory()
+        enterprise_customer2 = factories.EnterpriseCustomerFactory()
+        user = factories.UserFactory(email='albert.einstein@princeton.edu')
+        first_customer_user = factories.EnterpriseCustomerUserFactory(
+            enterprise_customer=enterprise_customer1,
+            user_id=user.id
+        )
+        second_customer_user = factories.EnterpriseCustomerUserFactory(
+            enterprise_customer=enterprise_customer2,
+            user_id=user.id,
+            active=False
+        )
+        all_customer_users = [first_customer_user, second_customer_user]
+        fetched_object = EnterpriseCustomerUser.objects.get(user_id=user.id)
+        self.assertIn(fetched_object, all_customer_users)
+        self.assertEqual(fetched_object.active, True)
+        EnterpriseCustomerUser.objects.filter(user_id=user.id).delete()
+        with raises(EnterpriseCustomerUser.DoesNotExist):
+            EnterpriseCustomerUser.objects.get(user_id=user.id)
+
     @ddt.data("albert.einstein@princeton.edu", "richard.feynman@caltech.edu", "leo.susskind@stanford.edu")
     def test_link_user_existing_user(self, user_email):
         enterprise_customer = factories.EnterpriseCustomerFactory()


### PR DESCRIPTION
Description: This PR updates the Manager for EnterpriseCustomerUser model with an overridden get() method. This will enable a learner to be associated with multiple enterprises and the get() will pick the first entry from the queryset. As part of [ENT-2338](https://openedx.atlassian.net/browse/ENT-2338) it will be ensured that the first entry is always the one currently relevant for the learner.

JIRA: https://openedx.atlassian.net/browse/ENT-2346

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
