### PR TITLE
Replaced EDX_API_KEY with JWT in EnrollmentApiClient

### DIFF
--- a/enterprise/admin/__init__.py
+++ b/enterprise/admin/__init__.py
@@ -369,7 +369,7 @@ class EnterpriseCustomerUserAdmin(admin.ModelAdmin):
             enterprise_customer_user: The instance of EnterpriseCustomerUser
                 being rendered with this admin form.
         """
-        enrollment_client = EnrollmentApiClient()
+        enrollment_client = EnrollmentApiClient(enterprise_customer_user.user)
         enrollments = enrollment_client.get_enrolled_courses(enterprise_customer_user.username)
         return [enrollment['course_details']['course_id'] for enrollment in enrollments]
 

--- a/enterprise/admin/forms.py
+++ b/enterprise/admin/forms.py
@@ -193,7 +193,7 @@ class ManageLearnersForm(forms.Form):
         if not course_id:
             return None
         try:
-            client = EnrollmentApiClient()
+            client = EnrollmentApiClient(self._user)
             return client.get_course_details(course_id)
         except (HttpClientError, HttpServerError):
             raise ValidationError(ValidationMessages.INVALID_COURSE_ID.format(course_id=course_id))

--- a/enterprise/admin/views.py
+++ b/enterprise/admin/views.py
@@ -443,7 +443,7 @@ class EnterpriseCustomerManageLearnersView(View):
             enterprise_customer=enterprise_customer,
             user_id=user.id
         )
-        enrollment_client = EnrollmentApiClient()
+        enrollment_client = EnrollmentApiClient(user)
         succeeded = True
         for course_id in course_ids:
             try:
@@ -489,7 +489,7 @@ class EnterpriseCustomerManageLearnersView(View):
             Boolean: Whether or not enrollment exists
 
         """
-        enrollment_client = EnrollmentApiClient()
+        enrollment_client = EnrollmentApiClient(user)
         try:
             enrollments = enrollment_client.get_course_enrollment(user.username, course_id)
             if enrollments and course_mode == enrollments.get('mode'):

--- a/enterprise/api_client/lms.py
+++ b/enterprise/api_client/lms.py
@@ -132,13 +132,14 @@ class EmbargoApiClient(object):
                 return redirect_url
 
 
-class EnrollmentApiClient(LmsApiClient):
+class EnrollmentApiClient(JwtLmsApiClient):
     """
     Object builds an API client to make calls to the Enrollment API.
     """
 
     API_BASE_URL = settings.ENTERPRISE_ENROLLMENT_API_URL
 
+    @JwtLmsApiClient.refresh_token
     def get_course_details(self, course_id):
         """
         Query the Enrollment API for the course details of the given course_id.
@@ -158,6 +159,7 @@ class EnrollmentApiClient(LmsApiClient):
             )
             return {}
 
+    @JwtLmsApiClient.refresh_token
     def _sort_course_modes(self, modes):
         """
         Sort the course mode dictionaries by slug according to the COURSE_MODE_SORT_ORDER constant.
@@ -180,6 +182,7 @@ class EnrollmentApiClient(LmsApiClient):
         # Sort slug weights in descending order
         return sorted(modes, key=slug_weight, reverse=True)
 
+    @JwtLmsApiClient.refresh_token
     def get_course_modes(self, course_id):
         """
         Query the Enrollment API for the specific course modes that are available for the given course_id.
@@ -195,6 +198,7 @@ class EnrollmentApiClient(LmsApiClient):
         modes = details.get('course_modes', [])
         return self._sort_course_modes([mode for mode in modes if mode['slug'] not in EXCLUDED_COURSE_MODES])
 
+    @JwtLmsApiClient.refresh_token
     def has_course_mode(self, course_run_id, mode):
         """
         Query the Enrollment API to see whether a course run has a given course mode available.
@@ -209,6 +213,7 @@ class EnrollmentApiClient(LmsApiClient):
         course_modes = self.get_course_modes(course_run_id)
         return any(course_mode for course_mode in course_modes if course_mode['slug'] == mode)
 
+    @JwtLmsApiClient.refresh_token
     def enroll_user_in_course(self, username, course_id, mode, cohort=None):
         """
         Call the enrollment API to enroll the user in the course specified by course_id.
@@ -232,6 +237,7 @@ class EnrollmentApiClient(LmsApiClient):
             }
         )
 
+    @JwtLmsApiClient.refresh_token
     def unenroll_user_from_course(self, username, course_id):
         """
         Call the enrollment API to unenroll the user in the course specified by course_id.
@@ -253,6 +259,7 @@ class EnrollmentApiClient(LmsApiClient):
 
         return False
 
