### PR TITLE
ENT-2501: Updated edx-rbac

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,11 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+[2.0.35] - 2019-12-30
+---------------------
+
+* Version upgrade for edx-rbac
+
 [2.0.34] - 2019-12-24
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "2.0.34"
+__version__ = "2.0.35"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -10,145 +10,147 @@ amqp==1.4.9
 aniso8601==8.0.0
 anyjson==0.3.3
 argparse==1.4.0           # via caniusepython3
-asn1crypto==0.24.0
 astroid==1.5.3            # via pylint, pylint-celery
 atomicwrites==1.3.0
-attrs==19.1.0
+attrs==19.3.0
 babel==2.7.0
-backports.functools-lru-cache==1.5  # via astroid, caniusepython3, isort, pylint
+backports.functools-lru-cache==1.6.1  # via astroid, caniusepython3, isort, pylint
 billiard==3.3.0.23
 bleach==2.1.4
-caniusepython3==7.1.0
+caniusepython3==7.2.0
 celery==3.1.25
-certifi==2019.9.11
-cffi==1.12.3
+certifi==2019.11.28
+cffi==1.13.2
 chardet==3.0.4
 click-log==0.3.2          # via edx-lint
 click==7.0
-code-annotations==0.3.2
+code-annotations==0.3.3
 configparser==4.0.2
-contextlib2==0.6.0
+contextlib2==0.6.0.post1
 cookies==2.2.1
-coverage==4.5.4
-cryptography==2.7
-ddt==1.2.1
+coverage==5.0.1
+cryptography==2.8
+ddt==1.2.2
 defusedxml==0.5.0
-diff-cover==2.3.0
-distlib==0.2.9.post0      # via caniusepython3
-django-config-models==1.0.1
-django-countries==4.6.1
-django-crum==0.7.3
+diff-cover==2.5.0
+distlib==0.3.0            # via caniusepython3
+django-config-models==1.0.3
+django-countries==5.5
+django-crum==0.7.5
 django-fernet-fields==0.6
 django-filter==1.0.4
 django-ipware==2.1.0
 django-model-utils==3.0.0
 django-multi-email-field==0.5.1
-django-object-actions==1.1.0
-django-simple-history==2.7.3
+django-object-actions==2.0.0
+django-simple-history==2.8.0
 django-waffle==0.12.0
-django==1.11.24
+django==1.11.27
 djangorestframework-jwt==1.11.0
 djangorestframework-xml==1.4.0
 djangorestframework==3.7.7
 doc8==0.8.0
 docutils==0.15.2
-edx-django-utils==2.0.0
-edx-drf-extensions==2.4.0
-edx-i18n-tools==0.4.8
+edx-django-utils==2.0.2
+edx-drf-extensions==2.4.5
+edx-i18n-tools==0.5.0
 edx-lint==1.3.0
-edx-opaque-keys[django]==2.0.0
-edx-rbac==1.0.3
+edx-opaque-keys[django]==2.0.1
+edx-rbac==1.0.5
 edx-rest-api-client==1.9.2
 edx-sphinx-theme==1.5.0
 enum34==1.1.6
 factory-boy==2.12.0
-faker==2.0.2
+faker==3.0.0
 filelock==3.0.12          # via tox
 freezegun==0.3.12
 funcsigs==1.0.2
-future==0.17.1
+future==0.18.2
 futures==3.3.0 ; python_version == "2.7"
 html5lib==1.0.1
 idna==2.8
-imagesize==1.1.0
-importlib-metadata==0.23
-inflect==2.1.0
-ipaddress==1.0.22
+imagesize==1.2.0
+importlib-metadata==1.3.0
+inflect==3.0.2
+ipaddress==1.0.23
 isort==4.3.21
 jinja2-pluralize==0.3.0
-jinja2==2.10.1
+jinja2==2.10.3
 jsondiff==1.1.1
 jsonfield==2.0.2
 kombu==3.0.37
-lazy-object-proxy==1.4.2  # via astroid
+lazy-object-proxy==1.4.3  # via astroid
 markupsafe==1.1.1
 mccabe==0.6.1             # via pylint
 mock==3.0.5
 more-itertools==5.0.0
-newrelic==5.0.2.126
+newrelic==5.4.1.134
 packaging==19.2
 path.py==8.2.1
-pathlib2==2.3.4
-pbr==5.4.3
-pillow==6.1.0
-pip-tools==4.1.0
+pathlib2==2.3.5
+pbr==5.4.4
+pillow==6.2.1
+pip-tools==4.3.0
 pkginfo==1.5.0.1          # via twine
-pluggy==0.13.0
-pockets==0.7.2
+pluggy==0.13.1
+pockets==0.9.1
 polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1
-py==1.8.0
+py==1.8.1
 pycodestyle==2.5.0
 pycparser==2.19
-pycryptodomex==3.9.0
+pycryptodomex==3.9.4
 pydocstyle==3.0.0
