### PR TITLE
ENT-2042: Replace EDX-API-KEY with JWT in CourseApiClient

### DIFF
--- a/enterprise/admin/__init__.py
+++ b/enterprise/admin/__init__.py
@@ -37,7 +37,7 @@ from enterprise.admin.views import (
     EnterpriseCustomerTransmitCoursesView,
     TemplatePreviewView,
 )
-from enterprise.api_client.lms import CourseApiClient, EnrollmentApiClient
+from enterprise.api_client.lms import CourseApiClient, CourseJwtApiClient, EnrollmentApiClient
 from enterprise.models import (
     EnrollmentNotificationEmailTemplate,
     EnterpriseCatalogQuery,
@@ -377,7 +377,7 @@ class EnterpriseCustomerUserAdmin(admin.ModelAdmin):
         enrollment_client = EnrollmentApiClient()
         enrolled_courses = enrollment_client.get_enrolled_courses(enterprise_customer_user.username)
         course_details = []
-        courses_client = CourseApiClient()
+        courses_client = CourseJwtApiClient(enterprise_customer_user.user)
         for course in enrolled_courses:
             course_id = course['course_details']['course_id']
             name = courses_client.get_course_details(course_id)['name']

--- a/enterprise/api_client/lms.py
+++ b/enterprise/api_client/lms.py
@@ -341,6 +341,32 @@ class CourseApiClient(LmsApiClient):
             return None
 
 
+class CourseJwtApiClient(JwtLmsApiClient):
+    """
+    Object builds an API client to make calls to the Course API.
+    """
+
+    API_BASE_URL = settings.LMS_INTERNAL_ROOT_URL + '/api/courses/v1/'
+    APPEND_SLASH = True
+
+    @JwtLmsApiClient.refresh_token
+    def get_course_details(self, course_id):
+        """
+        Retrieve all available details about a course.
+
+        Args:
+            course_id (str): The course ID identifying the course for which to retrieve details.
+
+        Returns:
+            dict: Contains keys identifying those course details available from the courses API (e.g., name).
+        """
+        try:
+            return self.client.courses(course_id).get()
+        except (SlumberBaseException, ConnectionError, Timeout) as exc:
+            LOGGER.exception('Details not found for course [%s] due to: [%s]', course_id, str(exc))
+            return None
+
+
 class ThirdPartyAuthApiClient(LmsApiClient):
     """
     Object builds an API client to make calls to the Third Party Auth API.

--- a/tests/test_enterprise/api_client/test_lms.py
+++ b/tests/test_enterprise/api_client/test_lms.py
@@ -384,6 +384,7 @@ def test_unenroll_already_unenrolled():
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_get_full_course_details():
     course_id = "course-v1:edX+DemoX+Demo_Course"
     expected_response = {
@@ -394,12 +395,13 @@ def test_get_full_course_details():
         _url("courses", "courses/course-v1:edX+DemoX+Demo_Course/"),
         json=expected_response,
     )
-    client = lms_api.CourseApiClient()
+    client = lms_api.CourseJwtApiClient('enterprise-user-goes-here')
     actual_response = client.get_course_details(course_id)
     assert actual_response == expected_response
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_get_full_course_details_not_found():
     course_id = "course-v1:edX+DemoX+Demo_Course"
     responses.add(
@@ -407,7 +409,7 @@ def test_get_full_course_details_not_found():
         _url("courses", "courses/course-v1:edX+DemoX+Demo_Course/"),
         status=404,
     )
-    client = lms_api.CourseApiClient()
+    client = lms_api.CourseJwtApiClient('enterprise-user-goes-here')
     actual_response = client.get_course_details(course_id)
     assert actual_response is None
 


### PR DESCRIPTION
This PR is about replacing the `EDX-API-KEY` with `OAuth` authentication method using `JWT.` There are three clients that are relying on the `EDX-API-KEY` based authentication; `CourseApiClient,` `EnrollmentApiClient,` and `ThirdPartyAuthApiClient.` This PR only covers one end-point of the `CourseApiClient` which is `EnterpriseCustomerUserAdmin->enrolled_courses`