### PR TITLE
ENT-2042: Replaced-EDX-API-KEY-in-remaining-endpoints of CourseApiClient

### DIFF
--- a/enterprise/admin/__init__.py
+++ b/enterprise/admin/__init__.py
@@ -393,8 +393,9 @@ class EnterpriseCustomerUserAdmin(admin.ModelAdmin):
         courses_details = []
         for course_id in course_ids:
             course_detail = courses_client.get_course_details(course_id)
-            name = course_detail.get('name')
-            courses_details.append({'course_id': course_id, 'course_name': name})
+            if course_detail:
+                name = course_detail.get('name')
+                courses_details.append({'course_id': course_id, 'course_name': name})
         template = '<a href="{url}">{course_name}</a>'
         joiner = '<br/>'
         return joiner.join(

--- a/tests/test_enterprise/api_client/test_lms.py
+++ b/tests/test_enterprise/api_client/test_lms.py
@@ -19,6 +19,7 @@ from enterprise.utils import NotConnectedToOpenEdX
 URL_BASE_NAMES = {
     'enrollment': lms_api.EnrollmentApiClient,
     'courses': lms_api.CourseApiClient,
+    'courses_jwt': lms_api.CourseApiClientJwt,
     'third_party_auth': lms_api.ThirdPartyAuthApiClient,
     'third_party_auth_jwt': lms_api.ThirdPartyAuthApiClientJwt,
     'course_grades': lms_api.GradesApiClient,
@@ -398,6 +399,7 @@ def test_unenroll_already_unenrolled():
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_get_full_course_details():
     course_id = "course-v1:edX+DemoX+Demo_Course"
     expected_response = {
@@ -405,23 +407,24 @@ def test_get_full_course_details():
     }
     responses.add(
         responses.GET,
-        _url("courses", "courses/course-v1:edX+DemoX+Demo_Course/"),
+        _url("courses_jwt", "courses/course-v1:edX+DemoX+Demo_Course/"),
         json=expected_response,
     )
-    client = lms_api.CourseApiClient()
+    client = lms_api.CourseApiClientJwt('user-goes-here')
     actual_response = client.get_course_details(course_id)
     assert actual_response == expected_response
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_get_full_course_details_not_found():
     course_id = "course-v1:edX+DemoX+Demo_Course"
     responses.add(
         responses.GET,
-        _url("courses", "courses/course-v1:edX+DemoX+Demo_Course/"),
+        _url("courses_jwt", "courses/course-v1:edX+DemoX+Demo_Course/"),
         status=404,
     )
-    client = lms_api.CourseApiClient()
+    client = lms_api.CourseApiClientJwt('user-goes-here')
     actual_response = client.get_course_details(course_id)
     assert actual_response is None
 

--- a/tests/test_enterprise/views/test_grant_data_sharing_permissions.py
+++ b/tests/test_enterprise/views/test_grant_data_sharing_permissions.py
@@ -86,7 +86,7 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.CourseApiClient')
+    @mock.patch('enterprise.views.CourseApiClientJwt')
     @ddt.data(
         (False, True, None),
         (False, False, None),
@@ -202,7 +202,7 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
             assert response.context[key] == value  # pylint:disable=no-member
 
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.CourseApiClient')
+    @mock.patch('enterprise.views.CourseApiClientJwt')
     def test_get_course_specific_consent_improperly_configured_course_catalog(
             self,
             course_api_client_mock,
@@ -249,7 +249,7 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
             assert mock_render.call_args_list[0][1]['status'] == 404
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
-    @mock.patch('enterprise.views.CourseApiClient')
+    @mock.patch('enterprise.views.CourseApiClientJwt')
     def test_get_course_specific_consent_invalid_get_params(
             self,
             course_api_client_mock,
@@ -289,7 +289,7 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
         assert response.status_code == 404
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
-    @mock.patch('enterprise.views.CourseApiClient')
+    @mock.patch('enterprise.views.CourseApiClientJwt')
     def test_get_course_specific_consent_unauthenticated_user(
             self,
             course_api_client_mock,
@@ -332,7 +332,7 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
         )
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
-    @mock.patch('enterprise.views.CourseApiClient')
+    @mock.patch('enterprise.views.CourseApiClientJwt')
     def test_get_course_specific_consent_bad_api_response(
             self,
             course_api_client_mock,
@@ -366,7 +366,7 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
         assert response.status_code == 404
 
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.CourseApiClient')
+    @mock.patch('enterprise.views.CourseApiClientJwt')
     def test_get_course_specific_consent_not_needed(
             self,
             course_api_client_mock,
@@ -405,7 +405,7 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
         assert response.status_code == 404
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
-    @mock.patch('enterprise.views.CourseApiClient')
+    @mock.patch('enterprise.views.CourseApiClientJwt')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.reverse')
     @ddt.data(
@@ -469,7 +469,7 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
             assert dsc.granted is consent_provided
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
-    @mock.patch('enterprise.views.CourseApiClient')
+    @mock.patch('enterprise.views.CourseApiClientJwt')
     @mock.patch('enterprise.views.reverse')
     def test_post_course_specific_consent_no_user(
             self,
@@ -516,7 +516,7 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
         )
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
-    @mock.patch('enterprise.views.CourseApiClient')
+    @mock.patch('enterprise.views.CourseApiClientJwt')
     @mock.patch('enterprise.views.reverse')
     def test_post_course_specific_consent_bad_api_response(
             self,
@@ -910,7 +910,7 @@ class TestGrantDataSharingPermissionsWithDB(TestCase):
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    @mock.patch('enterprise.views.CourseApiClient')
+    @mock.patch('enterprise.views.CourseApiClientJwt')
     @mock.patch('enterprise.views.get_data_sharing_consent')
     @ddt.data(
         (False, True, True),


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
