### PR TITLE
ENT-2464: Added management command to reset SAPSF completion data

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,11 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+[2.0.49] - 2020-01-15
+---------------------
+
+* Added management command to reset SAPSF completion data.
+
 [2.0.48] - 2020-01-14
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "2.0.48"
+__version__ = "2.0.49"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/integrated_channel/management/commands/reset_sapsf_learner_transmissions.py
+++ b/integrated_channels/integrated_channel/management/commands/reset_sapsf_learner_transmissions.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+"""
+Reset SAPSF learner transmissions between two dates.
+"""
+from __future__ import absolute_import, unicode_literals
+
+from django.apps import apps
+from django.core.management.base import BaseCommand
+from django.utils.dateparse import parse_datetime
+from django.utils.translation import ugettext as _
+
+
+class Command(BaseCommand):
+    """
+    Management command which resets SAPSF learner course completion data between two dates.
+    That would allow us to resend course completion data.
+
+    `./manage.py lms reset_sapsf_learner_transmissions
+    --start_datetime=2020-01-14T00:00:00Z --end_datetime=2020-01-14T15:11:00Z`
+    """
+    help = _('''
+    Reset SAPSF learner transmissions for the given EnterpriseCustomer and Channel between two dates.
+    ''')
+
+    def add_arguments(self, parser):
+        """
+        Add required --start_datetime and --end_datetime arguments to the parser.
+        """
+        parser.add_argument(
+            '--start_datetime',
+            dest='start_datetime',
+            required=True,
+            help=_('Start date and time in YYYY-MM-DDTHH:MM:SSZ format.'),
+        )
+
+        parser.add_argument(
+            '--end_datetime',
+            dest='end_datetime',
+            required=True,
+            help=_('End date and time in YYYY-MM-DDTHH:MM:SSZ format.'),
+        )
+
+        super(Command, self).add_arguments(parser)
+
+    def handle(self, *args, **options):
+        """
+        Resets SAPSF learner course completion data between two dates.
+        """
+        start_datetime = parse_datetime(options['start_datetime'])
+        end_datetime = parse_datetime(options['end_datetime'])
+
+        if not start_datetime or not end_datetime:
+            self.stdout.write(self.style.ERROR("FAILED: start or end dates times are not valid"))
+            return
+
+        SapSuccessFactorsLearnerDataTransmissionAudit = apps.get_model(  # pylint: disable=invalid-name
+            'sap_success_factors',
+            'SapSuccessFactorsLearnerDataTransmissionAudit'
+        )
+        enrollment_ids = SapSuccessFactorsLearnerDataTransmissionAudit.objects.filter(
+            created__gte=start_datetime, created__lte=end_datetime
+        ).values_list('enterprise_course_enrollment_id', flat=True)
+
+        for enrollment_id in enrollment_ids:
+            SapSuccessFactorsLearnerDataTransmissionAudit.objects.filter(
+                enterprise_course_enrollment_id=enrollment_id,
+                error_message=''
+            ).update(error_message='Invalid data sent', status='400')
+            self.stdout.write(
+                self.style.SUCCESS('Successfully updated transmissions with these enrollment id ["%s"]' % enrollment_id)
+            )


### PR DESCRIPTION
Added management command to reset SAPSF completion data.
It would allow us resend those completion enteries which are reset.
ENT-2464

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
