### PR TITLE
ENT-2482: Restrict PendingEnterpriseCustomerUser for multiple EnterpriseCustomers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,11 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+[2.4.0] - 2020-02-25
+--------------------
+
+* Restricted PendingEnterpriseCustomerUser to be linked with only one EnterpriseCustomer at a time
+
 [2.3.9] - 2020-02-17
 --------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "2.3.9"
+__version__ = "2.4.0"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/admin/utils.py
+++ b/enterprise/admin/utils.py
@@ -93,6 +93,10 @@ class ValidationMessages:
     PROGRAM_IS_INACTIVE = _(
         "Enrollment in program {program_id} is closed because it is in "
         "{status} status.")
+    PENDING_USER_ALREADY_LINKED = _(
+        "Pending user with email address {user_email} is already linked with another Enterprise {ec_name}, "
+        "you will be able to add the learner once the user creates account or other enterprise "
+        "deletes the pending user")
     USER_ALREADY_REGISTERED = _(
         "User with email address {email} is already registered with Enterprise "
         "Customer {ec_name}")


### PR DESCRIPTION
This PR restricts a PendingEnterpriseCustomerUser to be linked with multiple enterprises at the same time. The user will be able to link with another enterprise once he/she registers or the other enterprise unlinks that user. 

Ticket: https://openedx.atlassian.net/browse/ENT-2482

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
