### PR TITLE
Replaced EDX_API_KEY with JWT in ThirdPartyAuthApiClient 

### DIFF
--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -642,9 +642,10 @@ class EnterpriseCustomerCourseEnrollmentsSerializer(serializers.Serializer):
         It first uses the third party auth api to find the associated username to do the lookup.
         """
         enterprise_customer = self.context.get('enterprise_customer')
+        request_user = self.context.get('request_user')
 
         try:
-            tpa_client = ThirdPartyAuthApiClient()
+            tpa_client = ThirdPartyAuthApiClient(request_user)
             username = tpa_client.get_username_from_remote_id(
                 enterprise_customer.identity_provider, value
             )

--- a/enterprise/api_client/lms.py
+++ b/enterprise/api_client/lms.py
@@ -376,7 +376,6 @@ class ThirdPartyAuthApiClient(JwtLmsApiClient):
         """
         return self._get_results(identity_provider, 'remote_id', remote_id, 'username')
 
-    @JwtLmsApiClient.refresh_token
     def _get_results(self, identity_provider, param_name, param_value, result_field_name):
         """
         Calls the third party auth api endpoint to get the mapping between usernames and remote ids.

--- a/enterprise/api_client/lms.py
+++ b/enterprise/api_client/lms.py
@@ -341,13 +341,14 @@ class CourseApiClient(LmsApiClient):
             return None
 
 
-class ThirdPartyAuthApiClient(LmsApiClient):
+class ThirdPartyAuthApiClient(JwtLmsApiClient):
     """
     Object builds an API client to make calls to the Third Party Auth API.
     """
 
     API_BASE_URL = settings.LMS_INTERNAL_ROOT_URL + '/api/third_party_auth/v0/'
 
+    @JwtLmsApiClient.refresh_token
     def get_remote_id(self, identity_provider, username):
         """
         Retrieve the remote identifier for the given username.
@@ -361,6 +362,7 @@ class ThirdPartyAuthApiClient(LmsApiClient):
         """
         return self._get_results(identity_provider, 'username', username, 'remote_id')
 
+    @JwtLmsApiClient.refresh_token
     def get_username_from_remote_id(self, identity_provider, remote_id):
         """
         Retrieve the remote identifier for the given username.
@@ -374,6 +376,7 @@ class ThirdPartyAuthApiClient(LmsApiClient):
         """
         return self._get_results(identity_provider, 'remote_id', remote_id, 'username')
 
+    @JwtLmsApiClient.refresh_token
     def _get_results(self, identity_provider, param_name, param_value, result_field_name):
         """
         Calls the third party auth api endpoint to get the mapping between usernames and remote ids.

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -726,7 +726,7 @@ class EnterpriseCustomerUser(TimeStampedModel):
         user = self.user
         identity_provider = self.enterprise_customer.identity_provider
         if user and identity_provider:
-            client = ThirdPartyAuthApiClient()
+            client = ThirdPartyAuthApiClient(user)
             return client.get_remote_id(self.enterprise_customer.identity_provider, user.username)
         return None
 

--- a/tests/test_enterprise/api_client/test_lms.py
+++ b/tests/test_enterprise/api_client/test_lms.py
@@ -413,6 +413,7 @@ def test_get_full_course_details_not_found():
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_get_remote_id_not_found():
     username = "Darth"
     provider_id = "DeathStar"
@@ -424,12 +425,13 @@ def test_get_remote_id_not_found():
         match_querystring=True,
         status=404
     )
-    client = lms_api.ThirdPartyAuthApiClient()
+    client = lms_api.ThirdPartyAuthApiClient('user-goes-here')
     actual_response = client.get_remote_id(provider_id, username)
     assert actual_response is None
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_get_remote_id_no_results():
     username = "Darth"
     provider_id = "DeathStar"
@@ -450,12 +452,13 @@ def test_get_remote_id_no_results():
         match_querystring=True,
         json=expected_response,
     )
-    client = lms_api.ThirdPartyAuthApiClient()
+    client = lms_api.ThirdPartyAuthApiClient('user-goes-here')
     actual_response = client.get_remote_id(provider_id, username)
     assert actual_response is None
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_get_remote_id():
     username = "Darth"
     provider_id = "DeathStar"
@@ -476,12 +479,13 @@ def test_get_remote_id():
         match_querystring=True,
         json=expected_response,
     )
-    client = lms_api.ThirdPartyAuthApiClient()
+    client = lms_api.ThirdPartyAuthApiClient('user-goes-here')
     actual_response = client.get_remote_id(provider_id, username)
     assert actual_response == "LukeIamYrFather"
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_get_username_from_remote_id_not_found():
     remote_id = "Darth"
     provider_id = "DeathStar"
@@ -493,12 +497,13 @@ def test_get_username_from_remote_id_not_found():
         match_querystring=True,
         status=404
     )
-    client = lms_api.ThirdPartyAuthApiClient()
+    client = lms_api.ThirdPartyAuthApiClient('user-goes-here')
     actual_response = client.get_username_from_remote_id(provider_id, remote_id)
     assert actual_response is None
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_get_username_from_remote_id_no_results():
     remote_id = "Darth"
     provider_id = "DeathStar"
@@ -519,12 +524,13 @@ def test_get_username_from_remote_id_no_results():
         match_querystring=True,
         json=expected_response,
     )
-    client = lms_api.ThirdPartyAuthApiClient()
+    client = lms_api.ThirdPartyAuthApiClient('user-goes-here')
     actual_response = client.get_username_from_remote_id(provider_id, remote_id)
     assert actual_response is None
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_get_username_from_remote_id():
     remote_id = "LukeIamYrFather"
     provider_id = "DeathStar"
@@ -544,7 +550,7 @@ def test_get_username_from_remote_id():
         match_querystring=True,
         json=expected_response,
     )
-    client = lms_api.ThirdPartyAuthApiClient()
+    client = lms_api.ThirdPartyAuthApiClient('user-goes-here')
     actual_response = client.get_username_from_remote_id(provider_id, remote_id)
     assert actual_response == "Darth"
 


### PR DESCRIPTION
This PR is about replacing the `EDX-API-KEY` with `OAuth` authentication method using `JWT.` There are three clients that are relying on the `EDX-API-KEY` based authentication; `CourseApiClient,` `EnrollmentApiClient,` and `ThirdPartyAuthApiClient.` This PR only covers the `ThirdPartyAuthApiClient.`