### PR TITLE
ENT-2042 Enrollment Api Client admin-forms-endpoint

### DIFF
--- a/enterprise/admin/forms.py
+++ b/enterprise/admin/forms.py
@@ -31,7 +31,7 @@ from enterprise.admin.utils import (
 )
 from enterprise.admin.widgets import SubmitInput
 from enterprise.api_client.discovery import CourseCatalogApiClient
-from enterprise.api_client.lms import EnrollmentApiClient
+from enterprise.api_client.lms import EnrollmentApiClient, EnrollmentApiClientJwt
 from enterprise.models import (
     EnterpriseCustomer,
     EnterpriseCustomerCatalog,
@@ -193,7 +193,7 @@ class ManageLearnersForm(forms.Form):
         if not course_id:
             return None
         try:
-            client = EnrollmentApiClient()
+            client = EnrollmentApiClientJwt(self._user)
             return client.get_course_details(course_id)
         except (HttpClientError, HttpServerError):
             raise ValidationError(ValidationMessages.INVALID_COURSE_ID.format(course_id=course_id))

--- a/enterprise/admin/forms.py
+++ b/enterprise/admin/forms.py
@@ -31,7 +31,7 @@ from enterprise.admin.utils import (
 )
 from enterprise.admin.widgets import SubmitInput
 from enterprise.api_client.discovery import CourseCatalogApiClient
-from enterprise.api_client.lms import EnrollmentApiClient, EnrollmentApiClientJwt
+from enterprise.api_client.lms import EnrollmentApiClientJwt
 from enterprise.models import (
     EnterpriseCustomer,
     EnterpriseCustomerCatalog,

--- a/enterprise/api_client/lms.py
+++ b/enterprise/api_client/lms.py
@@ -316,6 +316,198 @@ class EnrollmentApiClient(LmsApiClient):
         return self.client.enrollment.get(user=username)
 
 
+class EnrollmentApiClientJwt(JwtLmsApiClient):
+    """
+    Object builds an API client to make calls to the Enrollment API.
+    """
+
+    API_BASE_URL = settings.ENTERPRISE_ENROLLMENT_API_URL
+
+    @JwtLmsApiClient.refresh_token
+    def get_course_details(self, course_id):
+        """
+        Query the Enrollment API for the course details of the given course_id.
+
+        Args:
+            course_id (str): The string value of the course's unique identifier
+
+        Returns:
+            dict: A dictionary containing details about the course, in an enrollment context (allowed modes, etc.)
+        """
+        try:
+            return self.client.course(course_id).get()
+        except (SlumberBaseException, ConnectionError, Timeout) as exc:
+            LOGGER.exception(
+                'Failed to retrieve course enrollment details for course [%s] due to: [%s]',
+                course_id, str(exc)
+            )
+            return {}
+
+    def _sort_course_modes(self, modes):
+        """
+        Sort the course mode dictionaries by slug according to the COURSE_MODE_SORT_ORDER constant.
+
+        Arguments:
+            modes (list): A list of course mode dictionaries.
+        Returns:
+            list: A list with the course modes dictionaries sorted by slug.
+
+        """
+        def slug_weight(mode):
+            """
+            Assign a weight to the course mode dictionary based on the position of its slug in the sorting list.
+            """
+            sorting_slugs = COURSE_MODE_SORT_ORDER
+            sorting_slugs_size = len(sorting_slugs)
+            if mode['slug'] in sorting_slugs:
+                return sorting_slugs_size - sorting_slugs.index(mode['slug'])
+            return 0
+        # Sort slug weights in descending order
+        return sorted(modes, key=slug_weight, reverse=True)
+
+    @JwtLmsApiClient.refresh_token
+    def get_course_modes(self, course_id):
+        """
+        Query the Enrollment API for the specific course modes that are available for the given course_id.
+
+        Arguments:
+            course_id (str): The string value of the course's unique identifier
+
+        Returns:
+            list: A list of course mode dictionaries.
+
+        """
+        details = self.get_course_details(course_id)
+        modes = details.get('course_modes', [])
+        return self._sort_course_modes([mode for mode in modes if mode['slug'] not in EXCLUDED_COURSE_MODES])
+
+    @JwtLmsApiClient.refresh_token
+    def has_course_mode(self, course_run_id, mode):
+        """
+        Query the Enrollment API to see whether a course run has a given course mode available.
+
+        Arguments:
+            course_run_id (str): The string value of the course run's unique identifier
+
+        Returns:
+            bool: Whether the course run has the given mode avaialble for enrollment.
+
+        """
+        course_modes = self.get_course_modes(course_run_id)
+        return any(course_mode for course_mode in course_modes if course_mode['slug'] == mode)
+
+    @JwtLmsApiClient.refresh_token
+    def enroll_user_in_course(self, username, course_id, mode, cohort=None):
+        """
+        Call the enrollment API to enroll the user in the course specified by course_id.
+
+        Args:
+            username (str): The username by which the user goes on the OpenEdX platform
+            course_id (str): The string value of the course's unique identifier
+            mode (str): The enrollment mode which should be used for the enrollment
+            cohort (str): Add the user to this named cohort
+
+        Returns:
+            dict: A dictionary containing details of the enrollment, including course details, mode, username, etc.
+
+        """
+        return self.client.enrollment.post(
+            {
+                'user': username,
+                'course_details': {'course_id': course_id},
+                'mode': mode,
+                'cohort': cohort,
+            }
+        )
+
+    @JwtLmsApiClient.refresh_token
+    def unenroll_user_from_course(self, username, course_id):
+        """
+        Call the enrollment API to unenroll the user in the course specified by course_id.
+        Args:
+            username (str): The username by which the user goes on the OpenEdx platform
+            course_id (str): The string value of the course's unique identifier
+        Returns:
+            bool: Whether the unenrollment succeeded
+        """
+        enrollment = self.get_course_enrollment(username, course_id)
+        if enrollment and enrollment['is_active']:
+            response = self.client.enrollment.post({
+                'user': username,
+                'course_details': {'course_id': course_id},
+                'is_active': False,
+                'mode': enrollment['mode']
+            })
+            return not response['is_active']
+
+        return False
+
+    @JwtLmsApiClient.refresh_token
+    def get_course_enrollment(self, username, course_id):
+        """
+        Query the enrollment API to get information about a single course enrollment.
+
+        Args:
+            username (str): The username by which the user goes on the OpenEdX platform
+            course_id (str): The string value of the course's unique identifier
+
+        Returns:
+            dict: A dictionary containing details of the enrollment, including course details, mode, username, etc.
+
+        """
+        endpoint = getattr(
+            self.client.enrollment,
+            '{username},{course_id}'.format(username=username, course_id=course_id)
+        )
+        try:
+            result = endpoint.get()
+        except HttpNotFoundError:
+            # This enrollment data endpoint returns a 404 if either the username or course_id specified isn't valid
+            LOGGER.error(
+                'Course enrollment details not found for invalid username or course; username=[%s], course=[%s]',
+                username,
+                course_id
+            )
+            return None
+        # This enrollment data endpoint returns an empty string if the username and course_id is valid, but there's
+        # no matching enrollment found
+        if not result:
+            LOGGER.info('Failed to find course enrollment details for user [%s] and course [%s]', username, course_id)
+            return None
+
+        return result
+
+    @JwtLmsApiClient.refresh_token
+    def is_enrolled(self, username, course_run_id):
+        """
+        Query the enrollment API and determine if a learner is enrolled in a course run.
+
+        Args:
+            username (str): The username by which the user goes on the OpenEdX platform
+            course_run_id (str): The string value of the course's unique identifier
+
+        Returns:
+            bool: Indicating whether the user is enrolled in the course run. Returns False under any errors.
+
+        """
+        enrollment = self.get_course_enrollment(username, course_run_id)
+        return enrollment is not None and enrollment.get('is_active', False)
+
+    @JwtLmsApiClient.refresh_token
+    def get_enrolled_courses(self, username):
+        """
+        Query the enrollment API to get a list of the courses a user is enrolled in.
+
+        Args:
+            username (str): The username by which the user goes on the OpenEdX platform
+
+        Returns:
+            list: A list of course objects, along with relevant user-specific enrollment details.
+
+        """
+        return self.client.enrollment.get(user=username)
+
+
 class CourseApiClient(LmsApiClient):
     """
     Object builds an API client to make calls to the Course API.

--- a/tests/test_admin/test_forms.py
+++ b/tests/test_admin/test_forms.py
@@ -203,7 +203,7 @@ class TestManageLearnersForm(TestWithCourseCatalogApiMixin, unittest.TestCase):
         assert form.is_valid()
         assert form.cleaned_data[form.Fields.COURSE] is None
 
-    @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
+    @mock.patch("enterprise.admin.forms.EnrollmentApiClientJwt")
     def test_clean_course_valid(self, enrollment_client):
         instance = enrollment_client.return_value
         instance.get_course_details.side_effect = fake_enrollment_api.get_course_details
@@ -215,7 +215,7 @@ class TestManageLearnersForm(TestWithCourseCatalogApiMixin, unittest.TestCase):
         assert form.cleaned_data[form.Fields.COURSE] == course_details
 
     @ddt.data("course-v1:does+not+exist", "invalid_course_id")
-    @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
+    @mock.patch("enterprise.admin.forms.EnrollmentApiClientJwt")
     def test_clean_course_invalid(self, course_id, enrollment_client):
         instance = enrollment_client.return_value
         instance.get_course_details.side_effect = fake_enrollment_api.get_course_details
@@ -225,7 +225,7 @@ class TestManageLearnersForm(TestWithCourseCatalogApiMixin, unittest.TestCase):
             form.Fields.COURSE: [ValidationMessages.INVALID_COURSE_ID.format(course_id=course_id)],
         }
 
-    @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
+    @mock.patch("enterprise.admin.forms.EnrollmentApiClientJwt")
     def test_clean_valid_course_empty_mode(self, enrollment_client):
         instance = enrollment_client.return_value
         instance.get_course_details.side_effect = fake_enrollment_api.get_course_details
@@ -234,7 +234,7 @@ class TestManageLearnersForm(TestWithCourseCatalogApiMixin, unittest.TestCase):
         assert not form.is_valid()
         assert form.errors == {"__all__": [ValidationMessages.COURSE_WITHOUT_COURSE_MODE]}
 
-    @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
+    @mock.patch("enterprise.admin.forms.EnrollmentApiClientJwt")
     def test_clean_valid_course_invalid_mode(self, enrollment_client):
         instance = enrollment_client.return_value
         instance.get_course_details.side_effect = fake_enrollment_api.get_course_details
@@ -365,7 +365,7 @@ class TestManageLearnersForm(TestWithCourseCatalogApiMixin, unittest.TestCase):
             )]
         }
 
-    @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
+    @mock.patch("enterprise.admin.forms.EnrollmentApiClientJwt")
     def test_clean_both_course_and_program_passed(self, enrollment_client):
         instance = enrollment_client.return_value
         instance.get_course_details.side_effect = fake_enrollment_api.get_course_details

--- a/tests/test_admin/test_view.py
+++ b/tests/test_admin/test_view.py
@@ -632,7 +632,7 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
     @mock.patch("enterprise.admin.views.track_enrollment")
     @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.admin.views.EnrollmentApiClient")
-    @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
+    @mock.patch("enterprise.admin.forms.EnrollmentApiClientJwt")
     @ddt.data(True, False)
     def test_post_enroll_user(
             self,
@@ -759,7 +759,7 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
     @mock.patch("enterprise.admin.views.track_enrollment")
     @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.admin.views.EnrollmentApiClient")
-    @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
+    @mock.patch("enterprise.admin.forms.EnrollmentApiClientJwt")
     def test_post_multi_enroll_user(
             self,
             forms_client,
@@ -775,7 +775,7 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
     @mock.patch("enterprise.admin.views.track_enrollment")
     @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.admin.views.EnrollmentApiClient")
-    @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
+    @mock.patch("enterprise.admin.forms.EnrollmentApiClientJwt")
     def test_post_multi_enroll_pending_user(
             self,
             forms_client,
@@ -791,7 +791,7 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
     @mock.patch("enterprise.admin.views.track_enrollment")
     @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.admin.views.EnrollmentApiClient")
-    @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
+    @mock.patch("enterprise.admin.forms.EnrollmentApiClientJwt")
     def test_post_enroll_no_course_detail(
             self,
             forms_client,
@@ -831,7 +831,7 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
     @mock.patch("enterprise.admin.views.track_enrollment")
     @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.admin.views.EnrollmentApiClient")
-    @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
+    @mock.patch("enterprise.admin.forms.EnrollmentApiClientJwt")
     def test_post_enroll_course_when_enrollment_closed(
             self,
             forms_client,
@@ -878,7 +878,7 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
     @mock.patch("enterprise.admin.views.track_enrollment")
     @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.admin.views.EnrollmentApiClient")
-    @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
+    @mock.patch("enterprise.admin.forms.EnrollmentApiClientJwt")
     def test_post_enroll_course_when_enrollment_closed_mode_changed(
             self, forms_client, views_client, course_catalog_client, track_enrollment
     ):
@@ -914,7 +914,7 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
     @mock.patch("enterprise.admin.views.track_enrollment")
     @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.admin.views.EnrollmentApiClient")
-    @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
+    @mock.patch("enterprise.admin.forms.EnrollmentApiClientJwt")
     def test_post_enroll_course_when_enrollment_closed_no_sce_exists(
             self, forms_client, views_client, course_catalog_client, track_enrollment
     ):
@@ -949,7 +949,7 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
     @mock.patch("enterprise.admin.views.track_enrollment")
     @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.admin.views.EnrollmentApiClient")
-    @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
+    @mock.patch("enterprise.admin.forms.EnrollmentApiClientJwt")
     def test_post_enroll_with_missing_course_start_date(
             self,
             forms_client,
@@ -999,7 +999,7 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
     @mock.patch("enterprise.utils.reverse")
     @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.admin.views.EnrollmentApiClient")
-    @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
+    @mock.patch("enterprise.admin.forms.EnrollmentApiClientJwt")
     def test_post_enrollment_error(
             self,
             forms_client,
@@ -1031,7 +1031,7 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
     @mock.patch("enterprise.utils.reverse")
     @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.admin.views.EnrollmentApiClient")
-    @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
+    @mock.patch("enterprise.admin.forms.EnrollmentApiClientJwt")
     def test_post_enrollment_error_bad_error_string(
             self,
             forms_client,
@@ -1350,7 +1350,7 @@ class TestEnterpriseCustomerManageLearnersViewPostBulkUpload(BaseTestEnterpriseC
     @mock.patch("enterprise.admin.views.track_enrollment")
     @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.admin.views.EnrollmentApiClient")
-    @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
+    @mock.patch("enterprise.admin.forms.EnrollmentApiClientJwt")
     def test_post_link_and_enroll(
             self,
             forms_client,
@@ -1404,7 +1404,7 @@ class TestEnterpriseCustomerManageLearnersViewPostBulkUpload(BaseTestEnterpriseC
     @mock.patch("enterprise.admin.views.track_enrollment")
     @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.admin.views.EnrollmentApiClient")
-    @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
+    @mock.patch("enterprise.admin.forms.EnrollmentApiClientJwt")
     def test_post_link_and_enroll_no_course_details(
             self,
             forms_client,
@@ -1455,7 +1455,7 @@ class TestEnterpriseCustomerManageLearnersViewPostBulkUpload(BaseTestEnterpriseC
     @mock.patch("enterprise.admin.views.track_enrollment")
     @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.admin.views.EnrollmentApiClient")
-    @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
+    @mock.patch("enterprise.admin.forms.EnrollmentApiClientJwt")
     @mock.patch("enterprise.admin.forms.CourseCatalogApiClient")
     def test_post_link_and_enroll_no_notification(
             self,

--- a/tests/test_enterprise/api_client/test_lms.py
+++ b/tests/test_enterprise/api_client/test_lms.py
@@ -20,6 +20,7 @@ from enterprise.utils import NotConnectedToOpenEdX
 
 URL_BASE_NAMES = {
     'enrollment': lms_api.EnrollmentApiClient,
+    'enrollment_jwt': lms_api.EnrollmentApiClientJwt,
     'courses': lms_api.CourseApiClient,
     'third_party_auth': lms_api.ThirdPartyAuthApiClient,
     'course_grades': lms_api.GradesApiClient,
@@ -50,34 +51,36 @@ def test_enrollment_api_client():
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_get_enrollment_course_details():
     course_id = "course-v1:edX+DemoX+Demo_Course"
     expected_response = {"course_id": course_id}
     responses.add(
         responses.GET,
         _url(
-            "enrollment",
+            "enrollment_jwt",
             "course/{}".format(course_id),
         ),
         json=expected_response
     )
-    client = lms_api.EnrollmentApiClient()
+    client = lms_api.EnrollmentApiClientJwt('user-goes-here')
     actual_response = client.get_course_details(course_id)
     assert actual_response == expected_response
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_get_enrollment_course_details_with_exception():
     course_id = "course-v1:edX+DemoX+Demo_Course"
     responses.add(
         responses.GET,
         _url(
-            "enrollment",
+            "enrollment_jwt",
             "course/{}".format(course_id),
         ),
         status=400
     )
-    client = lms_api.EnrollmentApiClient()
+    client = lms_api.EnrollmentApiClientJwt('user-goes-here')
     actual_response = client.get_course_details(course_id)
     assert actual_response == {}
 


### PR DESCRIPTION
This PR is about replacing the `EDX-API-KEY` with `OAuth` authentication method using `JWT.` There are three clients that are relying on the `EDX-API-KEY` based authentication; `CourseApiClient,` `EnrollmentApiClient,` and `ThirdPartyAuthApiClient.` This PR only covers the `admin/forms.py` endpoint by cloning the original `EnrollmentApiClient` and using that one in the mentioned endpoint.