### PR TITLE
Removing use of BearerAuthentication + clean up

### DIFF
--- a/consent/api/v1/views.py
+++ b/consent/api/v1/views.py
@@ -7,7 +7,6 @@ from __future__ import absolute_import, unicode_literals
 
 from logging import getLogger
 
-from edx_rest_framework_extensions.auth.bearer.authentication import BearerAuthentication
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.response import Response
@@ -70,7 +69,7 @@ class DataSharingConsentView(APIView):
     """
 
     permission_classes = (permissions.IsStaffOrUserInRequest,)
-    authentication_classes = (JwtAuthentication, BearerAuthentication, SessionAuthentication,)
+    authentication_classes = (JwtAuthentication, SessionAuthentication,)
     throttle_classes = (ServiceUserThrottle,)
 
     REQUIRED_PARAM_USERNAME = 'username'

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "2.5.5"
+__version__ = "3.0.0"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -9,7 +9,6 @@ from smtplib import SMTPException
 
 from django_filters.rest_framework import DjangoFilterBackend
 from edx_rbac.decorators import permission_required
-from edx_rest_framework_extensions.auth.bearer.authentication import BearerAuthentication
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from rest_framework import filters, permissions, status, viewsets
 from rest_framework.authentication import SessionAuthentication
@@ -54,7 +53,7 @@ class EnterpriseViewSet:
     """
 
     permission_classes = (permissions.IsAuthenticated,)
-    authentication_classes = (JwtAuthentication, BearerAuthentication, SessionAuthentication,)
+    authentication_classes = (JwtAuthentication, SessionAuthentication,)
     throttle_classes = (ServiceUserThrottle,)
 
     def ensure_data_exists(self, request, data, error_message=None):
@@ -517,7 +516,7 @@ class CouponCodesView(APIView):
     API to request coupon codes.
     """
     permission_classes = (permissions.IsAuthenticated,)
-    authentication_classes = (JwtAuthentication, BearerAuthentication, SessionAuthentication,)
+    authentication_classes = (JwtAuthentication, SessionAuthentication,)
     throttle_classes = (ServiceUserThrottle,)
 
     REQUIRED_PARAM_EMAIL = 'email'

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -159,7 +159,8 @@ def get_oauth2authentication_class():
     try:
         from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser as OAuth2Authentication
     except ImportError:
-        from edx_rest_framework_extensions.auth.bearer.authentication import BearerAuthentication \
+        #Temporary until OAuth2Authentication has been moved out of edx-platform
+        from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication \
             as OAuth2Authentication
 
     return OAuth2Authentication

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -159,7 +159,7 @@ def get_oauth2authentication_class():
     try:
         from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser as OAuth2Authentication
     except ImportError:
-        #Temporary until OAuth2Authentication has been moved out of edx-platform
+        # Temporary until OAuth2Authentication has been moved out of edx-platform
         from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication \
             as OAuth2Authentication
 

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -151,20 +151,6 @@ def get_all_field_names(model, excluded=None):
     excluded_fields = excluded or []
     return [f.name for f in model._meta.get_fields() if f.name not in excluded_fields]
 
-
-def get_oauth2authentication_class():
-    """
-    Return oauth2 authentication class to authenticate REST APIs with Bearer token.
-    """
-    try:
-        from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser as OAuth2Authentication
-    except ImportError:
-        from edx_rest_framework_extensions.auth.bearer.authentication import BearerAuthentication \
-            as OAuth2Authentication
-
-    return OAuth2Authentication
-
-
 def get_catalog_admin_url(catalog_id):
     """
     Get url to catalog details admin page.

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -159,9 +159,7 @@ def get_oauth2authentication_class():
     try:
         from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser as OAuth2Authentication
     except ImportError:
-        # Temporary until OAuth2Authentication has been moved out of edx-platform
-        from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication \
-            as OAuth2Authentication
+        return None
 
     return OAuth2Authentication
 

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -152,6 +152,19 @@ def get_all_field_names(model, excluded=None):
     return [f.name for f in model._meta.get_fields() if f.name not in excluded_fields]
 
 