-pygments==2.4.2
+pygments==2.5.2
 pyjwkest==1.3.2
 pyjwt==1.5.2
 pylint-celery==0.3        # via edx-lint
 pylint-django==0.7.2      # via edx-lint
-pylint-plugin-utils==0.5  # via pylint-celery, pylint-django
+pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
 pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pymongo==2.9.1
-pyparsing==2.4.2
+pymongo==3.9.0
+pyparsing==2.4.6
 pytest-catchlog==1.2.2
-pytest-cov==2.7.1
-pytest-django==3.5.1
-pytest==4.6.5
+pytest-cov==2.8.1
+pytest-django==3.7.0
+pytest==4.6.8
 python-dateutil==2.4.0
-python-slugify==3.0.4
-pytz==2019.2
-pyyaml==5.1.2
+python-slugify==4.0.0
+pytz==2019.3
+pyyaml==5.2
 readme-renderer==24.0
 requests-toolbelt==0.9.1  # via twine
 requests==2.22.0
-responses==0.10.6
+responses==0.10.9
 rest-condition==1.0.3
 restructuredtext-lint==1.3.0
 rules==2.1
 scandir==1.10.0
-semantic-version==2.8.2
+semantic-version==2.8.4
 singledispatch==3.4.0.3   # via astroid, pylint
-six==1.12.0
+six==1.13.0
 slumber==0.7.1
-snowballstemmer==1.9.1
+snowballstemmer==2.0.0
 sphinx==1.8.5
 sphinxcontrib-napoleon==0.6.1
 sphinxcontrib-websupport==1.1.2
 stevedore==1.31.0
-testfixtures==6.10.0
+testfixtures==6.10.3
 text-unidecode==1.3
 toml==0.10.0              # via tox
 tox-battery==0.5.1
-tox==3.14.0
-tqdm==4.36.1              # via twine
+tox==3.14.3
+tqdm==4.41.0              # via twine
 twine==1.11.0
 typing==3.7.4.1
 unicodecsv==0.14.1
-urllib3==1.25.5
-virtualenv==16.7.5        # via tox
+urllib3==1.25.7
+virtualenv==16.7.9        # via tox
 wcwidth==0.1.7
 webencodings==0.5.1
 wheel==0.33.6
 wrapt==1.11.2             # via astroid
 zipp==0.6.0
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -9,86 +9,88 @@ alabaster==0.7.12         # via sphinx
 amqp==1.4.9               # via kombu
 aniso8601==8.0.0
 anyjson==0.3.3            # via kombu
-asn1crypto==0.24.0
 babel==2.7.0              # via sphinx
 billiard==3.3.0.23
 bleach==2.1.4
 celery==3.1.25
-certifi==2019.9.11
-cffi==1.12.3
+certifi==2019.11.28
+cffi==1.13.2
 chardet==3.0.4
 click==7.0
-code-annotations==0.3.2
-cryptography==2.7
+code-annotations==0.3.3
+cryptography==2.8
 defusedxml==0.5.0
-django-config-models==1.0.1
-django-countries==4.6.1
-django-crum==0.7.3
+django-config-models==1.0.3
+django-countries==5.5
+django-crum==0.7.5
 django-fernet-fields==0.6
 django-filter==1.0.4
 django-ipware==2.1.0
 django-model-utils==3.0.0
 django-multi-email-field==0.5.1
-django-object-actions==1.1.0
-django-simple-history==2.7.3
+django-object-actions==2.0.0
+django-simple-history==2.8.0
 django-waffle==0.12.0
-django==1.11.24
+django==1.11.27
 djangorestframework-jwt==1.11.0
 djangorestframework-xml==1.4.0
 djangorestframework==3.7.7
 doc8==0.8.0
 docutils==0.15.2
-edx-django-utils==2.0.0
-edx-drf-extensions==2.4.0
-edx-opaque-keys[django]==2.0.0
-edx-rbac==1.0.3
+edx-django-utils==2.0.2
+edx-drf-extensions==2.4.5
+edx-opaque-keys[django]==2.0.1
+edx-rbac==1.0.5
 edx-rest-api-client==1.9.2
 edx-sphinx-theme==1.5.0
 enum34==1.1.6
-future==0.17.1
+future==0.18.2
 html5lib==1.0.1
 idna==2.8
-imagesize==1.1.0          # via sphinx
-ipaddress==1.0.22
-jinja2==2.10.1
+imagesize==1.2.0          # via sphinx
+ipaddress==1.0.23
+jinja2==2.10.3
 jsondiff==1.1.1
 jsonfield==2.0.2
 kombu==3.0.37
 markupsafe==1.1.1         # via jinja2
-newrelic==5.0.2.126
+newrelic==5.4.1.134
 packaging==19.2           # via sphinx
 path.py==8.2.1