+    @JwtLmsApiClient.refresh_token
     def get_course_enrollment(self, username, course_id):
         """
         Query the enrollment API to get information about a single course enrollment.
@@ -287,6 +294,7 @@ class EnrollmentApiClient(LmsApiClient):
 
         return result
 
+    @JwtLmsApiClient.refresh_token
     def is_enrolled(self, username, course_run_id):
         """
         Query the enrollment API and determine if a learner is enrolled in a course run.
@@ -302,6 +310,7 @@ class EnrollmentApiClient(LmsApiClient):
         enrollment = self.get_course_enrollment(username, course_run_id)
         return enrollment is not None and enrollment.get('is_active', False)
 
+    @JwtLmsApiClient.refresh_token
     def get_enrolled_courses(self, username):
         """
         Query the enrollment API to get a list of the courses a user is enrolled in.

--- a/enterprise/api_client/lms.py
+++ b/enterprise/api_client/lms.py
@@ -159,7 +159,6 @@ class EnrollmentApiClient(JwtLmsApiClient):
             )
             return {}
 
-    @JwtLmsApiClient.refresh_token
     def _sort_course_modes(self, modes):
         """
         Sort the course mode dictionaries by slug according to the COURSE_MODE_SORT_ORDER constant.

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -734,7 +734,7 @@ class EnterpriseCustomerUser(TimeStampedModel):
         """
         Enroll a user into a course track, and register an enterprise course enrollment.
         """
-        enrollment_api_client = EnrollmentApiClient()
+        enrollment_api_client = EnrollmentApiClient(self.user)
         # Check to see if the user's already enrolled and we have an enterprise course enrollment to track it.
         course_enrollment = enrollment_api_client.get_course_enrollment(self.username, course_run_id) or {}
         enrolled_in_course = course_enrollment and course_enrollment.get('is_active', False)
@@ -796,7 +796,7 @@ class EnterpriseCustomerUser(TimeStampedModel):
         """
         Unenroll a user from a course track.
         """
-        enrollment_api_client = EnrollmentApiClient()
+        enrollment_api_client = EnrollmentApiClient(self.user)
         if enrollment_api_client.unenroll_user_from_course(self.username, course_run_id):
             EnterpriseCourseEnrollment.objects.filter(enterprise_customer_user=self, course_id=course_run_id).delete()
             return True
@@ -1197,7 +1197,7 @@ class EnterpriseCourseEnrollment(TimeStampedModel):
 
         :return: Whether the course enrollment mode is of an audit type.
         """
-        course_enrollment_api = EnrollmentApiClient()
+        course_enrollment_api = EnrollmentApiClient(self.enterprise_customer_user.user)
         course_enrollment = course_enrollment_api.get_course_enrollment(
             self.enterprise_customer_user.username,
             self.course_id

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -936,7 +936,7 @@ class HandleConsentEnrollment(View):
         if not enrollment_course_mode:
             return redirect(LMS_DASHBOARD_URL)
 
-        enrollment_api_client = EnrollmentApiClient()
+        enrollment_api_client = EnrollmentApiClient(request.user)
         course_modes = enrollment_api_client.get_course_modes(course_id)
 
         # Verify that the request user belongs to the enterprise against the
@@ -1046,7 +1046,7 @@ class CourseEnrollmentView(NonAtomicView):
         course modes returned using the EnterpriseCustomerCatalog's
         field "enabled_course_modes".
         """
-        modes = EnrollmentApiClient().get_course_modes(course_run_id)
+        modes = EnrollmentApiClient(request.user).get_course_modes(course_run_id)
         if not modes:
             LOGGER.warning('[Enterprise Enrollment] Unable to get course modes. '
                            'CourseRun: {course_run_id}'.format(course_run_id=course_run_id))
@@ -1389,7 +1389,7 @@ class CourseEnrollmentView(NonAtomicView):
                 )
                 track_enrollment('course-landing-page-enrollment', request.user.id, course_id, request.get_full_path())
 
-            client = EnrollmentApiClient()
+            client = EnrollmentApiClient(request.user)
             client.enroll_user_in_course(
                 request.user.username,
                 course_id,
@@ -1492,7 +1492,7 @@ class CourseEnrollmentView(NonAtomicView):
             enterprise_customer=enterprise_customer
         )
 
