### PR TITLE
ENT-2042 Replaced Edx-Api-Key in EnterpriseCustomerCourseEnrollmentsSerializer

### DIFF
--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -646,9 +646,14 @@ class EnterpriseCustomerCourseEnrollmentsSerializer(serializers.Serializer):
 
         It first uses the third party auth api to find the associated username to do the lookup.
         """
-        enterprise_customer = self.context.get('enterprise_customer')
-        request_user = self.context.get('request_user')
-
+        try:
+            enterprise_customer = self.context.get('enterprise_customer')
+            request_user = self.context.get('request_user')
+        except KeyError:
+            LOGGER.error(
+                'EnterpriseCustomer or Request User is not in the context of Serializer class'
+            )
+            return None
         try:
             tpa_client = ThirdPartyAuthApiClientJwt(request_user)
             username = tpa_client.get_username_from_remote_id(

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -16,7 +16,7 @@ from django.contrib.sites.models import Site
 from django.utils.translation import ugettext_lazy as _
 
 from enterprise import models, utils
-from enterprise.api_client.lms import ThirdPartyAuthApiClient
+from enterprise.api_client.lms import ThirdPartyAuthApiClientJwt
 from enterprise.constants import ENTERPRISE_PERMISSION_GROUPS
 from enterprise.utils import CourseEnrollmentDowngradeError, CourseEnrollmentPermissionError, track_enrollment
 
@@ -647,9 +647,10 @@ class EnterpriseCustomerCourseEnrollmentsSerializer(serializers.Serializer):
         It first uses the third party auth api to find the associated username to do the lookup.
         """
         enterprise_customer = self.context.get('enterprise_customer')
+        request_user = self.context.get('request_user')
 
         try:
-            tpa_client = ThirdPartyAuthApiClient()
+            tpa_client = ThirdPartyAuthApiClientJwt(request_user)
             username = tpa_client.get_username_from_remote_id(
                 enterprise_customer.identity_provider, value
             )

--- a/enterprise/api_client/lms.py
+++ b/enterprise/api_client/lms.py
@@ -14,7 +14,7 @@ from opaque_keys.edx.keys import CourseKey
 from requests import Session
 from requests.exceptions import ConnectionError, Timeout  # pylint: disable=redefined-builtin
 from slumber.exceptions import HttpNotFoundError, SlumberBaseException
-from six.moves.urllib.parse import urljoin
+from requests.compat import urljoin
 
 from django.conf import settings
 from django.utils import timezone

--- a/enterprise/api_client/lms.py
+++ b/enterprise/api_client/lms.py
@@ -13,8 +13,8 @@ from edx_rest_api_client.client import EdxRestApiClient
 from opaque_keys.edx.keys import CourseKey
 from requests import Session
 from requests.exceptions import ConnectionError, Timeout  # pylint: disable=redefined-builtin
-from slumber.exceptions import HttpNotFoundError, SlumberBaseException
 from requests.compat import urljoin
+from slumber.exceptions import HttpNotFoundError, SlumberBaseException
 
 from django.conf import settings
 from django.utils import timezone

--- a/enterprise/api_client/lms.py
+++ b/enterprise/api_client/lms.py
@@ -14,6 +14,7 @@ from opaque_keys.edx.keys import CourseKey
 from requests import Session
 from requests.exceptions import ConnectionError, Timeout  # pylint: disable=redefined-builtin
 from slumber.exceptions import HttpNotFoundError, SlumberBaseException
+from six.moves.urllib.parse import urljoin
 
 from django.conf import settings
 from django.utils import timezone
@@ -402,8 +403,7 @@ class ThirdPartyAuthApiClientJwt(JwtLmsApiClient):
     """
     Object builds an API client to make calls to the Third Party Auth API.
     """
-
-    API_BASE_URL = settings.LMS_INTERNAL_ROOT_URL + '/api/third_party_auth/v0/'
+    API_BASE_URL = urljoin(settings.LMS_INTERNAL_ROOT_URL, '/api/third_party_auth/v0/')
 
     @JwtLmsApiClient.refresh_token
     def get_remote_id(self, identity_provider, username):

--- a/enterprise/api_client/lms.py
+++ b/enterprise/api_client/lms.py
@@ -398,6 +398,65 @@ class ThirdPartyAuthApiClient(LmsApiClient):
         return None
 
 
