### PR TITLE
ENT-2042 Replaced Edx-Api-Key in Enrollment Api Client models-endpoint

### DIFF
--- a/enterprise/api_client/lms.py
+++ b/enterprise/api_client/lms.py
@@ -316,6 +316,198 @@ class EnrollmentApiClient(LmsApiClient):
         return self.client.enrollment.get(user=username)
 
 
+class EnrollmentApiClientJwt(JwtLmsApiClient):
+    """
+    Object builds an API client to make calls to the Enrollment API.
+    """
+
+    API_BASE_URL = settings.ENTERPRISE_ENROLLMENT_API_URL
+
+    @JwtLmsApiClient.refresh_token
+    def get_course_details(self, course_id):
+        """
+        Query the Enrollment API for the course details of the given course_id.
+
+        Args:
+            course_id (str): The string value of the course's unique identifier
+
+        Returns:
+            dict: A dictionary containing details about the course, in an enrollment context (allowed modes, etc.)
+        """
+        try:
+            return self.client.course(course_id).get()
+        except (SlumberBaseException, ConnectionError, Timeout) as exc:
+            LOGGER.exception(
+                'Failed to retrieve course enrollment details for course [%s] due to: [%s]',
+                course_id, str(exc)
+            )
+            return {}
+
+    def _sort_course_modes(self, modes):
+        """
+        Sort the course mode dictionaries by slug according to the COURSE_MODE_SORT_ORDER constant.
+
+        Arguments:
+            modes (list): A list of course mode dictionaries.
+        Returns:
+            list: A list with the course modes dictionaries sorted by slug.
+
+        """
+        def slug_weight(mode):
+            """
+            Assign a weight to the course mode dictionary based on the position of its slug in the sorting list.
+            """
+            sorting_slugs = COURSE_MODE_SORT_ORDER
+            sorting_slugs_size = len(sorting_slugs)
+            if mode['slug'] in sorting_slugs:
+                return sorting_slugs_size - sorting_slugs.index(mode['slug'])
+            return 0
+        # Sort slug weights in descending order
+        return sorted(modes, key=slug_weight, reverse=True)
+
+    @JwtLmsApiClient.refresh_token
+    def get_course_modes(self, course_id):
+        """
+        Query the Enrollment API for the specific course modes that are available for the given course_id.
+
+        Arguments:
+            course_id (str): The string value of the course's unique identifier
+
+        Returns:
+            list: A list of course mode dictionaries.
+
+        """
+        details = self.get_course_details(course_id)
+        modes = details.get('course_modes', [])
+        return self._sort_course_modes([mode for mode in modes if mode['slug'] not in EXCLUDED_COURSE_MODES])
+
+    @JwtLmsApiClient.refresh_token
+    def has_course_mode(self, course_run_id, mode):
+        """
+        Query the Enrollment API to see whether a course run has a given course mode available.
+
+        Arguments:
+            course_run_id (str): The string value of the course run's unique identifier
+
+        Returns:
+            bool: Whether the course run has the given mode avaialble for enrollment.
+
+        """
+        course_modes = self.get_course_modes(course_run_id)
+        return any(course_mode for course_mode in course_modes if course_mode['slug'] == mode)
+
+    @JwtLmsApiClient.refresh_token
+    def enroll_user_in_course(self, username, course_id, mode, cohort=None):
+        """
+        Call the enrollment API to enroll the user in the course specified by course_id.
+
+        Args:
+            username (str): The username by which the user goes on the OpenEdX platform
+            course_id (str): The string value of the course's unique identifier
+            mode (str): The enrollment mode which should be used for the enrollment
+            cohort (str): Add the user to this named cohort
+
+        Returns:
+            dict: A dictionary containing details of the enrollment, including course details, mode, username, etc.
+
+        """
+        return self.client.enrollment.post(
+            {
+                'user': username,
+                'course_details': {'course_id': course_id},
+                'mode': mode,
+                'cohort': cohort,
+            }
+        )
+
+    @JwtLmsApiClient.refresh_token
+    def unenroll_user_from_course(self, username, course_id):
+        """
+        Call the enrollment API to unenroll the user in the course specified by course_id.
+        Args:
+            username (str): The username by which the user goes on the OpenEdx platform
+            course_id (str): The string value of the course's unique identifier
+        Returns:
+            bool: Whether the unenrollment succeeded
+        """
+        enrollment = self.get_course_enrollment(username, course_id)
+        if enrollment and enrollment['is_active']:
+            response = self.client.enrollment.post({
+                'user': username,
+                'course_details': {'course_id': course_id},
+                'is_active': False,
+                'mode': enrollment['mode']
+            })
+            return not response['is_active']
+
+        return False
+
+    @JwtLmsApiClient.refresh_token
+    def get_course_enrollment(self, username, course_id):
+        """
+        Query the enrollment API to get information about a single course enrollment.
+
+        Args:
+            username (str): The username by which the user goes on the OpenEdX platform
+            course_id (str): The string value of the course's unique identifier
+
+        Returns:
+            dict: A dictionary containing details of the enrollment, including course details, mode, username, etc.
+
+        """
+        endpoint = getattr(
+            self.client.enrollment,
+            '{username},{course_id}'.format(username=username, course_id=course_id)
+        )
+        try:
+            result = endpoint.get()
+        except HttpNotFoundError:
+            # This enrollment data endpoint returns a 404 if either the username or course_id specified isn't valid
+            LOGGER.error(
+                'Course enrollment details not found for invalid username or course; username=[%s], course=[%s]',
+                username,
+                course_id
+            )
+            return None
+        # This enrollment data endpoint returns an empty string if the username and course_id is valid, but there's
+        # no matching enrollment found
+        if not result:
+            LOGGER.info('Failed to find course enrollment details for user [%s] and course [%s]', username, course_id)
+            return None
+
+        return result
+
+    @JwtLmsApiClient.refresh_token
+    def is_enrolled(self, username, course_run_id):
+        """
+        Query the enrollment API and determine if a learner is enrolled in a course run.
+
+        Args:
+            username (str): The username by which the user goes on the OpenEdX platform
+            course_run_id (str): The string value of the course's unique identifier
+
+        Returns:
+            bool: Indicating whether the user is enrolled in the course run. Returns False under any errors.
+
+        """
+        enrollment = self.get_course_enrollment(username, course_run_id)
+        return enrollment is not None and enrollment.get('is_active', False)
+
+    @JwtLmsApiClient.refresh_token
+    def get_enrolled_courses(self, username):
+        """
+        Query the enrollment API to get a list of the courses a user is enrolled in.
+
+        Args:
+            username (str): The username by which the user goes on the OpenEdX platform
+
+        Returns:
+            list: A list of course objects, along with relevant user-specific enrollment details.
+
+        """
+        return self.client.enrollment.get(user=username)
+
+
 class CourseApiClient(LmsApiClient):
     """
     Object builds an API client to make calls to the Course API.

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -41,7 +41,7 @@ from model_utils.models import TimeStampedModel
 from enterprise import utils
 from enterprise.api_client.discovery import CourseCatalogApiClient, get_course_catalog_api_service_client
 from enterprise.api_client.ecommerce import EcommerceApiClient
-from enterprise.api_client.lms import EnrollmentApiClient, EnrollmentApiClientJwt, ThirdPartyAuthApiClient, parse_lms_api_datetime
+from enterprise.api_client.lms import EnrollmentApiClientJwt, ThirdPartyAuthApiClient, parse_lms_api_datetime
 from enterprise.constants import ALL_ACCESS_CONTEXT, ENTERPRISE_OPERATOR_ROLE, json_serialized_course_modes
 from enterprise.utils import (
     CourseEnrollmentDowngradeError,

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -41,7 +41,7 @@ from model_utils.models import TimeStampedModel
 from enterprise import utils
 from enterprise.api_client.discovery import CourseCatalogApiClient, get_course_catalog_api_service_client
 from enterprise.api_client.ecommerce import EcommerceApiClient
-from enterprise.api_client.lms import EnrollmentApiClient, ThirdPartyAuthApiClient, parse_lms_api_datetime
+from enterprise.api_client.lms import EnrollmentApiClient, EnrollmentApiClientJwt, ThirdPartyAuthApiClient, parse_lms_api_datetime
 from enterprise.constants import ALL_ACCESS_CONTEXT, ENTERPRISE_OPERATOR_ROLE, json_serialized_course_modes
 from enterprise.utils import (
     CourseEnrollmentDowngradeError,
@@ -734,7 +734,7 @@ class EnterpriseCustomerUser(TimeStampedModel):
         """
         Enroll a user into a course track, and register an enterprise course enrollment.
         """
-        enrollment_api_client = EnrollmentApiClient()
+        enrollment_api_client = EnrollmentApiClientJwt(self.user)
         # Check to see if the user's already enrolled and we have an enterprise course enrollment to track it.
         course_enrollment = enrollment_api_client.get_course_enrollment(self.username, course_run_id) or {}
         enrolled_in_course = course_enrollment and course_enrollment.get('is_active', False)
@@ -796,7 +796,7 @@ class EnterpriseCustomerUser(TimeStampedModel):
         """
         Unenroll a user from a course track.
         """
-        enrollment_api_client = EnrollmentApiClient()
+        enrollment_api_client = EnrollmentApiClientJwt(self.user)
         if enrollment_api_client.unenroll_user_from_course(self.username, course_run_id):
             EnterpriseCourseEnrollment.objects.filter(enterprise_customer_user=self, course_id=course_run_id).delete()
             return True
@@ -1198,7 +1198,7 @@ class EnterpriseCourseEnrollment(TimeStampedModel):
 
         :return: Whether the course enrollment mode is of an audit type.
         """
