### PR TITLE
ENT-2042 Replaced Edx-Api-Key in Enrollment Api Client (remaining endpoints)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,11 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+[2.0.47] - 2020-01-13
+---------------------
+
+* Replaced Edx-Api-Key in the remaining endpoints of EnrollmentApiClient
+
 [2.0.46] - 2020-01-10
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "2.0.46"
+__version__ = "2.0.47"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/admin/__init__.py
+++ b/enterprise/admin/__init__.py
@@ -38,7 +38,7 @@ from enterprise.admin.views import (
     EnterpriseCustomerTransmitCoursesView,
     TemplatePreviewView,
 )
-from enterprise.api_client.lms import CourseApiClient, EnrollmentApiClient
+from enterprise.api_client.lms import CourseApiClient, EnrollmentApiClientJwt
 from enterprise.models import (
     EnrollmentNotificationEmailTemplate,
     EnterpriseCatalogQuery,
@@ -369,7 +369,7 @@ class EnterpriseCustomerUserAdmin(admin.ModelAdmin):
             enterprise_customer_user: The instance of EnterpriseCustomerUser
                 being rendered with this admin form.
         """
-        enrollment_client = EnrollmentApiClient()
+        enrollment_client = EnrollmentApiClientJwt(enterprise_customer_user.user)
         enrollments = enrollment_client.get_enrolled_courses(enterprise_customer_user.username)
         return [enrollment['course_details']['course_id'] for enrollment in enrollments]
 

--- a/enterprise/admin/forms.py
+++ b/enterprise/admin/forms.py
@@ -31,7 +31,7 @@ from enterprise.admin.utils import (
 )
 from enterprise.admin.widgets import SubmitInput
 from enterprise.api_client.discovery import CourseCatalogApiClient
-from enterprise.api_client.lms import EnrollmentApiClient
+from enterprise.api_client.lms import EnrollmentApiClientJwt
 from enterprise.models import (
     EnterpriseCustomer,
     EnterpriseCustomerCatalog,
@@ -211,7 +211,7 @@ class ManageLearnersForm(forms.Form):
         if not course_id:
             return None
         try:
-            client = EnrollmentApiClient()
+            client = EnrollmentApiClientJwt(self._user)
             return client.get_course_details(course_id)
         except (HttpClientError, HttpServerError):
             raise ValidationError(ValidationMessages.INVALID_COURSE_ID.format(course_id=course_id))

--- a/enterprise/api_client/lms.py
+++ b/enterprise/api_client/lms.py
@@ -320,6 +320,10 @@ class EnrollmentApiClient(LmsApiClient):
 class EnrollmentApiClientJwt(JwtLmsApiClient):
     """
     Object builds an API client to make calls to the Enrollment API.
+
+    The Edx_Api_Key has been deprecated which is why we are shifting to this new client that is based on
+    JwtLmsApiClient. In the future, if anyone wants to use EnrollmentApiClient client, make sure to use this one and
+    not the original one.
     """
 
     API_BASE_URL = settings.ENTERPRISE_ENROLLMENT_API_URL

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -36,7 +36,7 @@ from enterprise import constants, messages
 from enterprise.api.v1.serializers import EnterpriseCustomerUserWriteSerializer
 from enterprise.api_client.discovery import get_course_catalog_api_service_client
 from enterprise.api_client.ecommerce import EcommerceApiClient
-from enterprise.api_client.lms import CourseApiClient, EmbargoApiClient, EnrollmentApiClient
+from enterprise.api_client.lms import CourseApiClient, EmbargoApiClient, EnrollmentApiClientJwt
 from enterprise.decorators import enterprise_login_required, force_fresh_session
 from enterprise.forms import ENTERPRISE_SELECT_SUBTITLE, EnterpriseSelectionForm
 from enterprise.models import (
@@ -941,7 +941,7 @@ class HandleConsentEnrollment(View):
         if not enrollment_course_mode:
             return redirect(LMS_DASHBOARD_URL)
 
-        enrollment_api_client = EnrollmentApiClient()
+        enrollment_api_client = EnrollmentApiClientJwt(request.user)
         course_modes = enrollment_api_client.get_course_modes(course_id)
 
         # Verify that the request user belongs to the enterprise against the
@@ -1051,7 +1051,7 @@ class CourseEnrollmentView(NonAtomicView):
         course modes returned using the EnterpriseCustomerCatalog's
         field "enabled_course_modes".
         """
-        modes = EnrollmentApiClient().get_course_modes(course_run_id)
+        modes = EnrollmentApiClientJwt(request.user).get_course_modes(course_run_id)
         if not modes:
             LOGGER.warning('[Enterprise Enrollment] Unable to get course modes. '
                            'CourseRun: {course_run_id}'.format(course_run_id=course_run_id))
@@ -1394,7 +1394,7 @@ class CourseEnrollmentView(NonAtomicView):
                 )
                 track_enrollment('course-landing-page-enrollment', request.user.id, course_id, request.get_full_path())
 