-        enrollment_client = EnrollmentApiClient()
+        enrollment_client = EnrollmentApiClient(request.user)
         enrolled_course = enrollment_client.get_course_enrollment(request.user.username, course_id)
         try:
             enterprise_course_enrollment = EnterpriseCourseEnrollment.objects.get(
@@ -1970,7 +1970,7 @@ class RouterView(NonAtomicView):
         except ImproperlyConfigured:
             raise Http404
 
-        users_all_enrolled_courses = EnrollmentApiClient().get_enrolled_courses(user.username)
+        users_all_enrolled_courses = EnrollmentApiClient(user).get_enrolled_courses(user.username)
         users_active_course_runs = get_active_course_runs(
             course,
             users_all_enrolled_courses
@@ -1999,7 +1999,7 @@ class RouterView(NonAtomicView):
         return request.GET.get('audit') and \
             request.path == self.COURSE_ENROLLMENT_VIEW_URL.format(enterprise_customer.uuid, course_identifier) and \
             enterprise_customer.catalog_contains_course(resource_id) and \
-            EnrollmentApiClient().has_course_mode(resource_id, 'audit')
+            EnrollmentApiClient(request.user).has_course_mode(resource_id, 'audit')
 
     def redirect(self, request, *args, **kwargs):
         """

--- a/tests/test_enterprise/api_client/test_lms.py
+++ b/tests/test_enterprise/api_client/test_lms.py
@@ -13,8 +13,6 @@ import responses
 from pytest import raises
 from slumber.exceptions import HttpNotFoundError
 
-from django.conf import settings
-
 from enterprise.api_client import lms as lms_api
 from enterprise.utils import NotConnectedToOpenEdX
 
@@ -39,17 +37,18 @@ def _url(base_name, path):
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_enrollment_api_client():
     expected_response = {"message": "test"}
     responses.add(responses.GET, _url("enrollment", "test"), json=expected_response)
-    client = lms_api.EnrollmentApiClient()
+    client = lms_api.EnrollmentApiClient('user-goes-here')
+    client.connect()
     actual_response = client.client.test.get()
     assert actual_response == expected_response
-    request = responses.calls[0][0]
-    assert request.headers['X-Edx-Api-Key'] == settings.EDX_API_KEY
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_get_enrollment_course_details():
     course_id = "course-v1:edX+DemoX+Demo_Course"
     expected_response = {"course_id": course_id}
@@ -61,12 +60,13 @@ def test_get_enrollment_course_details():
         ),
         json=expected_response
     )
-    client = lms_api.EnrollmentApiClient()
+    client = lms_api.EnrollmentApiClient('user-goes-here')
     actual_response = client.get_course_details(course_id)
     assert actual_response == expected_response
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_get_enrollment_course_details_with_exception():
     course_id = "course-v1:edX+DemoX+Demo_Course"
     responses.add(
@@ -77,12 +77,13 @@ def test_get_enrollment_course_details_with_exception():
         ),
         status=400
     )
-    client = lms_api.EnrollmentApiClient()
+    client = lms_api.EnrollmentApiClient('user-goes-here')
     actual_response = client.get_course_details(course_id)
     assert actual_response == {}
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_enroll_user_in_course():
     user = "some_user"
     course_id = "course-v1:edX+DemoX+Demo_Course"
@@ -98,7 +99,7 @@ def test_enroll_user_in_course():
         ),
         json=expected_response
     )
-    client = lms_api.EnrollmentApiClient()
+    client = lms_api.EnrollmentApiClient('user-goes-here')
     actual_response = client.enroll_user_in_course(user, course_id, mode, cohort=cohort)
     assert actual_response == expected_response
     request = responses.calls[0][0]
@@ -106,6 +107,7 @@ def test_enroll_user_in_course():
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_get_course_enrollment():
     user = "some_user"
     course_id = "course-v1:edX+DemoX+Demo_Course"
@@ -120,12 +122,13 @@ def test_get_course_enrollment():
         ),
         json=expected_response
     )
-    client = lms_api.EnrollmentApiClient()
+    client = lms_api.EnrollmentApiClient('user-goes-here')
     actual_response = client.get_course_enrollment(user, course_id)
     assert actual_response == expected_response
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_is_enrolled():
     user = "some_user"
     course_id = "course-v1:edX+DemoX+Demo_Course"
@@ -141,12 +144,13 @@ def test_is_enrolled():
         ),
         json=expected_response
     )
-    client = lms_api.EnrollmentApiClient()
+    client = lms_api.EnrollmentApiClient('user-goes-here')
     actual_response = client.is_enrolled(user, course_id)
     assert actual_response is True
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 @mock.patch('enterprise.api_client.lms.COURSE_MODE_SORT_ORDER', ['a', 'list', 'containing', 'most', 'of', 'the'])
 @mock.patch('enterprise.api_client.lms.EXCLUDED_COURSE_MODES', ['course'])
 def test_get_enrollment_course_modes():
@@ -174,12 +178,13 @@ def test_get_enrollment_course_modes():
         ),
         json=response
     )
-    client = lms_api.EnrollmentApiClient()
+    client = lms_api.EnrollmentApiClient('user-goes-here')
     actual_response = client.get_course_modes(course_id)
     assert actual_response == expected_return
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 @mock.patch('enterprise.api_client.lms.COURSE_MODE_SORT_ORDER', ['a', 'list', 'containing', 'most', 'of', 'the'])
 def test_has_course_modes():
     course_id = "course-v1:edX+DemoX+Demo_Course"
@@ -200,12 +205,13 @@ def test_has_course_modes():
         ),
         json=response
     )
-    client = lms_api.EnrollmentApiClient()
+    client = lms_api.EnrollmentApiClient('user-goes-here')
     actual_response = client.has_course_mode(course_id, 'list')
     assert actual_response is True
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 @mock.patch('enterprise.api_client.lms.COURSE_MODE_SORT_ORDER', ['a', 'list', 'containing', 'most', 'of', 'the'])
 @mock.patch('enterprise.api_client.lms.EXCLUDED_COURSE_MODES', ['course'])
 def test_doesnt_have_course_modes():
@@ -227,12 +233,13 @@ def test_doesnt_have_course_modes():
         ),
         json=response
     )
-    client = lms_api.EnrollmentApiClient()
+    client = lms_api.EnrollmentApiClient('user-goes-here')
     actual_response = client.has_course_mode(course_id, 'course')
     assert actual_response is False
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_get_course_enrollment_invalid():
     user = "some_user"
     course_id = "course-v1:edX+DemoX+Demo_Course"
@@ -244,12 +251,13 @@ def test_get_course_enrollment_invalid():
         ),
         status=404,
     )
-    client = lms_api.EnrollmentApiClient()
+    client = lms_api.EnrollmentApiClient('user-goes-here')
     actual_response = client.get_course_enrollment(user, course_id)
     assert actual_response is None
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_get_course_enrollment_not_found():
     user = "some_user"
     course_id = "course-v1:edX+DemoX+Demo_Course"
@@ -261,12 +269,13 @@ def test_get_course_enrollment_not_found():
         ),
         body='',
     )
-    client = lms_api.EnrollmentApiClient()
+    client = lms_api.EnrollmentApiClient('user-goes-here')
     actual_response = client.get_course_enrollment(user, course_id)
     assert actual_response is None
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_is_enrolled_false():
     user = "some_user"
     course_id = "course-v1:edX+DemoX+Demo_Course"
@@ -278,12 +287,13 @@ def test_is_enrolled_false():
         ),
         status=404,
     )
-    client = lms_api.EnrollmentApiClient()
+    client = lms_api.EnrollmentApiClient('user-goes-here')
     actual_response = client.is_enrolled(user, course_id)
     assert actual_response is False
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_is_enrolled_but_not_active():
     user = "some_user"
     course_id = "course-v1:edX+DemoX+Demo_Course"
@@ -299,12 +309,13 @@ def test_is_enrolled_but_not_active():
         ),
         json=expected_response
     )
-    client = lms_api.EnrollmentApiClient()
+    client = lms_api.EnrollmentApiClient('user-goes-here')
     actual_response = client.is_enrolled(user, course_id)
     assert actual_response is False
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_get_enrolled_courses():
     user = "some_user"
     course_id = "course-v1:edx+DemoX+Demo_Course"
@@ -321,12 +332,13 @@ def test_get_enrolled_courses():
         match_querystring=True,
         json=expected_response,
     )
-    client = lms_api.EnrollmentApiClient()
+    client = lms_api.EnrollmentApiClient('user-goes-here')
     actual_response = client.get_enrolled_courses(user)
     assert actual_response == expected_response
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_unenroll():
     user = "some_user"
     course_id = "course-v1:edx+DemoX+Demo_Course"
@@ -350,12 +362,13 @@ def test_unenroll():
         ),
         json=expected_response
     )
-    client = lms_api.EnrollmentApiClient()
+    client = lms_api.EnrollmentApiClient('user-goes-here')
     unenrolled = client.unenroll_user_from_course(user, course_id)
     assert unenrolled
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_unenroll_already_unenrolled():
     user = "some_user"
     course_id = "course-v1:edx+DemoX+Demo_Course"
@@ -378,7 +391,7 @@ def test_unenroll_already_unenrolled():
         ),
         json=expected_response
     )
-    client = lms_api.EnrollmentApiClient()
+    client = lms_api.EnrollmentApiClient('user-goes-here')
     unenrolled = client.unenroll_user_from_course(user, course_id)
     assert not unenrolled
 


### PR DESCRIPTION
This PR is about replacing the `EDX-API-KEY` with `OAuth` authentication method using `JWT.` There are three clients that are relying on the `EDX-API-KEY` based authentication; `CourseApiClient,` `EnrollmentApiClient,` and `ThirdPartyAuthApiClient.` This PR only covers the `EnrollmentmentApiClient.`