+class ThirdPartyAuthApiClientJwt(JwtLmsApiClient):
+    """
+    Object builds an API client to make calls to the Third Party Auth API.
+    """
+
+    API_BASE_URL = settings.LMS_INTERNAL_ROOT_URL + '/api/third_party_auth/v0/'
+
+    @JwtLmsApiClient.refresh_token
+    def get_remote_id(self, identity_provider, username):
+        """
+        Retrieve the remote identifier for the given username.
+
+        Args:
+        * ``identity_provider`` (str): identifier slug for the third-party authentication service used during SSO.
+        * ``username`` (str): The username ID identifying the user for which to retrieve the remote name.
+
+        Returns:
+            string or None: the remote name of the given user.  None if not found.
+        """
+        return self._get_results(identity_provider, 'username', username, 'remote_id')
+
+    @JwtLmsApiClient.refresh_token
+    def get_username_from_remote_id(self, identity_provider, remote_id):
+        """
+        Retrieve the remote identifier for the given username.
+
+        Args:
+        * ``identity_provider`` (str): identifier slug for the third-party authentication service used during SSO.
+        * ``remote_id`` (str): The remote id identifying the user for which to retrieve the usernamename.
+
+        Returns:
+            string or None: the username of the given user.  None if not found.
+        """
+        return self._get_results(identity_provider, 'remote_id', remote_id, 'username')
+
+    def _get_results(self, identity_provider, param_name, param_value, result_field_name):
+        """
+        Calls the third party auth api endpoint to get the mapping between usernames and remote ids.
+        """
+        try:
+            kwargs = {param_name: param_value}
+            returned = self.client.providers(identity_provider).users.get(**kwargs)
+            results = returned.get('results', [])
+        except HttpNotFoundError:
+            LOGGER.error(
+                'username not found for third party provider={provider}, {querystring_param}={id}'.format(
+                    provider=identity_provider,
+                    querystring_param=param_name,
+                    id=param_value
+                )
+            )
+            results = []
+
+        for row in results:
+            if row.get(param_name) == param_value:
+                return row.get(result_field_name)
+        return None
+
+
 class GradesApiClient(JwtLmsApiClient):
     """
     Object builds an API client to make calls to the LMS Grades API.

--- a/enterprise/api_client/lms.py
+++ b/enterprise/api_client/lms.py
@@ -12,8 +12,8 @@ from time import time
 from edx_rest_api_client.client import EdxRestApiClient
 from opaque_keys.edx.keys import CourseKey
 from requests import Session
-from requests.exceptions import ConnectionError, Timeout  # pylint: disable=redefined-builtin
 from requests.compat import urljoin
+from requests.exceptions import ConnectionError, Timeout  # pylint: disable=redefined-builtin
 from slumber.exceptions import HttpNotFoundError, SlumberBaseException
 
 from django.conf import settings

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -1557,7 +1557,7 @@ class TestEnterpriseAPIViews(APITest):
     )
     @ddt.unpack
     @mock.patch('enterprise.models.EnterpriseCustomer.catalog_contains_course')
-    @mock.patch('enterprise.api.v1.serializers.ThirdPartyAuthApiClient')
+    @mock.patch('enterprise.api.v1.serializers.ThirdPartyAuthApiClientJwt')
     @mock.patch('enterprise.models.EnrollmentApiClient')
     @mock.patch('enterprise.models.utils.track_event', mock.MagicMock())
     def test_enterprise_customer_course_enrollments_detail_errors(
@@ -1701,7 +1701,7 @@ class TestEnterpriseAPIViews(APITest):
     )
     @ddt.unpack
     @mock.patch('enterprise.models.EnterpriseCustomer.catalog_contains_course')
-    @mock.patch('enterprise.api.v1.serializers.ThirdPartyAuthApiClient')
+    @mock.patch('enterprise.api.v1.serializers.ThirdPartyAuthApiClientJwt')
     @mock.patch('enterprise.models.EnrollmentApiClient')
     @mock.patch('enterprise.models.EnterpriseCustomer.notify_enrolled_learners')
     @mock.patch('enterprise.models.utils.track_event', mock.MagicMock())
@@ -1806,7 +1806,7 @@ class TestEnterpriseAPIViews(APITest):
             mock_notify_learners.assert_not_called()
 
     @mock.patch('enterprise.models.EnterpriseCustomer.catalog_contains_course')
-    @mock.patch('enterprise.api.v1.serializers.ThirdPartyAuthApiClient')
+    @mock.patch('enterprise.api.v1.serializers.ThirdPartyAuthApiClientJwt')
     @mock.patch('enterprise.models.EnrollmentApiClient')
     @mock.patch('enterprise.models.utils.track_event', mock.MagicMock())
     def test_enterprise_customer_course_enrollments_detail_multiple(

--- a/tests/test_enterprise/api_client/test_lms.py
+++ b/tests/test_enterprise/api_client/test_lms.py
@@ -22,6 +22,7 @@ URL_BASE_NAMES = {
     'enrollment': lms_api.EnrollmentApiClient,
     'courses': lms_api.CourseApiClient,
     'third_party_auth': lms_api.ThirdPartyAuthApiClient,
+    'third_party_auth_jwt': lms_api.ThirdPartyAuthApiClientJwt,
     'course_grades': lms_api.GradesApiClient,
     'certificates': lms_api.CertificatesApiClient,
 }
@@ -482,23 +483,25 @@ def test_get_remote_id():
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_get_username_from_remote_id_not_found():
     remote_id = "Darth"
     provider_id = "DeathStar"
     responses.add(
         responses.GET,
-        _url("third_party_auth", "providers/{provider}/users?remote_id={user}".format(
+        _url("third_party_auth_jwt", "providers/{provider}/users?remote_id={user}".format(
             provider=provider_id, user=remote_id
         )),
         match_querystring=True,
         status=404
     )
-    client = lms_api.ThirdPartyAuthApiClient()
+    client = lms_api.ThirdPartyAuthApiClientJwt('user-goes-here')
     actual_response = client.get_username_from_remote_id(provider_id, remote_id)
     assert actual_response is None
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_get_username_from_remote_id_no_results():
     remote_id = "Darth"
     provider_id = "DeathStar"
@@ -513,18 +516,19 @@ def test_get_username_from_remote_id_no_results():
     }
     responses.add(
         responses.GET,
-        _url("third_party_auth", "providers/{provider}/users?remote_id={user}".format(
+        _url("third_party_auth_jwt", "providers/{provider}/users?remote_id={user}".format(
             provider=provider_id, user=remote_id
         )),
         match_querystring=True,
         json=expected_response,
     )
-    client = lms_api.ThirdPartyAuthApiClient()
+    client = lms_api.ThirdPartyAuthApiClientJwt('user-goes-here')
     actual_response = client.get_username_from_remote_id(provider_id, remote_id)
     assert actual_response is None
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_get_username_from_remote_id():
     remote_id = "LukeIamYrFather"
     provider_id = "DeathStar"
@@ -538,13 +542,13 @@ def test_get_username_from_remote_id():
     }
     responses.add(
         responses.GET,
-        _url("third_party_auth", "providers/{provider}/users?remote_id={user}".format(
+        _url("third_party_auth_jwt", "providers/{provider}/users?remote_id={user}".format(
             provider=provider_id, user=remote_id
         )),
         match_querystring=True,
         json=expected_response,
     )
-    client = lms_api.ThirdPartyAuthApiClient()
+    client = lms_api.ThirdPartyAuthApiClientJwt('user-goes-here')
     actual_response = client.get_username_from_remote_id(provider_id, remote_id)
     assert actual_response == "Darth"
 

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -545,7 +545,7 @@ def stub_transmit_learner_data_apis(testcase, certificate, self_paced, end_date,
         # Third Party API remote_id response
         responses.add(
             responses.GET,
-            urljoin(lms_api.ThirdPartyAuthApiClient.API_BASE_URL,
+            urljoin(lms_api.ThirdPartyAuthApiClientJwt.API_BASE_URL,
                     "providers/{provider}/users?username={user}".format(provider=testcase.identity_provider,
                                                                         user=user.username)),
             match_querystring=True,


### PR DESCRIPTION
This PR is about replacing the `EDX-API-KEY` with `OAuth` authentication method using `JWT.` There are three clients that are relying on the `EDX-API-KEY` based authentication; `CourseApiClient,` `EnrollmentApiClient,` and `ThirdPartyAuthApiClient.` This PR only covers the `enterprise/api/v1/serializers.py/EnterpriseCustomerCourseEnrollmentsSerializer` endpoint by cloning the original `ThirdPartyAuthApiClient` and using that one in the mentioned endpoint. It also covers all the test cases of the endpoint.