### PR TITLE
Revert EnrollmentApiClient initialization with service worker user

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,13 +11,18 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+[2.1.6] - 2020-01-28
+--------------------
+
+* Revert Initialized EnrollmentApiClient with enterprise service worker user
+
 [2.1.5] - 2020-01-27
----------------------
+--------------------
 
 * Added totalHours field for successfactors export
 
 [2.1.4] - 2020-01-24
----------------------
+--------------------
 
 * add boolean field to track linked/unlinked EnterpriseCustomerUser records
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "2.1.5"
+__version__ = "2.1.6"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/admin/views.py
+++ b/enterprise/admin/views.py
@@ -53,7 +53,6 @@ from enterprise.models import (
 from enterprise.utils import (
     get_configuration_value_for_site,
     get_ecommerce_worker_user,
-    get_enterprise_worker_user,
     send_email_notification_message,
     track_enrollment,
 )
@@ -444,8 +443,7 @@ class EnterpriseCustomerManageLearnersView(View):
             enterprise_customer=enterprise_customer,
             user_id=user.id
         )
-        worker_user = get_enterprise_worker_user()
-        enrollment_client = EnrollmentApiClient(worker_user)
+        enrollment_client = EnrollmentApiClient(user)
         succeeded = True
         for course_id in course_ids:
             try:

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -49,7 +49,6 @@ from enterprise.utils import (
     NotConnectedToOpenEdX,
     get_configuration_value,
     get_ecommerce_worker_user,
-    get_enterprise_worker_user,
 )
 from enterprise.validators import validate_image_extension, validate_image_size
 
@@ -736,8 +735,7 @@ class EnterpriseCustomerUser(TimeStampedModel):
         """
         Enroll a user into a course track, and register an enterprise course enrollment.
         """
-        worker_user = get_enterprise_worker_user()
-        enrollment_api_client = EnrollmentApiClient(worker_user)
+        enrollment_api_client = EnrollmentApiClient(self.user)
         # Check to see if the user's already enrolled and we have an enterprise course enrollment to track it.
         course_enrollment = enrollment_api_client.get_course_enrollment(self.username, course_run_id) or {}
         enrolled_in_course = course_enrollment and course_enrollment.get('is_active', False)
@@ -800,8 +798,7 @@ class EnterpriseCustomerUser(TimeStampedModel):
         """
         Unenroll a user from a course track.
         """
-        worker_user = get_enterprise_worker_user()
-        enrollment_api_client = EnrollmentApiClient(worker_user)
+        enrollment_api_client = EnrollmentApiClient(self.user)
         if enrollment_api_client.unenroll_user_from_course(self.username, course_run_id):
             EnterpriseCourseEnrollment.objects.filter(enterprise_customer_user=self, course_id=course_run_id).delete()
             return True

--- a/tests/test_admin/test_view.py
+++ b/tests/test_admin/test_view.py
@@ -157,9 +157,6 @@ class BaseTestEnterpriseCustomerManageLearnersView(TestCase):
         """
         super(BaseTestEnterpriseCustomerManageLearnersView, self).setUp()
         self.user = UserFactory.create(is_staff=True, is_active=True, id=1)
-        self.worker_user = UserFactory(
-            username=settings.ENTERPRISE_SERVICE_WORKER_USERNAME, is_staff=True, is_active=True
-        )
         self.user.set_password("QWERTY")
         self.user.save()
         self.enterprise_customer = EnterpriseCustomerFactory()
@@ -637,7 +634,7 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
     @mock.patch("enterprise.admin.views.EcommerceApiClient")
     @mock.patch("enterprise.admin.views.track_enrollment")
     @mock.patch("enterprise.models.CourseCatalogApiClient")
-    @mock.patch("enterprise.admin.views.EnrollmentApiClient", autospec=True)
+    @mock.patch("enterprise.admin.views.EnrollmentApiClient")
     @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
     @ddt.data(
         (True, True),
@@ -683,9 +680,6 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
             ecommerce_api_client_mock.assert_not_called()
         else:
             ecommerce_api_client_mock.assert_called_once()
-        # Assert EnrollmentApiClient is initialized with enterprise worker user since enrollment API raise
-        # error if EnrollmentApiClient is initialized with same user who is going to be enrolled
-        views_client.assert_called_once_with(self.worker_user)
         views_instance.enroll_user_in_course.assert_called_once_with(
             user.username,
             course_id,


### PR DESCRIPTION
Revert EnrollmentApiClient should call enrollment API with enterprise service worker user

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