+def get_oauth2authentication_class():
+    """
+    Return oauth2 authentication class to authenticate REST APIs with Bearer token.
+    """
+    try:
+        from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser as OAuth2Authentication
+    except ImportError:
+        from edx_rest_framework_extensions.auth.bearer.authentication import BearerAuthentication \
+            as OAuth2Authentication
+
+    return OAuth2Authentication
+
+
 def get_catalog_admin_url(catalog_id):
     """
     Get url to catalog details admin page.

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -151,6 +151,7 @@ def get_all_field_names(model, excluded=None):
     excluded_fields = excluded or []
     return [f.name for f in model._meta.get_fields() if f.name not in excluded_fields]
 
+
 def get_catalog_admin_url(catalog_id):
     """
     Get url to catalog details admin page.

--- a/enterprise_learner_portal/api/v1/views.py
+++ b/enterprise_learner_portal/api/v1/views.py
@@ -4,7 +4,6 @@ Views for enterprise_learner_portal app.
 """
 from __future__ import absolute_import, unicode_literals
 
-from edx_rest_framework_extensions.auth.bearer.authentication import BearerAuthentication
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from rest_framework import permissions
 from rest_framework.authentication import SessionAuthentication
@@ -30,7 +29,7 @@ class EnterpriseCourseEnrollmentView(APIView):
     View for returning information around a user's enterprise course enrollments.
     """
     permission_classes = (permissions.IsAuthenticated,)
-    authentication_classes = (JwtAuthentication, BearerAuthentication, SessionAuthentication,)
+    authentication_classes = (JwtAuthentication,  SessionAuthentication,)
 
     def get(self, request):
         """

--- a/enterprise_learner_portal/api/v1/views.py
+++ b/enterprise_learner_portal/api/v1/views.py
@@ -29,7 +29,7 @@ class EnterpriseCourseEnrollmentView(APIView):
     View for returning information around a user's enterprise course enrollments.
     """
     permission_classes = (permissions.IsAuthenticated,)
-    authentication_classes = (JwtAuthentication,  SessionAuthentication,)
+    authentication_classes = (JwtAuthentication, SessionAuthentication,)
 
     def get(self, request):
         """

--- a/integrated_channels/cornerstone/views.py
+++ b/integrated_channels/cornerstone/views.py
@@ -17,7 +17,7 @@ try:
     from openedx.core.lib.api.authentication import OAuth2Authentication
 except ImportError:
     # Temp fix until OAuth2Authentication has been moved out of edx-platform
-    from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication as OAuth2Authentication
+    OAuth2Authentication = JwtAuthentication
 
 
 class CornerstoneCoursesListView(generics.ListAPIView):

--- a/integrated_channels/cornerstone/views.py
+++ b/integrated_channels/cornerstone/views.py
@@ -9,15 +9,17 @@ from rest_framework import generics, permissions, renderers, status
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.response import Response
 
+from enterprise.api.throttles import ServiceUserThrottle
+from enterprise.utils import get_enterprise_customer, get_enterprise_worker_user
+from integrated_channels.cornerstone.models import CornerstoneEnterpriseCustomerConfiguration
+
+
 try:
     from openedx.core.lib.api.authentication import OAuth2Authentication
 except ImportError:
     # Temp fix until OAuth2Authentication has been moved out of edx-platform
     OAuth2Authentication = JwtAuthentication
 
-from enterprise.api.throttles import ServiceUserThrottle
-from enterprise.utils import get_enterprise_customer, get_enterprise_worker_user
-from integrated_channels.cornerstone.models import CornerstoneEnterpriseCustomerConfiguration
 
 
 class CornerstoneCoursesListView(generics.ListAPIView):

--- a/integrated_channels/cornerstone/views.py
+++ b/integrated_channels/cornerstone/views.py
@@ -4,9 +4,7 @@ Views containing APIs for cornerstone integrated channel
 from __future__ import absolute_import, unicode_literals
 
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
-from enterprise.api.throttles import ServiceUserThrottle
-from enterprise.utils import get_enterprise_customer, get_enterprise_worker_user
-from integrated_channels.cornerstone.models import CornerstoneEnterpriseCustomerConfiguration
+
 from rest_framework import generics, permissions, renderers, status
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.response import Response
@@ -16,6 +14,10 @@ try:
 except ImportError:
     # Temp fix until OAuth2Authentication has been moved out of edx-platform
     OAuth2Authentication = JwtAuthentication
+
+from enterprise.api.throttles import ServiceUserThrottle
+from enterprise.utils import get_enterprise_customer, get_enterprise_worker_user
+from integrated_channels.cornerstone.models import CornerstoneEnterpriseCustomerConfiguration
 
 
 class CornerstoneCoursesListView(generics.ListAPIView):

--- a/integrated_channels/cornerstone/views.py
+++ b/integrated_channels/cornerstone/views.py
@@ -4,6 +4,7 @@ Views containing APIs for cornerstone integrated channel
 from __future__ import absolute_import, unicode_literals
 
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
+
 from openedx.core.lib.api.authentication import OAuth2Authentication
 
 from rest_framework import generics, permissions, renderers, status
@@ -13,6 +14,11 @@ from rest_framework.response import Response
 from enterprise.api.throttles import ServiceUserThrottle
 from enterprise.utils import get_enterprise_customer, get_enterprise_worker_user
 from integrated_channels.cornerstone.models import CornerstoneEnterpriseCustomerConfiguration
+
+try:
+    from openedx.core.lib.api.authentication import OAuth2Authentication
+except ImportError:
+    OAuth2Authentication = None
 
 
 class CornerstoneCoursesListView(generics.ListAPIView):

--- a/integrated_channels/cornerstone/views.py
+++ b/integrated_channels/cornerstone/views.py
@@ -4,12 +4,14 @@ Views containing APIs for cornerstone integrated channel
 from __future__ import absolute_import, unicode_literals
 
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
+from openedx.core.lib.api.authentication import OAuth2Authentication
+
 from rest_framework import generics, permissions, renderers, status
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.response import Response
 
 from enterprise.api.throttles import ServiceUserThrottle
-from enterprise.utils import get_enterprise_customer, get_enterprise_worker_user, get_oauth2authentication_class
+from enterprise.utils import get_enterprise_customer, get_enterprise_worker_user
 from integrated_channels.cornerstone.models import CornerstoneEnterpriseCustomerConfiguration
 
 
@@ -73,7 +75,7 @@ class CornerstoneCoursesListView(generics.ListAPIView):
 
     """
     permission_classes = (permissions.IsAuthenticated,)
