### PR TITLE
Revert Edx-Api-Key-replacement-changes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,13 +11,18 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+[2.1.7] - 2020-01-28
+--------------------
+
+* Revert Edx-Api-Key-replacement-changes
+
 [2.1.5] - 2020-01-27
----------------------
+--------------------
 
 * Added totalHours field for successfactors export
 
 [2.1.4] - 2020-01-24
----------------------
+--------------------
 
 * add boolean field to track linked/unlinked EnterpriseCustomerUser records
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "2.1.6"
+__version__ = "2.1.7"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/admin/__init__.py
+++ b/enterprise/admin/__init__.py
@@ -370,7 +370,7 @@ class EnterpriseCustomerUserAdmin(admin.ModelAdmin):
             enterprise_customer_user: The instance of EnterpriseCustomerUser
                 being rendered with this admin form.
         """
-        enrollment_client = EnrollmentApiClient(enterprise_customer_user.user)
+        enrollment_client = EnrollmentApiClient()
         enrollments = enrollment_client.get_enrolled_courses(enterprise_customer_user.username)
         return [enrollment['course_details']['course_id'] for enrollment in enrollments]
 

--- a/enterprise/admin/forms.py
+++ b/enterprise/admin/forms.py
@@ -211,7 +211,7 @@ class ManageLearnersForm(forms.Form):
         if not course_id:
             return None
         try:
-            client = EnrollmentApiClient(self._user)
+            client = EnrollmentApiClient()
             return client.get_course_details(course_id)
         except (HttpClientError, HttpServerError):
             raise ValidationError(ValidationMessages.INVALID_COURSE_ID.format(course_id=course_id))

--- a/enterprise/admin/views.py
+++ b/enterprise/admin/views.py
@@ -53,7 +53,6 @@ from enterprise.models import (
 from enterprise.utils import (
     get_configuration_value_for_site,
     get_ecommerce_worker_user,
-    get_enterprise_worker_user,
     send_email_notification_message,
     track_enrollment,
 )
@@ -444,8 +443,7 @@ class EnterpriseCustomerManageLearnersView(View):
             enterprise_customer=enterprise_customer,
             user_id=user.id
         )
-        worker_user = get_enterprise_worker_user()
-        enrollment_client = EnrollmentApiClient(worker_user)
+        enrollment_client = EnrollmentApiClient()
         succeeded = True
         for course_id in course_ids:
             try:
@@ -491,7 +489,7 @@ class EnterpriseCustomerManageLearnersView(View):
             Boolean: Whether or not enrollment exists
 
         """
-        enrollment_client = EnrollmentApiClient(user)
+        enrollment_client = EnrollmentApiClient()
         try:
             enrollments = enrollment_client.get_course_enrollment(user.username, course_id)
             if enrollments and course_mode == enrollments.get('mode'):

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -41,7 +41,7 @@ from model_utils.models import TimeStampedModel
 from enterprise import utils
 from enterprise.api_client.discovery import CourseCatalogApiClient, get_course_catalog_api_service_client
 from enterprise.api_client.ecommerce import EcommerceApiClient