-            client = EnrollmentApiClient()
+            client = EnrollmentApiClientJwt(request.user)
             client.enroll_user_in_course(
                 request.user.username,
                 course_id,
@@ -1497,7 +1497,7 @@ class CourseEnrollmentView(NonAtomicView):
             enterprise_customer=enterprise_customer
         )
 
-        enrollment_client = EnrollmentApiClient()
+        enrollment_client = EnrollmentApiClientJwt(request.user)
         enrolled_course = enrollment_client.get_course_enrollment(request.user.username, course_id)
         try:
             enterprise_course_enrollment = EnterpriseCourseEnrollment.objects.get(
@@ -1975,7 +1975,7 @@ class RouterView(NonAtomicView):
         except ImproperlyConfigured:
             raise Http404
 
-        users_all_enrolled_courses = EnrollmentApiClient().get_enrolled_courses(user.username)
+        users_all_enrolled_courses = EnrollmentApiClientJwt(user).get_enrolled_courses(user.username)
         users_active_course_runs = get_active_course_runs(
             course,
             users_all_enrolled_courses
@@ -2004,7 +2004,7 @@ class RouterView(NonAtomicView):
         return request.GET.get('audit') and \
             request.path == self.COURSE_ENROLLMENT_VIEW_URL.format(enterprise_customer.uuid, course_identifier) and \
             enterprise_customer.catalog_contains_course(resource_id) and \
-            EnrollmentApiClient().has_course_mode(resource_id, 'audit')
+            EnrollmentApiClientJwt(request.user).has_course_mode(resource_id, 'audit')
 
     def redirect(self, request, *args, **kwargs):
         """

--- a/tests/test_admin/test_forms.py
+++ b/tests/test_admin/test_forms.py
@@ -213,7 +213,7 @@ class TestManageLearnersForm(TestWithCourseCatalogApiMixin, unittest.TestCase):
         assert form.is_valid()
         assert form.cleaned_data[form.Fields.COURSE] is None
 
-    @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
+    @mock.patch("enterprise.admin.forms.EnrollmentApiClientJwt")
     def test_clean_course_valid(self, enrollment_client):
         instance = enrollment_client.return_value
         instance.get_course_details.side_effect = fake_enrollment_api.get_course_details
@@ -225,7 +225,7 @@ class TestManageLearnersForm(TestWithCourseCatalogApiMixin, unittest.TestCase):
         assert form.cleaned_data[form.Fields.COURSE] == course_details
 
     @ddt.data("course-v1:does+not+exist", "invalid_course_id")
-    @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
+    @mock.patch("enterprise.admin.forms.EnrollmentApiClientJwt")
     def test_clean_course_invalid(self, course_id, enrollment_client):
         instance = enrollment_client.return_value
         instance.get_course_details.side_effect = fake_enrollment_api.get_course_details
@@ -235,7 +235,7 @@ class TestManageLearnersForm(TestWithCourseCatalogApiMixin, unittest.TestCase):
             form.Fields.COURSE: [ValidationMessages.INVALID_COURSE_ID.format(course_id=course_id)],
         }
 
-    @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
+    @mock.patch("enterprise.admin.forms.EnrollmentApiClientJwt")
     def test_clean_valid_course_empty_mode(self, enrollment_client):
         instance = enrollment_client.return_value
         instance.get_course_details.side_effect = fake_enrollment_api.get_course_details
@@ -244,7 +244,7 @@ class TestManageLearnersForm(TestWithCourseCatalogApiMixin, unittest.TestCase):
         assert not form.is_valid()
         assert form.errors == {"__all__": [ValidationMessages.COURSE_WITHOUT_COURSE_MODE]}
 
-    @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
+    @mock.patch("enterprise.admin.forms.EnrollmentApiClientJwt")
     def test_clean_valid_course_invalid_mode(self, enrollment_client):
         instance = enrollment_client.return_value
         instance.get_course_details.side_effect = fake_enrollment_api.get_course_details
@@ -375,7 +375,7 @@ class TestManageLearnersForm(TestWithCourseCatalogApiMixin, unittest.TestCase):
             )]
         }
 
-    @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
+    @mock.patch("enterprise.admin.forms.EnrollmentApiClientJwt")
     def test_clean_both_course_and_program_passed(self, enrollment_client):
         instance = enrollment_client.return_value
         instance.get_course_details.side_effect = fake_enrollment_api.get_course_details

--- a/tests/test_admin/test_view.py
+++ b/tests/test_admin/test_view.py
@@ -635,7 +635,7 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
     @mock.patch("enterprise.admin.views.track_enrollment")
     @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.admin.views.EnrollmentApiClientJwt")
-    @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
+    @mock.patch("enterprise.admin.forms.EnrollmentApiClientJwt")
     @ddt.data(
         (True, True),
         (False, True),
@@ -774,7 +774,7 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
     @mock.patch("enterprise.admin.views.track_enrollment")
     @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.admin.views.EnrollmentApiClientJwt")
-    @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
+    @mock.patch("enterprise.admin.forms.EnrollmentApiClientJwt")
     def test_post_multi_enroll_user(
             self,
             forms_client,
@@ -790,7 +790,7 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
     @mock.patch("enterprise.admin.views.track_enrollment")
     @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.admin.views.EnrollmentApiClientJwt")
-    @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
+    @mock.patch("enterprise.admin.forms.EnrollmentApiClientJwt")
     def test_post_multi_enroll_pending_user(
             self,
             forms_client,
@@ -806,7 +806,7 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
     @mock.patch("enterprise.admin.views.track_enrollment")
     @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.admin.views.EnrollmentApiClientJwt")
-    @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
+    @mock.patch("enterprise.admin.forms.EnrollmentApiClientJwt")
     def test_post_enroll_no_course_detail(
             self,
             forms_client,
@@ -846,7 +846,7 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
     @mock.patch("enterprise.admin.views.track_enrollment")
     @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.admin.views.EnrollmentApiClientJwt")
-    @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
+    @mock.patch("enterprise.admin.forms.EnrollmentApiClientJwt")
     def test_post_enroll_course_when_enrollment_closed(
             self,
             forms_client,
@@ -893,7 +893,7 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
     @mock.patch("enterprise.admin.views.track_enrollment")
     @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.admin.views.EnrollmentApiClientJwt")
-    @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
+    @mock.patch("enterprise.admin.forms.EnrollmentApiClientJwt")
     def test_post_enroll_course_when_enrollment_closed_mode_changed(
             self, forms_client, views_client, course_catalog_client, track_enrollment
     ):
@@ -929,7 +929,7 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
     @mock.patch("enterprise.admin.views.track_enrollment")
     @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.admin.views.EnrollmentApiClientJwt")
-    @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
+    @mock.patch("enterprise.admin.forms.EnrollmentApiClientJwt")
     def test_post_enroll_course_when_enrollment_closed_no_sce_exists(
             self, forms_client, views_client, course_catalog_client, track_enrollment
     ):
@@ -964,7 +964,7 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
     @mock.patch("enterprise.admin.views.track_enrollment")
     @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.admin.views.EnrollmentApiClientJwt")
-    @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
+    @mock.patch("enterprise.admin.forms.EnrollmentApiClientJwt")
     def test_post_enroll_with_missing_course_start_date(
             self,
             forms_client,
@@ -1014,7 +1014,7 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
     @mock.patch("enterprise.utils.reverse")
     @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.admin.views.EnrollmentApiClientJwt")
-    @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
+    @mock.patch("enterprise.admin.forms.EnrollmentApiClientJwt")
     def test_post_enrollment_error(
             self,
             forms_client,
@@ -1046,7 +1046,7 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
     @mock.patch("enterprise.utils.reverse")
     @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.admin.views.EnrollmentApiClientJwt")
-    @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
+    @mock.patch("enterprise.admin.forms.EnrollmentApiClientJwt")
     def test_post_enrollment_error_bad_error_string(
             self,
             forms_client,
@@ -1365,7 +1365,7 @@ class TestEnterpriseCustomerManageLearnersViewPostBulkUpload(BaseTestEnterpriseC
     @mock.patch("enterprise.admin.views.track_enrollment")
     @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.admin.views.EnrollmentApiClientJwt")
-    @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
+    @mock.patch("enterprise.admin.forms.EnrollmentApiClientJwt")
     def test_post_link_and_enroll(
             self,
             forms_client,
@@ -1419,7 +1419,7 @@ class TestEnterpriseCustomerManageLearnersViewPostBulkUpload(BaseTestEnterpriseC
     @mock.patch("enterprise.admin.views.track_enrollment")
     @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.admin.views.EnrollmentApiClientJwt")
-    @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
+    @mock.patch("enterprise.admin.forms.EnrollmentApiClientJwt")
     def test_post_link_and_enroll_no_course_details(
             self,
             forms_client,
@@ -1470,7 +1470,7 @@ class TestEnterpriseCustomerManageLearnersViewPostBulkUpload(BaseTestEnterpriseC
     @mock.patch("enterprise.admin.views.track_enrollment")
     @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.admin.views.EnrollmentApiClientJwt")
-    @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
+    @mock.patch("enterprise.admin.forms.EnrollmentApiClientJwt")
     @mock.patch("enterprise.admin.forms.CourseCatalogApiClient")
     def test_post_link_and_enroll_no_notification(
             self,

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -1558,7 +1558,7 @@ class TestEnterpriseAPIViews(APITest):
     @ddt.unpack
     @mock.patch('enterprise.models.EnterpriseCustomer.catalog_contains_course')
     @mock.patch('enterprise.api.v1.serializers.ThirdPartyAuthApiClient')
-    @mock.patch('enterprise.models.EnrollmentApiClient')
+    @mock.patch('enterprise.models.EnrollmentApiClientJwt')
     @mock.patch('enterprise.models.utils.track_event', mock.MagicMock())
     def test_enterprise_customer_course_enrollments_detail_errors(
             self,
@@ -1702,7 +1702,7 @@ class TestEnterpriseAPIViews(APITest):
     @ddt.unpack
     @mock.patch('enterprise.models.EnterpriseCustomer.catalog_contains_course')
     @mock.patch('enterprise.api.v1.serializers.ThirdPartyAuthApiClient')
-    @mock.patch('enterprise.models.EnrollmentApiClient')
+    @mock.patch('enterprise.models.EnrollmentApiClientJwt')
     @mock.patch('enterprise.models.EnterpriseCustomer.notify_enrolled_learners')
     @mock.patch('enterprise.models.utils.track_event', mock.MagicMock())
     def test_enterprise_customer_course_enrollments_detail_success(
@@ -1807,7 +1807,7 @@ class TestEnterpriseAPIViews(APITest):
 
     @mock.patch('enterprise.models.EnterpriseCustomer.catalog_contains_course')
     @mock.patch('enterprise.api.v1.serializers.ThirdPartyAuthApiClient')
-    @mock.patch('enterprise.models.EnrollmentApiClient')
+    @mock.patch('enterprise.models.EnrollmentApiClientJwt')
     @mock.patch('enterprise.models.utils.track_event', mock.MagicMock())
     def test_enterprise_customer_course_enrollments_detail_multiple(
             self,

--- a/tests/test_enterprise/api_client/test_lms.py
+++ b/tests/test_enterprise/api_client/test_lms.py
@@ -52,34 +52,47 @@ def test_enrollment_api_client():
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
+def test_enrollment_jwt_api_client():
+    expected_response = {"message": "test"}
+    responses.add(responses.GET, _url("enrollment_jwt", "test"), json=expected_response)
+    client = lms_api.EnrollmentApiClientJwt('user-goes-here')
+    client.connect()
+    actual_response = client.client.test.get()
+    assert actual_response == expected_response
+
+
+@responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_get_enrollment_course_details():
     course_id = "course-v1:edX+DemoX+Demo_Course"
     expected_response = {"course_id": course_id}
     responses.add(
         responses.GET,
         _url(
-            "enrollment",
+            "enrollment_jwt",
             "course/{}".format(course_id),
         ),
         json=expected_response
     )
-    client = lms_api.EnrollmentApiClient()
+    client = lms_api.EnrollmentApiClientJwt('user-goes-here')
     actual_response = client.get_course_details(course_id)
     assert actual_response == expected_response
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_get_enrollment_course_details_with_exception():
     course_id = "course-v1:edX+DemoX+Demo_Course"
     responses.add(
         responses.GET,
         _url(
-            "enrollment",
+            "enrollment_jwt",
             "course/{}".format(course_id),
         ),
         status=400
     )
-    client = lms_api.EnrollmentApiClient()
+    client = lms_api.EnrollmentApiClientJwt('user-goes-here')
     actual_response = client.get_course_details(course_id)
     assert actual_response == {}
 
@@ -130,6 +143,7 @@ def test_get_course_enrollment():
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_is_enrolled():
     user = "some_user"
     course_id = "course-v1:edX+DemoX+Demo_Course"
@@ -140,17 +154,18 @@ def test_is_enrolled():
     responses.add(
         responses.GET,
         _url(
-            "enrollment",
+            "enrollment_jwt",
             "enrollment/{username},{course_id}".format(username=user, course_id=course_id),
         ),
         json=expected_response
     )
-    client = lms_api.EnrollmentApiClient()
+    client = lms_api.EnrollmentApiClientJwt(user)
     actual_response = client.is_enrolled(user, course_id)
     assert actual_response is True
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 @mock.patch('enterprise.api_client.lms.COURSE_MODE_SORT_ORDER', ['a', 'list', 'containing', 'most', 'of', 'the'])
 @mock.patch('enterprise.api_client.lms.EXCLUDED_COURSE_MODES', ['course'])
 def test_get_enrollment_course_modes():
@@ -173,17 +188,18 @@ def test_get_enrollment_course_modes():
     responses.add(
         responses.GET,
         _url(
-            "enrollment",
+            "enrollment_jwt",
             "course/{}".format(course_id),
         ),
         json=response
     )
-    client = lms_api.EnrollmentApiClient()
+    client = lms_api.EnrollmentApiClientJwt('user-goes-here')
     actual_response = client.get_course_modes(course_id)
     assert actual_response == expected_return
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 @mock.patch('enterprise.api_client.lms.COURSE_MODE_SORT_ORDER', ['a', 'list', 'containing', 'most', 'of', 'the'])
 def test_has_course_modes():
     course_id = "course-v1:edX+DemoX+Demo_Course"
@@ -199,17 +215,18 @@ def test_has_course_modes():
     responses.add(
         responses.GET,
         _url(
-            "enrollment",
+            "enrollment_jwt",
             "course/{}".format(course_id),
         ),
         json=response
     )
-    client = lms_api.EnrollmentApiClient()
+    client = lms_api.EnrollmentApiClientJwt('user-goes-here')
     actual_response = client.has_course_mode(course_id, 'list')
     assert actual_response is True
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 @mock.patch('enterprise.api_client.lms.COURSE_MODE_SORT_ORDER', ['a', 'list', 'containing', 'most', 'of', 'the'])
 @mock.patch('enterprise.api_client.lms.EXCLUDED_COURSE_MODES', ['course'])
 def test_doesnt_have_course_modes():
@@ -226,12 +243,12 @@ def test_doesnt_have_course_modes():
     responses.add(
         responses.GET,
         _url(
-            "enrollment",
+            "enrollment_jwt",
             "course/{}".format(course_id),
         ),
         json=response
     )
-    client = lms_api.EnrollmentApiClient()
+    client = lms_api.EnrollmentApiClientJwt('user-goes-here')
     actual_response = client.has_course_mode(course_id, 'course')
     assert actual_response is False
 
@@ -273,23 +290,25 @@ def test_get_course_enrollment_not_found():
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_is_enrolled_false():
     user = "some_user"
     course_id = "course-v1:edX+DemoX+Demo_Course"
     responses.add(
         responses.GET,
         _url(
-            "enrollment",
+            "enrollment_jwt",
             "enrollment/{username},{course_id}".format(username=user, course_id=course_id),
         ),
         status=404,
     )
-    client = lms_api.EnrollmentApiClient()
+    client = lms_api.EnrollmentApiClientJwt(user)
     actual_response = client.is_enrolled(user, course_id)
     assert actual_response is False
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_is_enrolled_but_not_active():
     user = "some_user"
     course_id = "course-v1:edX+DemoX+Demo_Course"
@@ -300,17 +319,18 @@ def test_is_enrolled_but_not_active():
     responses.add(
         responses.GET,
         _url(
-            "enrollment",
+            "enrollment_jwt",
             "enrollment/{username},{course_id}".format(username=user, course_id=course_id),
         ),
         json=expected_response
     )
-    client = lms_api.EnrollmentApiClient()
+    client = lms_api.EnrollmentApiClientJwt(user)
     actual_response = client.is_enrolled(user, course_id)
     assert actual_response is False
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_get_enrolled_courses():
     user = "some_user"
     course_id = "course-v1:edx+DemoX+Demo_Course"
@@ -323,16 +343,17 @@ def test_get_enrolled_courses():
     ]
     responses.add(
         responses.GET,
-        _url("enrollment", "enrollment") + '?user={}'.format(user),
+        _url("enrollment_jwt", "enrollment") + '?user={}'.format(user),
         match_querystring=True,
         json=expected_response,
     )
-    client = lms_api.EnrollmentApiClient()
+    client = lms_api.EnrollmentApiClientJwt(user)
     actual_response = client.get_enrolled_courses(user)
     assert actual_response == expected_response
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_unenroll():
     user = "some_user"
     course_id = "course-v1:edx+DemoX+Demo_Course"
@@ -342,7 +363,7 @@ def test_unenroll():
     responses.add(
         responses.GET,
         _url(
-            "enrollment",
+            "enrollment_jwt",
             "enrollment/{username},{course_id}".format(username=user, course_id=course_id),
         ),
         json=expected_response
@@ -351,17 +372,18 @@ def test_unenroll():
     responses.add(
         responses.POST,
         _url(
-            "enrollment",
+            "enrollment_jwt",
             "enrollment",
         ),
         json=expected_response
     )
-    client = lms_api.EnrollmentApiClient()
+    client = lms_api.EnrollmentApiClientJwt(user)
     unenrolled = client.unenroll_user_from_course(user, course_id)
     assert unenrolled
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_unenroll_already_unenrolled():
     user = "some_user"
     course_id = "course-v1:edx+DemoX+Demo_Course"
@@ -370,7 +392,7 @@ def test_unenroll_already_unenrolled():
     responses.add(
         responses.GET,
         _url(
-            "enrollment",
+            "enrollment_jwt",
             "enrollment/{username},{course_id}".format(username=user, course_id=course_id),
         ),
         json=expected_response
@@ -379,12 +401,12 @@ def test_unenroll_already_unenrolled():
     responses.add(
         responses.POST,
         _url(
-            "enrollment",
+            "enrollment_jwt",
             "enrollment",
         ),
         json=expected_response
     )
-    client = lms_api.EnrollmentApiClient()
+    client = lms_api.EnrollmentApiClientJwt(user)
     unenrolled = client.unenroll_user_from_course(user, course_id)
     assert not unenrolled
 

--- a/tests/test_enterprise/test_signals.py
+++ b/tests/test_enterprise/test_signals.py
@@ -103,7 +103,7 @@ class TestUserPostSaveSignalHandler(unittest.TestCase):
 
     @mock.patch('enterprise.utils.track_event')
     @mock.patch('enterprise.signals.track_enrollment')
-    @mock.patch('enterprise.models.EnrollmentApiClient')
+    @mock.patch('enterprise.models.EnrollmentApiClientJwt')
     def test_handle_user_post_save_with_pending_course_enrollment(
             self,
             mock_course_enrollment,

--- a/tests/test_enterprise/views/test_course_enrollment_view.py
+++ b/tests/test_enterprise/views/test_course_enrollment_view.py
@@ -154,7 +154,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
     @mock.patch('enterprise.utils.Registry')
     def test_get_course_enrollment_page(
@@ -216,7 +216,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
     @mock.patch('enterprise.utils.Registry')
     @ddt.data(True, False)
@@ -259,7 +259,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
     @mock.patch('enterprise.utils.Registry')
     @ddt.data(
@@ -377,7 +377,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
     @mock.patch('enterprise.utils.Registry')
     def test_get_course_enrollment_page_with_invalid_catalog(
@@ -447,7 +447,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
     @mock.patch('enterprise.utils.Registry')
     def test_course_enrollment_page_with_catalog_for_invalid_course_modes(
@@ -530,7 +530,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
     @mock.patch('enterprise.utils.Registry')
     @ddt.data(True, False)
@@ -606,7 +606,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
     @mock.patch('enterprise.utils.Registry')
     @ddt.data(True, False)
@@ -679,7 +679,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
     @mock.patch('enterprise.utils.Registry')
     def test_get_course_enrollment_page_course_unenrollable_context(
@@ -724,7 +724,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
     @mock.patch('enterprise.utils.Registry')
     def test_get_course_enrollment_page_edge_case_formatting(
@@ -787,7 +787,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
     @mock.patch('enterprise.utils.Registry')
     def test_get_course_enrollment_page_with_empty_fields(
@@ -851,7 +851,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
     @mock.patch('enterprise.utils.Registry')
     def test_get_course_specific_enrollment_view_audit_enabled(
@@ -918,7 +918,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
     @mock.patch('enterprise.utils.Registry')
     def test_get_course_enrollment_page_with_no_start_date(
@@ -968,7 +968,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.utils.Registry')
     def test_get_course_enrollment_page_for_non_existing_course(
             self,
@@ -1017,7 +1017,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.utils.Registry')
     def test_get_course_enrollment_page_for_error_in_getting_course(
             self,
@@ -1066,7 +1066,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.utils.Registry')
     def test_get_course_specific_enrollment_view_with_course_mode_error(
             self,
@@ -1114,7 +1114,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     def test_get_course_specific_enrollment_view_for_invalid_ec_uuid(
             self,
             enrollment_api_client_mock,
@@ -1182,7 +1182,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
 
     @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.utils.Registry')
     def test_get_course_landing_page_for_enrolled_user(
             self,
@@ -1234,7 +1234,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
     @mock.patch('enterprise.views.track_enrollment')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.views.get_data_sharing_consent')
     @mock.patch('enterprise.utils.Registry')
     @ddt.data(
@@ -1347,7 +1347,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
                 assert enterprise_course_enrollment.source.slug == EnterpriseEnrollmentSource.ENROLLMENT_URL
 
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.views.get_data_sharing_consent')
     @mock.patch('enterprise.utils.Registry')
     def test_post_course_specific_enrollment_view_consent_needed(
@@ -1418,7 +1418,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
         )
 
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.views.get_data_sharing_consent')
     @mock.patch('enterprise.utils.Registry')
     def test_post_course_specific_enrollment_view_consent_needed_with_catalog_querystring(
@@ -1505,7 +1505,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
     @mock.patch('enterprise.utils.Registry')
     def test_post_course_specific_enrollment_view_incompatible_mode(
@@ -1570,7 +1570,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.views.get_data_sharing_consent')
     @mock.patch('enterprise.utils.Registry')
     def test_post_course_specific_enrollment_view_premium_mode(
@@ -1622,7 +1622,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
     @mock.patch('enterprise.utils.Registry')
     def test_get_course_enrollment_page_with_ecommerce_error(
@@ -1690,7 +1690,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
     def test_get_course_enrollment_page_creates_enterprise_customer_user(
             self,

--- a/tests/test_enterprise/views/test_handle_consent_enrollment.py
+++ b/tests/test_enterprise/views/test_handle_consent_enrollment.py
@@ -102,7 +102,7 @@ class TestHandleConsentEnrollmentView(EnterpriseViewMixin, TestCase):
         self.assertRedirects(response, redirect_url, fetch_redirect_response=False)
 
     @mock.patch('enterprise.views.ProgramDataExtender')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.utils.Registry')
     def test_handle_consent_enrollment_404(
             self,
@@ -144,7 +144,7 @@ class TestHandleConsentEnrollmentView(EnterpriseViewMixin, TestCase):
 
     @mock.patch('enterprise.views.ProgramDataExtender')
     @mock.patch('enterprise.views.get_enterprise_customer_user')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.utils.Registry')
     def test_handle_consent_enrollment_with_invalid_course_mode(
             self,
@@ -191,7 +191,7 @@ class TestHandleConsentEnrollmentView(EnterpriseViewMixin, TestCase):
 
     @mock.patch('enterprise.views.ProgramDataExtender')
     @mock.patch('enterprise.views.track_enrollment')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.utils.Registry')
     def test_handle_consent_enrollment_with_audit_course_mode(
             self,
@@ -249,7 +249,7 @@ class TestHandleConsentEnrollmentView(EnterpriseViewMixin, TestCase):
 
     @mock.patch('enterprise.views.ProgramDataExtender')
     @mock.patch('enterprise.views.track_enrollment')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.utils.Registry')
     def test_handle_consent_enrollment_with_professional_course_mode(
             self,

--- a/tests/test_enterprise/views/test_router_view.py
+++ b/tests/test_enterprise/views/test_router_view.py
@@ -101,7 +101,7 @@ class TestRouterView(TestCase):
         (True, True, True, True, True),
     )
     @ddt.unpack
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     def test_eligible_for_direct_audit_enrollment(
             self,
             request_has_audit_query_param,
@@ -168,7 +168,7 @@ class TestRouterView(TestCase):
         True, False
     )
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.views.RouterView', new_callable=views.RouterView)
     def test_get_redirects_with_course_key(
             self,
@@ -212,7 +212,7 @@ class TestRouterView(TestCase):
             assert mock_render.call_args_list[0][1]['status'] == 404
 
     @mock.patch('enterprise.views.get_global_context')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     def test_get_raises_404_with_bad_course_key(self, catalog_api_mock, enrollment_api_mock, mock_global_context):
         """
@@ -234,7 +234,7 @@ class TestRouterView(TestCase):
             assert mock_render.call_args_list[0][1]['status'] == 404
 
     @mock.patch('enterprise.views.track_enrollment')
-    @mock.patch('enterprise.models.EnrollmentApiClient')
+    @mock.patch('enterprise.models.EnrollmentApiClientJwt')
     @mock.patch('enterprise.views.RouterView', new_callable=views.RouterView)
     def test_get_direct_audit_enrollment(self, router_view_mock, enrollment_api_client_mock, track_enrollment_mock):
         """
@@ -257,7 +257,7 @@ class TestRouterView(TestCase):
             fetch_redirect_response=False,
         )
 
-    @mock.patch('enterprise.models.EnrollmentApiClient')
+    @mock.patch('enterprise.models.EnrollmentApiClientJwt')
     @mock.patch('enterprise.views.RouterView', new_callable=views.RouterView)
     def test_get_direct_audit_enrollment_user_already_enrolled(self, router_view_mock, enrollment_api_client_mock):
         """

--- a/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_learner_data.py
+++ b/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_learner_data.py
@@ -104,7 +104,7 @@ class TestLearnerExporter(unittest.TestCase):
         assert learner_data_record.completed_timestamp == (self.NOW_TIMESTAMP if completed_date is not None else None)
         assert learner_data_record.grade == 'A+'
 
-    @mock.patch('enterprise.models.EnrollmentApiClient')
+    @mock.patch('enterprise.models.EnrollmentApiClientJwt')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.GradesApiClient')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CourseApiClientJwt')
     def test_collect_learner_data_without_consent(self, mock_course_api, mock_grades_api, mock_enrollment_api):
@@ -143,7 +143,7 @@ class TestLearnerExporter(unittest.TestCase):
         learner_data = list(self.exporter.export())
         assert not learner_data
 
-    @mock.patch('enterprise.models.EnrollmentApiClient')
+    @mock.patch('enterprise.models.EnrollmentApiClientJwt')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CourseApiClientJwt')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CertificatesApiClient')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
@@ -181,7 +181,7 @@ class TestLearnerExporter(unittest.TestCase):
             assert report.completed_timestamp is None
             assert report.grade == LearnerExporter.GRADE_INCOMPLETE
 
