### PR TITLE
soft delete enterprisecustomeruser records

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,11 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+[2.3.0] - 2020-01-29
+--------------------
+
+* Add soft deletion support for EnterpriseCustomerUser model
+
 [2.2.0] - 2020-01-28
 --------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "2.2.0"
+__version__ = "2.3.0"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/test_utils/factories.py
+++ b/test_utils/factories.py
@@ -114,6 +114,7 @@ class EnterpriseCustomerUserFactory(factory.django.DjangoModelFactory):
     enterprise_customer = factory.SubFactory(EnterpriseCustomerFactory)
     user_id = factory.LazyAttribute(lambda x: FAKER.pyint())
     active = True
+    linked = True
 
 
 class PendingEnterpriseCustomerUserFactory(factory.django.DjangoModelFactory):


### PR DESCRIPTION
**Description:** Currently whenever we unlink an Enterprise Learner from an Enterprise, all the Enterprise Course Enrollments for the learner gets deleted due to `CASCADING`. To avoid this we have added soft deletion for `EnterpriseCustomerUser` records. The behaviour will remain same and get queryset methods will not return a soft deleted `EnterpriseCustomerUser` record and its related `EnterpriseCourseEnrollment` records but all the creation methods like `get_or_create/update_or_create/create` will always return an `EnterpriseCustomerUser` record either by creating a new object in database or by updating an existing soft-deleted object.

**JIRA:** https://openedx.atlassian.net/browse/ENT-2538

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
