### PR TITLE
ENT-2666 Constrain django-countries version

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -7,7 +7,6 @@ celery
 code-annotations
 cryptography
 django-config-models
-django-countries
 django-crum
 django-fernet-fields
 django-filter
@@ -42,3 +41,4 @@ testfixtures
 unicodecsv
 
 # Explicitly pinned packages. Anything pinned here must match edx-platform's pinned packages.
+django-countries==5.5  # pinned because 6.0 causes much longer load times on enterprise customer django admin screen

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -15,9 +15,9 @@ attrs==19.3.0
 babel==2.8.0
 backports.functools-lru-cache==1.6.1  # via caniusepython3
 billiard==3.3.0.23
-bleach==3.1.0
+bleach==3.1.1
 caniusepython3==7.2.0
-celery==3.1.25
+celery==3.1.26.post2
 certifi==2019.11.28
 cffi==1.14.0
 chardet==3.0.4
@@ -47,24 +47,23 @@ djangorestframework-xml==1.4.0
 djangorestframework==3.9.4
 doc8==0.8.0
 docutils==0.16
-edx-django-utils==2.0.4
-edx-drf-extensions==2.4.6
+edx-django-utils==3.0
+edx-drf-extensions==3.0.0
 edx-i18n-tools==0.5.0
 edx-lint==1.4.1
 edx-opaque-keys[django]==2.0.1
-edx-rbac==1.0.5
-edx-rest-api-client==3.0.2
+edx-rbac==1.1.0
+edx-rest-api-client==4.0.1
 edx-sphinx-theme==1.5.0
 edx-tincan-py35==0.0.5
 factory-boy==2.12.0
-faker==4.0.0
+faker==4.0.1
 filelock==3.0.12          # via tox, virtualenv
-freezegun==0.3.14
+freezegun==0.3.15
 future==0.18.2
-idna==2.8
+idna==2.9
 imagesize==1.2.0
 importlib-metadata==1.5.0
-importlib-resources==1.0.2  # via virtualenv
 inflect==3.0.2
 isort==4.3.21
 jinja2-pluralize==0.3.0
@@ -77,14 +76,13 @@ markupsafe==1.1.1
 mccabe==0.6.1             # via pylint
 mock==3.0.5
 more-itertools==8.2.0
-newrelic==5.6.0.135
+newrelic==5.8.0.136
 packaging==20.1
 path.py==12.4.0
 path==13.1.0
-pathlib2==2.3.5
 pbr==5.4.4
 pillow==7.0.0
-pip-tools==4.4.1
+pip-tools==4.5.1
 pkginfo==1.5.0.1          # via twine
 pluggy==0.13.1
 pockets==0.9.1
@@ -93,7 +91,7 @@ psutil==1.2.1
 py==1.8.1
 pycodestyle==2.5.0
 pycparser==2.19
-pycryptodomex==3.9.6
+pycryptodomex==3.9.7
 pydocstyle==5.0.2
 pygments==2.5.2
 pyjwkest==1.3.2
@@ -114,8 +112,8 @@ pytz==2019.3
 pyyaml==5.3
 readme-renderer==24.0
 requests-toolbelt==0.9.1  # via twine
-requests==2.22.0
-responses==0.10.9
+requests==2.23.0
+responses==0.10.11
 rest-condition==1.0.3
 restructuredtext-lint==1.3.0
 rules==2.2
@@ -123,26 +121,26 @@ semantic-version==2.8.4
 six==1.14.0
 slumber==0.7.1
 snowballstemmer==2.0.0
-sphinx==2.4.1
-sphinxcontrib-applehelp==1.0.1
-sphinxcontrib-devhelp==1.0.1
-sphinxcontrib-htmlhelp==1.0.2
+sphinx==2.4.3
+sphinxcontrib-applehelp==1.0.2
+sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-htmlhelp==1.0.3
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-napoleon==0.6.1
-sphinxcontrib-qthelp==1.0.2
-sphinxcontrib-serializinghtml==1.1.3
-stevedore==1.31.0
-testfixtures==6.12.0
+sphinxcontrib-qthelp==1.0.3
+sphinxcontrib-serializinghtml==1.1.4
+stevedore==1.32.0
+testfixtures==6.14.0
 text-unidecode==1.3
 toml==0.10.0              # via tox
 tox-battery==0.5.1
-tox==3.14.3
-tqdm==4.42.1              # via twine
+tox==3.14.5
+tqdm==4.43.0              # via twine
 twine==1.11.0
 typed-ast==1.4.1          # via astroid
 unicodecsv==0.14.1
 urllib3==1.25.8
-virtualenv==20.0.2        # via tox
+virtualenv==20.0.7        # via tox
 wcwidth==0.1.8
 webencodings==0.5.1
 wheel==0.34.2

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -5,13 +5,13 @@
 #    make upgrade
 #
 alabaster==0.7.12         # via sphinx
-amqp==1.4.9
+amqp==1.4.9               # via kombu
 aniso8601==8.0.0
-anyjson==0.3.3
+anyjson==0.3.3            # via kombu
 babel==2.8.0              # via sphinx
 billiard==3.3.0.23
-bleach==3.1.0
-celery==3.1.25
+bleach==3.1.1
+celery==3.1.26.post2
 certifi==2019.11.28
 cffi==1.14.0
 chardet==3.0.4
@@ -36,24 +36,23 @@ djangorestframework-xml==1.4.0
 djangorestframework==3.9.4
 doc8==0.8.0
 docutils==0.16
-edx-django-utils==2.0.4
-edx-drf-extensions==2.4.6
+edx-django-utils==3.0
+edx-drf-extensions==3.0.0
 edx-opaque-keys[django]==2.0.1
-edx-rbac==1.0.5
-edx-rest-api-client==3.0.2
+edx-rbac==1.1.0
+edx-rest-api-client==4.0.1
 edx-sphinx-theme==1.5.0
 edx-tincan-py35==0.0.5
 future==0.18.2
-idna==2.8
+idna==2.9
 imagesize==1.2.0          # via sphinx
