### PR TITLE
Replaced EDX_API_KEY with JWT in CourseApiClient

### DIFF
--- a/enterprise/admin/__init__.py
+++ b/enterprise/admin/__init__.py
@@ -331,7 +331,7 @@ class EnterpriseCustomerUserAdmin(admin.ModelAdmin):
                 being rendered with this admin form.
         """
         enterprise_course_ids = self._get_enterprise_course_enrollments(enterprise_customer_user)
-        courses_string = mark_safe(self.get_enrolled_course_string(enterprise_course_ids))
+        courses_string = mark_safe(self.get_enrolled_course_string(enterprise_course_ids, enterprise_customer_user))
         return courses_string or 'None'
 
     def other_enrollments(self, enterprise_customer_user):
@@ -346,7 +346,7 @@ class EnterpriseCustomerUserAdmin(admin.ModelAdmin):
         enterprise_course_ids = self._get_enterprise_course_enrollments(enterprise_customer_user)
         # remove overlapping enterprise enrollments from all enrollments
         course_ids = set(all_course_ids) - set(enterprise_course_ids)
-        courses_string = mark_safe(self.get_enrolled_course_string(course_ids))
+        courses_string = mark_safe(self.get_enrolled_course_string(course_ids, enterprise_customer_user))
         return courses_string or 'None'
 
     def _get_enterprise_course_enrollments(self, enterprise_customer_user):
@@ -382,11 +382,11 @@ class EnterpriseCustomerUserAdmin(admin.ModelAdmin):
             return readonly_fields + tuple(get_all_field_names(self.model))
         return readonly_fields
 
-    def get_enrolled_course_string(self, course_ids):
+    def get_enrolled_course_string(self, course_ids, enterprise_customer_user):
         """
         Get an HTML string representing the courses the user is enrolled in.
         """
-        courses_client = CourseApiClient()
+        courses_client = CourseApiClient(enterprise_customer_user.user)
         course_details = []
         for course_id in course_ids:
             name = courses_client.get_course_details(course_id)['name']

--- a/enterprise/api_client/lms.py
+++ b/enterprise/api_client/lms.py
@@ -316,7 +316,7 @@ class EnrollmentApiClient(LmsApiClient):
         return self.client.enrollment.get(user=username)
 
 
-class CourseApiClient(LmsApiClient):
+class CourseApiClient(JwtLmsApiClient):
     """
     Object builds an API client to make calls to the Course API.
     """
@@ -324,6 +324,7 @@ class CourseApiClient(LmsApiClient):
     API_BASE_URL = settings.LMS_INTERNAL_ROOT_URL + '/api/courses/v1/'
     APPEND_SLASH = True
 
+    @JwtLmsApiClient.refresh_token
     def get_course_details(self, course_id):
         """
         Retrieve all available details about a course.

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -215,12 +215,12 @@ class GrantDataSharingPermissions(View):
 
     preview_mode = False
 
-    def course_or_program_exist(self, course_id, program_uuid):
+    def course_or_program_exist(self, request, course_id, program_uuid):
         """
         Return whether the input course or program exist.
         """
         try:
-            course_exists = course_id and CourseApiClient().get_course_details(course_id)
+            course_exists = course_id and CourseApiClient(request.user).get_course_details(course_id)
             program_exists = program_uuid and get_course_catalog_api_service_client().program_exists(program_uuid)
             return course_exists or program_exists
         except ImproperlyConfigured as error:
@@ -555,7 +555,7 @@ class GrantDataSharingPermissions(View):
         context_data = get_global_context(request, enterprise_customer)
 
         if not self.preview_mode:
-            if not self.course_or_program_exist(course_id, program_uuid):
+            if not self.course_or_program_exist(request, course_id, program_uuid):
                 error_code = 'ENTGDS000'
                 log_message = (
                     '[Enterprise DSC API] The course or program with a given id does not exist. '
@@ -771,7 +771,7 @@ class GrantDataSharingPermissions(View):
             )
             return render_page_with_error_code_message(request, context_data, error_code, log_message)
 