-from enterprise.api_client.lms import EnrollmentApiClient, ThirdPartyAuthApiClientJwt, parse_lms_api_datetime
+from enterprise.api_client.lms import EnrollmentApiClient, ThirdPartyAuthApiClient, parse_lms_api_datetime
 from enterprise.constants import ALL_ACCESS_CONTEXT, ENTERPRISE_OPERATOR_ROLE, json_serialized_course_modes
 from enterprise.utils import (
     CourseEnrollmentDowngradeError,
@@ -49,7 +49,6 @@ from enterprise.utils import (
     NotConnectedToOpenEdX,
     get_configuration_value,
     get_ecommerce_worker_user,
-    get_enterprise_worker_user,
 )
 from enterprise.validators import validate_image_extension, validate_image_size
 
@@ -728,7 +727,7 @@ class EnterpriseCustomerUser(TimeStampedModel):
         user = self.user
         identity_provider = self.enterprise_customer.identity_provider
         if user and identity_provider:
-            client = ThirdPartyAuthApiClientJwt(user)
+            client = ThirdPartyAuthApiClient()
             return client.get_remote_id(self.enterprise_customer.identity_provider, user.username)
         return None
 
@@ -736,8 +735,7 @@ class EnterpriseCustomerUser(TimeStampedModel):
         """
         Enroll a user into a course track, and register an enterprise course enrollment.
         """
-        worker_user = get_enterprise_worker_user()
-        enrollment_api_client = EnrollmentApiClient(worker_user)
+        enrollment_api_client = EnrollmentApiClient()
         # Check to see if the user's already enrolled and we have an enterprise course enrollment to track it.
         course_enrollment = enrollment_api_client.get_course_enrollment(self.username, course_run_id) or {}
         enrolled_in_course = course_enrollment and course_enrollment.get('is_active', False)
@@ -800,8 +798,7 @@ class EnterpriseCustomerUser(TimeStampedModel):
         """
         Unenroll a user from a course track.
         """
-        worker_user = get_enterprise_worker_user()
-        enrollment_api_client = EnrollmentApiClient(worker_user)
+        enrollment_api_client = EnrollmentApiClient()
         if enrollment_api_client.unenroll_user_from_course(self.username, course_run_id):
             EnterpriseCourseEnrollment.objects.filter(enterprise_customer_user=self, course_id=course_run_id).delete()
             return True
@@ -1203,7 +1200,7 @@ class EnterpriseCourseEnrollment(TimeStampedModel):
 
         :return: Whether the course enrollment mode is of an audit type.
         """
-        course_enrollment_api = EnrollmentApiClient(self.enterprise_customer_user.user)
+        course_enrollment_api = EnrollmentApiClient()
         course_enrollment = course_enrollment_api.get_course_enrollment(
             self.enterprise_customer_user.username,
             self.course_id

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -941,7 +941,7 @@ class HandleConsentEnrollment(View):
         if not enrollment_course_mode:
             return redirect(LMS_DASHBOARD_URL)
 
-        enrollment_api_client = EnrollmentApiClient(request.user)
+        enrollment_api_client = EnrollmentApiClient()
         course_modes = enrollment_api_client.get_course_modes(course_id)
 
         # Verify that the request user belongs to the enterprise against the
@@ -1051,7 +1051,7 @@ class CourseEnrollmentView(NonAtomicView):
         course modes returned using the EnterpriseCustomerCatalog's
         field "enabled_course_modes".
         """
-        modes = EnrollmentApiClient(request.user).get_course_modes(course_run_id)
+        modes = EnrollmentApiClient().get_course_modes(course_run_id)
         if not modes:
             LOGGER.warning('[Enterprise Enrollment] Unable to get course modes. '
                            'CourseRun: {course_run_id}'.format(course_run_id=course_run_id))
@@ -1394,7 +1394,7 @@ class CourseEnrollmentView(NonAtomicView):
                 )
                 track_enrollment('course-landing-page-enrollment', request.user.id, course_id, request.get_full_path())
 
-            client = EnrollmentApiClient(request.user)
+            client = EnrollmentApiClient()
             client.enroll_user_in_course(
                 request.user.username,
                 course_id,
@@ -1497,7 +1497,7 @@ class CourseEnrollmentView(NonAtomicView):
             enterprise_customer=enterprise_customer
         )
 