-pbr==5.4.3
-pillow==6.1.0
-pockets==0.7.2            # via sphinxcontrib-napoleon
+pbr==5.4.4
+pillow==6.2.1
+pockets==0.9.1            # via sphinxcontrib-napoleon
 psutil==1.2.1
 pycparser==2.19           # via cffi
-pycryptodomex==3.9.0      # via pyjwkest
-pygments==2.4.2           # via readme-renderer, sphinx
+pycryptodomex==3.9.4      # via pyjwkest
+pygments==2.5.2           # via readme-renderer, sphinx
 pyjwkest==1.3.2
 pyjwt==1.5.2
-pymongo==2.9.1
-pyparsing==2.4.2          # via packaging
+pymongo==3.9.0
+pyparsing==2.4.6          # via packaging
 python-dateutil==2.4.0
-python-slugify==3.0.4
-pytz==2019.2
-pyyaml==5.1.2
+python-slugify==4.0.0
+pytz==2019.3
+pyyaml==5.2
 readme-renderer==24.0
 requests==2.22.0
 rest-condition==1.0.3
 restructuredtext-lint==1.3.0  # via doc8
 rules==2.1
-semantic-version==2.8.2
-six==1.12.0
+semantic-version==2.8.4
+six==1.13.0
 slumber==0.7.1
-snowballstemmer==1.9.1    # via sphinx
+snowballstemmer==2.0.0    # via sphinx
 sphinx==1.8.5
 sphinxcontrib-napoleon==0.6.1
 sphinxcontrib-websupport==1.1.2  # via sphinx
 stevedore==1.31.0
-testfixtures==6.10.0
+testfixtures==6.10.3
 text-unidecode==1.3       # via python-slugify
 typing==3.7.4.1           # via sphinx
 unicodecsv==0.14.1
-urllib3==1.25.5
+urllib3==1.25.7
 webencodings==0.5.1       # via html5lib
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/edx-platform-constraints.txt
+++ b/requirements/edx-platform-constraints.txt
@@ -11,11 +11,9 @@ aniso8601==8.0.0          # via tincan
 anyjson==0.3.3            # via kombu
 appdirs==1.4.3            # via fs
 argh==0.26.2
-asn1crypto==0.24.0
-attrs==17.4.0
+attrs==19.3.0
 babel==1.3
-backports.functools-lru-cache==1.5  # via soupsieve
-beautifulsoup4==4.8.0     # via pynliner
+beautifulsoup4==4.8.2     # via pynliner
 billiard==3.3.0.23        # via celery
 bleach==2.1.4
 boto3==1.4.8
@@ -24,30 +22,30 @@ botocore==1.8.17
 git+https://github.com/edx/bridgekeeper.git@4e34894e4ac5d0467ed1901811a81fd87ee01937#egg=bridgekeeper==0.0
 git+https://github.com/edx/openedx-calc.git@e9b698c85ad1152002bc0868f475f153dce88952#egg=calc==0.4
 celery==3.1.25
-certifi==2019.9.11
-cffi==1.12.3
+certifi==2019.11.28
+cffi==1.13.2
 chardet==3.0.4
 git+https://github.com/edx/openedx-chem.git@ff4e3a03d3c7610e47a9af08eb648d8aabe2eb18#egg=chem==1.0.0
 click==7.0                # via code-annotations, user-util
-code-annotations==0.3.2   # via edx-enterprise
-contextlib2==0.6.0
+code-annotations==0.3.3   # via edx-enterprise
+contextlib2==0.6.0.post1
 coreapi==2.3.3            # via drf-yasg
 coreschema==0.0.4         # via coreapi, drf-yasg
 git+https://github.com/edx/crowdsourcehinter.git@a7ffc85b134b7d8909bf1fefd23dbdb8eb28e467#egg=crowdsourcehinter-xblock==0.2
-cryptography==2.7
+cryptography==2.8
 cssutils==1.0.2           # via pynliner
-ddt==1.2.1
-decorator==4.4.0          # via pycontracts
+ddt==1.2.2
+decorator==4.4.1          # via pycontracts
 defusedxml==0.5.0
 django-appconf==1.0.3     # via django-statici18n
 django-babel-underscore==0.5.2
 django-babel==0.6.2       # via django-babel-underscore
 git+https://github.com/edx/django-celery.git@756cb57aad765cb2b0d37372c1855b8f5f37e6b0#egg=django-celery==3.2.1+edx.2
 django-classy-tags==0.9.0  # via django-sekizai
-django-config-models==1.0.1
-django-cors-headers==2.1.0
-django-countries==4.6.1
-django-crum==0.7.3
+django-config-models==1.0.3
+django-cors-headers==2.5.3
+django-countries==5.5
+django-crum==0.7.5
 django-fernet-fields==0.6
 django-filter==1.0.4
 django-ipware==2.1.0