-importlib-metadata==1.5.0
+importlib-metadata==1.5.0  # via path
 jinja2==2.11.1
 jsondiff==1.2.0
 jsonfield2==3.0.3
 kombu==3.0.37
-markupsafe==1.1.1
-more-itertools==8.2.0
-newrelic==5.6.0.135
+markupsafe==1.1.1         # via jinja2
+newrelic==5.8.0.136
 packaging==20.1           # via sphinx
 path.py==12.4.0
 path==13.1.0
@@ -61,8 +60,8 @@ pbr==5.4.4
 pillow==7.0.0
 pockets==0.9.1            # via sphinxcontrib-napoleon
 psutil==1.2.1
-pycparser==2.19
-pycryptodomex==3.9.6
+pycparser==2.19           # via cffi
+pycryptodomex==3.9.7      # via pyjwkest
 pygments==2.5.2           # via readme-renderer, sphinx
 pyjwkest==1.3.2
 pyjwt==1.5.2
@@ -73,7 +72,7 @@ python-slugify==4.0.0
 pytz==2019.3
 pyyaml==5.3
 readme-renderer==24.0
-requests==2.22.0
+requests==2.23.0
 rest-condition==1.0.3
 restructuredtext-lint==1.3.0  # via doc8
 rules==2.2
@@ -81,21 +80,21 @@ semantic-version==2.8.4
 six==1.14.0
 slumber==0.7.1
 snowballstemmer==2.0.0    # via sphinx
-sphinx==2.4.1
-sphinxcontrib-applehelp==1.0.1  # via sphinx
-sphinxcontrib-devhelp==1.0.1  # via sphinx
-sphinxcontrib-htmlhelp==1.0.2  # via sphinx
+sphinx==2.4.3
+sphinxcontrib-applehelp==1.0.2  # via sphinx
+sphinxcontrib-devhelp==1.0.2  # via sphinx
+sphinxcontrib-htmlhelp==1.0.3  # via sphinx
 sphinxcontrib-jsmath==1.0.1  # via sphinx
 sphinxcontrib-napoleon==0.6.1
-sphinxcontrib-qthelp==1.0.2  # via sphinx
-sphinxcontrib-serializinghtml==1.1.3  # via sphinx
-stevedore==1.31.0
-testfixtures==6.12.0
-text-unidecode==1.3
+sphinxcontrib-qthelp==1.0.3  # via sphinx
+sphinxcontrib-serializinghtml==1.1.4  # via sphinx
+stevedore==1.32.0
+testfixtures==6.14.0
+text-unidecode==1.3       # via python-slugify
 unicodecsv==0.14.1
 urllib3==1.25.8
 webencodings==0.5.1
-zipp==1.0.0
+zipp==1.0.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/edx-platform-constraints.txt
+++ b/requirements/edx-platform-constraints.txt
@@ -6,238 +6,236 @@
 #    make upgrade
 #
 amqp==1.4.9               # via kombu
-analytics-python==1.2.9
+analytics-python==1.2.9   # via -r requirements/edx/base.in
 aniso8601==8.0.0          # via edx-tincan-py35
 anyjson==0.3.3            # via kombu
 appdirs==1.4.3            # via fs
-attrs==19.3.0
-babel==2.8.0
+attrs==19.3.0             # via -r requirements/edx/base.in, edx-ace
+babel==2.8.0              # via -r requirements/edx/base.in, django-babel, django-babel-underscore
 beautifulsoup4==4.8.2     # via pynliner
 billiard==3.3.0.23        # via celery
-bleach==3.1.0
-boto3==1.4.8
-boto==2.39.0
-botocore==1.8.17
-git+https://github.com/edx/bridgekeeper.git@2423e8d8788c2132ebeec509e1a7b17e1f5b9364#egg=bridgekeeper==0.0
-git+https://github.com/edx/openedx-calc.git@e9b698c85ad1152002bc0868f475f153dce88952#egg=calc==0.4
-celery==3.1.25
-certifi==2019.11.28
-cffi==1.14.0
-chardet==3.0.4
-git+https://github.com/edx/openedx-chem.git@ff4e3a03d3c7610e47a9af08eb648d8aabe2eb18#egg=chem==1.0.0
+bleach==3.1.1             # via -r requirements/edx/base.in, edx-enterprise, lti-consumer-xblock, ora2
+boto3==1.4.8              # via -r requirements/edx/base.in, fs-s3fs
+boto==2.39.0              # via -r requirements/edx/base.in, django-ses, edxval, ora2
+botocore==1.8.17          # via -r requirements/edx/base.in, boto3, s3transfer
+git+https://github.com/edx/bridgekeeper.git@2423e8d8788c2132ebeec509e1a7b17e1f5b9364#egg=bridgekeeper==0.0  # via -r requirements/edx/github.in
+git+https://github.com/edx/openedx-calc.git@e9b698c85ad1152002bc0868f475f153dce88952#egg=calc==0.4  # via -r requirements/edx/github.in
+celery==3.1.26.post2      # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, django-celery, edx-celeryutils, edx-enterprise
+certifi==2019.11.28       # via -r requirements/edx/paver.txt, requests
+cffi==1.14.0              # via -r requirements/edx/../edx-sandbox/shared.txt, cryptography
+chardet==3.0.4            # via -r requirements/edx/paver.txt, pdfminer.six, pysrt, requests
+git+https://github.com/edx/openedx-chem.git@ff4e3a03d3c7610e47a9af08eb648d8aabe2eb18#egg=chem==1.0.0  # via -r requirements/edx/github.in
 click==7.0                # via code-annotations, user-util
 code-annotations==0.3.3   # via edx-enterprise
-contextlib2==0.6.0.post1
+contextlib2==0.6.0.post1  # via -r requirements/edx/base.in
 coreapi==2.3.3            # via drf-yasg
 coreschema==0.0.4         # via coreapi, drf-yasg
