### PR TITLE
ENT-2672 | Removed the 'EDX_API_KEY' from CourseApiClient and directl…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,11 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+[3.0.4] - 2020-03-31
+--------------------
+
+* Removed the 'EDX_API_KEY' from CourseApiClient.
+
 
 [3.0.3] - 2020-03-27
 --------------------

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "3.0.3"
+__version__ = "3.0.4"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api_client/lms.py
+++ b/enterprise/api_client/lms.py
@@ -58,6 +58,23 @@ class LmsApiClient:
         )
 
 
+class NoAuthenticationLmsApiClient:
+    """
+    Object builds an API client to make calls to the edxapp LMS API.
+
+    Authentication is not required.
+    """
+
+    API_BASE_URL = settings.LMS_INTERNAL_ROOT_URL + '/api/'
+    APPEND_SLASH = False
+
+    def __init__(self):
+        """
+        Create an LMS API client.
+        """
+        self.client = EdxRestApiClient(self.API_BASE_URL, append_slash=self.APPEND_SLASH)
+
+
 class JwtLmsApiClient:
     """
     LMS client authenticates using a JSON Web Token (JWT) for the given user.
@@ -317,7 +334,7 @@ class EnrollmentApiClient(LmsApiClient):
         return self.client.enrollment.get(user=username)
 
 
-class CourseApiClient(LmsApiClient):
+class CourseApiClient(NoAuthenticationLmsApiClient):
     """
     Object builds an API client to make calls to the Course API.
     """


### PR DESCRIPTION
…y called the EdxRestApiClient.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
