### PR TITLE
initialize enrollmentapi client with service user

### DIFF
--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -49,6 +49,7 @@ from enterprise.utils import (
     NotConnectedToOpenEdX,
     get_configuration_value,
     get_ecommerce_worker_user,
+    get_enterprise_worker_user,
 )
 from enterprise.validators import validate_image_extension, validate_image_size
 
@@ -734,7 +735,8 @@ class EnterpriseCustomerUser(TimeStampedModel):
         """
         Enroll a user into a course track, and register an enterprise course enrollment.
         """
-        enrollment_api_client = EnrollmentApiClient(self.user)
+        worker_user = get_enterprise_worker_user()
+        enrollment_api_client = EnrollmentApiClient(worker_user)
         # Check to see if the user's already enrolled and we have an enterprise course enrollment to track it.
         course_enrollment = enrollment_api_client.get_course_enrollment(self.username, course_run_id) or {}
         enrolled_in_course = course_enrollment and course_enrollment.get('is_active', False)
@@ -797,7 +799,8 @@ class EnterpriseCustomerUser(TimeStampedModel):
         """
         Unenroll a user from a course track.
         """
-        enrollment_api_client = EnrollmentApiClient(self.user)
+        worker_user = get_enterprise_worker_user()
+        enrollment_api_client = EnrollmentApiClient(worker_user)
         if enrollment_api_client.unenroll_user_from_course(self.username, course_run_id):
             EnterpriseCourseEnrollment.objects.filter(enterprise_customer_user=self, course_id=course_run_id).delete()
             return True

--- a/tests/test_admin/test_view.py
+++ b/tests/test_admin/test_view.py
@@ -157,7 +157,7 @@ class BaseTestEnterpriseCustomerManageLearnersView(TestCase):
         """
         super(BaseTestEnterpriseCustomerManageLearnersView, self).setUp()
         self.user = UserFactory.create(is_staff=True, is_active=True, id=1)
-        self.worker_user = UserFactory.create(
+        self.worker_user = UserFactory(
             username=settings.ENTERPRISE_SERVICE_WORKER_USERNAME, is_staff=True, is_active=True
         )
         self.user.set_password("QWERTY")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -15,6 +15,7 @@ from opaque_keys.edx.keys import CourseKey
 from pytest import mark, raises
 from testfixtures import LogCapture
 
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.files import File
 from django.core.files.storage import Storage
@@ -357,6 +358,15 @@ class TestEnterpriseCustomerUser(unittest.TestCase):
     Tests of the EnterpriseCustomerUser model.
     """
 
+    def setUp(self):
+        """
+        Test set up
+        """
+        super(TestEnterpriseCustomerUser, self).setUp()
+        self.worker_user = factories.UserFactory(
+            username=settings.ENTERPRISE_SERVICE_WORKER_USERNAME, is_staff=True, is_active=True
+        )
+
     @ddt.data(str, repr)
     def test_string_conversion(self, method):
         """
@@ -425,7 +435,7 @@ class TestEnterpriseCustomerUser(unittest.TestCase):
             assert mock_third_party_api.return_value.get_remote_id.call_count == 0
 
     @mock.patch('enterprise.utils.segment')
-    @mock.patch('enterprise.models.EnrollmentApiClient')
+    @mock.patch('enterprise.models.EnrollmentApiClient', autospec=True)
     @mock.patch('enterprise.models.EnterpriseCustomerUser.create_order_for_enrollment')
     @ddt.data('audit', 'verified')
     def test_enroll_learner(self, course_mode, enrollment_order_mock, enrollment_api_client_mock, analytics_mock):
@@ -441,6 +451,18 @@ class TestEnterpriseCustomerUser(unittest.TestCase):
             enrollment_order_mock.assert_called_once()
         else:
             enrollment_order_mock.assert_not_called()
+
+        enrollment_api_client_mock.assert_called_once_with(self.worker_user)
+
+    @mock.patch('enterprise.models.EnrollmentApiClient', autospec=True)
+    def test_unenroll_client_user(self, enrollment_api_client_mock):
+        """
+        Verify that `EnrollmentApiClient` is created with correct user in `EnterpriseCustomerUser.unenroll`.
+        """
+        enterprise_customer_user = factories.EnterpriseCustomerUserFactory()
+        enterprise_customer_user.unenroll('course-v1:edX+DemoX+Demo_Course')
+        enrollment_api_client_mock.return_value.unenroll_user_from_course.assert_called_once()
+        enrollment_api_client_mock.assert_called_once_with(self.worker_user)
 
     @mock.patch('enterprise.models.EnrollmentApiClient')
     @mock.patch('enterprise.models.EnterpriseCustomerUser.create_order_for_enrollment')


### PR DESCRIPTION
**Description:** For enroll/unenroll, initialize the `EnrollmentApiClient` with servier user. 


**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