-git+https://github.com/edx/crowdsourcehinter.git@a7ffc85b134b7d8909bf1fefd23dbdb8eb28e467#egg=crowdsourcehinter-xblock==0.2
-cryptography==2.8
+git+https://github.com/edx/crowdsourcehinter.git@a7ffc85b134b7d8909bf1fefd23dbdb8eb28e467#egg=crowdsourcehinter-xblock==0.2  # via -r requirements/edx/github.in
+cryptography==2.8         # via -r requirements/edx/../edx-sandbox/shared.txt, django-fernet-fields, edx-enterprise
 cssutils==1.0.2           # via pynliner
-ddt==1.2.2
+ddt==1.2.2                # via xblock-drag-and-drop-v2, xblock-poll
 decorator==4.4.1          # via pycontracts
-defusedxml==0.5.0
-git+https://github.com/django-compressor/django-appconf@1526a842ee084b791aa66c931b3822091a442853#egg=django-appconf
-django-babel-underscore==0.5.2
+defusedxml==0.5.0         # via -r requirements/edx/base.in, djangorestframework-xml, ora2, python3-openid, python3-saml, safe-lxml, social-auth-core
+git+https://github.com/django-compressor/django-appconf@1526a842ee084b791aa66c931b3822091a442853#egg=django-appconf  # via -r requirements/edx/github.in, django-statici18n
+django-babel-underscore==0.5.2  # via -r requirements/edx/base.in
 django-babel==0.6.2       # via django-babel-underscore
-git+https://github.com/edx/django-celery.git@756cb57aad765cb2b0d37372c1855b8f5f37e6b0#egg=django-celery==3.2.1+edx.2
+git+https://github.com/edx/django-celery.git@756cb57aad765cb2b0d37372c1855b8f5f37e6b0#egg=django-celery==3.2.1+edx.2  # via -r requirements/edx/github.in, edx-celeryutils, super-csv
 django-classy-tags==1.0.0  # via django-sekizai
-django-config-models==2.0.0
-django-cors-headers==2.5.3
-django-countries==5.5
-django-crum==0.7.5
-django-fernet-fields==0.6
-django-filter==2.2.0
-django-ipware==2.1.0
+django-config-models==2.0.0  # via -r requirements/edx/base.in, edx-enterprise
+django-cors-headers==2.5.3  # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
+django-countries==5.5     # via -r requirements/edx/base.in, edx-enterprise
+django-crum==0.7.5        # via -r requirements/edx/base.in, edx-enterprise, edx-proctoring, edx-rbac, super-csv
+django-fernet-fields==0.6  # via -r requirements/edx/base.in, edx-enterprise
+django-filter==2.2.0      # via -r requirements/edx/base.in, edx-enterprise
+django-ipware==2.1.0      # via -r requirements/edx/base.in, edx-enterprise, edx-proctoring
 django-js-asset==1.2.2    # via django-mptt
-git+https://gitlab.com/Ayub-khan/django-method-override.git@5270af321be2e576d8e8b3c4191711a19975c356#egg=django-method-override==1.0.4
-django-model-utils==3.0.0
-django-mptt==0.11.0
+git+https://gitlab.com/Ayub-khan/django-method-override.git@5270af321be2e576d8e8b3c4191711a19975c356#egg=django-method-override==1.0.4  # via -r requirements/edx/github.in
+django-model-utils==3.0.0  # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, django-user-tasks, edx-bulk-grades, edx-celeryutils, edx-completion, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-rbac, edx-submissions, edx-when, edxval, ora2, super-csv
+django-mptt==0.11.0       # via -r requirements/edx/base.in, django-wiki
 django-multi-email-field==0.6.1  # via edx-enterprise
-django-mysql==3.3.0
-git+https://github.com/edx/django-oauth-plus.git@b9b64a3ac24fd11f471763c88462bbf3c53e46e6#egg=django-oauth-plus==2.2.9.edx-4
-django-oauth-toolkit==1.1.3
+django-mysql==3.3.0       # via -r requirements/edx/base.in
+django-oauth-toolkit==1.1.3  # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
 django-object-actions==2.0.0  # via edx-enterprise
-django-pipeline==1.7.0
-django-pyfs==2.1
-django-ratelimit-backend==2.0
-django-require==1.0.11
-django-sekizai==1.1.0
-django-ses==0.8.14
-django-simple-history==2.8.0
-django-splash==0.2.6
-django-statici18n==1.9.0
-django-storages==1.8
-django-user-tasks==0.3.0
-django-waffle==0.18.0
-django-webpack-loader==0.6.0
-django==1.11.28
-djangorestframework-jwt==1.11.0
-git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4bc70c03de308a277197c#egg=djangorestframework-oauth==1.1.1
+django-pipeline==1.7.0    # via -r requirements/edx/base.in
+django-pyfs==2.1          # via -r requirements/edx/base.in
+django-ratelimit-backend==2.0  # via -r requirements/edx/base.in
+django-require==1.0.11    # via -r requirements/edx/base.in
+django-sekizai==1.1.0     # via -r requirements/edx/base.in, django-wiki
+django-ses==0.8.14        # via -r requirements/edx/base.in
+django-simple-history==2.8.0  # via -r requirements/edx/base.in, edx-enterprise, edx-organizations, ora2
+django-splash==0.2.6      # via -r requirements/edx/base.in
+django-statici18n==1.9.0  # via -r requirements/edx/base.in
+django-storages==1.8      # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, edxval
+django-user-tasks==0.3.0  # via -r requirements/edx/base.in
+django-waffle==0.18.0     # via -r requirements/edx/base.in, edx-django-utils, edx-drf-extensions, edx-enterprise, edx-proctoring
+django-webpack-loader==0.7.0  # via -r requirements/edx/base.in, edx-proctoring
+django==1.11.28           # via -r requirements/edx/base.in, code-annotations, django-appconf, django-babel, django-babel-underscore, django-celery, django-classy-tags, django-config-models, django-cors-headers, django-crum, django-fernet-fields, django-filter, django-method-override, django-model-utils, django-mptt, django-multi-email-field, django-mysql, django-oauth-toolkit, django-pyfs, django-ratelimit-backend, django-sekizai, django-splash, django-statici18n, django-storages, django-wiki, drf-yasg, edx-ace, edx-api-doc-tools, edx-bulk-grades, edx-celeryutils, edx-completion, edx-django-oauth2-provider, edx-django-release-util, edx-django-sites-extensions, edx-django-utils, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-milestones, edx-oauth2-provider, edx-opaque-keys, edx-organizations, edx-proctoring, edx-rbac, edx-search, edx-submissions, edx-when, edxval, event-tracking, help-tokens, jsonfield2, ora2, rest-condition, super-csv, xss-utils
+djangorestframework-jwt==1.11.0  # via -r requirements/edx/base.in, edx-drf-extensions
 djangorestframework-xml==1.4.0  # via edx-enterprise
