### PR TITLE
ENT-2622: Reset user authentication cookies

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,11 @@ Change Log
 .. There should always be an "Unreleased" section for changes pending release.
 
 
+[2.5.4] - 2020-03-12
+--------------------
+
+* Reset authentication cookies on enterprise selection to update JWT cookie with user's enterprise
+
 [2.5.3] - 2020-03-11
 --------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "2.5.3"
+__version__ = "2.5.4"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -74,6 +74,12 @@ try:
 except ImportError:
     ProgramDataExtender = None
 
+try:
+    from openedx.core.djangoapps.user_authn import cookies as user_authn_cookies
+except ImportError:
+    user_authn_cookies = None
+
+
 LOGGER = getLogger(__name__)
 BASKET_URL = urljoin(settings.ECOMMERCE_PUBLIC_URL_ROOT, '/basket/add/')
 LMS_DASHBOARD_URL = urljoin(settings.LMS_ROOT_URL, '/dashboard')
@@ -909,7 +915,11 @@ class EnterpriseSelectionView(FormView):
                 self.request.user.username,
                 enterprise_customer,
             )
-            return JsonResponse({})
+            response = JsonResponse({})
+            return user_authn_cookies.set_logged_in_cookies(
+                self.request, response, self.request.user
+            ) if user_authn_cookies else response
+
         return None
 
 


### PR DESCRIPTION
Changes to reset user authentication cookies after successfull selection of enterprise by learner. This should update JWT cookies which would help us accurately map learner's enterprise where we fetch learner's enterprise from JWT cookie.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