@@ -56,24 +54,24 @@ django-model-utils==3.0.0
 django-mptt==0.8.7
 django-multi-email-field==0.5.1  # via edx-enterprise
 django-mysql==2.4.1
-git+https://github.com/edx/django-oauth-plus.git@66155b545b23ebc01ec438849d303077e8198dfd#egg=django-oauth-plus==2.2.9.edx-3
+git+https://github.com/edx/django-oauth-plus.git@b9b64a3ac24fd11f471763c88462bbf3c53e46e6#egg=django-oauth-plus==2.2.9.edx-4
 django-oauth-toolkit==1.1.3
-django-object-actions==1.1.0  # via edx-enterprise
+django-object-actions==2.0.0  # via edx-enterprise
 django-pipeline==1.6.14
-django-pyfs==2.0
+django-pyfs==2.1
 django-ratelimit-backend==1.1.1
 django-ratelimit==2.0.0
 django-require==1.0.11
 django-sekizai==1.0.0
-django-ses==0.8.4
-django-simple-history==2.7.3
-django-splash==0.2.2
+django-ses==0.8.13
+django-simple-history==2.8.0
+django-splash==0.2.5
 django-statici18n==1.4.0
 django-storages==1.4.1
-django-user-tasks==0.2.0
+django-user-tasks==0.3.0
 django-waffle==0.12.0
 django-webpack-loader==0.6.0
-django==1.11.24
+django==1.11.27
 djangorestframework-jwt==1.11.0
 git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4bc70c03de308a277197c#egg=djangorestframework-oauth==1.1.1
 djangorestframework-xml==1.4.0  # via edx-enterprise
@@ -81,54 +79,52 @@ djangorestframework==3.7.7
 docopt==0.6.2
 docutils==0.15.2          # via botocore
 drf-yasg==1.16
-edx-ace==0.1.10
+edx-ace==0.1.13
 edx-analytics-data-api-client==0.15.3
-edx-bulk-grades==0.6.4
+edx-bulk-grades==0.6.6
 edx-ccx-keys==1.0.0
-edx-celeryutils==0.3.0
-edx-completion==2.0.0
+edx-celeryutils==0.3.1
+edx-completion==3.0.2
 edx-django-oauth2-provider==1.3.5
-edx-django-release-util==0.3.1
-edx-django-sites-extensions==2.3.1
-edx-django-utils==2.0.0
-edx-drf-extensions==2.4.0
-edx-enterprise==1.10.4
-edx-i18n-tools==0.4.8
-edx-milestones==0.2.3
+edx-django-release-util==0.3.2
+edx-django-sites-extensions==2.4.2
+edx-django-utils==2.0.2
+edx-drf-extensions==2.4.5
+edx-enterprise==2.0.34
+edx-i18n-tools==0.5.0
+edx-milestones==0.2.6
 edx-oauth2-provider==1.3.1
-edx-opaque-keys[django]==2.0.0
-edx-organizations==2.1.0
+edx-opaque-keys[django]==2.0.1
+edx-organizations==2.2.0
 edx-proctoring-proctortrack==1.0.5
-edx-proctoring==2.0.9
-edx-rbac==1.0.3           # via edx-enterprise
+edx-proctoring==2.2.2
+edx-rbac==1.0.5           # via edx-enterprise
 edx-rest-api-client==1.9.2
 edx-search==1.2.2
-git+https://github.com/mitodl/edx-sga.git@3828ba9e413080a81b907a3381e5ffa05e063f81#egg=edx-sga==0.8.3
-edx-submissions==3.0.1
+edx-sga==0.10.0
+edx-submissions==3.0.3
 edx-user-state-client==1.1.2
-edx-when==0.4
-edxval==1.1.27
+edx-when==0.5.2
+edxval==1.1.33
 elasticsearch==1.9.0      # via edx-search
-enum34==1.1.6
-event-tracking==0.2.9
+enum34==1.1.6             # via edxval
+event-tracking==0.3.0
 feedparser==5.1.3
 fs-s3fs==0.1.8
 fs==2.0.18
-funcsigs==1.0.2
-future==0.17.1            # via edx-celeryutils, edx-enterprise, pyjwkest
-futures==3.3.0 ; python_version == "2.7"  # via django-pipeline, python-swiftclient, s3transfer, xblock-utils
+future==0.18.2            # via django-ses, edx-celeryutils, edx-enterprise, pyjwkest
 geoip2==2.9.0
 glob2==0.7
-gunicorn==19.9.0
-help-tokens==1.0.4
+gunicorn==20.0.4
+help-tokens==1.0.5
 html5lib==1.0.1
-httplib2==0.13.1
+httplib2==0.15.0
 idna==2.8
 inflection==0.3.1         # via drf-yasg
-ipaddress==1.0.22
+ipaddress==1.0.23
 isodate==0.6.0            # via python3-saml
 itypes==1.1.0             # via coreapi
