### PR TITLE
ENT-2042 Replaced Edx-Api-Key in model-EnterpriseCustomerUser-endpoint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,13 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+[2.0.43] - 2020-01-08
+---------------------
+
+* Replaced Edx-Api-Key in the ThirdPartyAuthApiClient
+* Changed the client in one endpoint of ThirdPartyAuthApiClient
+* Endpoint name: model-EnterpriseCustomerUser
+
 [2.0.42] - 2020-01-07
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "2.0.42"
+__version__ = "2.0.43"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -41,7 +41,7 @@ from model_utils.models import TimeStampedModel
 from enterprise import utils
 from enterprise.api_client.discovery import CourseCatalogApiClient, get_course_catalog_api_service_client
 from enterprise.api_client.ecommerce import EcommerceApiClient
-from enterprise.api_client.lms import EnrollmentApiClient, ThirdPartyAuthApiClient, parse_lms_api_datetime
+from enterprise.api_client.lms import EnrollmentApiClient, ThirdPartyAuthApiClientJwt, parse_lms_api_datetime
 from enterprise.constants import ALL_ACCESS_CONTEXT, ENTERPRISE_OPERATOR_ROLE, json_serialized_course_modes
 from enterprise.utils import (
     CourseEnrollmentDowngradeError,
@@ -726,7 +726,7 @@ class EnterpriseCustomerUser(TimeStampedModel):
         user = self.user
         identity_provider = self.enterprise_customer.identity_provider
         if user and identity_provider:
-            client = ThirdPartyAuthApiClient()
+            client = ThirdPartyAuthApiClientJwt(user)
             return client.get_remote_id(self.enterprise_customer.identity_provider, user.username)
         return None
 

--- a/tests/test_enterprise/api_client/test_lms.py
+++ b/tests/test_enterprise/api_client/test_lms.py
@@ -23,6 +23,7 @@ URL_BASE_NAMES = {
     'enrollment_jwt': lms_api.EnrollmentApiClientJwt,
     'courses': lms_api.CourseApiClient,
     'third_party_auth': lms_api.ThirdPartyAuthApiClient,
+    'third_party_auth_jwt': lms_api.ThirdPartyAuthApiClientJwt,
     'course_grades': lms_api.GradesApiClient,
     'certificates': lms_api.CertificatesApiClient,
 }
@@ -418,23 +419,25 @@ def test_get_full_course_details_not_found():
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_get_remote_id_not_found():
     username = "Darth"
     provider_id = "DeathStar"
     responses.add(
         responses.GET,
-        _url("third_party_auth", "providers/{provider}/users?username={user}".format(
+        _url("third_party_auth_jwt", "providers/{provider}/users?username={user}".format(
             provider=provider_id, user=username
         )),
         match_querystring=True,
         status=404
     )
-    client = lms_api.ThirdPartyAuthApiClient()
+    client = lms_api.ThirdPartyAuthApiClientJwt('user-goes-here')
     actual_response = client.get_remote_id(provider_id, username)
     assert actual_response is None
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_get_remote_id_no_results():
     username = "Darth"
     provider_id = "DeathStar"
@@ -449,18 +452,19 @@ def test_get_remote_id_no_results():
     }
     responses.add(
         responses.GET,
-        _url("third_party_auth", "providers/{provider}/users?username={user}".format(
+        _url("third_party_auth_jwt", "providers/{provider}/users?username={user}".format(
             provider=provider_id, user=username
         )),
         match_querystring=True,
         json=expected_response,
     )
-    client = lms_api.ThirdPartyAuthApiClient()
+    client = lms_api.ThirdPartyAuthApiClientJwt('user-goes-here')
     actual_response = client.get_remote_id(provider_id, username)
     assert actual_response is None
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_get_remote_id():
     username = "Darth"
     provider_id = "DeathStar"
@@ -475,13 +479,13 @@ def test_get_remote_id():
     }
     responses.add(
         responses.GET,
-        _url("third_party_auth", "providers/{provider}/users?username={user}".format(
+        _url("third_party_auth_jwt", "providers/{provider}/users?username={user}".format(
             provider=provider_id, user=username
         )),
         match_querystring=True,
         json=expected_response,
     )
-    client = lms_api.ThirdPartyAuthApiClient()
+    client = lms_api.ThirdPartyAuthApiClientJwt('user-goes-here')
     actual_response = client.get_remote_id(provider_id, username)
     assert actual_response == "LukeIamYrFather"
 

--- a/tests/test_integrated_channels/test_degreed/test_exporters/test_learner_data.py
+++ b/tests/test_integrated_channels/test_degreed/test_exporters/test_learner_data.py
@@ -52,7 +52,7 @@ class TestDegreedLearnerExporter(unittest.TestCase):
         self.idp = factories.EnterpriseCustomerIdentityProviderFactory(
             enterprise_customer=self.enterprise_customer
         )
-        tpa_client_mock = mock.patch('enterprise.models.ThirdPartyAuthApiClient')
+        tpa_client_mock = mock.patch('enterprise.models.ThirdPartyAuthApiClientJwt')
         self.tpa_client = tpa_client_mock.start()
         self.tpa_client.return_value.get_remote_id.return_value = 'fake-remote-id'
         self.addCleanup(tpa_client_mock.stop)

--- a/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_learner_data.py
+++ b/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_learner_data.py
@@ -60,7 +60,7 @@ class TestLearnerExporter(unittest.TestCase):
         self.idp = factories.EnterpriseCustomerIdentityProviderFactory(
             enterprise_customer=self.enterprise_customer
         )
-        tpa_client_mock = mock.patch('enterprise.models.ThirdPartyAuthApiClient')
+        tpa_client_mock = mock.patch('enterprise.models.ThirdPartyAuthApiClientJwt')
         self.tpa_client = tpa_client_mock.start().return_value
         # Default remote ID
         self.tpa_client.get_remote_id.return_value = 'fake-remote-id'

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -407,7 +407,7 @@ class TestEnterpriseCustomerUser(unittest.TestCase):
         ('fake-identity', 'saml-user-id', True),
     )
     @ddt.unpack
-    @mock.patch('enterprise.models.ThirdPartyAuthApiClient')
+    @mock.patch('enterprise.models.ThirdPartyAuthApiClientJwt')
     def test_get_remote_id(self, provider_id, expected_value, called, mock_third_party_api):
         user = factories.UserFactory(username="hi")
         enterprise_customer_user = factories.EnterpriseCustomerUserFactory(user_id=user.id)


### PR DESCRIPTION
This PR is about replacing the `EDX-API-KEY` with `OAuth` authentication method using `JWT.` There are three clients that are relying on the `EDX-API-KEY` based authentication; `CourseApiClient,` `EnrollmentApiClient,` and `ThirdPartyAuthApiClient.` This PR only covers the `enterprise/models/EntepriseCustomerUser` endpoint by cloning the original `ThirdPartyAuthApiClient` and using that one in the mentioned endpoint. It also covers all the test cases of the endpoint. It also covers all the test cases related to it.