### PR TITLE
ENT-2614: Fixed TypeError when JSON is passed bytes instead of str

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,11 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+[2.3.6] - 2020-02-06
+--------------------
+
+* Fixed learner data transmission command when grades API return `user_not_enrolled` error
+
 [2.3.4] - 2020-02-04
 --------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "2.3.5"
+__version__ = "2.3.6"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/integrated_channel/exporters/learner_data.py
+++ b/integrated_channels/integrated_channel/exporters/learner_data.py
@@ -9,7 +9,6 @@ enterprise customer.
 
 from __future__ import absolute_import, unicode_literals
 
-import json
 from logging import getLogger
 
 from slumber.exceptions import HttpNotFoundError
@@ -323,8 +322,8 @@ class LearnerExporter(Exporter):
 
         except HttpNotFoundError as error:
             # Grade not found, so we have nothing to report.
-            if hasattr(error, 'content'):
-                response_content = json.loads(error.content)
+            if hasattr(error, 'response'):
+                response_content = error.response.json()  # pylint: disable=no-member
                 if response_content.get('error_code', '') == 'user_not_enrolled':
                     # This means the user has an enterprise enrollment record but is not enrolled in the course yet
                     LOGGER.info(


### PR DESCRIPTION
Fixed TypeError when JSON is passed bytes instead of str.
This happens when  when grades API return `user_not_enrolled` error.
ENT-2614

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
