### PR TITLE
ENT-2042 Replaced Edx-Api-Key in CourseApiClient in GrantDataSharing endpoint

### DIFF
--- a/enterprise/api_client/lms.py
+++ b/enterprise/api_client/lms.py
@@ -341,6 +341,32 @@ class CourseApiClient(LmsApiClient):
             return None
 
 
+class CourseApiClientJwt(JwtLmsApiClient):
+    """
+    Object builds an API client to make calls to the Course API.
+    """
+
+    API_BASE_URL = settings.LMS_INTERNAL_ROOT_URL + '/api/courses/v1/'
+    APPEND_SLASH = True
+
+    @JwtLmsApiClient.refresh_token
+    def get_course_details(self, course_id):
+        """
+        Retrieve all available details about a course.
+
+        Args:
+            course_id (str): The course ID identifying the course for which to retrieve details.
+
+        Returns:
+            dict: Contains keys identifying those course details available from the courses API (e.g., name).
+        """
+        try:
+            return self.client.courses(course_id).get()
+        except (SlumberBaseException, ConnectionError, Timeout) as exc:
+            LOGGER.exception('Details not found for course [%s] due to: [%s]', course_id, str(exc))
+            return None
+
+
 class ThirdPartyAuthApiClient(LmsApiClient):
     """
     Object builds an API client to make calls to the Third Party Auth API.

--- a/tests/test_enterprise/views/test_grant_data_sharing_permissions.py
+++ b/tests/test_enterprise/views/test_grant_data_sharing_permissions.py
@@ -86,7 +86,7 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.CourseApiClient')
+    @mock.patch('enterprise.views.CourseApiClientJwt')
     @ddt.data(
         (False, True, None),
         (False, False, None),
@@ -202,7 +202,7 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
             assert response.context[key] == value  # pylint:disable=no-member
 
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.CourseApiClient')
+    @mock.patch('enterprise.views.CourseApiClientJwt')
     def test_get_course_specific_consent_improperly_configured_course_catalog(
             self,
             course_api_client_mock,
@@ -249,7 +249,7 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
             assert mock_render.call_args_list[0][1]['status'] == 404
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
-    @mock.patch('enterprise.views.CourseApiClient')
+    @mock.patch('enterprise.views.CourseApiClientJwt')
     def test_get_course_specific_consent_invalid_get_params(
             self,
             course_api_client_mock,
@@ -289,7 +289,7 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
         assert response.status_code == 404
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
-    @mock.patch('enterprise.views.CourseApiClient')
+    @mock.patch('enterprise.views.CourseApiClientJwt')
     def test_get_course_specific_consent_unauthenticated_user(
             self,
             course_api_client_mock,
@@ -332,7 +332,7 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
         )
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
-    @mock.patch('enterprise.views.CourseApiClient')
+    @mock.patch('enterprise.views.CourseApiClientJwt')
     def test_get_course_specific_consent_bad_api_response(
             self,
             course_api_client_mock,
@@ -366,7 +366,7 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
         assert response.status_code == 404
 
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.CourseApiClient')
+    @mock.patch('enterprise.views.CourseApiClientJwt')
     def test_get_course_specific_consent_not_needed(
             self,
             course_api_client_mock,
@@ -405,7 +405,7 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
         assert response.status_code == 404
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
-    @mock.patch('enterprise.views.CourseApiClient')
+    @mock.patch('enterprise.views.CourseApiClientJwt')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.reverse')
     @ddt.data(
@@ -469,7 +469,7 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
             assert dsc.granted is consent_provided
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
-    @mock.patch('enterprise.views.CourseApiClient')
+    @mock.patch('enterprise.views.CourseApiClientJwt')
     @mock.patch('enterprise.views.reverse')
     def test_post_course_specific_consent_no_user(
             self,
@@ -516,7 +516,7 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
         )
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
-    @mock.patch('enterprise.views.CourseApiClient')
+    @mock.patch('enterprise.views.CourseApiClientJwt')
     @mock.patch('enterprise.views.reverse')
     def test_post_course_specific_consent_bad_api_response(
             self,
@@ -910,7 +910,7 @@ class TestGrantDataSharingPermissionsWithDB(TestCase):
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.CourseApiClient')
+    @mock.patch('enterprise.views.CourseApiClientJwt')
     @mock.patch('enterprise.views.get_data_sharing_consent')
     @ddt.data(
         (False, True, True),


### PR DESCRIPTION
This PR is about replacing the `EDX-API-KEY` with `OAuth` authentication method using `JWT.` There are three clients that are relying on the `EDX-API-KEY` based authentication; `CourseApiClient,` `EnrollmentApiClient,` and `ThirdPartyAuthApiClient.` This PR only covers the `enterprise/views` endpoint by cloning the original `CourseApiClient` and using that one in the mentioned endpoint.