### PR TITLE
ENT-2501: Updated context for user with multiple linked enterprises

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,11 +11,15 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+[2.0.42] - 2020-01-07
+---------------------
+
+* Updated context for user with multiple linked enterprises
+
 [2.0.41] - 2020-01-06
 ---------------------
 
 * Added enterprise discount percentage in a manual enrollment
-
 
 [2.0.40] - 2020-01-06
 ---------------------

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "2.0.41"
+__version__ = "2.0.42"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name


### PR DESCRIPTION
**Description** This PR updates the EnterpriseRoleAssignmentContextMixin to incorporate the case where a user may have multiple contexts e.g. a user with multiple linked enterprises

**JIRA** https://openedx.atlassian.net/browse/ENT-2501


**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
