### PR TITLE
ENT-2537: Added logging around enrollment/completion transmission of xAPI

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,11 @@ Change Log
 .. There should always be an "Unreleased" section for changes pending release.
 
 
+[3.0.2] - 2020-03-26
+--------------------
+
+* Improved xApi logging to include statement and LRS endpoint'
+
 [3.0.1] - 2020-03-18
 --------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "3.0.1"
+__version__ = "3.0.2"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/xapi/client.py
+++ b/integrated_channels/xapi/client.py
@@ -49,6 +49,11 @@ class EnterpriseXAPIClient:
         Raises:
             ClientError: If xAPI statement fails to save.
         """
+        LOGGER.info(
+            "[Integrated Channel][xAPI] Sending statement %s to LRS endpoint %s ",
+            statement.to_json(),
+            self.lrs.endpoint
+        )
         response = self.lrs.save_statement(statement)
 
         if not response:

--- a/integrated_channels/xapi/management/commands/send_course_completions.py
+++ b/integrated_channels/xapi/management/commands/send_course_completions.py
@@ -131,6 +131,12 @@ class Command(BaseCommand):
         persistent_course_grades = self.get_course_completions(lrs_configuration.enterprise_customer, days)
         users = self.prefetch_users(persistent_course_grades)
         course_overviews = self.prefetch_courses(persistent_course_grades)
+        LOGGER.info(
+            '[Integrated Channel][xAPI] Found %s course completion for enterprise customer: [%s] during last %s days',
+            len(persistent_course_grades),
+            lrs_configuration.enterprise_customer,
+            days,
+        )
 
         for persistent_course_grade in persistent_course_grades:
             error_message = None

--- a/integrated_channels/xapi/management/commands/send_course_enrollments.py
+++ b/integrated_channels/xapi/management/commands/send_course_enrollments.py
@@ -119,7 +119,15 @@ class Command(BaseCommand):
                 of the LRS where to send xAPI  learner analytics.
             days (int): Include course enrollment of this number of days.
         """
-        for course_enrollment in self.get_course_enrollments(lrs_configuration.enterprise_customer, days):
+        course_enrollments = self.get_course_enrollments(lrs_configuration.enterprise_customer, days)
+        LOGGER.info(
+            '[Integrated Channel][xAPI] Found %s course enrollments for enterprise customer: [%s] during last %s days',
+            len(course_enrollments),
+            lrs_configuration.enterprise_customer,
+            days,
+        )
+
+        for course_enrollment in course_enrollments:
             error_message = None
             course_id = six.text_type(course_enrollment.course.id)
             try:

--- a/tests/test_integrated_channels/test_xapi/test_client.py
+++ b/tests/test_integrated_channels/test_xapi/test_client.py
@@ -12,6 +12,7 @@ from pytest import mark, raises
 
 from integrated_channels.exceptions import ClientError
 from integrated_channels.xapi.client import EnterpriseXAPIClient
+from integrated_channels.xapi.statements.base import EnterpriseStatement
 from test_utils import factories
 
 
@@ -25,6 +26,7 @@ class TestXAPILRSConfiguration(unittest.TestCase):
         super(TestXAPILRSConfiguration, self).setUp()
         self.x_api_lrs_config = factories.XAPILRSConfigurationFactory()
         self.x_api_client = EnterpriseXAPIClient(self.x_api_lrs_config)
+        self.statement = EnterpriseStatement()
 
     @mock.patch('integrated_channels.xapi.client.RemoteLRS', mock.MagicMock())
     def test_save_statement(self):
@@ -32,8 +34,8 @@ class TestXAPILRSConfiguration(unittest.TestCase):
         Verify that save_statement sends xAPI statement to LRS.
         """
         # verify that request completes without an error.
-        self.x_api_client.save_statement({})
-        self.x_api_client.lrs.save_statement.assert_called_once_with({})
+        self.x_api_client.save_statement(self.statement)
+        self.x_api_client.lrs.save_statement.assert_called_once_with(self.statement)
 
     @mock.patch('integrated_channels.xapi.client.RemoteLRS', mock.MagicMock())
     def test_save_statement_raises_client_error(self):
@@ -43,4 +45,4 @@ class TestXAPILRSConfiguration(unittest.TestCase):
         self.x_api_client.lrs.save_statement = mock.Mock(return_value=None)
 
         with raises(ClientError):
-            self.x_api_client.save_statement({})
+            self.x_api_client.save_statement(self.statement)


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