-        course_enrollment_api = EnrollmentApiClient()
+        course_enrollment_api = EnrollmentApiClientJwt(self.enterprise_customer_user.user)
         course_enrollment = course_enrollment_api.get_course_enrollment(
             self.enterprise_customer_user.username,
             self.course_id

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -1558,7 +1558,7 @@ class TestEnterpriseAPIViews(APITest):
     @ddt.unpack
     @mock.patch('enterprise.models.EnterpriseCustomer.catalog_contains_course')
     @mock.patch('enterprise.api.v1.serializers.ThirdPartyAuthApiClient')
-    @mock.patch('enterprise.models.EnrollmentApiClient')
+    @mock.patch('enterprise.models.EnrollmentApiClientJwt')
     @mock.patch('enterprise.models.utils.track_event', mock.MagicMock())
     def test_enterprise_customer_course_enrollments_detail_errors(
             self,
@@ -1702,7 +1702,7 @@ class TestEnterpriseAPIViews(APITest):
     @ddt.unpack
     @mock.patch('enterprise.models.EnterpriseCustomer.catalog_contains_course')
     @mock.patch('enterprise.api.v1.serializers.ThirdPartyAuthApiClient')
-    @mock.patch('enterprise.models.EnrollmentApiClient')
+    @mock.patch('enterprise.models.EnrollmentApiClientJwt')
     @mock.patch('enterprise.models.EnterpriseCustomer.notify_enrolled_learners')
     @mock.patch('enterprise.models.utils.track_event', mock.MagicMock())
     def test_enterprise_customer_course_enrollments_detail_success(
@@ -1807,7 +1807,7 @@ class TestEnterpriseAPIViews(APITest):
 
     @mock.patch('enterprise.models.EnterpriseCustomer.catalog_contains_course')
     @mock.patch('enterprise.api.v1.serializers.ThirdPartyAuthApiClient')
-    @mock.patch('enterprise.models.EnrollmentApiClient')
+    @mock.patch('enterprise.models.EnrollmentApiClientJwt')
     @mock.patch('enterprise.models.utils.track_event', mock.MagicMock())
     def test_enterprise_customer_course_enrollments_detail_multiple(
             self,

--- a/tests/test_enterprise/api_client/test_lms.py
+++ b/tests/test_enterprise/api_client/test_lms.py
@@ -20,6 +20,7 @@ from enterprise.utils import NotConnectedToOpenEdX
 
 URL_BASE_NAMES = {
     'enrollment': lms_api.EnrollmentApiClient,
+    'enrollment_jwt': lms_api.EnrollmentApiClientJwt,
     'courses': lms_api.CourseApiClient,
     'third_party_auth': lms_api.ThirdPartyAuthApiClient,
     'course_grades': lms_api.GradesApiClient,
@@ -327,6 +328,7 @@ def test_get_enrolled_courses():
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_unenroll():
     user = "some_user"
     course_id = "course-v1:edx+DemoX+Demo_Course"
@@ -345,17 +347,18 @@ def test_unenroll():
     responses.add(
         responses.POST,
         _url(
-            "enrollment",
+            "enrollment_jwt",
             "enrollment",
         ),
         json=expected_response
     )
-    client = lms_api.EnrollmentApiClient()
+    client = lms_api.EnrollmentApiClientJwt(user)
     unenrolled = client.unenroll_user_from_course(user, course_id)
     assert unenrolled
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_unenroll_already_unenrolled():
     user = "some_user"
     course_id = "course-v1:edx+DemoX+Demo_Course"
@@ -364,7 +367,7 @@ def test_unenroll_already_unenrolled():
     responses.add(
         responses.GET,
         _url(
-            "enrollment",
+            "enrollment_jwt",
             "enrollment/{username},{course_id}".format(username=user, course_id=course_id),
         ),
         json=expected_response
@@ -373,12 +376,12 @@ def test_unenroll_already_unenrolled():
     responses.add(
         responses.POST,
         _url(
-            "enrollment",
+            "enrollment_jwt",
             "enrollment",
         ),
         json=expected_response
     )
-    client = lms_api.EnrollmentApiClient()
+    client = lms_api.EnrollmentApiClientJwt(user)
     unenrolled = client.unenroll_user_from_course(user, course_id)
     assert not unenrolled
 

--- a/tests/test_enterprise/test_signals.py
+++ b/tests/test_enterprise/test_signals.py
@@ -103,7 +103,7 @@ class TestUserPostSaveSignalHandler(unittest.TestCase):
 
     @mock.patch('enterprise.utils.track_event')
     @mock.patch('enterprise.signals.track_enrollment')
-    @mock.patch('enterprise.models.EnrollmentApiClient')
+    @mock.patch('enterprise.models.EnrollmentApiClientJwt')
     def test_handle_user_post_save_with_pending_course_enrollment(
             self,
             mock_course_enrollment,

--- a/tests/test_enterprise/views/test_router_view.py
+++ b/tests/test_enterprise/views/test_router_view.py
@@ -233,7 +233,7 @@ class TestRouterView(TestCase):
             assert mock_render.call_args_list[0][1]['status'] == 404
 
     @mock.patch('enterprise.views.track_enrollment')
-    @mock.patch('enterprise.models.EnrollmentApiClient')
+    @mock.patch('enterprise.models.EnrollmentApiClientJwt')
     @mock.patch('enterprise.views.RouterView', new_callable=views.RouterView)
     def test_get_direct_audit_enrollment(self, router_view_mock, enrollment_api_client_mock, track_enrollment_mock):
         """
@@ -256,7 +256,7 @@ class TestRouterView(TestCase):
             fetch_redirect_response=False,
         )
 
-    @mock.patch('enterprise.models.EnrollmentApiClient')
+    @mock.patch('enterprise.models.EnrollmentApiClientJwt')
     @mock.patch('enterprise.views.RouterView', new_callable=views.RouterView)
     def test_get_direct_audit_enrollment_user_already_enrolled(self, router_view_mock, enrollment_api_client_mock):
         """

--- a/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_learner_data.py
+++ b/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_learner_data.py
@@ -104,7 +104,7 @@ class TestLearnerExporter(unittest.TestCase):
         assert learner_data_record.completed_timestamp == (self.NOW_TIMESTAMP if completed_date is not None else None)
         assert learner_data_record.grade == 'A+'
 
-    @mock.patch('enterprise.models.EnrollmentApiClient')
+    @mock.patch('enterprise.models.EnrollmentApiClientJwt')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.GradesApiClient')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CourseApiClient')
     def test_collect_learner_data_without_consent(self, mock_course_api, mock_grades_api, mock_enrollment_api):
@@ -143,7 +143,7 @@ class TestLearnerExporter(unittest.TestCase):
         learner_data = list(self.exporter.export())
         assert not learner_data
 
-    @mock.patch('enterprise.models.EnrollmentApiClient')
+    @mock.patch('enterprise.models.EnrollmentApiClientJwt')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CourseApiClient')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CertificatesApiClient')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
@@ -181,7 +181,7 @@ class TestLearnerExporter(unittest.TestCase):
             assert report.completed_timestamp is None
             assert report.grade == LearnerExporter.GRADE_INCOMPLETE
 
-    @mock.patch('enterprise.models.EnrollmentApiClient')
+    @mock.patch('enterprise.models.EnrollmentApiClientJwt')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CourseApiClient')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CertificatesApiClient')
     def test_learner_data_instructor_paced_no_certificate_null_sso_id(
@@ -210,7 +210,7 @@ class TestLearnerExporter(unittest.TestCase):
         learner_data = list(self.exporter.export())
         assert not learner_data
 
-    @mock.patch('enterprise.models.EnrollmentApiClient')
+    @mock.patch('enterprise.models.EnrollmentApiClientJwt')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CourseApiClient')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CertificatesApiClient')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
@@ -257,7 +257,7 @@ class TestLearnerExporter(unittest.TestCase):
             assert report.completed_timestamp == self.NOW_TIMESTAMP
             assert report.grade == LearnerExporter.GRADE_PASSING
 
-    @mock.patch('enterprise.models.EnrollmentApiClient')
+    @mock.patch('enterprise.models.EnrollmentApiClientJwt')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.GradesApiClient')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CourseApiClient')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
@@ -316,7 +316,7 @@ class TestLearnerExporter(unittest.TestCase):
         (False, TOMORROW, None, LearnerExporter.GRADE_INCOMPLETE),
     )
     @ddt.unpack
-    @mock.patch('enterprise.models.EnrollmentApiClient')
+    @mock.patch('enterprise.models.EnrollmentApiClientJwt')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.GradesApiClient')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CourseApiClient')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
@@ -373,7 +373,7 @@ class TestLearnerExporter(unittest.TestCase):
         ('instructor', LearnerExporter.GRADE_PASSING),
     )
     @ddt.unpack