-        enrollment_client = EnrollmentApiClient(request.user)
+        enrollment_client = EnrollmentApiClient()
         enrolled_course = enrollment_client.get_course_enrollment(request.user.username, course_id)
         try:
             enterprise_course_enrollment = EnterpriseCourseEnrollment.objects.get(
@@ -1975,7 +1975,7 @@ class RouterView(NonAtomicView):
         except ImproperlyConfigured:
             raise Http404
 
-        users_all_enrolled_courses = EnrollmentApiClient(user).get_enrolled_courses(user.username)
+        users_all_enrolled_courses = EnrollmentApiClient().get_enrolled_courses(user.username)
         users_active_course_runs = get_active_course_runs(
             course,
             users_all_enrolled_courses
@@ -2004,7 +2004,7 @@ class RouterView(NonAtomicView):
         return request.GET.get('audit') and \
             request.path == self.COURSE_ENROLLMENT_VIEW_URL.format(enterprise_customer.uuid, course_identifier) and \
             enterprise_customer.catalog_contains_course(resource_id) and \
-            EnrollmentApiClient(request.user).has_course_mode(resource_id, 'audit')
+            EnrollmentApiClient().has_course_mode(resource_id, 'audit')
 
     def redirect(self, request, *args, **kwargs):
         """

--- a/integrated_channels/integrated_channel/exporters/learner_data.py
+++ b/integrated_channels/integrated_channel/exporters/learner_data.py
@@ -19,7 +19,7 @@ from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 
 from consent.models import DataSharingConsent
-from enterprise.api_client.lms import CertificatesApiClient, CourseApiClientJwt, GradesApiClient
+from enterprise.api_client.lms import CertificatesApiClient, CourseApiClient, GradesApiClient
 from enterprise.models import EnterpriseCourseEnrollment
 from integrated_channels.integrated_channel.exporters import Exporter
 from integrated_channels.utils import is_already_transmitted, parse_datetime_to_epoch_millis
@@ -142,7 +142,7 @@ class LearnerExporter(Exporter):
             # pylint: disable=unsubscriptable-object
             if course_details is None or course_details['course_id'] != course_id:
                 if self.course_api is None:
-                    self.course_api = CourseApiClientJwt(self.user)
+                    self.course_api = CourseApiClient()
                 course_details = self.course_api.get_course_details(course_id)
 
             if course_details is None:

--- a/tests/test_admin/test_view.py
+++ b/tests/test_admin/test_view.py
@@ -157,9 +157,6 @@ class BaseTestEnterpriseCustomerManageLearnersView(TestCase):
         """
         super(BaseTestEnterpriseCustomerManageLearnersView, self).setUp()
         self.user = UserFactory.create(is_staff=True, is_active=True, id=1)
-        self.worker_user = UserFactory(
-            username=settings.ENTERPRISE_SERVICE_WORKER_USERNAME, is_staff=True, is_active=True
-        )
         self.user.set_password("QWERTY")
         self.user.save()
         self.enterprise_customer = EnterpriseCustomerFactory()
@@ -637,7 +634,7 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
     @mock.patch("enterprise.admin.views.EcommerceApiClient")
     @mock.patch("enterprise.admin.views.track_enrollment")
     @mock.patch("enterprise.models.CourseCatalogApiClient")
-    @mock.patch("enterprise.admin.views.EnrollmentApiClient", autospec=True)
+    @mock.patch("enterprise.admin.views.EnrollmentApiClient")
     @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
     @ddt.data(
         (True, True),
@@ -683,9 +680,6 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
             ecommerce_api_client_mock.assert_not_called()
         else:
             ecommerce_api_client_mock.assert_called_once()
-        # Assert EnrollmentApiClient is initialized with enterprise worker user since enrollment API raise
-        # error if EnrollmentApiClient is initialized with same user who is going to be enrolled
-        views_client.assert_called_once_with(self.worker_user)
         views_instance.enroll_user_in_course.assert_called_once_with(
             user.username,
             course_id,

--- a/tests/test_integrated_channels/test_cornerstone/test_exporters/test_learner_data.py
+++ b/tests/test_integrated_channels/test_cornerstone/test_exporters/test_learner_data.py
@@ -141,7 +141,7 @@ class TestCornerstoneLearnerExporter(unittest.TestCase):
         responses.add(
             responses.GET,
             urljoin(
-                lms_api.CourseApiClientJwt.API_BASE_URL,
+                lms_api.CourseApiClient.API_BASE_URL,
                 "courses/{course}/".format(course=self.course_id)
             ),
             json={
@@ -202,7 +202,7 @@ class TestCornerstoneLearnerExporter(unittest.TestCase):
         responses.add(
             responses.GET,
             urljoin(
-                lms_api.CourseApiClientJwt.API_BASE_URL,
+                lms_api.CourseApiClient.API_BASE_URL,
                 "courses/{course}/".format(course=course_id)
             ),
             json={

--- a/tests/test_integrated_channels/test_degreed/test_exporters/test_learner_data.py
+++ b/tests/test_integrated_channels/test_degreed/test_exporters/test_learner_data.py
@@ -52,7 +52,7 @@ class TestDegreedLearnerExporter(unittest.TestCase):
         self.idp = factories.EnterpriseCustomerIdentityProviderFactory(
             enterprise_customer=self.enterprise_customer
         )
-        tpa_client_mock = mock.patch('enterprise.models.ThirdPartyAuthApiClientJwt')
+        tpa_client_mock = mock.patch('enterprise.models.ThirdPartyAuthApiClient')
         self.tpa_client = tpa_client_mock.start()
         self.tpa_client.return_value.get_remote_id.return_value = 'fake-remote-id'
         self.addCleanup(tpa_client_mock.stop)

--- a/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_learner_data.py
+++ b/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_learner_data.py
@@ -60,7 +60,7 @@ class TestLearnerExporter(unittest.TestCase):
         self.idp = factories.EnterpriseCustomerIdentityProviderFactory(
             enterprise_customer=self.enterprise_customer
         )
-        tpa_client_mock = mock.patch('enterprise.models.ThirdPartyAuthApiClientJwt')
+        tpa_client_mock = mock.patch('enterprise.models.ThirdPartyAuthApiClient')
         self.tpa_client = tpa_client_mock.start().return_value
         # Default remote ID
         self.tpa_client.get_remote_id.return_value = 'fake-remote-id'
@@ -106,7 +106,7 @@ class TestLearnerExporter(unittest.TestCase):
 
     @mock.patch('enterprise.models.EnrollmentApiClient')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.GradesApiClient')
-    @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CourseApiClientJwt')
+    @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CourseApiClient')
     def test_collect_learner_data_without_consent(self, mock_course_api, mock_grades_api, mock_enrollment_api):
         factories.EnterpriseCourseEnrollmentFactory(
             enterprise_customer_user=self.enterprise_customer_user,
@@ -130,7 +130,7 @@ class TestLearnerExporter(unittest.TestCase):
         assert not learner_data
         assert mock_grades_api.call_count == 0
 
-    @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CourseApiClientJwt')
+    @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CourseApiClient')
     def test_collect_learner_data_no_course_details(self, mock_course_api):
         factories.EnterpriseCourseEnrollmentFactory(
             enterprise_customer_user=self.enterprise_customer_user,
@@ -144,7 +144,7 @@ class TestLearnerExporter(unittest.TestCase):
         assert not learner_data
 
     @mock.patch('enterprise.models.EnrollmentApiClient')
-    @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CourseApiClientJwt')
+    @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CourseApiClient')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CertificatesApiClient')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     def test_learner_data_instructor_paced_no_certificate(
@@ -182,7 +182,7 @@ class TestLearnerExporter(unittest.TestCase):
             assert report.grade == LearnerExporter.GRADE_INCOMPLETE
 
     @mock.patch('enterprise.models.EnrollmentApiClient')
-    @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CourseApiClientJwt')
+    @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CourseApiClient')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CertificatesApiClient')
     def test_learner_data_instructor_paced_no_certificate_null_sso_id(
             self, mock_certificate_api, mock_course_api, mock_enrollment_api
@@ -211,7 +211,7 @@ class TestLearnerExporter(unittest.TestCase):
         assert not learner_data
 
     @mock.patch('enterprise.models.EnrollmentApiClient')
-    @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CourseApiClientJwt')
+    @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CourseApiClient')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CertificatesApiClient')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     def test_learner_data_instructor_paced_with_certificate(
@@ -259,7 +259,7 @@ class TestLearnerExporter(unittest.TestCase):
 
     @mock.patch('enterprise.models.EnrollmentApiClient')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.GradesApiClient')
-    @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CourseApiClientJwt')
+    @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CourseApiClient')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     def test_learner_data_self_paced_no_grades(
             self,
@@ -318,7 +318,7 @@ class TestLearnerExporter(unittest.TestCase):
     @ddt.unpack
     @mock.patch('enterprise.models.EnrollmentApiClient')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.GradesApiClient')
-    @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CourseApiClientJwt')
+    @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CourseApiClient')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     def test_learner_data_self_paced_course(
             self,
@@ -376,7 +376,7 @@ class TestLearnerExporter(unittest.TestCase):
     @mock.patch('enterprise.models.EnrollmentApiClient')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CertificatesApiClient')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.GradesApiClient')
-    @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CourseApiClientJwt')
+    @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CourseApiClient')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     def test_learner_data_multiple_courses(
             self,
@@ -505,7 +505,7 @@ class TestLearnerExporter(unittest.TestCase):
     @ddt.unpack
     @mock.patch('enterprise.models.EnrollmentApiClient')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.GradesApiClient')
-    @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CourseApiClientJwt')
+    @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CourseApiClient')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     def test_learner_data_audit_data_reporting(
             self,
@@ -562,7 +562,7 @@ class TestLearnerExporter(unittest.TestCase):
 
     @mock.patch('enterprise.models.EnrollmentApiClient')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.GradesApiClient')
-    @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CourseApiClientJwt')
+    @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CourseApiClient')
     def test_learner_exporter_with_skip_transmitted(self, mock_course_api, mock_grades_api, mock_enrollment_api):
         enterprise_course_enrollment = factories.EnterpriseCourseEnrollmentFactory(
             enterprise_customer_user=self.enterprise_customer_user,

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -557,7 +557,7 @@ def stub_transmit_learner_data_apis(testcase, certificate, self_paced, end_date,
         # Course API course_details response
         responses.add(
             responses.GET,
-            urljoin(lms_api.CourseApiClientJwt.API_BASE_URL,
+            urljoin(lms_api.CourseApiClient.API_BASE_URL,
                     "courses/{course}/".format(course=testcase.course_id)),
             json=dict(
                 course_id=COURSE_ID,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -15,7 +15,6 @@ from opaque_keys.edx.keys import CourseKey
 from pytest import mark, raises
 from testfixtures import LogCapture
 
-from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.files import File
 from django.core.files.storage import Storage
@@ -358,15 +357,6 @@ class TestEnterpriseCustomerUser(unittest.TestCase):
     Tests of the EnterpriseCustomerUser model.
     """
 
-    def setUp(self):
-        """
-        Test set up
-        """
-        super(TestEnterpriseCustomerUser, self).setUp()
-        self.worker_user = factories.UserFactory(
-            username=settings.ENTERPRISE_SERVICE_WORKER_USERNAME, is_staff=True, is_active=True
-        )
-
     @ddt.data(str, repr)
     def test_string_conversion(self, method):
         """
@@ -417,7 +407,7 @@ class TestEnterpriseCustomerUser(unittest.TestCase):
         ('fake-identity', 'saml-user-id', True),
     )
     @ddt.unpack
-    @mock.patch('enterprise.models.ThirdPartyAuthApiClientJwt')
+    @mock.patch('enterprise.models.ThirdPartyAuthApiClient')
     def test_get_remote_id(self, provider_id, expected_value, called, mock_third_party_api):
         user = factories.UserFactory(username="hi")
         enterprise_customer_user = factories.EnterpriseCustomerUserFactory(user_id=user.id)
@@ -435,7 +425,7 @@ class TestEnterpriseCustomerUser(unittest.TestCase):
             assert mock_third_party_api.return_value.get_remote_id.call_count == 0
 
     @mock.patch('enterprise.utils.segment')
-    @mock.patch('enterprise.models.EnrollmentApiClient', autospec=True)
+    @mock.patch('enterprise.models.EnrollmentApiClient')
     @mock.patch('enterprise.models.EnterpriseCustomerUser.create_order_for_enrollment')
     @ddt.data('audit', 'verified')
     def test_enroll_learner(self, course_mode, enrollment_order_mock, enrollment_api_client_mock, analytics_mock):
@@ -451,18 +441,6 @@ class TestEnterpriseCustomerUser(unittest.TestCase):
             enrollment_order_mock.assert_called_once()
         else:
             enrollment_order_mock.assert_not_called()
-
-        enrollment_api_client_mock.assert_called_once_with(self.worker_user)
-
-    @mock.patch('enterprise.models.EnrollmentApiClient', autospec=True)
-    def test_unenroll_client_user(self, enrollment_api_client_mock):
-        """
-        Verify that `EnrollmentApiClient` is created with correct user in `EnterpriseCustomerUser.unenroll`.
-        """
-        enterprise_customer_user = factories.EnterpriseCustomerUserFactory()
-        enterprise_customer_user.unenroll('course-v1:edX+DemoX+Demo_Course')
-        enrollment_api_client_mock.return_value.unenroll_user_from_course.assert_called_once()
-        enrollment_api_client_mock.assert_called_once_with(self.worker_user)
 
     @mock.patch('enterprise.models.EnrollmentApiClient')
     @mock.patch('enterprise.models.EnterpriseCustomerUser.create_order_for_enrollment')


### PR DESCRIPTION
Revert EnrollmentApiClient should call enrollment API with enterprise service worker user

Revert-Edx-Api-Key-replacement-changes

added-EnterpriseCatalogApiClient-import

Updated version and changelog

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
