### PR TITLE
ENT-2497: Updated session after multiple enterprise selection

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ Change Log
 
 Unreleased
 ----------
+[2.0.29] - 2019-12-04
+---------------------
+
+* Update the enterprise customer in the session in case of customer with multiple linked enterprises
 
 [2.0.28] - 2019-12-3
 ---------------------

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "2.0.28"
+__version__ = "2.0.29"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -900,6 +900,11 @@ class EnterpriseSelectionView(FormView):
         })
         if serializer.is_valid():
             serializer.save()
+            enterprise_customer_user = EnterpriseCustomerUser.objects.get(
+                user_id=self.request.user.id,
+                enterprise_customer=enterprise_customer
+            )
+            enterprise_customer_user.update_session(self.request)
             LOGGER.info(
                 '[Enterprise Selection Page] Learner activated an enterprise. User: %s, EnterpriseCustomer: %s',
                 self.request.user.username,

--- a/tests/test_enterprise/views/test_enterprise_selection.py
+++ b/tests/test_enterprise/views/test_enterprise_selection.py
@@ -128,7 +128,8 @@ class TestEnterpriseSelectionView(TestCase):
 
         # after selection only the selected enterprise should be active for learner
         assert EnterpriseCustomerUser.objects.get(user_id=user_id, enterprise_customer=new_enterprise).active
-
+        # selected enterprise is set correctly in the session
+        self.assertEqual(self.client.session['enterprise_customer']['uuid'], new_enterprise)
         # all other enterprises for learner should be non-active
         for obj in EnterpriseCustomerUser.objects.filter(user_id=user_id).exclude(enterprise_customer=new_enterprise):
             assert not obj.active


### PR DESCRIPTION
**JIRA**: https://openedx.atlassian.net/browse/ENT-2497

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
