### PR TITLE
ENT-2042 Replaced Edx-Api-Key in Enrollment Api Client in CourseEnrollmentView-endpoint

### DIFF
--- a/enterprise/api_client/lms.py
+++ b/enterprise/api_client/lms.py
@@ -316,6 +316,198 @@ class EnrollmentApiClient(LmsApiClient):
         return self.client.enrollment.get(user=username)
 
 
+class EnrollmentApiClientJwt(JwtLmsApiClient):
+    """
+    Object builds an API client to make calls to the Enrollment API.
+    """
+
+    API_BASE_URL = settings.ENTERPRISE_ENROLLMENT_API_URL
+
+    @JwtLmsApiClient.refresh_token
+    def get_course_details(self, course_id):
+        """
+        Query the Enrollment API for the course details of the given course_id.
+
+        Args:
+            course_id (str): The string value of the course's unique identifier
+
+        Returns:
+            dict: A dictionary containing details about the course, in an enrollment context (allowed modes, etc.)
+        """
+        try:
+            return self.client.course(course_id).get()
+        except (SlumberBaseException, ConnectionError, Timeout) as exc:
+            LOGGER.exception(
+                'Failed to retrieve course enrollment details for course [%s] due to: [%s]',
+                course_id, str(exc)
+            )
+            return {}
+
+    def _sort_course_modes(self, modes):
+        """
+        Sort the course mode dictionaries by slug according to the COURSE_MODE_SORT_ORDER constant.
+
+        Arguments:
+            modes (list): A list of course mode dictionaries.
+        Returns:
+            list: A list with the course modes dictionaries sorted by slug.
+
+        """
+        def slug_weight(mode):
+            """
+            Assign a weight to the course mode dictionary based on the position of its slug in the sorting list.
+            """
+            sorting_slugs = COURSE_MODE_SORT_ORDER
+            sorting_slugs_size = len(sorting_slugs)
+            if mode['slug'] in sorting_slugs:
+                return sorting_slugs_size - sorting_slugs.index(mode['slug'])
+            return 0
+        # Sort slug weights in descending order
+        return sorted(modes, key=slug_weight, reverse=True)
+
+    @JwtLmsApiClient.refresh_token
+    def get_course_modes(self, course_id):
+        """
+        Query the Enrollment API for the specific course modes that are available for the given course_id.
+
+        Arguments:
+            course_id (str): The string value of the course's unique identifier
+
+        Returns:
+            list: A list of course mode dictionaries.
+
+        """
+        details = self.get_course_details(course_id)
+        modes = details.get('course_modes', [])
+        return self._sort_course_modes([mode for mode in modes if mode['slug'] not in EXCLUDED_COURSE_MODES])
+
+    @JwtLmsApiClient.refresh_token
+    def has_course_mode(self, course_run_id, mode):
+        """
+        Query the Enrollment API to see whether a course run has a given course mode available.
+
+        Arguments:
+            course_run_id (str): The string value of the course run's unique identifier
+
+        Returns:
+            bool: Whether the course run has the given mode avaialble for enrollment.
+
+        """
+        course_modes = self.get_course_modes(course_run_id)
+        return any(course_mode for course_mode in course_modes if course_mode['slug'] == mode)
+
+    @JwtLmsApiClient.refresh_token
+    def enroll_user_in_course(self, username, course_id, mode, cohort=None):
+        """
+        Call the enrollment API to enroll the user in the course specified by course_id.
+
+        Args:
+            username (str): The username by which the user goes on the OpenEdX platform
+            course_id (str): The string value of the course's unique identifier
+            mode (str): The enrollment mode which should be used for the enrollment
+            cohort (str): Add the user to this named cohort
+
+        Returns:
+            dict: A dictionary containing details of the enrollment, including course details, mode, username, etc.
+
+        """
+        return self.client.enrollment.post(
+            {
+                'user': username,
+                'course_details': {'course_id': course_id},
+                'mode': mode,
+                'cohort': cohort,
+            }
+        )
+
+    @JwtLmsApiClient.refresh_token
+    def unenroll_user_from_course(self, username, course_id):
+        """
+        Call the enrollment API to unenroll the user in the course specified by course_id.
+        Args:
+            username (str): The username by which the user goes on the OpenEdx platform
+            course_id (str): The string value of the course's unique identifier
+        Returns:
+            bool: Whether the unenrollment succeeded
+        """
+        enrollment = self.get_course_enrollment(username, course_id)
+        if enrollment and enrollment['is_active']:
+            response = self.client.enrollment.post({
+                'user': username,
+                'course_details': {'course_id': course_id},
+                'is_active': False,
+                'mode': enrollment['mode']
+            })
+            return not response['is_active']
+
+        return False
+
+    @JwtLmsApiClient.refresh_token
+    def get_course_enrollment(self, username, course_id):
+        """
+        Query the enrollment API to get information about a single course enrollment.
+
+        Args:
+            username (str): The username by which the user goes on the OpenEdX platform
+            course_id (str): The string value of the course's unique identifier
+
+        Returns:
+            dict: A dictionary containing details of the enrollment, including course details, mode, username, etc.
+
+        """
+        endpoint = getattr(
+            self.client.enrollment,
+            '{username},{course_id}'.format(username=username, course_id=course_id)
+        )
+        try:
+            result = endpoint.get()
+        except HttpNotFoundError:
+            # This enrollment data endpoint returns a 404 if either the username or course_id specified isn't valid
+            LOGGER.error(
+                'Course enrollment details not found for invalid username or course; username=[%s], course=[%s]',
+                username,
+                course_id
+            )
+            return None
+        # This enrollment data endpoint returns an empty string if the username and course_id is valid, but there's
+        # no matching enrollment found
+        if not result:
+            LOGGER.info('Failed to find course enrollment details for user [%s] and course [%s]', username, course_id)
+            return None
+
+        return result
+
+    @JwtLmsApiClient.refresh_token
+    def is_enrolled(self, username, course_run_id):
+        """
+        Query the enrollment API and determine if a learner is enrolled in a course run.
+
+        Args:
+            username (str): The username by which the user goes on the OpenEdX platform
+            course_run_id (str): The string value of the course's unique identifier
+
+        Returns:
+            bool: Indicating whether the user is enrolled in the course run. Returns False under any errors.
+
+        """
+        enrollment = self.get_course_enrollment(username, course_run_id)
+        return enrollment is not None and enrollment.get('is_active', False)
+
+    @JwtLmsApiClient.refresh_token
+    def get_enrolled_courses(self, username):
+        """
+        Query the enrollment API to get a list of the courses a user is enrolled in.
+
+        Args:
+            username (str): The username by which the user goes on the OpenEdX platform
+
+        Returns:
+            list: A list of course objects, along with relevant user-specific enrollment details.
+
+        """
+        return self.client.enrollment.get(user=username)
+
+
 class CourseApiClient(LmsApiClient):
     """
     Object builds an API client to make calls to the Course API.

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -36,7 +36,7 @@ from enterprise import constants, messages
 from enterprise.api.v1.serializers import EnterpriseCustomerUserWriteSerializer
 from enterprise.api_client.discovery import get_course_catalog_api_service_client
 from enterprise.api_client.ecommerce import EcommerceApiClient
-from enterprise.api_client.lms import CourseApiClient, EmbargoApiClient, EnrollmentApiClient
+from enterprise.api_client.lms import CourseApiClient, EmbargoApiClient, EnrollmentApiClient, EnrollmentApiClientJwt
 from enterprise.decorators import enterprise_login_required, force_fresh_session
 from enterprise.forms import ENTERPRISE_SELECT_SUBTITLE, EnterpriseSelectionForm
 from enterprise.models import (
@@ -1051,7 +1051,7 @@ class CourseEnrollmentView(NonAtomicView):
         course modes returned using the EnterpriseCustomerCatalog's
         field "enabled_course_modes".
         """