-djangorestframework==3.9.4
-docopt==0.6.2
+djangorestframework==3.9.4  # via -r requirements/edx/base.in, django-config-models, django-user-tasks, drf-yasg, edx-api-doc-tools, edx-completion, edx-drf-extensions, edx-enterprise, edx-organizations, edx-proctoring, edx-submissions, ora2, rest-condition, super-csv
+docopt==0.6.2             # via xmodule
 docutils==0.16            # via botocore
-drf-yasg==1.17.0          # via edx-api-doc-tools
-edx-ace==0.1.13
-edx-analytics-data-api-client==0.15.3
-edx-api-doc-tools==1.0.2
-edx-bulk-grades==0.6.6
-edx-ccx-keys==1.0.0
-edx-celeryutils==0.3.2
-edx-completion==3.0.2
-edx-django-oauth2-provider==1.3.5
-edx-django-release-util==0.3.6
-edx-django-sites-extensions==2.4.3
-edx-django-utils==2.0.4
-edx-drf-extensions==2.4.6
-edx-enterprise==2.3.8
-edx-i18n-tools==0.5.0
-edx-milestones==0.2.6
-edx-oauth2-provider==1.3.1
-edx-opaque-keys[django]==2.0.1
-edx-organizations==2.2.1
-edx-proctoring-proctortrack==1.0.5
-edx-proctoring==2.2.6
-edx-rbac==1.0.5           # via edx-enterprise
-edx-rest-api-client==3.0.2
-edx-search==1.2.2
-edx-sga==0.10.0
-edx-submissions==3.0.4
+drf-yasg==1.17.0          # via -c requirements/edx/../constraints.txt, edx-api-doc-tools
+edx-ace==0.1.13           # via -r requirements/edx/base.in
+edx-analytics-data-api-client==0.15.3  # via -r requirements/edx/base.in
+edx-api-doc-tools==1.0.2  # via -r requirements/edx/base.in
+edx-bulk-grades==0.6.6    # via -r requirements/edx/base.in, staff-graded-xblock
+edx-ccx-keys==1.0.0       # via -r requirements/edx/base.in
+edx-celeryutils==0.3.2    # via -r requirements/edx/base.in, super-csv
+edx-completion==3.1.1     # via -r requirements/edx/base.in
+edx-django-oauth2-provider==1.3.5  # via -r requirements/edx/base.in, edx-oauth2-provider, edx-organizations, edxval
+edx-django-release-util==0.3.6  # via -r requirements/edx/base.in
+edx-django-sites-extensions==2.4.3  # via -r requirements/edx/base.in
+edx-django-utils==3.0     # via -r requirements/edx/base.in, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client
+edx-drf-extensions==3.0.0  # via -r requirements/edx/base.in, edx-completion, edx-enterprise, edx-organizations, edx-proctoring, edx-rbac, edx-when, edxval
+edx-enterprise==2.4.1     # via -r requirements/edx/base.in
+edx-i18n-tools==0.5.0     # via ora2
+edx-milestones==0.2.6     # via -r requirements/edx/base.in
+edx-oauth2-provider==1.3.1  # via -r requirements/edx/base.in
+edx-opaque-keys[django]==2.0.1  # via -r requirements/edx/paver.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, xmodule
+edx-organizations==3.0.0  # via -r requirements/edx/base.in
+edx-proctoring-proctortrack==1.0.5  # via -r requirements/edx/base.in
+edx-proctoring==2.3.0     # via -r requirements/edx/base.in, edx-proctoring-proctortrack
+edx-rbac==1.1.0           # via edx-enterprise
+edx-rest-api-client==4.0.1  # via -r requirements/edx/base.in, edx-enterprise, edx-proctoring
+edx-search==1.3.3         # via -r requirements/edx/base.in
+edx-sga==0.10.0           # via -r requirements/edx/base.in
+edx-submissions==3.0.4    # via -r requirements/edx/base.in, ora2
 edx-tincan-py35==0.0.5    # via edx-enterprise
-edx-user-state-client==1.1.2
-edx-when==0.7.0
-edxval==1.2.3
+edx-user-state-client==1.1.2  # via -r requirements/edx/base.in
+edx-when==1.0.2           # via -r requirements/edx/base.in, edx-proctoring
+edxval==1.2.3             # via -r requirements/edx/base.in
 elasticsearch==1.9.0      # via edx-search
-enum34==1.1.6             # via edxval
-event-tracking==0.3.0
-fs-s3fs==0.1.8
-fs==2.0.18
+enum34==1.1.9             # via edxval
+event-tracking==0.3.0     # via -r requirements/edx/base.in, edx-proctoring, edx-search
+fs-s3fs==0.1.8            # via -r requirements/edx/base.in, django-pyfs
+fs==2.0.18                # via -r requirements/edx/base.in, django-pyfs, fs-s3fs, xblock
 future==0.18.2            # via django-ses, edx-celeryutils, edx-enterprise, pycontracts, pyjwkest
-geoip2==3.0.0
-glob2==0.7
-gunicorn==20.0.4
-help-tokens==1.0.5
-html5lib==1.0.1
-httplib2==0.17.0
-idna==2.8
-importlib-metadata==1.5.0
+geoip2==3.0.0             # via -r requirements/edx/base.in
+glob2==0.7                # via -r requirements/edx/base.in
+gunicorn==20.0.4          # via -r requirements/edx/base.in
+help-tokens==1.0.5        # via -r requirements/edx/base.in
+html5lib==1.0.1           # via -r requirements/edx/base.in, ora2
+httplib2==0.17.0          # via oauth2
+idna==2.9                 # via -r requirements/edx/paver.txt, requests
+importlib-metadata==1.5.0  # via -r requirements/edx/paver.txt, path
 inflection==0.3.1         # via drf-yasg
