### PR TITLE
added logging of discovery request size

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,11 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+[2.0.37] - 2020-01-02
+---------------------
+
+* Added logging of response size when requests are made to discovery service for data not in cache
+
 [2.0.36] - 2019-12-30
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "2.0.36"
+__version__ = "2.0.37"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api_client/discovery.py
+++ b/enterprise/api_client/discovery.py
@@ -165,6 +165,10 @@ class CourseCatalogApiClient(object):
                     query_params,
                     traverse_pagination
                 )
+                LOGGER.info(
+                    'ENT-2489 | Response has size %d',
+                    len(response)
+                )
                 cache.set(cache_key, response, settings.ENTERPRISE_API_CACHE_TIMEOUT)
             else:
                 LOGGER.info(

--- a/enterprise/api_client/discovery.py
+++ b/enterprise/api_client/discovery.py
@@ -166,7 +166,8 @@ class CourseCatalogApiClient(object):
                     traverse_pagination
                 )
                 LOGGER.info(
-                    'ENT-2489 | Response has size %d',
+                    'ENT-2489 | Response from content_filter_query %s has size %d',
+                    content_filter_query,
                     len(response)
                 )
                 cache.set(cache_key, response, settings.ENTERPRISE_API_CACHE_TIMEOUT)


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