-    @mock.patch('enterprise.models.EnrollmentApiClient')
+    @mock.patch('enterprise.models.EnrollmentApiClientJwt')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CertificatesApiClient')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.GradesApiClient')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CourseApiClient')
@@ -503,7 +503,7 @@ class TestLearnerExporter(unittest.TestCase):
         (False, False, 'verified', 2),
     )
     @ddt.unpack
-    @mock.patch('enterprise.models.EnrollmentApiClient')
+    @mock.patch('enterprise.models.EnrollmentApiClientJwt')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.GradesApiClient')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CourseApiClient')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
@@ -560,7 +560,7 @@ class TestLearnerExporter(unittest.TestCase):
                 assert report.course_completed
                 assert report.grade == LearnerExporter.GRADE_PASSING
 
-    @mock.patch('enterprise.models.EnrollmentApiClient')
+    @mock.patch('enterprise.models.EnrollmentApiClientJwt')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.GradesApiClient')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CourseApiClient')
     def test_learner_exporter_with_skip_transmitted(self, mock_course_api, mock_grades_api, mock_enrollment_api):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -425,7 +425,7 @@ class TestEnterpriseCustomerUser(unittest.TestCase):
             assert mock_third_party_api.return_value.get_remote_id.call_count == 0
 
     @mock.patch('enterprise.utils.segment')