-ipaddress==1.0.23
+ipaddress==1.0.23         # via -r requirements/edx/base.in
 isodate==0.6.0            # via python3-saml
 itypes==1.1.0             # via coreapi
 jinja2==2.11.1            # via code-annotations, coreschema
-jmespath==0.9.4           # via boto3, botocore
+jmespath==0.9.5           # via boto3, botocore
 jsondiff==1.2.0           # via edx-enterprise
-jsonfield2==3.0.3
+jsonfield2==3.0.3         # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, edx-celeryutils, edx-enterprise, edx-proctoring, edx-submissions, ora2
 kombu==3.0.37             # via celery
-laboratory==1.0.2
-lazy==1.4
+laboratory==1.0.2         # via -r requirements/edx/base.in
+lazy==1.4                 # via -r requirements/edx/paver.txt, acid-xblock, ora2
 lepl==5.1.3               # via rfc6266-parser
-libsass==0.10.0
-loremipsum==1.0.5
-git+https://github.com/edx/xblock-lti-consumer.git@v1.2.3#egg=lti_consumer-xblock==1.2.3
-lxml==4.5.0
-mailsnake==1.6.4
-mako==1.0.2
-markdown==2.6.11
+libsass==0.10.0           # via -r requirements/edx/paver.txt, ora2
+loremipsum==1.0.5         # via ora2
+git+https://github.com/edx/xblock-lti-consumer.git@v1.2.3#egg=lti_consumer-xblock==1.2.3  # via -r requirements/edx/github.in
+lxml==4.5.0               # via -r requirements/edx/../edx-sandbox/shared.txt, capa, edxval, lti-consumer-xblock, ora2, safe-lxml, xblock, xmlsec
+mailsnake==1.6.4          # via -r requirements/edx/base.in
+mako==1.0.2               # via -r requirements/edx/base.in, acid-xblock, lti-consumer-xblock, xblock-google-drive, xblock-utils
+markdown==2.6.11          # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, django-wiki, staff-graded-xblock, xblock-poll
 markey==0.8               # via django-babel-underscore
-markupsafe==1.1.1
+markupsafe==1.1.1         # via -r requirements/edx/paver.txt, chem, jinja2, mako, xblock
 maxminddb==1.5.2          # via geoip2
-mock==3.0.5
-git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a#egg=MongoDBProxy==0.1.0+edx.2
-mongoengine==0.10.0
-more-itertools==8.2.0
+mock==3.0.5               # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.txt, xblock-drag-and-drop-v2, xblock-poll
+git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a#egg=MongoDBProxy==0.1.0+edx.2  # via -r requirements/edx/github.in
+mongoengine==0.10.0       # via -r requirements/edx/base.in
+more-itertools==8.2.0     # via -r requirements/edx/paver.txt, zipp
 mpmath==1.1.0             # via sympy
-mysqlclient==1.4.6
-newrelic==5.6.0.135
-nltk==3.4.5
-nodeenv==1.3.5
-numpy==1.18.1             # via scipy
-git+https://github.com/joestump/python-oauth2.git@b94f69b1ad195513547924e380d9265133e995fa#egg=oauth2
-oauthlib==2.1.0
-git+https://github.com/edx/edx-ora2.git@2.6.9#egg=ora2==2.6.9
+mysqlclient==1.4.6        # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
+newrelic==5.8.0.136       # via -r requirements/edx/base.in, edx-django-utils
+nltk==3.4.5               # via -r requirements/edx/../edx-sandbox/shared.txt, chem
+nodeenv==1.3.5            # via -r requirements/edx/base.in
+numpy==1.18.1             # via calc, chem, scipy
+git+https://github.com/joestump/python-oauth2.git@b94f69b1ad195513547924e380d9265133e995fa#egg=oauth2  # via -r requirements/edx/github.in
+oauthlib==2.1.0           # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, django-oauth-toolkit, lti-consumer-xblock, requests-oauthlib, social-auth-core
+git+https://github.com/edx/edx-ora2.git@2.6.12#egg=ora2==2.6.12  # via -r requirements/edx/github.in
 packaging==20.1           # via drf-yasg
-path.py==12.4.0           # via edx-enterprise, edx-i18n-tools
-path==13.1.0
-pathtools==0.1.2
-paver==1.3.4
-pbr==5.4.4
-pdfminer.six==20200124
-piexif==1.1.3
-pillow==7.0.0
+path.py==12.4.0           # via edx-enterprise, edx-i18n-tools, ora2, xmodule
+path==13.1.0              # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.txt, path.py
+pathtools==0.1.2          # via -r requirements/edx/paver.txt, watchdog
+paver==1.3.4              # via -r requirements/edx/paver.txt
+pbr==5.4.4                # via -r requirements/edx/paver.txt, stevedore
+pdfminer.six==20200124    # via -r requirements/edx/base.in
+piexif==1.1.3             # via -r requirements/edx/base.in
+pillow==7.0.0             # via -r requirements/edx/base.in, edx-enterprise, edx-organizations, edxval
 pkgconfig==1.5.1          # via xmlsec
 polib==1.1.0              # via edx-i18n-tools
