### PR TITLE
Update enterprise catalog urls to match new paths

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,11 @@ Change Log
 .. There should always be an "Unreleased" section for changes pending release.
 
 
+[3.0.3] - 2020-03-27
+--------------------
+
+* Updated enterprise-catalog endpoint urls to match rename
+
 [3.0.2] - 2020-03-26
 --------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "3.0.2"
+__version__ = "3.0.3"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api_client/enterprise_catalog.py
+++ b/enterprise/api_client/enterprise_catalog.py
@@ -24,7 +24,7 @@ class EnterpriseCatalogApiClient(JwtLmsApiClient):
     """
 
     API_BASE_URL = settings.ENTERPRISE_CATALOG_INTERNAL_ROOT_URL + '/api/v1/'
-    ENTERPRISE_CATALOG_ENDPOINT = 'enterprise-catalog'
+    ENTERPRISE_CATALOG_ENDPOINT = 'enterprise-catalogs'
     APPEND_SLASH = True
 
     @JwtLmsApiClient.refresh_token

--- a/tests/test_enterprise/api_client/test_enterprise_catalog.py
+++ b/tests/test_enterprise/api_client/test_enterprise_catalog.py
@@ -48,7 +48,7 @@ def test_create_enterprise_catalog():
     }
     responses.add(
         responses.POST,
-        _url("enterprise-catalog/"),
+        _url("enterprise-catalogs/"),
         json=expected_response
     )
     client = enterprise_catalog.EnterpriseCatalogApiClient('staff-user-goes-here')
@@ -78,7 +78,7 @@ def test_get_enterprise_catalog():
     }
     responses.add(
         responses.GET,
-        _url("enterprise-catalog/{catalog_uuid}/".format(catalog_uuid=TEST_ENTERPRISE_CATALOG_UUID)),
+        _url("enterprise-catalogs/{catalog_uuid}/".format(catalog_uuid=TEST_ENTERPRISE_CATALOG_UUID)),
         json=expected_response,
     )
     client = enterprise_catalog.EnterpriseCatalogApiClient('staff-user-goes-here')
@@ -99,7 +99,7 @@ def test_update_enterprise_catalog():
     }
     responses.add(
         responses.PUT,
-        _url("enterprise-catalog/{catalog_uuid}/".format(catalog_uuid=TEST_ENTERPRISE_CATALOG_UUID)),
+        _url("enterprise-catalogs/{catalog_uuid}/".format(catalog_uuid=TEST_ENTERPRISE_CATALOG_UUID)),
         json=expected_response,
     )
     client = enterprise_catalog.EnterpriseCatalogApiClient('staff-user-goes-here')
@@ -117,7 +117,7 @@ def test_update_enterprise_catalog():
 def test_delete_enterprise_catalog():
     responses.add(
         responses.DELETE,
-        _url("enterprise-catalog/{catalog_uuid}/".format(catalog_uuid=TEST_ENTERPRISE_CATALOG_UUID)),
+        _url("enterprise-catalogs/{catalog_uuid}/".format(catalog_uuid=TEST_ENTERPRISE_CATALOG_UUID)),
     )
     client = enterprise_catalog.EnterpriseCatalogApiClient('staff-user-goes-here')
     actual_response = client.delete_enterprise_catalog(TEST_ENTERPRISE_CATALOG_UUID)


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