-    @mock.patch('enterprise.models.EnrollmentApiClient')
+    @mock.patch('enterprise.models.EnrollmentApiClientJwt')
     def test_enroll_learner(self, enrollment_api_client_mock, analytics_mock, *args):  # pylint: disable=unused-argument
         """
         ``enroll_learner`` enrolls the learner and redirects to the LMS courseware.
@@ -436,7 +436,7 @@ class TestEnterpriseCustomerUser(unittest.TestCase):
         enrollment_api_client_mock.return_value.enroll_user_in_course.assert_called_once()
         analytics_mock.track.assert_called_once()
 
-    @mock.patch('enterprise.models.EnrollmentApiClient')
+    @mock.patch('enterprise.models.EnrollmentApiClientJwt')
     def test_enroll_learner_already_enrolled(self, enrollment_api_client_mock):
         """
         ``enroll_learner`` does not enroll the user, as they're already enrolled, and redirects to the LMS courseware.
@@ -450,7 +450,7 @@ class TestEnterpriseCustomerUser(unittest.TestCase):
         enrollment_api_client_mock.return_value.enroll_user_in_course.assert_not_called()
 
     @mock.patch('enterprise.utils.segment')
-    @mock.patch('enterprise.models.EnrollmentApiClient')
+    @mock.patch('enterprise.models.EnrollmentApiClientJwt')
     # pylint: disable=unused-argument
     def test_enroll_learner_upgrade_mode(self, enrollment_api_client_mock, analytics_mock, *args):
         """
@@ -465,7 +465,7 @@ class TestEnterpriseCustomerUser(unittest.TestCase):
         enrollment_api_client_mock.return_value.enroll_user_in_course.assert_called_once()
         analytics_mock.track.assert_called_once()
 
-    @mock.patch('enterprise.models.EnrollmentApiClient')
+    @mock.patch('enterprise.models.EnrollmentApiClientJwt')
     def test_enroll_learner_downgrade_mode(self, enrollment_api_client_mock):
         """
         ``enroll_learner`` does not enroll the user, as they're already enrolled, and redirects to the LMS courseware.


### PR DESCRIPTION
This PR is about replacing the `EDX-API-KEY` with `OAuth` authentication method using `JWT.` There are three clients that are relying on the `EDX-API-KEY` based authentication; `CourseApiClient,` `EnrollmentApiClient,` and `ThirdPartyAuthApiClient.` This PR only covers the `enterprise/models.py` endpoint by cloning the original `EnrollmentApiClient` and using that one in the mentioned endpoint.