-psutil==1.2.1
-py2neo==3.1.2
-pycontracts==1.8.12
-pycountry==19.8.18
-pycparser==2.19
-pycryptodome==3.9.6       # via pdfminer.six
-pycryptodomex==3.9.6
-pygments==2.5.2
-pyjwkest==1.3.2
-pyjwt==1.5.2
-pymongo==3.9.0
-pynliner==0.8.0
-pyparsing==2.2.0          # via packaging, pycontracts
-pysrt==1.1.2
-python-dateutil==2.4.0
-python-levenshtein==0.12.0
-python-memcached==1.59
+psutil==1.2.1             # via -r requirements/edx/paver.txt, edx-django-utils, edx-drf-extensions
+py2neo==3.1.2             # via -r requirements/edx/base.in
+pycontracts==1.8.12       # via -r requirements/edx/base.in, edx-user-state-client
+pycountry==19.8.18        # via -r requirements/edx/base.in
+pycparser==2.19           # via -r requirements/edx/../edx-sandbox/shared.txt, cffi
+pycryptodome==3.9.7       # via pdfminer.six
+pycryptodomex==3.9.7      # via -r requirements/edx/base.in, edx-proctoring, pyjwkest
+pygments==2.5.2           # via -r requirements/edx/base.in
+pyjwkest==1.3.2           # via -r requirements/edx/base.in, edx-drf-extensions
+pyjwt==1.5.2              # via -r requirements/edx/base.in, djangorestframework-jwt, edx-oauth2-provider, edx-rest-api-client, social-auth-core
+pymongo==3.9.0            # via -r requirements/edx/base.in, -r requirements/edx/paver.txt, edx-opaque-keys, event-tracking, mongodbproxy, mongoengine
+pynliner==0.8.0           # via -r requirements/edx/base.in
+pyparsing==2.2.0          # via calc, chem, packaging, pycontracts
+pysrt==1.1.2              # via -r requirements/edx/base.in, edxval
+python-dateutil==2.4.0    # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, analytics-python, botocore, edx-ace, edx-drf-extensions, edx-enterprise, edx-proctoring, ora2, xblock
+python-levenshtein==0.12.0  # via -r requirements/edx/base.in
+python-memcached==1.59    # via -r requirements/edx/paver.txt
 python-slugify==4.0.0     # via code-annotations
-python-swiftclient==3.8.1
-python3-openid==3.1.0 ; python_version >= "3"
-python3-saml==1.5.0
-pytz==2019.3
-pyuca==1.2
-pyyaml==5.3
-random2==1.0.1
-recommender-xblock==1.4.5
-redis==2.10.6
-requests-oauthlib==1.1.0
-requests==2.22.0
-rest-condition==1.0.3
-rfc6266-parser==0.0.6
+python-swiftclient==3.9.0  # via ora2
+python3-openid==3.1.0 ; python_version >= "3"  # via -r requirements/edx/base.in, social-auth-core
+python3-saml==1.5.0       # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
+pytz==2019.3              # via -r requirements/edx/base.in, babel, capa, celery, django, django-ses, edx-completion, edx-enterprise, edx-proctoring, edx-submissions, edx-tincan-py35, event-tracking, fs, ora2, xblock
+pyuca==1.2                # via -r requirements/edx/base.in
+pyyaml==5.3               # via -r requirements/edx/base.in, code-annotations, edx-django-release-util, edx-i18n-tools, xblock
+random2==1.0.1            # via -r requirements/edx/base.in
+recommender-xblock==1.4.5  # via -r requirements/edx/base.in
+redis==2.10.6             # via -r requirements/edx/base.in
+requests-oauthlib==1.1.0  # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, social-auth-core
+requests==2.23.0          # via -r requirements/edx/paver.txt, analytics-python, coreapi, django-oauth-toolkit, edx-analytics-data-api-client, edx-bulk-grades, edx-drf-extensions, edx-enterprise, edx-rest-api-client, geoip2, mailsnake, pyjwkest, python-swiftclient, requests-oauthlib, sailthru-client, slumber, social-auth-core
+rest-condition==1.0.3     # via -r requirements/edx/base.in, edx-drf-extensions
+rfc6266-parser==0.0.6     # via -r requirements/edx/base.in
 ruamel.yaml.clib==0.2.0   # via ruamel.yaml
-ruamel.yaml==0.16.7       # via drf-yasg
-rules==2.2
+ruamel.yaml==0.16.10      # via drf-yasg
+rules==2.2                # via -r requirements/edx/base.in, edx-enterprise, edx-proctoring
 s3transfer==0.1.13        # via boto3
-sailthru-client==2.2.3
-scipy==1.4.1
+sailthru-client==2.2.3    # via -r requirements/edx/base.in, edx-ace
+scipy==1.4.1              # via calc, chem
 semantic-version==2.8.4   # via edx-drf-extensions
-shapely==1.7.0
+shapely==1.7.0            # via -r requirements/edx/base.in
 shortuuid==0.5.0          # via edx-django-oauth2-provider
-simplejson==3.17.0
-six==1.14.0
+simplejson==3.17.0        # via -r requirements/edx/base.in, sailthru-client, super-csv, xblock-utils
+six==1.14.0               # via -r requirements/edx/../edx-sandbox/shared.txt, -r requirements/edx/base.in, -r requirements/edx/paver.txt, analytics-python, bleach, calc, cryptography, django-appconf, django-classy-tags, django-countries, django-pyfs, django-sekizai, django-simple-history, django-statici18n, drf-yasg, edx-ace, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-milestones, edx-opaque-keys, edx-rbac, edx-search, event-tracking, fs, fs-s3fs, help-tokens, html5lib, isodate, libsass, mock, nltk, packaging, paver, pycontracts, pyjwkest, python-dateutil, python-memcached, python-swiftclient, social-auth-app-django, social-auth-core, stevedore, xblock
 slumber==0.7.1            # via edx-bulk-grades, edx-enterprise, edx-rest-api-client
-social-auth-core==3.2.0
-git+https://github.com/jazzband/sorl-thumbnail.git@13bedfb7d2970809eda597e3ef79318a6fa80ac2#egg=sorl-thumbnail
-sortedcontainers==2.1.0
-soupsieve==1.9.5          # via beautifulsoup4
-sqlparse==0.3.0
-staff-graded-xblock==0.6
-stevedore==1.31.0
-super-csv==0.9.6
-sympy==1.5.1
-testfixtures==6.12.0      # via edx-enterprise
+social-auth-core==3.2.0   # via -r requirements/edx/base.in, social-auth-app-django
+git+https://github.com/jazzband/sorl-thumbnail.git@13bedfb7d2970809eda597e3ef79318a6fa80ac2#egg=sorl-thumbnail  # via -r requirements/edx/github.in
+sortedcontainers==2.1.0   # via -r requirements/edx/base.in, pdfminer.six
+soupsieve==2.0            # via beautifulsoup4
+sqlparse==0.3.0           # via -r requirements/edx/base.in
+staff-graded-xblock==0.7  # via -r requirements/edx/base.in
+stevedore==1.32.0         # via -r requirements/edx/base.in, -r requirements/edx/paver.txt, code-annotations, edx-ace, edx-enterprise, edx-opaque-keys
+super-csv==0.9.6          # via -r requirements/edx/base.in, edx-bulk-grades
+sympy==1.5.1              # via symmath
+testfixtures==6.14.0      # via edx-enterprise
 text-unidecode==1.3       # via python-slugify
