### PR TITLE
Mark the current learner enterprise-customer active flag to True

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,11 @@ Unreleased
 
 * Update the enterprise customer in the session in case of customer with multiple linked enterprises
 
+[2.0.29] - 2019-12-04
+---------------------
+
+* Get the enterprise_customer linked with SAML and mark it active.
+
 [2.0.28] - 2019-12-3
 ---------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,15 +13,15 @@ Change Log
 
 Unreleased
 ----------
+[2.0.30] - 2019-12-04
+---------------------
+
+* Get the enterprise_customer linked with SAML and mark it active.
+
 [2.0.29] - 2019-12-04
 ---------------------
 
 * Update the enterprise customer in the session in case of customer with multiple linked enterprises
-
-[2.0.29] - 2019-12-04
----------------------
-
-* Get the enterprise_customer linked with SAML and mark it active.
 
 [2.0.28] - 2019-12-3
 ---------------------

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "2.0.29"
+__version__ = "2.0.30"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/tpa_pipeline.py
+++ b/enterprise/tpa_pipeline.py
@@ -67,10 +67,11 @@ def handle_enterprise_logistration(backend, user, **kwargs):
         return
 
     # proceed with the creation of a link between the user and the enterprise customer, then exit.
+    defaults = {'active': True}
     enterprise_customer_user, _ = EnterpriseCustomerUser.objects.update_or_create(
         enterprise_customer=enterprise_customer,
-        active=True,
-        user_id=user.id
+        user_id=user.id,
+        defaults=defaults,
     )
     # if learner has activated enterprise we need to de-activate other enterprises learner is linked to
     EnterpriseCustomerUser.objects.filter(


### PR DESCRIPTION
Mark the current learner enterprise-customer active flag to True and all other enterprise-customers active flag to false

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