-jinja2==2.10.1            # via code-annotations, coreschema
+jinja2==2.10.3            # via code-annotations, coreschema
 jmespath==0.9.4           # via boto3, botocore
 jsondiff==1.1.1           # via edx-enterprise
 jsonfield==2.0.2
@@ -138,34 +134,33 @@ lazy==1.1
 lepl==5.1.3               # via rfc6266-parser
 libsass==0.10.0
 loremipsum==1.0.5
-git+https://github.com/edx/xblock-lti-consumer.git@v1.1.8#egg=lti_consumer-xblock==1.1.8
-lxml==3.8.0
+git+https://github.com/edx/xblock-lti-consumer.git@v1.2.3#egg=lti_consumer-xblock==1.2.3
+lxml==4.4.1
 mailsnake==1.6.4
 mako==1.0.2
 markdown==2.6.11
 markey==0.8               # via django-babel-underscore
 markupsafe==1.1.1
-maxminddb==1.4.1          # via geoip2
+maxminddb==1.5.2          # via geoip2
 mock==3.0.5
 git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a#egg=MongoDBProxy==0.1.0+edx.2
 mongoengine==0.10.0
 mpmath==1.1.0             # via sympy
-mysqlclient==1.4.4
-networkx==1.7
-newrelic==5.0.2.126
+mysqlclient==1.4.6
+newrelic==5.4.1.134
 nltk==3.4.5
-nodeenv==1.1.1
-numpy==1.16.5
+nodeenv==1.3.3
+numpy==1.18.0             # via scipy
 git+https://github.com/joestump/python-oauth2.git@b94f69b1ad195513547924e380d9265133e995fa#egg=oauth2
 oauthlib==2.1.0
-git+https://github.com/edx/edx-ora2.git@2.3.1#egg=ora2==2.3.1
+git+https://github.com/edx/edx-ora2.git@2.5.3#egg=ora2==2.5.3
 path.py==8.2.1
 pathtools==0.1.2
 paver==1.3.4
-pbr==5.4.3
-pdfminer.six==20181108
+pbr==5.4.4
+pdfminer.six==20191110
 piexif==1.0.2
-pillow==6.1.0
+pillow==6.2.1
 pkgconfig==1.5.1          # via xmlsec
 polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1
@@ -173,76 +168,73 @@ py2neo==3.1.2
 pycontracts==1.7.1
 pycountry==19.8.18
 pycparser==2.19
-pycryptodome==3.9.0       # via pdfminer.six
-pycryptodomex==3.4.7
-pygments==2.4.2
-pygraphviz==1.5
+pycryptodome==3.9.4       # via pdfminer.six
+pycryptodomex==3.9.4
+pygments==2.5.2
 pyjwkest==1.3.2
 pyjwt==1.5.2
-pymongo==2.9.1
+pymongo==3.9.0
 pynliner==0.8.0
 pyparsing==2.2.0          # via pycontracts
 pysrt==1.1.1
 python-dateutil==2.4.0
 python-levenshtein==0.12.0
 python-memcached==1.59
-python-openid==2.2.5 ; python_version == "2.7"  # via social-auth-core
-python-slugify==3.0.4     # via code-annotations
+python-slugify==4.0.0     # via code-annotations
 python-swiftclient==3.8.1
+python3-openid==3.1.0 ; python_version >= "3"
 python3-saml==1.5.0
-pytz==2019.2
+pytz==2019.3
 pyuca==1.1
-pyyaml==5.1.2
-recommender-xblock==1.4.4
+pyyaml==5.2
+random2==1.0.1
+recommender-xblock==1.4.5
 redis==2.10.6
-reportlab==3.5.26
 requests-oauthlib==1.1.0
 requests==2.22.0
 rest-condition==1.0.3
-rfc6266-parser==0.0.5.post2
-ruamel.ordereddict==0.4.14 ; python_version == "2.7"  # via ruamel.yaml
-ruamel.yaml.clib==0.1.2   # via ruamel.yaml
+rfc6266-parser==0.0.6
+ruamel.yaml.clib==0.2.0   # via ruamel.yaml
 ruamel.yaml==0.16.5       # via drf-yasg
 rules==2.1
 s3transfer==0.1.13        # via boto3
 sailthru-client==2.2.3
-scipy==1.2.1
-semantic-version==2.8.2   # via edx-drf-extensions
+scipy==1.4.1
+semantic-version==2.8.4   # via edx-drf-extensions
 shapely==1.6.4.post2
 shortuuid==0.5.0          # via edx-django-oauth2-provider
-simplejson==3.16.0        # via mailsnake, sailthru-client
-singledispatch==3.4.0.3
-six==1.12.0
+simplejson==3.17.0
+six==1.13.0
 slumber==0.7.1            # via edx-bulk-grades, edx-enterprise, edx-rest-api-client
