### PR TITLE
Update log level for content changes to debug

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,12 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+
+[2.4.1] - 2020-02-26
+--------------------
+
+* Update log level from INFO to DEBUG for transmit_content_metadata management command
+
 [2.4.0] - 2020-02-25
 --------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "2.4.0"
+__version__ = "2.4.1"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/integrated_channel/exporters/content_metadata.py
+++ b/integrated_channels/integrated_channel/exporters/content_metadata.py
@@ -83,7 +83,7 @@ class ContentMetadataExporter(Exporter):
         LOGGER.info('Retrieved content metadata for enterprise [%s]', self.enterprise_customer.name)
         for item in content_metadata_items:
             transformed = self._transform_item(item)
-            LOGGER.info(
+            LOGGER.debug(
                 'Exporting content metadata item with plugin configuration [%s]: [%s]',
                 self.enterprise_configuration,
                 json.dumps(transformed, indent=4),

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -154,8 +154,10 @@ class TestTransmitCourseMetadataManagementCommand(unittest.TestCase, EnterpriseM
     @mock.patch('integrated_channels.degreed.client.DegreedAPIClient.create_content_metadata')
     @mock.patch('integrated_channels.sap_success_factors.client.SAPSuccessFactorsAPIClient.get_oauth_access_token')
     @mock.patch('integrated_channels.sap_success_factors.client.SAPSuccessFactorsAPIClient.update_content_metadata')
+    @mock.patch('integrated_channels.integrated_channel.management.commands.transmit_content_metadata.transmit_content_metadata.delay')  # pylint: disable=line-too-long
     def test_transmit_content_metadata_task_with_error(
             self,
+            transmit_content_metadata_mock,
             sapsf_update_content_metadata_mock,
             sapsf_get_oauth_access_token_mock,
             degreed_create_content_metadata_mock,
@@ -209,64 +211,14 @@ class TestTransmitCourseMetadataManagementCommand(unittest.TestCase, EnterpriseM
             active=True,
         )
 
-        # Verify that first integrated channel logs failure but the second
-        # integrated channel still successfully transmits courseware data.
-        expected_messages = [
-            # SAPSF
-            '[Integrated Channel] Content metadata transmission started. Configuration:'
-            ' <SAPSuccessFactorsEnterpriseCustomerConfiguration for Enterprise Veridian Dynamics>',
-            '[Integrated Channel] Transmission of content metadata failed.'
-            ' ChannelCode: SAP, ChannelId: 1, Username: C-3PO',
-            '[Integrated Channel] Content metadata transmission task finished. Configuration:'
-            ' {configuration},Duration: 0.0'.format(configuration=self.sapsf),
-            '[Integrated Channel] Content metadata transmission started. Configuration:'
-            ' <SAPSuccessFactorsEnterpriseCustomerConfiguration for Enterprise Dummy Enterprise>',
-            'Retrieved content metadata for enterprise [{}]'.format(dummy_enterprise_customer.name),
-            'Exporting content metadata item with plugin configuration '
-            '[<SAPSuccessFactorsEnterpriseCustomerConfiguration for Enterprise Dummy Enterprise>]',
-            'Exporting content metadata item with plugin configuration '
-            '[<SAPSuccessFactorsEnterpriseCustomerConfiguration for Enterprise Dummy Enterprise>]',
-            'Exporting content metadata item with plugin configuration '
-            '[<SAPSuccessFactorsEnterpriseCustomerConfiguration for Enterprise Dummy Enterprise>]',
-            'Preparing to transmit creation of [3] content metadata items with plugin configuration '
-            '[<SAPSuccessFactorsEnterpriseCustomerConfiguration for Enterprise Dummy Enterprise>]',
-            'Preparing to transmit update of [0] content metadata items with plugin configuration '
-            '[<SAPSuccessFactorsEnterpriseCustomerConfiguration for Enterprise Dummy Enterprise>]',
-            'Preparing to transmit deletion of [0] content metadata items with plugin configuration '
-            '[<SAPSuccessFactorsEnterpriseCustomerConfiguration for Enterprise Dummy Enterprise>]',
-            '[Integrated Channel] Content metadata transmission task finished. Configuration:'
-            ' {configuration},Duration: 0.0'.format(configuration=dummy_sapsf),
-
-            # Degreed
-            '[Integrated Channel] Content metadata transmission started. Configuration:'
-            ' <DegreedEnterpriseCustomerConfiguration for Enterprise Veridian Dynamics>',
-            '[Integrated Channel] Transmission of content metadata failed.'
-            ' ChannelCode: DEGREED, ChannelId: 1, Username: C-3PO',
-            '[Integrated Channel] Content metadata transmission task finished. Configuration:'
-            ' {configuration},Duration: 0.0'.format(configuration=self.degreed),
-            '[Integrated Channel] Content metadata transmission started. Configuration:'
-            ' <DegreedEnterpriseCustomerConfiguration for Enterprise Dummy Enterprise>',
-            'Retrieved content metadata for enterprise [{}]'.format(dummy_enterprise_customer.name),
-            'Exporting content metadata item with plugin configuration '
-            '[<DegreedEnterpriseCustomerConfiguration for Enterprise Dummy Enterprise>]',
-            'Exporting content metadata item with plugin configuration '
-            '[<DegreedEnterpriseCustomerConfiguration for Enterprise Dummy Enterprise>]',
-            'Exporting content metadata item with plugin configuration '
-            '[<DegreedEnterpriseCustomerConfiguration for Enterprise Dummy Enterprise>]',
-            'Preparing to transmit creation of [3] content metadata items with plugin configuration '
-            '[<DegreedEnterpriseCustomerConfiguration for Enterprise Dummy Enterprise>]',
-            'Preparing to transmit update of [0] content metadata items with plugin configuration '
-            '[<DegreedEnterpriseCustomerConfiguration for Enterprise Dummy Enterprise>]',
-            'Preparing to transmit deletion of [0] content metadata items with plugin configuration '
-            '[<DegreedEnterpriseCustomerConfiguration for Enterprise Dummy Enterprise>]',
-            '[Integrated Channel] Content metadata transmission task finished. Configuration:'
-            ' {configuration},Duration: 0.0'.format(configuration=dummy_degreed)
+        expected_calls = [
+            mock.call('C-3PO', 'SAP', 1),
+            mock.call('C-3PO', 'DEGREED', 1)
         ]
 
-        with LogCapture(level=logging.INFO) as log_capture:
-            call_command('transmit_content_metadata', '--catalog_user', 'C-3PO')
-            for index, message in enumerate(expected_messages):
-                assert message in log_capture.records[index].getMessage()
+        call_command('transmit_content_metadata', '--catalog_user', 'C-3PO')
+
+        transmit_content_metadata_mock.assert_has_calls(expected_calls, any_order=True)
 
     @responses.activate
     @freeze_time(NOW)
@@ -274,8 +226,10 @@ class TestTransmitCourseMetadataManagementCommand(unittest.TestCase, EnterpriseM
     @mock.patch('integrated_channels.degreed.client.DegreedAPIClient.create_content_metadata')
     @mock.patch('integrated_channels.sap_success_factors.client.SAPSuccessFactorsAPIClient.get_oauth_access_token')
     @mock.patch('integrated_channels.sap_success_factors.client.SAPSuccessFactorsAPIClient.update_content_metadata')
+    @mock.patch('integrated_channels.integrated_channel.management.commands.transmit_content_metadata.transmit_content_metadata.delay')  # pylint: disable=line-too-long
     def test_transmit_content_metadata_task_success(
             self,
+            transmit_content_metadata_mock,
             sapsf_update_content_metadata_mock,
             sapsf_get_oauth_access_token_mock,
             degreed_create_content_metadata_mock,
@@ -291,50 +245,14 @@ class TestTransmitCourseMetadataManagementCommand(unittest.TestCase, EnterpriseM
         enterprise_catalog_uuid = str(self.enterprise_customer.enterprise_customer_catalogs.first().uuid)
         self.mock_enterprise_customer_catalogs(enterprise_catalog_uuid)
 
-        expected_messages = [
-            # SAPSF
-            '[Integrated Channel] Content metadata transmission started. Configuration:'
-            ' <SAPSuccessFactorsEnterpriseCustomerConfiguration for Enterprise Veridian Dynamics>',
-            'Retrieved content metadata for enterprise [{}]'.format(self.enterprise_customer.name),
-            'Exporting content metadata item with plugin configuration '
-            '[<SAPSuccessFactorsEnterpriseCustomerConfiguration for Enterprise Veridian Dynamics>]',
-            'Exporting content metadata item with plugin configuration '
-            '[<SAPSuccessFactorsEnterpriseCustomerConfiguration for Enterprise Veridian Dynamics>]',
-            'Exporting content metadata item with plugin configuration '
-            '[<SAPSuccessFactorsEnterpriseCustomerConfiguration for Enterprise Veridian Dynamics>]',
-            'Preparing to transmit creation of [3] content metadata items with plugin configuration '
-            '[<SAPSuccessFactorsEnterpriseCustomerConfiguration for Enterprise Veridian Dynamics>]',
-            'Preparing to transmit update of [0] content metadata items with plugin configuration '
-            '[<SAPSuccessFactorsEnterpriseCustomerConfiguration for Enterprise Veridian Dynamics>]',
-            'Preparing to transmit deletion of [0] content metadata items with plugin configuration '
-            '[<SAPSuccessFactorsEnterpriseCustomerConfiguration for Enterprise Veridian Dynamics>]',
-            '[Integrated Channel] Content metadata transmission task finished. Configuration:'
-            ' {configuration},Duration: 0.0'.format(configuration=self.sapsf),
-
-            # Degreed
-            '[Integrated Channel] Content metadata transmission started. Configuration:'
-            ' <DegreedEnterpriseCustomerConfiguration for Enterprise Veridian Dynamics>',
-            'Retrieved content metadata for enterprise [{}]'.format(self.enterprise_customer.name),
-            'Exporting content metadata item with plugin configuration '
-            '[<DegreedEnterpriseCustomerConfiguration for Enterprise Veridian Dynamics>]',
-            'Exporting content metadata item with plugin configuration '
-            '[<DegreedEnterpriseCustomerConfiguration for Enterprise Veridian Dynamics>]',
-            'Exporting content metadata item with plugin configuration '
-            '[<DegreedEnterpriseCustomerConfiguration for Enterprise Veridian Dynamics>]',
-            'Preparing to transmit creation of [3] content metadata items with plugin configuration '
-            '[<DegreedEnterpriseCustomerConfiguration for Enterprise Veridian Dynamics>]',
-            'Preparing to transmit update of [0] content metadata items with plugin configuration '
-            '[<DegreedEnterpriseCustomerConfiguration for Enterprise Veridian Dynamics>]',
-            'Preparing to transmit deletion of [0] content metadata items with plugin configuration '
-            '[<DegreedEnterpriseCustomerConfiguration for Enterprise Veridian Dynamics>]',
-            '[Integrated Channel] Content metadata transmission task finished. Configuration:'
-            ' {configuration},Duration: 0.0'.format(configuration=self.degreed)
+        expected_calls = [
+            mock.call('C-3PO', 'SAP', 1),
+            mock.call('C-3PO', 'DEGREED', 1),
         ]
 
-        with LogCapture(level=logging.INFO) as log_capture:
-            call_command('transmit_content_metadata', '--catalog_user', 'C-3PO')
-            for index, message in enumerate(expected_messages):
-                assert message in log_capture.records[index].getMessage()
+        call_command('transmit_content_metadata', '--catalog_user', 'C-3PO')
+
+        transmit_content_metadata_mock.assert_has_calls(expected_calls, any_order=True)
 
     @responses.activate
     def test_transmit_content_metadata_task_no_channel(self):


### PR DESCRIPTION
This logger is extremely noisy (over 150k per hour).


**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
