### PR TITLE
Fix xAPI CourseOverview fetching

### DIFF
--- a/integrated_channels/xapi/management/commands/send_course_completions.py
+++ b/integrated_channels/xapi/management/commands/send_course_completions.py
@@ -219,6 +219,6 @@ class Command(BaseCommand):
         Returns:
             (dict): A dictionary containing course_id to course_overview mapping.
         """
-        return CourseOverview.get_from_ids_if_exists(
+        return CourseOverview.get_from_ids(
             [grade.course_id for grade in persistent_course_grades]
         )


### PR DESCRIPTION
@mattdrayer @moconnell1453 

The xAPI completion reporting code references `CourseOverview.get_from_ids_if_exists`. This function was removed from edx-platform in https://github.com/edx/edx-platform/pull/22918 and replaced with a similar function, `CourseOverview.get_from_ids`. This commit
updates the reference to the new function.

https://openedx.atlassian.net/browse/ENT-2703

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