-social-auth-app-django==2.1.0
-social-auth-core==1.7.0
+social-auth-app-django==3.1.0
+social-auth-core==3.2.0
 sorl-thumbnail==12.3
 sortedcontainers==2.1.0
-soupsieve==1.9.3          # via beautifulsoup4
+soupsieve==1.9.5          # via beautifulsoup4
 sqlparse==0.3.0
-staff-graded-xblock==0.5
+staff-graded-xblock==0.6
 stevedore==1.31.0
-super-csv==0.9.4
-sympy==1.4
-testfixtures==6.10.0      # via edx-enterprise
+super-csv==0.9.6
+sympy==1.5
+testfixtures==6.10.3      # via edx-enterprise
 text-unidecode==1.3       # via python-slugify
 tincan==0.0.5             # via edx-enterprise
 unicodecsv==0.14.1
-uritemplate==3.0.0        # via coreapi, drf-yasg
-urllib3==1.25.5
+uritemplate==3.0.1        # via coreapi, drf-yasg
+urllib3==1.25.7
 user-util==0.1.5
 voluptuous==0.11.7
 watchdog==0.9.0
-web-fragments==0.3.0
+web-fragments==0.3.1
 webencodings==0.5.1       # via html5lib
 webob==1.8.5              # via xblock
 wrapt==1.10.5
-git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.4#egg=xblock-drag-and-drop-v2==2.2.4
-git+https://github.com/open-craft/xblock-poll@add89e14558c30f3c8dc7431e5cd6536fff6d941#egg=xblock-poll==1.5.1
-xblock-utils==1.2.2
-xblock==1.2.5
+git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.6#egg=xblock-drag-and-drop-v2==2.2.6
+git+https://github.com/open-craft/xblock-poll@3c7dcaf6c933d914188f0740a60711603f948d26#egg=xblock-poll==1.9.1
+xblock-utils==1.2.3
+xblock==1.2.9
 xmlsec==1.3.3             # via python3-saml
-xss-utils==0.1.1
+xss-utils==0.1.2
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.2.0        # via fs, lazy, python-levenshtein
+# setuptools

--- a/requirements/js_test.txt
+++ b/requirements/js_test.txt
@@ -5,22 +5,25 @@
 #    make upgrade
 #
 argparse==1.4.0           # via jasmine
-backports.functools-lru-cache==1.5  # via cheroot, jaraco.functools
-cheroot==6.5.8            # via cherrypy
+backports.functools-lru-cache==1.6.1  # via cheroot, jaraco.functools
+cheroot==8.2.1            # via cherrypy
 cherrypy==17.3.0
-contextlib2==0.6.0        # via cherrypy
+contextlib2==0.6.0.post1  # via cherrypy
 glob2==0.7                # via jasmine-core
-jaraco.functools==2.0     # via tempora
+jaraco.functools==2.0     # via cheroot, tempora
 jasmine-core==2.99.1      # via jasmine
 jasmine==2.9.0
-jinja2==2.10.1            # via jasmine
+jinja2==2.10.3            # via jasmine
 markupsafe==1.1.1         # via jinja2
 more-itertools==5.0.0     # via cheroot, cherrypy, jaraco.functools
 ordereddict==1.1          # via jasmine-core
-portend==2.5              # via cherrypy
-pytz==2019.2              # via tempora
+portend==2.6              # via cherrypy
+pytz==2019.3              # via tempora
 pyyaml==3.10              # via jasmine
 selenium==3.6.0           # via jasmine
-six==1.12.0               # via cheroot, cherrypy, jasmine, more-itertools, tempora
+six==1.13.0               # via cheroot, cherrypy, jasmine, more-itertools, tempora
 tempora==1.14.1           # via portend
 zc.lockfile==2.0          # via cherrypy
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -6,65 +6,64 @@
 #
 -e git+https://github.com/edx/TinCanPython.git@0.0.5.py.35#egg=tincan==0.0.5.py.35
 aniso8601==8.0.0
-asn1crypto==0.24.0        # via cryptography
 billiard==3.3.0.23        # via celery
 bleach==2.1.4
 celery==3.1.25
-certifi==2019.9.11        # via requests
-cffi==1.12.3              # via cryptography
+certifi==2019.11.28       # via requests
+cffi==1.13.2              # via cryptography
 chardet==3.0.4            # via requests
 click==7.0                # via code-annotations
-code-annotations==0.3.2
-cryptography==2.7
+code-annotations==0.3.3
+cryptography==2.8
 defusedxml==0.5.0         # via djangorestframework-xml
-django-config-models==1.0.1
-django-countries==4.6.1
-django-crum==0.7.3
+django-config-models==1.0.3
+django-countries==5.5
+django-crum==0.7.5
 django-fernet-fields==0.6
 django-filter==1.0.4
 django-ipware==2.1.0
 django-model-utils==3.0.0
 django-multi-email-field==0.5.1