-        if not self.course_or_program_exist(course_id, program_uuid):
+        if not self.course_or_program_exist(request, course_id, program_uuid):
             error_code = 'ENTGDS006'
             log_message = (
                 '[Enterprise DSC API] The course or program with a given id does not exist. '

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -215,12 +215,12 @@ class GrantDataSharingPermissions(View):
 
     preview_mode = False
 
-    def course_or_program_exist(self, request, course_id, program_uuid):
+    def course_or_program_exist(self, request_user, course_id, program_uuid):
         """
         Return whether the input course or program exist.
         """
         try:
-            course_exists = course_id and CourseApiClient(request.user).get_course_details(course_id)
+            course_exists = course_id and CourseApiClient(request_user).get_course_details(course_id)
             program_exists = program_uuid and get_course_catalog_api_service_client().program_exists(program_uuid)
             return course_exists or program_exists
         except ImproperlyConfigured as error:
@@ -555,7 +555,8 @@ class GrantDataSharingPermissions(View):
         context_data = get_global_context(request, enterprise_customer)
 
         if not self.preview_mode:
-            if not self.course_or_program_exist(request, course_id, program_uuid):
+            request_user = request.user
+            if not self.course_or_program_exist(request_user, course_id, program_uuid):
                 error_code = 'ENTGDS000'
                 log_message = (
                     '[Enterprise DSC API] The course or program with a given id does not exist. '
@@ -771,7 +772,8 @@ class GrantDataSharingPermissions(View):
             )
             return render_page_with_error_code_message(request, context_data, error_code, log_message)
 
-        if not self.course_or_program_exist(request, course_id, program_uuid):
+        request_user = request.user
+        if not self.course_or_program_exist(request_user, course_id, program_uuid):
             error_code = 'ENTGDS006'
             log_message = (
                 '[Enterprise DSC API] The course or program with a given id does not exist. '

--- a/integrated_channels/integrated_channel/exporters/learner_data.py
+++ b/integrated_channels/integrated_channel/exporters/learner_data.py
@@ -146,7 +146,7 @@ class LearnerExporter(Exporter):
             # pylint: disable=unsubscriptable-object
             if course_details is None or course_details['course_id'] != course_id:
                 if self.course_api is None:
-                    self.course_api = CourseApiClient()
+                    self.course_api = CourseApiClient(self.user)
                 course_details = self.course_api.get_course_details(course_id)
 
             if course_details is None:

--- a/tests/test_enterprise/api_client/test_lms.py
+++ b/tests/test_enterprise/api_client/test_lms.py
@@ -384,6 +384,7 @@ def test_unenroll_already_unenrolled():
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_get_full_course_details():
     course_id = "course-v1:edX+DemoX+Demo_Course"
     expected_response = {
@@ -394,12 +395,13 @@ def test_get_full_course_details():
         _url("courses", "courses/course-v1:edX+DemoX+Demo_Course/"),
         json=expected_response,
     )
-    client = lms_api.CourseApiClient()
+    client = lms_api.CourseApiClient('user-goes-here')
     actual_response = client.get_course_details(course_id)
     assert actual_response == expected_response
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_get_full_course_details_not_found():
     course_id = "course-v1:edX+DemoX+Demo_Course"
     responses.add(
@@ -407,7 +409,7 @@ def test_get_full_course_details_not_found():
         _url("courses", "courses/course-v1:edX+DemoX+Demo_Course/"),
         status=404,
     )
-    client = lms_api.CourseApiClient()
+    client = lms_api.CourseApiClient('user-goes-here')
     actual_response = client.get_course_details(course_id)
     assert actual_response is None
 


### PR DESCRIPTION
This PR is about replacing the `EDX-API-KEY` with `OAuth` authentication method using `JWT.` There are three clients that are relying on the `EDX-API-KEY` based authentication; `CourseApiClient,` `EnrollmentApiClient,` and `ThirdPartyAuthApiClient.` This PR only covers the `CourseApiClient.`