### PR TITLE
Bumped version for previous commit

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,16 @@ Change Log
 .. There should always be an "Unreleased" section for changes pending release.
 
 
+[3.0.1] - 2020-03-18
+--------------------
+
+* Updated xApi integrated channel to use the updated CourseOverview method 'get_from_ids()'
+
+[3.0.0] - 2020-03-16
+--------------------
+
+* Removed use of Bearer Authentication
+
 [2.5.5] - 2020-03-13
 --------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "3.0.0"
+__version__ = "3.0.1"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name


### PR DESCRIPTION
Updated the use of CourseOverview's method 'get_from_ids()'
with the xApi integrated channels

ENT-2703