### PR TITLE
Learner attached to multiple enterprises, logging in via SSO(Google,FB)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,11 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+[2.3.7] - 2020-02-07
+--------------------
+
+* Learner attached to multiple enterprises, logging in via SSO should be taken to Enterprise selection page
+
 [2.3.6] - 2020-02-06
 --------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "2.3.6"
+__version__ = "2.3.7"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name


### PR DESCRIPTION
Learner attached to multiple enterprises, logging in via SSO(Google, Fb), show him multiple enterprise selection page.

**Testing Requirements:**
Please create 2 users. 
user1 should be linked to 2 or more enterprises.
User2 should be linked to 1 enterprise.
Please setup google social auth and Facebook social auth on your local machine.

**Pre PR:**
1- When you will log in with the Google or Facebook social auth and it has edx linked account.
If the linked edx account is the part of multiple enterprises then multiple enterprises page is not shown to the user.
**Post PR:**
**1-** When you will log in with the Google or Facebook social auth and it has edx linked account. If the linked edx account is the part of multiple enterprises then multiple enterprises page is shown to the user.
**2-** Once the user select the active enterprise then the user should be redirected to the dashboard or the URL he has requested before login.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
