### PR TITLE
ENT-1961 | Making the manual enrollment reason field optional via con…

### DIFF
--- a/enterprise/admin/forms.py
+++ b/enterprise/admin/forms.py
@@ -40,12 +40,14 @@ from enterprise.models import (
     EnterpriseFeatureUserRoleAssignment,
     SystemWideEnterpriseUserRoleAssignment,
 )
-from enterprise.utils import MultipleProgramMatchError
+from enterprise.utils import MultipleProgramMatchError, get_configuration_value
 
 try:
     from third_party_auth.models import SAMLProviderConfig as saml_provider_configuration
 except ImportError:
     saml_provider_configuration = None
+
+ENABLE_MANUAL_ENROLLMENT_REASON_FIELD = 'ENABLE_MANUAL_ENROLLMENT_REASON_FIELD'
 
 logger = getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -89,7 +91,6 @@ class ManageLearnersForm(forms.Form):
             ("honor", _("Honor")),
         ],
     )
-    reason = forms.CharField(label=_("Reason for manual enrollment"), required=True)
 
     class NotificationTypes(object):
         """
@@ -150,6 +151,8 @@ class ManageLearnersForm(forms.Form):
         self._user = user
         self._enterprise_customer = kwargs.pop('enterprise_customer', None)
         super(ManageLearnersForm, self).__init__(*args, **kwargs)
+        if get_configuration_value(ENABLE_MANUAL_ENROLLMENT_REASON_FIELD, False):
+            self.fields['reason'] = forms.CharField(label=_("Reason for manual enrollment"), required=True)
 
     def clean_email_or_username(self):
         """

--- a/enterprise/admin/views.py
+++ b/enterprise/admin/views.py
@@ -542,6 +542,8 @@ class EnterpriseCustomerManageLearnersView(View):
             program_details: The details of the program in which we're enrolling
             course_mode (str): The mode with which we're enrolling in the program
             emails: An iterable of email addresses which need to be enrolled
+            enrollment_requester (User): The logged-in user who is adding the learner
+            enrollment_reason (str): Reason for manual enrollment.
 
         Returns:
             successes: A list of users who were successfully enrolled in all courses of the program
@@ -613,6 +615,8 @@ class EnterpriseCustomerManageLearnersView(View):
             course_id (str): The unique identifier of the course in which we're enrolling
             course_mode (str): The mode with which we're enrolling in the course
             emails: An iterable of email addresses which need to be enrolled
+            enrollment_requester (User): The logged-in user who is adding the learner
+            enrollment_reason (str): Reason for manual enrollment.
 
         Returns:
             successes: A list of users who were successfully enrolled in the course

--- a/tests/test_admin/test_forms.py
+++ b/tests/test_admin/test_forms.py
@@ -82,7 +82,8 @@ class TestManageLearnersForm(TestWithCourseCatalogApiMixin, unittest.TestCase):
             file_data = {ManageLearnersForm.Fields.BULK_UPLOAD: mock_file}
 
         customer = EnterpriseCustomerFactory()
-        return ManageLearnersForm(form_data, file_data, enterprise_customer=customer)
+        with mock.patch('enterprise.admin.forms.get_configuration_value', return_value=True):
+            return ManageLearnersForm(form_data, file_data, enterprise_customer=customer)
 
     @ddt.data(
         "qwe@asd.com", "email1@example.org", "john.t.kirk@starfleet.gov"


### PR DESCRIPTION
…figuration flag `ENABLE_MANUAL_ENROLLMENT_REASON_FIELD`.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
