### PR TITLE
ENT-2550 | capture enterprise customer info in manual enrollments

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,11 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+[2.3.1] - 2020-01-29
+---------------------
+
+* Updated calls to `manual enrollments api` to include enterprise customer info
+
 [2.3.0] - 2020-01-29
 --------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "2.3.0"
+__version__ = "2.3.1"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/admin/views.py
+++ b/enterprise/admin/views.py
@@ -829,6 +829,7 @@ class EnterpriseCustomerManageLearnersView(View):
             notify: Whether to notify (by email) the users that have been enrolled
         """
         pending_messages = []
+        succeeded = []
         paid_modes = ['verified', 'professional']
 
         if course_id:
@@ -883,7 +884,9 @@ class EnterpriseCustomerManageLearnersView(View):
             "email": success.email,
             "username": success.username,
             "course_run_key": course_id,
-            "discount_percentage": float(discount)
+            "discount_percentage": float(discount),
+            "enterprise_customer_name": enterprise_customer.name,
+            "enterprise_customer_uuid": str(enterprise_customer.uuid),
         } for success in succeeded]
         if mode in paid_modes:
             # Create an order to track the manual enrollments of non-pending accounts

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -887,6 +887,8 @@ class EnterpriseCustomerUser(TimeStampedModel):
                     'username': self.username,
                     'email': self.user_email,
                     'course_run_key': course_run_id,
+                    "enterprise_customer_name": self.enterprise_customer.name,
+                    "enterprise_customer_uuid": str(self.enterprise_customer.uuid),
                 }]
                 ecommerce_api_client.create_manual_enrollment_orders(course_enrollments)
         else:


### PR DESCRIPTION
update calls to manual enrollment api to include enterprise customer data

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
