### PR TITLE
ENT-2475 | Updating enterprise catalog migration command to accept in…

### DIFF
--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "2.1.5"
+__version__ = "2.1.6"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/management/commands/migrate_enterprise_catalogs.py
+++ b/enterprise/management/commands/migrate_enterprise_catalogs.py
@@ -31,10 +31,10 @@ class Command(BaseCommand):
             help=_('Username of a user authorized to access the Enterprise Catalog API.'),
         )
         parser.add_argument(
-            '--catalog_uuid',
-            dest='catalog_uuid',
-            metavar='ENT_CATALOG_UUID',
-            help=_('The specific uuid of an enterprise catalog to migrate.'),
+            '--catalog_uuids',
+            dest='catalog_uuids',
+            metavar='ENT_CATALOG_UUIDS',
+            help=_('Comma separated list of uuids of enterprise catalogs to migrate.'),
         )
         super(Command, self).add_arguments(parser)
 
@@ -47,9 +47,10 @@ class Command(BaseCommand):
 
         client = EnterpriseCatalogApiClient(user=user)
 
-        catalog_uuid = options.get('catalog_uuid')
-        if catalog_uuid:
-            queryset = EnterpriseCustomerCatalog.objects.filter(uuid=catalog_uuid)
+        catalog_uuids_string = options.get('catalog_uuids')
+        if catalog_uuids_string:
+            catalog_uuids_list = catalog_uuids_string.split(',')
+            queryset = EnterpriseCustomerCatalog.objects.filter(uuid__in=catalog_uuids_list)
         else:
             queryset = EnterpriseCustomerCatalog.objects.all()
 

--- a/enterprise/management/commands/migrate_enterprise_catalogs.py
+++ b/enterprise/management/commands/migrate_enterprise_catalogs.py
@@ -30,6 +30,12 @@ class Command(BaseCommand):
             metavar='LMS_API_USERNAME',
             help=_('Username of a user authorized to access the Enterprise Catalog API.'),
         )
+        parser.add_argument(
+            '--catalog_uuid',
+            dest='catalog_uuid',
+            metavar='ENT_CATALOG_UUID',
+            help=_('The specific uuid of an enterprise catalog to migrate.'),
+        )
         super(Command, self).add_arguments(parser)
 
     def handle(self, *args, **options):
@@ -40,7 +46,14 @@ class Command(BaseCommand):
             raise CommandError(_('A user with the username {username} was not found.').format(username=api_username))
 
         client = EnterpriseCatalogApiClient(user=user)
-        for enterprise_catalog in EnterpriseCustomerCatalog.objects.all():
+
+        catalog_uuid = options.get('catalog_uuid')
+        if catalog_uuid:
+            queryset = EnterpriseCustomerCatalog.objects.filter(uuid=catalog_uuid)
+        else:
+            queryset = EnterpriseCustomerCatalog.objects.all()
+
+        for enterprise_catalog in queryset:
             LOGGER.info('Migrating Enterprise Catalog {}'.format(enterprise_catalog.uuid))
             try:
                 client.create_enterprise_catalog(


### PR DESCRIPTION
…dividual catalog uuids

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