-unicodecsv==0.14.1
+unicodecsv==0.14.1        # via -r requirements/edx/base.in, edx-enterprise
 uritemplate==3.0.1        # via coreapi, drf-yasg
-urllib3==1.25.8
-user-util==0.1.5
-voluptuous==0.11.7
-watchdog==0.10.2
-web-fragments==0.3.1
+urllib3==1.25.8           # via -r requirements/edx/paver.txt, elasticsearch, geoip2, requests
+user-util==0.1.5          # via -r requirements/edx/base.in
+voluptuous==0.11.7        # via ora2
+watchdog==0.10.2          # via -r requirements/edx/paver.txt
+web-fragments==0.3.1      # via -r requirements/edx/base.in, staff-graded-xblock, xblock, xblock-utils
 webencodings==0.5.1       # via bleach, html5lib
-webob==1.8.6              # via xblock
-wrapt==1.11.2
-git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.8#egg=xblock-drag-and-drop-v2==2.2.8
-git+https://github.com/open-craft/xblock-poll@3c7dcaf6c933d914188f0740a60711603f948d26#egg=xblock-poll==1.9.1
-xblock-utils==1.2.4
-xblock==1.2.9
+webob==1.8.6              # via xblock, xmodule
+wrapt==1.11.2             # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.txt
+git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.8#egg=xblock-drag-and-drop-v2==2.2.8  # via -r requirements/edx/github.in
+git+https://github.com/open-craft/xblock-poll@3c7dcaf6c933d914188f0740a60711603f948d26#egg=xblock-poll==1.9.1  # via -r requirements/edx/github.in
+xblock-utils==1.2.4       # via -r requirements/edx/base.in, edx-sga, lti-consumer-xblock, staff-graded-xblock, xblock-drag-and-drop-v2, xblock-google-drive
+xblock==1.2.9             # via -r requirements/edx/base.in, acid-xblock, crowdsourcehinter-xblock, done-xblock, edx-completion, edx-sga, edx-user-state-client, edx-when, lti-consumer-xblock, ora2, rate-xblock, staff-graded-xblock, xblock-discussion, xblock-drag-and-drop-v2, xblock-google-drive, xblock-poll, xblock-utils
 xmlsec==1.3.3             # via python3-saml
-xss-utils==0.1.2
-zipp==1.0.0
+xss-utils==0.1.2          # via -r requirements/edx/base.in
+zipp==1.0.0               # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/js_test.txt
+++ b/requirements/js_test.txt
@@ -7,23 +7,22 @@
 cheroot==8.3.0            # via cherrypy
 cherrypy==18.5.0          # via jasmine
 glob2==0.7                # via jasmine-core
-importlib-resources==1.0.2  # via jaraco.text
-jaraco.classes==2.0       # via jaraco.collections
-jaraco.collections==2.1   # via cherrypy
-jaraco.functools==2.0     # via cheroot, jaraco.text, tempora
+jaraco.classes==3.1.0     # via jaraco.collections
+jaraco.collections==3.0.0  # via cherrypy
+jaraco.functools==3.0.0   # via cheroot, jaraco.text, tempora
 jaraco.text==3.2.0        # via jaraco.collections
 jasmine-core==3.1.0       # via jasmine
 jasmine==3.1.0
 jinja2==2.11.1            # via jasmine
 markupsafe==1.1.1         # via jinja2
-more-itertools==8.2.0     # via cheroot, cherrypy, jaraco.functools
+more-itertools==8.2.0     # via cheroot, cherrypy, jaraco.classes, jaraco.functools
 ordereddict==1.1          # via jasmine-core
 portend==2.6              # via cherrypy
 pytz==2019.3              # via tempora
 pyyaml==3.10              # via jasmine
 selenium==3.141.0         # via jasmine
-six==1.14.0               # via cheroot, jaraco.classes, jaraco.collections, jaraco.text, tempora
-tempora==1.14.1           # via portend
+six==1.14.0               # via cheroot, jaraco.collections, jaraco.text
+tempora==2.1.0            # via portend
 urllib3==1.25.8           # via selenium
 zc.lockfile==2.0          # via cherrypy
 

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -4,12 +4,10 @@
 #
 #    make upgrade
 #
-amqp==1.4.9               # via kombu
 aniso8601==8.0.0          # via edx-tincan-py35
-anyjson==0.3.3            # via kombu
 billiard==3.3.0.23        # via celery
-bleach==3.1.0
-celery==3.1.25
+bleach==3.1.1
+celery==3.1.26.post2
 certifi==2019.11.28       # via requests
 cffi==1.14.0              # via cryptography
 chardet==3.0.4            # via requests
@@ -32,46 +30,39 @@ django==1.11.28
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework-xml==1.4.0
 djangorestframework==3.9.4
-edx-django-utils==2.0.4
-edx-drf-extensions==2.4.6
+edx-django-utils==3.0
+edx-drf-extensions==3.0.0
 edx-opaque-keys[django]==2.0.1
-edx-rbac==1.0.5
-edx-rest-api-client==3.0.2
+edx-rbac==1.1.0
+edx-rest-api-client==4.0.1
 edx-tincan-py35==0.0.5
 future==0.18.2
-idna==2.8                 # via requests
-importlib-metadata==1.5.0  # via path
+idna==2.9                 # via requests
 jinja2==2.11.1            # via code-annotations
 jsondiff==1.2.0
 jsonfield2==3.0.3
 kombu==3.0.37             # via celery