-        modes = EnrollmentApiClient().get_course_modes(course_run_id)
+        modes = EnrollmentApiClientJwt(request.user).get_course_modes(course_run_id)
         if not modes:
             LOGGER.warning('[Enterprise Enrollment] Unable to get course modes. '
                            'CourseRun: {course_run_id}'.format(course_run_id=course_run_id))
@@ -1394,7 +1394,7 @@ class CourseEnrollmentView(NonAtomicView):
                 )
                 track_enrollment('course-landing-page-enrollment', request.user.id, course_id, request.get_full_path())
 
-            client = EnrollmentApiClient()
+            client = EnrollmentApiClientJwt(request.user)
             client.enroll_user_in_course(
                 request.user.username,
                 course_id,
@@ -1497,7 +1497,7 @@ class CourseEnrollmentView(NonAtomicView):
             enterprise_customer=enterprise_customer
         )
 
-        enrollment_client = EnrollmentApiClient()
+        enrollment_client = EnrollmentApiClientJwt(request.user)
         enrolled_course = enrollment_client.get_course_enrollment(request.user.username, course_id)
         try:
             enterprise_course_enrollment = EnterpriseCourseEnrollment.objects.get(

--- a/tests/test_enterprise/api_client/test_lms.py
+++ b/tests/test_enterprise/api_client/test_lms.py
@@ -20,6 +20,7 @@ from enterprise.utils import NotConnectedToOpenEdX
 
 URL_BASE_NAMES = {
     'enrollment': lms_api.EnrollmentApiClient,
+    'enrollment_jwt': lms_api.EnrollmentApiClientJwt,
     'courses': lms_api.CourseApiClient,
     'third_party_auth': lms_api.ThirdPartyAuthApiClient,
     'course_grades': lms_api.GradesApiClient,
@@ -147,6 +148,7 @@ def test_is_enrolled():
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 @mock.patch('enterprise.api_client.lms.COURSE_MODE_SORT_ORDER', ['a', 'list', 'containing', 'most', 'of', 'the'])
 @mock.patch('enterprise.api_client.lms.EXCLUDED_COURSE_MODES', ['course'])
 def test_get_enrollment_course_modes():
@@ -169,12 +171,12 @@ def test_get_enrollment_course_modes():
     responses.add(
         responses.GET,
         _url(
-            "enrollment",
+            "enrollment_jwt",
             "course/{}".format(course_id),
         ),
         json=response
     )
-    client = lms_api.EnrollmentApiClient()
+    client = lms_api.EnrollmentApiClientJwt('user-goes-here')
     actual_response = client.get_course_modes(course_id)
     assert actual_response == expected_return
 

--- a/tests/test_enterprise/api_client/test_lms.py
+++ b/tests/test_enterprise/api_client/test_lms.py
@@ -127,6 +127,7 @@ def test_get_course_enrollment():
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_is_enrolled():
     user = "some_user"
     course_id = "course-v1:edX+DemoX+Demo_Course"
@@ -137,12 +138,12 @@ def test_is_enrolled():
     responses.add(
         responses.GET,
         _url(
-            "enrollment",
+            "enrollment_jwt",
             "enrollment/{username},{course_id}".format(username=user, course_id=course_id),
         ),
         json=expected_response
     )
-    client = lms_api.EnrollmentApiClient()
+    client = lms_api.EnrollmentApiClientJwt(user)
     actual_response = client.is_enrolled(user, course_id)
     assert actual_response is True
 
@@ -269,23 +270,25 @@ def test_get_course_enrollment_not_found():
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_is_enrolled_false():
     user = "some_user"
     course_id = "course-v1:edX+DemoX+Demo_Course"
     responses.add(
         responses.GET,
         _url(
-            "enrollment",
+            "enrollment_jwt",
             "enrollment/{username},{course_id}".format(username=user, course_id=course_id),
         ),
         status=404,
     )
-    client = lms_api.EnrollmentApiClient()
+    client = lms_api.EnrollmentApiClientJwt(user)
     actual_response = client.is_enrolled(user, course_id)
     assert actual_response is False
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_is_enrolled_but_not_active():
     user = "some_user"
     course_id = "course-v1:edX+DemoX+Demo_Course"
@@ -296,12 +299,12 @@ def test_is_enrolled_but_not_active():
     responses.add(
         responses.GET,
         _url(
-            "enrollment",
+            "enrollment_jwt",
             "enrollment/{username},{course_id}".format(username=user, course_id=course_id),
         ),
         json=expected_response
     )
-    client = lms_api.EnrollmentApiClient()
+    client = lms_api.EnrollmentApiClientJwt(user)
     actual_response = client.is_enrolled(user, course_id)
     assert actual_response is False
 

--- a/tests/test_enterprise/views/test_course_enrollment_view.py
+++ b/tests/test_enterprise/views/test_course_enrollment_view.py
@@ -154,7 +154,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
     @mock.patch('enterprise.utils.Registry')
     def test_get_course_enrollment_page(
@@ -216,7 +216,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
     @mock.patch('enterprise.utils.Registry')
     @ddt.data(True, False)
@@ -259,7 +259,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
     @mock.patch('enterprise.utils.Registry')
     @ddt.data(
@@ -377,7 +377,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
     @mock.patch('enterprise.utils.Registry')
     def test_get_course_enrollment_page_with_invalid_catalog(
@@ -447,7 +447,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
     @mock.patch('enterprise.utils.Registry')
     def test_course_enrollment_page_with_catalog_for_invalid_course_modes(
@@ -530,7 +530,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
     @mock.patch('enterprise.utils.Registry')
     @ddt.data(True, False)
@@ -606,7 +606,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
     @mock.patch('enterprise.utils.Registry')
     @ddt.data(True, False)
@@ -679,7 +679,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
     @mock.patch('enterprise.utils.Registry')
     def test_get_course_enrollment_page_course_unenrollable_context(
@@ -724,7 +724,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
     @mock.patch('enterprise.utils.Registry')
     def test_get_course_enrollment_page_edge_case_formatting(
@@ -787,7 +787,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
     @mock.patch('enterprise.utils.Registry')
     def test_get_course_enrollment_page_with_empty_fields(
@@ -851,7 +851,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
     @mock.patch('enterprise.utils.Registry')
     def test_get_course_specific_enrollment_view_audit_enabled(
@@ -918,7 +918,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
     @mock.patch('enterprise.utils.Registry')
     def test_get_course_enrollment_page_with_no_start_date(
@@ -968,7 +968,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.utils.Registry')
     def test_get_course_enrollment_page_for_non_existing_course(
             self,
@@ -1017,7 +1017,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.utils.Registry')
     def test_get_course_enrollment_page_for_error_in_getting_course(
             self,
@@ -1066,7 +1066,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.utils.Registry')
     def test_get_course_specific_enrollment_view_with_course_mode_error(
             self,
@@ -1114,7 +1114,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     def test_get_course_specific_enrollment_view_for_invalid_ec_uuid(
             self,
             enrollment_api_client_mock,
@@ -1182,7 +1182,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
 
     @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.utils.Registry')
     def test_get_course_landing_page_for_enrolled_user(
             self,
@@ -1234,7 +1234,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
     @mock.patch('enterprise.views.track_enrollment')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.views.get_data_sharing_consent')
     @mock.patch('enterprise.utils.Registry')
     @ddt.data(
@@ -1347,7 +1347,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
                 assert enterprise_course_enrollment.source.slug == EnterpriseEnrollmentSource.ENROLLMENT_URL
 
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.views.get_data_sharing_consent')
     @mock.patch('enterprise.utils.Registry')
     def test_post_course_specific_enrollment_view_consent_needed(
@@ -1418,7 +1418,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
         )
 
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.views.get_data_sharing_consent')
     @mock.patch('enterprise.utils.Registry')
     def test_post_course_specific_enrollment_view_consent_needed_with_catalog_querystring(
@@ -1505,7 +1505,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
     @mock.patch('enterprise.utils.Registry')
     def test_post_course_specific_enrollment_view_incompatible_mode(
@@ -1570,7 +1570,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.views.get_data_sharing_consent')
     @mock.patch('enterprise.utils.Registry')
     def test_post_course_specific_enrollment_view_premium_mode(
@@ -1622,7 +1622,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
     @mock.patch('enterprise.utils.Registry')
     def test_get_course_enrollment_page_with_ecommerce_error(
@@ -1690,7 +1690,7 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.lms.embargo_api')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClientJwt')
     @mock.patch('enterprise.api_client.ecommerce.ecommerce_api_client')
     def test_get_course_enrollment_page_creates_enterprise_customer_user(
             self,


### PR DESCRIPTION
This PR is about replacing the `EDX-API-KEY` with `OAuth` authentication method using `JWT.` There are three clients that are relying on the `EDX-API-KEY` based authentication; `CourseApiClient,` `EnrollmentApiClient,` and `ThirdPartyAuthApiClient.` This PR only covers the `enterprise/views.py/CourseEnrollmentView` endpoint by cloning the original `EnrollmentApiClient` and using that one in the mentioned endpoint.