### PR TITLE
ENT-2513: Disable manual enrollment orders for audit enterprise learners

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,11 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+[2.0.34] - 2019-12-24
+---------------------
+
+* Disabled the manual enrollment orders for audit mode enterprise learners.
+
 [2.0.33] - 2019-12-23
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "2.0.33"
+__version__ = "2.0.34"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/admin/views.py
+++ b/enterprise/admin/views.py
@@ -828,6 +828,7 @@ class EnterpriseCustomerManageLearnersView(View):
             notify: Whether to notify (by email) the users that have been enrolled
         """
         pending_messages = []
+        paid_modes = ['verified', 'professional']
 
         if course_id:
             succeeded, pending, failed = cls.enroll_users_in_course(
@@ -882,8 +883,9 @@ class EnterpriseCustomerManageLearnersView(View):
             "username": success.username,
             "course_run_key": course_id,
         } for success in succeeded]
-        # Create an order to track the manual enrollments of non-pending accounts
-        EcommerceApiClient(get_ecommerce_worker_user()).create_manual_enrollment_orders(enrollments)
+        if mode in paid_modes:
+            # Create an order to track the manual enrollments of non-pending accounts
+            EcommerceApiClient(get_ecommerce_worker_user()).create_manual_enrollment_orders(enrollments)
         cls.send_messages(request, pending_messages)
 
     def get(self, request, customer_uuid):

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -779,8 +779,9 @@ class EnterpriseCustomerUser(TimeStampedModel):
                 'cohort': cohort,
                 'is_upgrading': is_upgrading,
             })
-            # create an ecommerce order for the course enrollment
-            self.create_order_for_enrollment(course_run_id)
+            if mode in paid_modes:
+                # create an ecommerce order for the course enrollment
+                self.create_order_for_enrollment(course_run_id)
         elif enrolled_in_course and course_enrollment.get('mode') in paid_modes and mode in audit_modes:
             # This enrollment is attempting to "downgrade" the user from a paid track they are already in.
             raise CourseEnrollmentDowngradeError(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -426,18 +426,25 @@ class TestEnterpriseCustomerUser(unittest.TestCase):
 
     @mock.patch('enterprise.utils.segment')
     @mock.patch('enterprise.models.EnrollmentApiClient')
-    def test_enroll_learner(self, enrollment_api_client_mock, analytics_mock, *args):  # pylint: disable=unused-argument
+    @mock.patch('enterprise.models.EnterpriseCustomerUser.create_order_for_enrollment')
+    @ddt.data('audit', 'verified')
+    def test_enroll_learner(self, course_mode, enrollment_order_mock, enrollment_api_client_mock, analytics_mock):
         """
         ``enroll_learner`` enrolls the learner and redirects to the LMS courseware.
         """
         enterprise_customer_user = factories.EnterpriseCustomerUserFactory()
         enrollment_api_client_mock.return_value.get_course_enrollment.return_value = None
-        enterprise_customer_user.enroll('course-v1:edX+DemoX+Demo_Course', 'audit')
+        enterprise_customer_user.enroll('course-v1:edX+DemoX+Demo_Course', course_mode)
         enrollment_api_client_mock.return_value.enroll_user_in_course.assert_called_once()
         analytics_mock.track.assert_called_once()
+        if course_mode == 'verified':
+            enrollment_order_mock.assert_called_once()
+        else:
+            enrollment_order_mock.assert_not_called()
 
     @mock.patch('enterprise.models.EnrollmentApiClient')
-    def test_enroll_learner_already_enrolled(self, enrollment_api_client_mock):
+    @mock.patch('enterprise.models.EnterpriseCustomerUser.create_order_for_enrollment')
+    def test_enroll_learner_already_enrolled(self, enrollment_order_mock, enrollment_api_client_mock):
         """
         ``enroll_learner`` does not enroll the user, as they're already enrolled, and redirects to the LMS courseware.
         """
@@ -448,11 +455,12 @@ class TestEnterpriseCustomerUser(unittest.TestCase):
         }
         enterprise_customer_user.enroll('course-v1:edX+DemoX+Demo_Course', 'audit')
         enrollment_api_client_mock.return_value.enroll_user_in_course.assert_not_called()
+        enrollment_order_mock.assert_not_called()
 
     @mock.patch('enterprise.utils.segment')
     @mock.patch('enterprise.models.EnrollmentApiClient')
-    # pylint: disable=unused-argument
-    def test_enroll_learner_upgrade_mode(self, enrollment_api_client_mock, analytics_mock, *args):
+    @mock.patch('enterprise.models.EnterpriseCustomerUser.create_order_for_enrollment')
+    def test_enroll_learner_upgrade_mode(self, enrollment_order_mock, enrollment_api_client_mock, analytics_mock):
         """
         ``enroll_learner`` enrolls the learner to a paid mode from previously being enrolled in audit.
         """
@@ -464,6 +472,7 @@ class TestEnterpriseCustomerUser(unittest.TestCase):
         enterprise_customer_user.enroll('course-v1:edX+DemoX+Demo_Course', 'verified')
         enrollment_api_client_mock.return_value.enroll_user_in_course.assert_called_once()
         analytics_mock.track.assert_called_once()
+        enrollment_order_mock.assert_called_once()
 
     @mock.patch('enterprise.models.EnrollmentApiClient')
     def test_enroll_learner_downgrade_mode(self, enrollment_api_client_mock):


### PR DESCRIPTION
Description: Audit type enrollment transactions would no longer create $0 orders for financial reporting.

JIRA: https://openedx.atlassian.net/browse/ENT-2513

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