-    authentication_classes = (JwtAuthentication, get_oauth2authentication_class(), SessionAuthentication,)
+    authentication_classes = (JwtAuthentication, OAuth2Authentication, SessionAuthentication,)
     throttle_classes = (ServiceUserThrottle,)
     renderer_classes = [renderers.JSONRenderer]
 

--- a/integrated_channels/cornerstone/views.py
+++ b/integrated_channels/cornerstone/views.py
@@ -16,7 +16,8 @@ from integrated_channels.cornerstone.models import CornerstoneEnterpriseCustomer
 try:
     from openedx.core.lib.api.authentication import OAuth2Authentication
 except ImportError:
-    OAuth2Authentication = None
+    # Temp fix until OAuth2Authentication has been moved out of edx-platform
+    from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication as OAuth2Authentication
 
 
 class CornerstoneCoursesListView(generics.ListAPIView):

--- a/integrated_channels/cornerstone/views.py
+++ b/integrated_channels/cornerstone/views.py
@@ -5,8 +5,6 @@ from __future__ import absolute_import, unicode_literals
 
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 
-from openedx.core.lib.api.authentication import OAuth2Authentication
-
 from rest_framework import generics, permissions, renderers, status
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.response import Response

--- a/integrated_channels/cornerstone/views.py
+++ b/integrated_channels/cornerstone/views.py
@@ -73,7 +73,13 @@ class CornerstoneCoursesListView(generics.ListAPIView):
 
     """
     permission_classes = (permissions.IsAuthenticated,)
-    authentication_classes = (JwtAuthentication, get_oauth2authentication_class(), SessionAuthentication,)
+
+    OAuth2Authentication = get_oauth2authentication_class()
+    if OAuth2Authentication is not None:
+        authentication_classes = (JwtAuthentication, OAuth2Authentication, SessionAuthentication,)
+    else:
+        authentication_classes = (JwtAuthentication, SessionAuthentication,)
+
     throttle_classes = (ServiceUserThrottle,)
     renderer_classes = [renderers.JSONRenderer]
 

--- a/integrated_channels/cornerstone/views.py
+++ b/integrated_channels/cornerstone/views.py
@@ -4,22 +4,13 @@ Views containing APIs for cornerstone integrated channel
 from __future__ import absolute_import, unicode_literals
 
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
-
 from rest_framework import generics, permissions, renderers, status
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.response import Response
 
 from enterprise.api.throttles import ServiceUserThrottle
-from enterprise.utils import get_enterprise_customer, get_enterprise_worker_user
+from enterprise.utils import get_enterprise_customer, get_enterprise_worker_user, get_oauth2authentication_class
 from integrated_channels.cornerstone.models import CornerstoneEnterpriseCustomerConfiguration
-
-
-try:
-    from openedx.core.lib.api.authentication import OAuth2Authentication
-except ImportError:
-    # Temp fix until OAuth2Authentication has been moved out of edx-platform
-    OAuth2Authentication = JwtAuthentication
-
 
 
 class CornerstoneCoursesListView(generics.ListAPIView):
@@ -82,7 +73,7 @@ class CornerstoneCoursesListView(generics.ListAPIView):
 
     """
     permission_classes = (permissions.IsAuthenticated,)
