### PR TITLE
ENT-2483 | Return boolean value of whether or not the course is active

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,13 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+
+[3.0.5] - 2020-03-31
+--------------------
+
+* Added "active" key in enterprise_catalog API for "course" content_type if the "course" has "course_run" available for enrollment.
+
+
 [3.0.4] - 2020-03-31
 --------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "3.0.4"
+__version__ = "3.0.5"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -18,7 +18,12 @@ from django.utils.translation import ugettext_lazy as _
 from enterprise import models, utils
 from enterprise.api_client.lms import ThirdPartyAuthApiClient
 from enterprise.constants import ENTERPRISE_PERMISSION_GROUPS
-from enterprise.utils import CourseEnrollmentDowngradeError, CourseEnrollmentPermissionError, track_enrollment
+from enterprise.utils import (
+    CourseEnrollmentDowngradeError,
+    CourseEnrollmentPermissionError,
+    has_course_run_available_for_enrollment,
+    track_enrollment,
+)
 
 LOGGER = getLogger(__name__)
 
@@ -245,6 +250,7 @@ class EnterpriseCustomerCatalogDetailSerializer(EnterpriseCustomerCatalogSeriali
             # Add the Enterprise enrollment URL to each content item returned from the discovery service.
             if content_type == 'course':
                 item['enrollment_url'] = instance.get_course_enrollment_url(item['key'])
+                item['active'] = has_course_run_available_for_enrollment(item['course_runs'])
             if content_type == 'courserun':
                 item['enrollment_url'] = instance.get_course_run_enrollment_url(item['key'])
             if content_type == 'program':

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -750,6 +750,32 @@ def is_course_run_enrollable(course_run):
            (not enrollment_end or enrollment_end > now)
 
 
+def is_course_run_available_for_enrollment(course_run):
+    """
+    Check if a course run is available for enrollment.
+    """
+    if course_run['availability'] not in ['Current', 'Starting Soon', 'Upcoming']:
+        # course run is archived so not available for enrollment
+        return False
+
+    # now check if the course run is enrollable on the basis of enrollment
+    # start and end date
+    return is_course_run_enrollable(course_run)
+
+
+def has_course_run_available_for_enrollment(course_runs):
+    """
+        Iterates over all course runs to check if there any course run that is available for enrollment.
+
+    :param course_runs: list of course runs
+    :returns True if found else false
+    """
+    for course_run in course_runs:
+        if is_course_run_available_for_enrollment(course_run):
+            return True
+    return False
+
+
 def is_course_run_upgradeable(course_run):
     """
     Return true if the course run has a verified seat with an unexpired upgrade deadline, false otherwise.

--- a/integrated_channels/sap_success_factors/exporters/content_metadata.py
+++ b/integrated_channels/sap_success_factors/exporters/content_metadata.py
@@ -10,13 +10,10 @@ from logging import getLogger
 from django.utils.translation import ugettext_lazy as _
 
 from enterprise.api_client.lms import parse_lms_api_datetime
-from enterprise.utils import get_closest_course_run
+from enterprise.utils import get_closest_course_run, is_course_run_available_for_enrollment
 from enterprise.views import CourseEnrollmentView
 from integrated_channels.integrated_channel.exporters.content_metadata import ContentMetadataExporter
-from integrated_channels.sap_success_factors.exporters.utils import (
-    course_available_for_enrollment,
-    transform_language_code,
-)
+from integrated_channels.sap_success_factors.exporters.utils import transform_language_code
 from integrated_channels.utils import (
     UNIX_MAX_DATE_STRING,
     UNIX_MIN_DATE_STRING,
@@ -170,7 +167,7 @@ class SapSuccessFactorsContentMetadataExporter(ContentMetadataExporter):  # pyli
         course_run_start = content_metadata_item.get('start')
 
         if course_run_start:
-            if course_available_for_enrollment(content_metadata_item):
+            if is_course_run_available_for_enrollment(content_metadata_item):
                 title += ' ({starts}: {:%B %Y})'.format(
                     parse_lms_api_datetime(course_run_start),
                     starts=_('Starts')
@@ -217,7 +214,7 @@ class SapSuccessFactorsContentMetadataExporter(ContentMetadataExporter):  # pyli
             if date_str:
                 date_str += '. '
 
-        if not course_available_for_enrollment(course_run):
+        if not is_course_run_available_for_enrollment(course_run):
             date_str += 'Enrollment is closed. '
 
         return date_str

--- a/integrated_channels/sap_success_factors/exporters/utils.py
+++ b/integrated_channels/sap_success_factors/exporters/utils.py
@@ -7,23 +7,9 @@ from __future__ import absolute_import, unicode_literals
 
 from logging import getLogger
 
-from enterprise.utils import is_course_run_enrollable
 from integrated_channels.sap_success_factors.constants import SUCCESSFACTORS_OCN_LANGUAGE_CODES
 
 LOGGER = getLogger(__name__)
-
-
-def course_available_for_enrollment(course_run):
-    """
-    Check if a course run is available for enrollment.
-    """
-    if course_run['availability'] not in ['Current', 'Starting Soon', 'Upcoming']:
-        # course is archived so not available for enrollment
-        return False
-
-    # now check if the course run is enrollable on the basis of enrollment
-    # start and end date
-    return is_course_run_enrollable(course_run)
 
 
 def transform_language_code(code):

--- a/test_utils/__init__.py
+++ b/test_utils/__init__.py
@@ -116,7 +116,12 @@ def update_course_run_with_enterprise_context(course_run, add_utm_info=True, ent
     return course_run
 
 
-def update_course_with_enterprise_context(course, add_utm_info=True, enterprise_catalog_uuid=None):
+def update_course_with_enterprise_context(
+        course,
+        add_utm_info=True,
+        enterprise_catalog_uuid=None,
+        add_active_info=True
+):
     """
     Populate a fake course response with any necessary Enterprise context for testing purposes.
     """
@@ -135,6 +140,9 @@ def update_course_with_enterprise_context(course, add_utm_info=True, enterprise_
     )
 
     course_runs = course.get('course_runs', [])
+
+    if add_active_info:
+        course['active'] = utils.has_course_run_available_for_enrollment(course_runs)
     for course_run in course_runs:
         update_course_run_with_enterprise_context(
             course_run,
@@ -167,7 +175,8 @@ def update_program_with_enterprise_context(program, add_utm_info=True, enterpris
         update_course_with_enterprise_context(
             course,
             add_utm_info=add_utm_info,
-            enterprise_catalog_uuid=enterprise_catalog_uuid
+            enterprise_catalog_uuid=enterprise_catalog_uuid,
+            add_active_info=False,
         )
 
     return program

--- a/test_utils/fake_catalog_api.py
+++ b/test_utils/fake_catalog_api.py
@@ -910,6 +910,7 @@ FAKE_SEARCH_ALL_COURSE_RESULT = {
     "short_description": None,
     "subject_uuids": [],
     "transcript_languages": [],
+    "course_runs": [],
     "full_description": None,
     "seat_types": [
         "audit",
@@ -950,7 +951,8 @@ FAKE_SEARCH_ALL_SHORT_COURSE_RESULT = {
     "key": "edX+DemoX",
     "short_description": None,
     "aggregation_key": "course:edX+DemoX",
-    "content_type": "course"
+    "content_type": "course",
+    "course_runs": [],
 }
 
 FAKE_SEARCH_ALL_SHORT_COURSE_RESULT_LIST = [
@@ -960,7 +962,8 @@ FAKE_SEARCH_ALL_SHORT_COURSE_RESULT_LIST = [
         "key": "edX+DemoX+2",
         "short_description": None,
         "aggregation_key": "course:edX+DemoX",
-        "content_type": "course"
+        "content_type": "course",
+        "course_runs": [],
     },
     {
         "title": "edX Demonstration Course 3",
@@ -968,7 +971,8 @@ FAKE_SEARCH_ALL_SHORT_COURSE_RESULT_LIST = [
         "key": "edX+DemoX+3",
         "short_description": None,
         "aggregation_key": "course:edX+DemoX",
-        "content_type": "course"
+        "content_type": "course",
+        "course_runs": [],
     },
 ]
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1175,6 +1175,75 @@ class TestEnterpriseUtils(unittest.TestCase):
         assert utils.is_course_run_enrollable(course_run) == expected_enrollment_eligibility
 
     @ddt.data(
+        (
+            [],
+            False,
+        ),
+        (
+            [
+                {
+                    "availability": "Current",
+                    "end": "3000-10-13T13:11:01Z",
+                    "enrollment_start": "2999-10-13T13:11:03Z",  # enrollment_start > now
+                    "enrollment_end": "3000-10-13T13:11:04Z",
+                },
+                {
+                    "availability": "Current",
+                    "end": "3000-10-13T13:11:01Z",
+                    "enrollment_start": "2014-10-13T13:11:03Z",
+                    "enrollment_end": "2999-10-13T13:11:04Z",
+                },
+            ],
+            True,
+        ),
+        (
+            [
+                {
+                    "availability": "Archived",
+                    "end": "3000-10-13T13:11:01Z",
+                    "enrollment_start": "2014-10-13T13:11:03Z",
+                    "enrollment_end": "2999-10-13T13:11:04Z",
+                },
+                {
+                    "availability": "Current",
+                    "end": "3000-10-13T13:11:01Z",
+                    "enrollment_start": "2014-10-13T13:11:03Z",
+                    "enrollment_end": "2999-10-13T13:11:04Z",
+                },
+            ],
+            True,
+        ),
+        (
+            [
+                {
+                    "availability": "Current",
+                    "end": "3000-10-13T13:11:01Z",
+                    "enrollment_start": "2014-10-13T13:11:03Z",
+                    "enrollment_end": "2999-10-13T13:11:04Z",
+                }
+            ],
+            True,
+        ),
+        (
+            [
+                {
+                    "availability": "Archived",
+                    "end": "3000-10-13T13:11:01Z",
+                    "enrollment_start": "2014-10-13T13:11:03Z",
+                    "enrollment_end": "2999-10-13T13:11:04Z",
+                }
+            ],
+            False,
+        )
+    )
+    @ddt.unpack
+    def test_contains_course_run_available_for_enrollment(self, course_runs, expected_enrollment_eligibility):
+        """
+        tests contains_course_run_available_for_enrollment functionality
+        """
+        assert utils.has_course_run_available_for_enrollment(course_runs) == expected_enrollment_eligibility
+
+    @ddt.data(
         ({"seats": [{"type": "verified", "upgrade_deadline": "3000-10-13T13:11:04Z"}]}, True),
         ({"seats": [{"type": "verified", "upgrade_deadline": None}]}, True),
         ({"seats": [{"type": "verified"}]}, True),


### PR DESCRIPTION
added `active` key in enterprise catalog
https://openedx.atlassian.net/browse/ENT-2483
**Merge checklist:**

- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
