### PR TITLE
Use Tincan PYPI package insteade of git download

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,11 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+[2.0.36] - 2019-12-30
+---------------------
+
+* Use `edx-tincan-py35` PYPI package instead of downloading via git
+
 [2.0.35] - 2019-12-30
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "2.0.35"
+__version__ = "2.0.36"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,9 +1,6 @@
 #
 # This file contains the dependencies explicitly needed for this library.
 #
-
--e git+https://github.com/edx/TinCanPython.git@0.0.5.py.35#egg=tincan==0.0.5.py.35
-
 # Packages directly used by this library that we do not need pinned to a specific version.
 bleach
 celery
@@ -27,6 +24,7 @@ edx-django-utils
 edx-drf-extensions
 edx-opaque-keys[django]
 edx-rest-api-client
+edx-tincan-py35
 edx-rbac
 future
 jsondiff

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,6 @@
 #
 #    make upgrade
 #
--e git+https://github.com/edx/TinCanPython.git@0.0.5.py.35#egg=tincan==0.0.5.py.35
 alabaster==0.7.12
 amqp==1.4.9
 aniso8601==8.0.0
@@ -59,6 +58,7 @@ edx-opaque-keys[django]==2.0.1
 edx-rbac==1.0.5
 edx-rest-api-client==1.9.2
 edx-sphinx-theme==1.5.0
+edx-tincan-py35==0.0.5
 enum34==1.1.6
 factory-boy==2.12.0
 faker==3.0.0

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -4,7 +4,6 @@
 #
 #    make upgrade
 #
--e git+https://github.com/edx/TinCanPython.git@0.0.5.py.35#egg=tincan==0.0.5.py.35
 alabaster==0.7.12         # via sphinx
 amqp==1.4.9               # via kombu
 aniso8601==8.0.0
@@ -43,6 +42,7 @@ edx-opaque-keys[django]==2.0.1
 edx-rbac==1.0.5
 edx-rest-api-client==1.9.2
 edx-sphinx-theme==1.5.0
+edx-tincan-py35==0.0.5
 enum34==1.1.6
 future==0.18.2
 html5lib==1.0.1

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -4,7 +4,6 @@
 #
 #    make upgrade
 #
--e git+https://github.com/edx/TinCanPython.git@0.0.5.py.35#egg=tincan==0.0.5.py.35
 aniso8601==8.0.0
 billiard==3.3.0.23        # via celery
 bleach==2.1.4
@@ -36,6 +35,7 @@ edx-drf-extensions==2.4.5
 edx-opaque-keys[django]==2.0.1
 edx-rbac==1.0.5
 edx-rest-api-client==1.9.2
+edx-tincan-py35==0.0.5
 enum34==1.1.6             # via cryptography
 future==0.18.2
 html5lib==1.0.1           # via bleach

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,7 +4,6 @@
 #
 #    make upgrade
 #
--e git+https://github.com/edx/TinCanPython.git@0.0.5.py.35#egg=tincan==0.0.5.py.35
 amqp==1.4.9               # via kombu
 aniso8601==8.0.0
 anyjson==0.3.3            # via kombu
@@ -46,6 +45,7 @@ edx-drf-extensions==2.4.5
 edx-opaque-keys[django]==2.0.1
 edx-rbac==1.0.5
 edx-rest-api-client==1.9.2
+edx-tincan-py35==0.0.5
 enum34==1.1.6
 factory-boy==2.12.0
 faker==3.0.0              # via factory-boy


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