-    authentication_classes = (JwtAuthentication, OAuth2Authentication, SessionAuthentication,)
+    authentication_classes = (JwtAuthentication, get_oauth2authentication_class(), SessionAuthentication,)
     throttle_classes = (ServiceUserThrottle,)
     renderer_classes = [renderers.JSONRenderer]
 

--- a/integrated_channels/cornerstone/views.py
+++ b/integrated_channels/cornerstone/views.py
@@ -4,14 +4,12 @@ Views containing APIs for cornerstone integrated channel
 from __future__ import absolute_import, unicode_literals
 
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
-
-from rest_framework import generics, permissions, renderers, status
-from rest_framework.authentication import SessionAuthentication
-from rest_framework.response import Response
-
 from enterprise.api.throttles import ServiceUserThrottle
 from enterprise.utils import get_enterprise_customer, get_enterprise_worker_user
 from integrated_channels.cornerstone.models import CornerstoneEnterpriseCustomerConfiguration
+from rest_framework import generics, permissions, renderers, status
+from rest_framework.authentication import SessionAuthentication
+from rest_framework.response import Response
 
 try:
     from openedx.core.lib.api.authentication import OAuth2Authentication

--- a/tox.ini
+++ b/tox.ini
@@ -94,11 +94,12 @@ deps =
     -r{toxinidir}/requirements/dev.txt
 commands =
     touch tests/__init__.py
-    pylint -j 0 integrated_channels
-    pylint -j 0 --py3k integrated_channels
-    pycodestyle integrated_channels
-    pydocstyle integrated_channels
-    isort --check-only --diff --recursive integrated_channels manage.py setup.py
+    pylint -j 0 enterprise enterprise_learner_portal consent integrated_channels tests test_utils requirements/check_pins.py
+    pylint -j 0 --py3k enterprise enterprise_learner_portal consent integrated_channels tests test_utils
+    rm tests/__init__.py
+    pycodestyle enterprise enterprise_learner_portal consent integrated_channels tests test_utils
+    pydocstyle enterprise enterprise_learner_portal consent integrated_channels tests test_utils
+    isort --check-only --diff --recursive tests test_utils enterprise enterprise_learner_portal consent integrated_channels manage.py setup.py
 
 [testenv:jasmine]
 passenv = JASMINE_BROWSER DISPLAY

--- a/tox.ini
+++ b/tox.ini
@@ -94,12 +94,11 @@ deps =
     -r{toxinidir}/requirements/dev.txt
 commands =
     touch tests/__init__.py
-    pylint -j 0 enterprise enterprise_learner_portal consent integrated_channels tests test_utils requirements/check_pins.py
-    pylint -j 0 --py3k enterprise enterprise_learner_portal consent integrated_channels tests test_utils
-    rm tests/__init__.py
-    pycodestyle enterprise enterprise_learner_portal consent integrated_channels tests test_utils
-    pydocstyle enterprise enterprise_learner_portal consent integrated_channels tests test_utils
-    isort --check-only --diff --recursive tests test_utils enterprise enterprise_learner_portal consent integrated_channels manage.py setup.py
+    pylint -j 0 integrated_channels
+    pylint -j 0 --py3k integrated_channels
+    pycodestyle integrated_channels
+    pydocstyle integrated_channels
+    isort --check-only --diff --recursive integrated_channels manage.py setup.py
 
 [testenv:jasmine]
 passenv = JASMINE_BROWSER DISPLAY


### PR DESCRIPTION
According to our investigation using new relic custom metrics, BearerAuthentication class is not used and is safe for removal.

[PR that adds metric](https://github.com/edx/edx-drf-extensions/pull/105)