-django-object-actions==1.1.0
-django-simple-history==2.7.3
+django-object-actions==2.0.0
+django-simple-history==2.8.0
 django-waffle==0.12.0
-django==1.11.24
+django==1.11.27
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework-xml==1.4.0
 djangorestframework==3.7.7
-edx-django-utils==2.0.0
-edx-drf-extensions==2.4.0
-edx-opaque-keys[django]==2.0.0
-edx-rbac==1.0.3
+edx-django-utils==2.0.2
+edx-drf-extensions==2.4.5
+edx-opaque-keys[django]==2.0.1
+edx-rbac==1.0.5
 edx-rest-api-client==1.9.2
 enum34==1.1.6             # via cryptography
-future==0.17.1
+future==0.18.2
 html5lib==1.0.1           # via bleach
 idna==2.8                 # via requests
-ipaddress==1.0.22         # via cryptography
-jinja2==2.10.1            # via code-annotations
+ipaddress==1.0.23         # via cryptography
+jinja2==2.10.3            # via code-annotations
 jsondiff==1.1.1
 jsonfield==2.0.2
 kombu==3.0.37             # via celery
-newrelic==5.0.2.126       # via edx-django-utils
+newrelic==5.4.1.134       # via edx-django-utils
 path.py==8.2.1
-pbr==5.4.3                # via stevedore
-pillow==6.1.0
+pbr==5.4.4                # via stevedore
+pillow==6.2.1
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 pyjwkest==1.3.2           # via edx-drf-extensions
 pyjwt==1.5.2              # via edx-rest-api-client
-pymongo==2.9.1            # via edx-opaque-keys
+pymongo==3.9.0            # via edx-opaque-keys
 python-dateutil==2.4.0
-python-slugify==3.0.4     # via code-annotations
-pytz==2019.2
-pyyaml==5.1.2             # via code-annotations
+python-slugify==4.0.0     # via code-annotations
+pytz==2019.3
+pyyaml==5.2               # via code-annotations
 requests==2.22.0
 rest-condition==1.0.3     # via edx-drf-extensions
 rules==2.1
-semantic-version==2.8.2   # via edx-drf-extensions
-six==1.12.0
+semantic-version==2.8.4   # via edx-drf-extensions
+six==1.13.0
 slumber==0.7.1
 stevedore==1.31.0
-testfixtures==6.10.0
+testfixtures==6.10.3
 unicodecsv==0.14.1
-urllib3==1.25.5           # via requests
+urllib3==1.25.7           # via requests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,101 +8,100 @@
 amqp==1.4.9               # via kombu
 aniso8601==8.0.0
 anyjson==0.3.3            # via kombu
-asn1crypto==0.24.0
 atomicwrites==1.3.0       # via pytest
-attrs==19.1.0             # via pytest
+attrs==19.3.0             # via pytest
 billiard==3.3.0.23
 bleach==2.1.4
 celery==3.1.25
-certifi==2019.9.11
-cffi==1.12.3
+certifi==2019.11.28
+cffi==1.13.2
 chardet==3.0.4
 click==7.0
-code-annotations==0.3.2
+code-annotations==0.3.3
 configparser==4.0.2       # via importlib-metadata
-contextlib2==0.6.0        # via importlib-metadata
+contextlib2==0.6.0.post1  # via importlib-metadata
 cookies==2.2.1            # via responses
-coverage==4.5.4           # via pytest-cov
-cryptography==2.7
-ddt==1.2.1
+coverage==5.0.1           # via pytest-cov
+cryptography==2.8
+ddt==1.2.2
 defusedxml==0.5.0
-diff-cover==2.3.0
-django-config-models==1.0.1
-django-countries==4.6.1
-django-crum==0.7.3
+diff-cover==2.5.0
+django-config-models==1.0.3
+django-countries==5.5
+django-crum==0.7.5
 django-fernet-fields==0.6
 django-filter==1.0.4
 django-ipware==2.1.0
 django-model-utils==3.0.0
 django-multi-email-field==0.5.1
-django-object-actions==1.1.0
-django-simple-history==2.7.3
+django-object-actions==2.0.0
+django-simple-history==2.8.0
 django-waffle==0.12.0
-django==1.11.24
+django==1.11.27
 djangorestframework-jwt==1.11.0
 djangorestframework-xml==1.4.0
 djangorestframework==3.7.7
-edx-django-utils==2.0.0
-edx-drf-extensions==2.4.0
-edx-opaque-keys[django]==2.0.0
-edx-rbac==1.0.3
+edx-django-utils==2.0.2
+edx-drf-extensions==2.4.5
+edx-opaque-keys[django]==2.0.1
+edx-rbac==1.0.5
 edx-rest-api-client==1.9.2
 enum34==1.1.6
 factory-boy==2.12.0
-faker==2.0.2              # via factory-boy
+faker==3.0.0              # via factory-boy
 freezegun==0.3.12
 funcsigs==1.0.2           # via mock, pytest