-markupsafe==1.1.1         # via jinja2
-more-itertools==8.2.0     # via zipp
-newrelic==5.6.0.135       # via edx-django-utils
+newrelic==5.8.0.136       # via edx-django-utils
 path.py==12.4.0
 path==13.1.0              # via path.py
 pbr==5.4.4                # via stevedore
 pillow==7.0.0
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
-pycparser==2.19           # via cffi
-pycryptodomex==3.9.6      # via pyjwkest
 pyjwkest==1.3.2           # via edx-drf-extensions
-pyjwt==1.5.2              # via djangorestframework-jwt, edx-rest-api-client
+pyjwt==1.5.2              # via edx-rest-api-client
 pymongo==3.9.0            # via edx-opaque-keys
 python-dateutil==2.4.0
 python-slugify==4.0.0     # via code-annotations
 pytz==2019.3
 pyyaml==5.3               # via code-annotations
-requests==2.22.0
+requests==2.23.0
 rest-condition==1.0.3     # via edx-drf-extensions
 rules==2.2
 semantic-version==2.8.4   # via edx-drf-extensions
 six==1.14.0
 slumber==0.7.1
-stevedore==1.31.0
-testfixtures==6.12.0
-text-unidecode==1.3       # via python-slugify
+stevedore==1.32.0
+testfixtures==6.14.0
 unicodecsv==0.14.1
 urllib3==1.25.8           # via requests
 webencodings==0.5.1       # via bleach
-zipp==1.0.0               # via importlib-metadata

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,13 +4,13 @@
 #
 #    make upgrade
 #
-amqp==1.4.9
+amqp==1.4.9               # via kombu
 aniso8601==8.0.0
-anyjson==0.3.3
+anyjson==0.3.3            # via kombu
 attrs==19.3.0             # via pytest
 billiard==3.3.0.23
-bleach==3.1.0
-celery==3.1.25
+bleach==3.1.1
+celery==3.1.26.post2
 certifi==2019.11.28
 cffi==1.14.0
 chardet==3.0.4
@@ -35,39 +35,38 @@ django-waffle==0.18.0
 djangorestframework-jwt==1.11.0
 djangorestframework-xml==1.4.0
 djangorestframework==3.9.4
-edx-django-utils==2.0.4
-edx-drf-extensions==2.4.6
+edx-django-utils==3.0
+edx-drf-extensions==3.0.0
 edx-opaque-keys[django]==2.0.1
-edx-rbac==1.0.5
-edx-rest-api-client==3.0.2
+edx-rbac==1.1.0
+edx-rest-api-client==4.0.1
 edx-tincan-py35==0.0.5
 factory-boy==2.12.0
-faker==4.0.0              # via factory-boy
-freezegun==0.3.14
+faker==4.0.1              # via factory-boy
+freezegun==0.3.15
 future==0.18.2
-idna==2.8
-importlib-metadata==1.5.0
+idna==2.9
+importlib-metadata==1.5.0  # via path, pluggy, pytest
 inflect==3.0.2            # via jinja2-pluralize
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.11.1
 jsondiff==1.2.0
 jsonfield2==3.0.3
 kombu==3.0.37
-markupsafe==1.1.1
+markupsafe==1.1.1         # via jinja2
 mock==3.0.5
-more-itertools==8.2.0
-newrelic==5.6.0.135
+more-itertools==8.2.0     # via pytest
+newrelic==5.8.0.136
 packaging==20.1           # via pytest
 path.py==12.4.0
 path==13.1.0
-pathlib2==2.3.5           # via pytest
 pbr==5.4.4
 pillow==7.0.0
 pluggy==0.13.1            # via diff-cover, pytest
 psutil==1.2.1
 py==1.8.1                 # via pytest, pytest-catchlog
-pycparser==2.19
-pycryptodomex==3.9.6
+pycparser==2.19           # via cffi
+pycryptodomex==3.9.7      # via pyjwkest
 pygments==2.5.2           # via diff-cover
 pyjwkest==1.3.2
 pyjwt==1.5.2
@@ -81,18 +80,18 @@ python-dateutil==2.4.0
 python-slugify==4.0.0
 pytz==2019.3
 pyyaml==5.3
-requests==2.22.0
-responses==0.10.9
+requests==2.23.0
+responses==0.10.11
 rest-condition==1.0.3
 rules==2.2
 semantic-version==2.8.4
 six==1.14.0
 slumber==0.7.1
-stevedore==1.31.0
-testfixtures==6.12.0
-text-unidecode==1.3
+stevedore==1.32.0
+testfixtures==6.14.0
+text-unidecode==1.3       # via faker, python-slugify
 unicodecsv==0.14.1
 urllib3==1.25.8
 wcwidth==0.1.8            # via pytest
 webencodings==0.5.1
-zipp==1.0.0
+zipp==1.0.0               # via importlib-metadata

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -7,23 +7,21 @@
 appdirs==1.4.3            # via virtualenv
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
-codecov==2.0.15
+codecov==2.0.16
 coverage==5.0.3           # via codecov
 distlib==0.3.0            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
-idna==2.8                 # via requests
+idna==2.9                 # via requests
 importlib-metadata==1.5.0  # via pluggy, tox, virtualenv
-importlib-resources==1.0.2  # via virtualenv
-more-itertools==8.2.0     # via zipp
 packaging==20.1           # via tox
 pluggy==0.13.1            # via tox
 py==1.8.1                 # via tox
 pyparsing==2.4.6          # via packaging
-requests==2.22.0          # via codecov
+requests==2.23.0          # via codecov
 six==1.14.0               # via packaging, tox, virtualenv
 toml==0.10.0              # via tox
 tox-battery==0.5.1
-tox==3.14.3
+tox==3.14.5
 urllib3==1.25.8           # via requests
-virtualenv==20.0.2        # via tox
+virtualenv==20.0.7        # via tox
 zipp==1.0.0               # via importlib-metadata


### PR DESCRIPTION
We believe the latest version of django-countries adversely impacted the enterprise customer django admin, making it unusable. Let's prevent this from being upgraded accidentally; constraining it here should consrtain edx-platform.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
