### PR TITLE
ENT-2676: Converted ThirdPartyAuthApiClient to JWT client

### DIFF
--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -652,7 +652,7 @@ class EnterpriseCustomerCourseEnrollmentsSerializer(serializers.Serializer):
         enterprise_customer = self.context.get('enterprise_customer')
 
         try:
-            tpa_client = ThirdPartyAuthApiClient()
+            tpa_client = ThirdPartyAuthApiClient(self.context['request_user'])
             username = tpa_client.get_username_from_remote_id(
                 enterprise_customer.identity_provider, value
             )

--- a/enterprise/api_client/lms.py
+++ b/enterprise/api_client/lms.py
@@ -342,13 +342,14 @@ class CourseApiClient(LmsApiClient):
             return None
 
 
-class ThirdPartyAuthApiClient(LmsApiClient):
+class ThirdPartyAuthApiClient(JwtLmsApiClient):
     """
     Object builds an API client to make calls to the Third Party Auth API.
     """
 
     API_BASE_URL = settings.LMS_INTERNAL_ROOT_URL + '/api/third_party_auth/v0/'
 
+    @JwtLmsApiClient.refresh_token
     def get_remote_id(self, identity_provider, username):
         """
         Retrieve the remote identifier for the given username.
@@ -362,6 +363,7 @@ class ThirdPartyAuthApiClient(LmsApiClient):
         """
         return self._get_results(identity_provider, 'username', username, 'remote_id')
 
+    @JwtLmsApiClient.refresh_token
     def get_username_from_remote_id(self, identity_provider, remote_id):
         """
         Retrieve the remote identifier for the given username.

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -53,6 +53,7 @@ from enterprise.utils import (
     NotConnectedToOpenEdX,
     get_configuration_value,
     get_ecommerce_worker_user,
+    get_enterprise_worker_user,
 )
 from enterprise.validators import validate_hex_color, validate_image_extension, validate_image_size
 
@@ -786,7 +787,8 @@ class EnterpriseCustomerUser(TimeStampedModel):
         user = self.user
         identity_provider = self.enterprise_customer.identity_provider
         if user and identity_provider:
-            client = ThirdPartyAuthApiClient()
+            enterprise_worker = get_enterprise_worker_user()
+            client = ThirdPartyAuthApiClient(enterprise_worker)
             return client.get_remote_id(self.enterprise_customer.identity_provider, user.username)
         return None
 

--- a/tests/test_enterprise/api_client/test_lms.py
+++ b/tests/test_enterprise/api_client/test_lms.py
@@ -413,6 +413,7 @@ def test_get_full_course_details_not_found():
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_get_remote_id_not_found():
     username = "Darth"
     provider_id = "DeathStar"
@@ -424,12 +425,13 @@ def test_get_remote_id_not_found():
         match_querystring=True,
         status=404
     )
-    client = lms_api.ThirdPartyAuthApiClient()
+    client = lms_api.ThirdPartyAuthApiClient('staff-user-goes-here')
     actual_response = client.get_remote_id(provider_id, username)
     assert actual_response is None
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_get_remote_id_no_results():
     username = "Darth"
     provider_id = "DeathStar"
@@ -450,12 +452,13 @@ def test_get_remote_id_no_results():
         match_querystring=True,
         json=expected_response,
     )
-    client = lms_api.ThirdPartyAuthApiClient()
+    client = lms_api.ThirdPartyAuthApiClient('staff-user-goes-here')
     actual_response = client.get_remote_id(provider_id, username)
     assert actual_response is None
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_get_remote_id():
     username = "Darth"
     provider_id = "DeathStar"
@@ -476,12 +479,13 @@ def test_get_remote_id():
         match_querystring=True,
         json=expected_response,
     )
-    client = lms_api.ThirdPartyAuthApiClient()
+    client = lms_api.ThirdPartyAuthApiClient('staff-user-goes-here')
     actual_response = client.get_remote_id(provider_id, username)
     assert actual_response == "LukeIamYrFather"
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_get_username_from_remote_id_not_found():
     remote_id = "Darth"
     provider_id = "DeathStar"
@@ -493,12 +497,13 @@ def test_get_username_from_remote_id_not_found():
         match_querystring=True,
         status=404
     )
-    client = lms_api.ThirdPartyAuthApiClient()
+    client = lms_api.ThirdPartyAuthApiClient('staff-user-goes-here')
     actual_response = client.get_username_from_remote_id(provider_id, remote_id)
     assert actual_response is None
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_get_username_from_remote_id_no_results():
     remote_id = "Darth"
     provider_id = "DeathStar"
@@ -519,12 +524,13 @@ def test_get_username_from_remote_id_no_results():
         match_querystring=True,
         json=expected_response,
     )
-    client = lms_api.ThirdPartyAuthApiClient()
+    client = lms_api.ThirdPartyAuthApiClient('staff-user-goes-here')
     actual_response = client.get_username_from_remote_id(provider_id, remote_id)
     assert actual_response is None
 
 
 @responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_get_username_from_remote_id():
     remote_id = "LukeIamYrFather"
     provider_id = "DeathStar"
@@ -544,7 +550,7 @@ def test_get_username_from_remote_id():
         match_querystring=True,
         json=expected_response,
     )
-    client = lms_api.ThirdPartyAuthApiClient()
+    client = lms_api.ThirdPartyAuthApiClient('staff-user-goes-here')
     actual_response = client.get_username_from_remote_id(provider_id, remote_id)
     assert actual_response == "Darth"
 


### PR DESCRIPTION
This PR has changes to Convert ThirdPartyAuthApiClient to JWT client.
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