-future==0.17.1
+future==0.18.2
 html5lib==1.0.1
 idna==2.8
-importlib-metadata==0.23  # via pluggy, pytest
-inflect==2.1.0            # via jinja2-pluralize
-ipaddress==1.0.22
+importlib-metadata==1.3.0  # via inflect, pluggy, pytest
+inflect==3.0.2            # via jinja2-pluralize
+ipaddress==1.0.23
 jinja2-pluralize==0.3.0   # via diff-cover
-jinja2==2.10.1
+jinja2==2.10.3
 jsondiff==1.1.1
 jsonfield==2.0.2
 kombu==3.0.37
 markupsafe==1.1.1         # via jinja2
 mock==3.0.5
 more-itertools==5.0.0     # via pytest, zipp
-newrelic==5.0.2.126
+newrelic==5.4.1.134
 packaging==19.2           # via pytest
 path.py==8.2.1
-pathlib2==2.3.4           # via importlib-metadata, pytest, pytest-django
-pbr==5.4.3
-pillow==6.1.0
-pluggy==0.13.0            # via pytest
+pathlib2==2.3.5           # via importlib-metadata, pytest, pytest-django
+pbr==5.4.4
+pillow==6.2.1
+pluggy==0.13.1            # via diff-cover, pytest
 psutil==1.2.1
-py==1.8.0                 # via pytest, pytest-catchlog
+py==1.8.1                 # via pytest, pytest-catchlog
 pycparser==2.19           # via cffi
-pycryptodomex==3.9.0      # via pyjwkest
-pygments==2.4.2           # via diff-cover
+pycryptodomex==3.9.4      # via pyjwkest
+pygments==2.5.2           # via diff-cover
 pyjwkest==1.3.2
 pyjwt==1.5.2
-pymongo==2.9.1
-pyparsing==2.4.2          # via packaging
+pymongo==3.9.0
+pyparsing==2.4.6          # via packaging
 pytest-catchlog==1.2.2
-pytest-cov==2.7.1
-pytest-django==3.5.1
-pytest==4.6.5             # via pytest-catchlog, pytest-cov, pytest-django
+pytest-cov==2.8.1
+pytest-django==3.7.0
+pytest==4.6.8             # via pytest-catchlog, pytest-cov, pytest-django
 python-dateutil==2.4.0
-python-slugify==3.0.4
-pytz==2019.2
-pyyaml==5.1.2
+python-slugify==4.0.0
+pytz==2019.3
+pyyaml==5.2
 requests==2.22.0
-responses==0.10.6
+responses==0.10.9
 rest-condition==1.0.3
 rules==2.1
 scandir==1.10.0           # via pathlib2
-semantic-version==2.8.2
-six==1.12.0
+semantic-version==2.8.4
+six==1.13.0
 slumber==0.7.1
 stevedore==1.31.0
-testfixtures==6.10.0
+testfixtures==6.10.3
 text-unidecode==1.3       # via faker, python-slugify
 unicodecsv==0.14.1
-urllib3==1.25.5
+urllib3==1.25.7
 wcwidth==0.1.7            # via pytest
 webencodings==0.5.1       # via html5lib
 zipp==0.6.0               # via importlib-metadata

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -4,27 +4,27 @@
 #
 #    make upgrade
 #
-certifi==2019.9.11        # via requests
+certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
 codecov==2.0.15
 configparser==4.0.2       # via importlib-metadata
-contextlib2==0.6.0        # via importlib-metadata
-coverage==4.5.4           # via codecov
+contextlib2==0.6.0.post1  # via importlib-metadata
+coverage==5.0.1           # via codecov
 filelock==3.0.12          # via tox
 idna==2.8                 # via requests
-importlib-metadata==0.23  # via pluggy, tox
+importlib-metadata==1.3.0  # via pluggy, tox
 more-itertools==5.0.0     # via zipp
 packaging==19.2           # via tox
-pathlib2==2.3.4           # via importlib-metadata
-pluggy==0.13.0            # via tox
-py==1.8.0                 # via tox
-pyparsing==2.4.2          # via packaging
+pathlib2==2.3.5           # via importlib-metadata
+pluggy==0.13.1            # via tox
+py==1.8.1                 # via tox
+pyparsing==2.4.6          # via packaging
 requests==2.22.0          # via codecov
 scandir==1.10.0           # via pathlib2
-six==1.12.0               # via more-itertools, packaging, pathlib2, tox
+six==1.13.0               # via more-itertools, packaging, pathlib2, tox
 toml==0.10.0              # via tox
 tox-battery==0.5.1
-tox==3.14.0
-urllib3==1.25.6           # via requests
-virtualenv==16.7.5        # via tox
+tox==3.14.3
+urllib3==1.25.7           # via requests
+virtualenv==16.7.9        # via tox
 zipp==0.6.0               # via importlib-metadata


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