-    @mock.patch('enterprise.models.EnrollmentApiClient')
+    @mock.patch('enterprise.models.EnrollmentApiClientJwt')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CourseApiClientJwt')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CertificatesApiClient')
     def test_learner_data_instructor_paced_no_certificate_null_sso_id(
@@ -210,7 +210,7 @@ class TestLearnerExporter(unittest.TestCase):
         learner_data = list(self.exporter.export())
         assert not learner_data
 
-    @mock.patch('enterprise.models.EnrollmentApiClient')
+    @mock.patch('enterprise.models.EnrollmentApiClientJwt')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CourseApiClientJwt')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CertificatesApiClient')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
@@ -257,7 +257,7 @@ class TestLearnerExporter(unittest.TestCase):
             assert report.completed_timestamp == self.NOW_TIMESTAMP
             assert report.grade == LearnerExporter.GRADE_PASSING
 
-    @mock.patch('enterprise.models.EnrollmentApiClient')
+    @mock.patch('enterprise.models.EnrollmentApiClientJwt')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.GradesApiClient')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CourseApiClientJwt')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
@@ -316,7 +316,7 @@ class TestLearnerExporter(unittest.TestCase):
         (False, TOMORROW, None, LearnerExporter.GRADE_INCOMPLETE),
     )
     @ddt.unpack
