### PR TITLE
ENT-1231 | Recommend utf8 csv files when manage learners bulk enroll fails

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,9 @@ Change Log
 
 Unreleased
 ----------
+
+* While uploading bulk users in 'manager learners' from django admin, better handling if invalid encoding found.
+
 [2.0.31] - 2019-12-11
 ---------------------
 

--- a/test_utils/file_helpers.py
+++ b/test_utils/file_helpers.py
@@ -14,7 +14,7 @@ class MakeCsvStreamContextManager(object):
     Context manager that creates a temporary csv file.
     """
 
-    def __init__(self, header, contents):
+    def __init__(self, header, contents, encoding='utf-8'):
         """
         Initialize context manager.
 
@@ -24,6 +24,7 @@ class MakeCsvStreamContextManager(object):
         """
         self._header = header
         self._contents = contents
+        self._encoding = encoding
         self._csv_stream = None
 
     def __enter__(self):
@@ -32,8 +33,7 @@ class MakeCsvStreamContextManager(object):
         """
         self._csv_stream = six.BytesIO()
 
-        writer = unicodecsv.writer(self._csv_stream)
-
+        writer = unicodecsv.writer(self._csv_stream, encoding=self._encoding)
         writer.writerow(self._header)
         writer.writerows(self._contents)
 

--- a/tests/test_admin/test_utilities.py
+++ b/tests/test_admin/test_utilities.py
@@ -90,6 +90,19 @@ class TestParseCSV(unittest.TestCase):
             with raises(ValidationError, message=expected_error_message):
                 list(parse_csv(stream, expected_columns={"Name", "Email"}))
 
+    def test_parse_csv_check_with_wrong_encoding(self):
+        header = ("email",)
+        contents = (
+            "honor@example.com",
+            "staff@example.com",
+        )
+
+        with MakeCsvStreamContextManager(header, contents, 'utf-16') as stream:
+            expected_error_message = ValidationMessages.INVALID_ENCODING
+
+            with raises(ValidationError, message=expected_error_message):
+                list(parse_csv(stream, expected_columns={"email"}))
+
 
 @mark.django_db
 class TestEmailConversion(unittest.TestCase):


### PR DESCRIPTION
while uploading bulk users in manager learners from admin, better handling if invalid encoding found.
ENT-1231

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