-    @mock.patch('enterprise.models.EnrollmentApiClient')
+    @mock.patch('enterprise.models.EnrollmentApiClientJwt')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.GradesApiClient')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CourseApiClientJwt')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
@@ -373,7 +373,7 @@ class TestLearnerExporter(unittest.TestCase):
         ('instructor', LearnerExporter.GRADE_PASSING),
     )
     @ddt.unpack
-    @mock.patch('enterprise.models.EnrollmentApiClient')
+    @mock.patch('enterprise.models.EnrollmentApiClientJwt')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CertificatesApiClient')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.GradesApiClient')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CourseApiClientJwt')
@@ -503,7 +503,7 @@ class TestLearnerExporter(unittest.TestCase):
         (False, False, 'verified', 2),
     )
     @ddt.unpack
-    @mock.patch('enterprise.models.EnrollmentApiClient')
+    @mock.patch('enterprise.models.EnrollmentApiClientJwt')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.GradesApiClient')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CourseApiClientJwt')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
@@ -560,7 +560,7 @@ class TestLearnerExporter(unittest.TestCase):
                 assert report.course_completed
                 assert report.grade == LearnerExporter.GRADE_PASSING
 
-    @mock.patch('enterprise.models.EnrollmentApiClient')
+    @mock.patch('enterprise.models.EnrollmentApiClientJwt')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.GradesApiClient')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CourseApiClientJwt')
     def test_learner_exporter_with_skip_transmitted(self, mock_course_api, mock_grades_api, mock_enrollment_api):

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -583,7 +583,7 @@ def stub_transmit_learner_data_apis(testcase, certificate, self_paced, end_date,
         # Enrollment API enrollment response
         responses.add(
             responses.GET,
-            urljoin(lms_api.EnrollmentApiClient.API_BASE_URL,
+            urljoin(lms_api.EnrollmentApiClientJwt.API_BASE_URL,
                     "enrollment/{username},{course_id}".format(username=user.username,
                                                                course_id=testcase.course_id)),
             match_querystring=True,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -425,7 +425,7 @@ class TestEnterpriseCustomerUser(unittest.TestCase):
             assert mock_third_party_api.return_value.get_remote_id.call_count == 0
 
     @mock.patch('enterprise.utils.segment')
-    @mock.patch('enterprise.models.EnrollmentApiClient')
+    @mock.patch('enterprise.models.EnrollmentApiClientJwt')
     @mock.patch('enterprise.models.EnterpriseCustomerUser.create_order_for_enrollment')
     @ddt.data('audit', 'verified')
     def test_enroll_learner(self, course_mode, enrollment_order_mock, enrollment_api_client_mock, analytics_mock):
@@ -442,7 +442,7 @@ class TestEnterpriseCustomerUser(unittest.TestCase):
         else:
             enrollment_order_mock.assert_not_called()
 
-    @mock.patch('enterprise.models.EnrollmentApiClient')
+    @mock.patch('enterprise.models.EnrollmentApiClientJwt')
     @mock.patch('enterprise.models.EnterpriseCustomerUser.create_order_for_enrollment')
     def test_enroll_learner_already_enrolled(self, enrollment_order_mock, enrollment_api_client_mock):
         """
@@ -458,7 +458,7 @@ class TestEnterpriseCustomerUser(unittest.TestCase):
         enrollment_order_mock.assert_not_called()
 
     @mock.patch('enterprise.utils.segment')
-    @mock.patch('enterprise.models.EnrollmentApiClient')
+    @mock.patch('enterprise.models.EnrollmentApiClientJwt')
     @mock.patch('enterprise.models.EnterpriseCustomerUser.create_order_for_enrollment')
     def test_enroll_learner_upgrade_mode(self, enrollment_order_mock, enrollment_api_client_mock, analytics_mock):
         """
@@ -474,7 +474,7 @@ class TestEnterpriseCustomerUser(unittest.TestCase):
         analytics_mock.track.assert_called_once()
         enrollment_order_mock.assert_called_once()
 
-    @mock.patch('enterprise.models.EnrollmentApiClient')
+    @mock.patch('enterprise.models.EnrollmentApiClientJwt')
     def test_enroll_learner_downgrade_mode(self, enrollment_api_client_mock):
         """
         ``enroll_learner`` does not enroll the user, as they're already enrolled, and redirects to the LMS courseware.


### PR DESCRIPTION
This PR only covers the remaining endpoints of EnrollmentApiClient by cloning the original `EnrollmentApiClient` and using that one in all the remaining endpoints.