### PR TITLE
ENT-2726 Bypass selection page for enrolment url triggered login

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,10 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+[3.0.6] - 2020-04-06
+--------------------
+
+* Added support for bypassing enterprise selection page for enrollment url triggered login
 
 [3.0.5] - 2020-03-31
 --------------------

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "3.0.5"
+__version__ = "3.0.6"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/tpa_pipeline.py
+++ b/enterprise/tpa_pipeline.py
@@ -3,6 +3,8 @@ Module provides elements to be used in third-party auth pipeline.
 """
 from __future__ import absolute_import, unicode_literals
 
+import re
+
 from django.urls import reverse
 
 from enterprise.models import EnterpriseCustomer, EnterpriseCustomerUser
@@ -142,7 +144,9 @@ def handle_redirect_after_social_auth_login(backend, user):
 
     """
     enterprise_customers_count = EnterpriseCustomerUser.objects.filter(user_id=user.id).count()
-    if enterprise_customers_count > 1:
+    next_url = backend.strategy.session_get('next')
+    using_enrollment_url = re.match(r'/enterprise/.*/course/.*/enroll', next_url)
+    if (enterprise_customers_count > 1) and not using_enrollment_url:
         select_enterprise_page_as_redirect_url(backend.strategy)
 
 

--- a/tests/test_tpa_pipeline.py
+++ b/tests/test_tpa_pipeline.py
@@ -148,6 +148,7 @@ class TestTpaPipeline(unittest.TestCase):
         kwargs = {'new_association': new_association}
         backend = self.get_mocked_sso_backend()
         backend.name = backend_name
+        backend.strategy.session_get.return_value = 'not-an-enrollment-url'
         self.user = UserFactory(is_active=True)
         multiple_enterprises_feature.return_value = multiple_enterprise_switch
         enterprise_customer = EnterpriseCustomerFactory(
@@ -190,6 +191,7 @@ class TestTpaPipeline(unittest.TestCase):
         kwargs = {'new_association': new_association}
         backend = self.get_mocked_sso_backend()
         backend.name = backend_name
+        backend.strategy.session_get.return_value = 'not-an-enrollment-url'
         self.user = UserFactory(is_active=True)
         multiple_enterprises_feature.return_value = True
         enterprise_customer = EnterpriseCustomerFactory(
@@ -206,6 +208,71 @@ class TestTpaPipeline(unittest.TestCase):
                 fake_get_ec.return_value = None
                 handle_enterprise_logistration(backend, self.user, **kwargs)
                 ent_page_redirect.assert_not_called()
+
+    @ddt.data(
+        (True, False, True, 'facebook'),
+        (False, False, True, 'facebook'),
+        (True, True, False, 'facebook'),
+        (False, True, False, 'facebook'),
+        (True, True, False, 'facebook'),
+        (False, True, False, 'facebook'),
+        (True, False, True, 'facebook'),
+        (False, False, True, 'facebook'),
+        (True, True, True, 'google-oauth2'),
+        (False, True, True, 'google-oauth2'),
+        (True, False, False, 'google-oauth2'),
+        (False, False, False, 'google-oauth2'),
+        (True, False, True, 'google-oauth2'),
+        (False, False, True, 'google-oauth2'),
+        (True, True, False, 'google-oauth2'),
+        (False, True, False, 'google-oauth2'),
+    )
+    @ddt.unpack
+    @mock.patch('enterprise.tpa_pipeline.is_multiple_user_enterprises_feature_enabled')
+    def test_bypass_enterprise_selection_page_for_enrollment_url_login(self,
+                                                                       using_enrollment_url,
+                                                                       new_association,
+                                                                       multiple_enterprise_switch,
+                                                                       backend_name,
+                                                                       multiple_enterprises_feature):
+        """
+        Test that enterprise selection page is bypassed if socialAuth user is part of multiple enterprises
+        and uses an enrollment url for login
+        """
+        kwargs = {'new_association': new_association}
+        backend = self.get_mocked_sso_backend()
+        backend.name = backend_name
+        if using_enrollment_url:
+            backend.strategy.session_get.return_value = '/enterprise/12e87171-fb0a/course/course-v1:Test/enroll'
+        else:
+            backend.strategy.session_get.return_value = 'not-an-enrollment-url'
+        self.user = UserFactory(is_active=True)
+        multiple_enterprises_feature.return_value = multiple_enterprise_switch
+        enterprise_customer = EnterpriseCustomerFactory(
+            enable_data_sharing_consent=False
+        )
+        enterprise_customer_old = EnterpriseCustomerFactory(
+            enable_data_sharing_consent=False
+        )
+        EnterpriseCustomerUser.objects.create(
+            enterprise_customer=enterprise_customer_old,
+            user_id=self.user.id,
+            active=False
+        )
+        EnterpriseCustomerUser.objects.create(
+            enterprise_customer=enterprise_customer,
+            user_id=self.user.id,
+            active=True
+        )
+        with mock.patch('enterprise.tpa_pipeline.get_enterprise_customer_for_running_pipeline') as fake_get_ec:
+            with mock.patch(
+                    'enterprise.tpa_pipeline.select_enterprise_page_as_redirect_url') as ent_page_redirect:  # pylint: disable=invalid-name
+                fake_get_ec.return_value = None
+                handle_enterprise_logistration(backend, self.user, **kwargs)
+                if new_association or not multiple_enterprise_switch or using_enrollment_url:
+                    ent_page_redirect.assert_not_called()
+                else:
+                    ent_page_redirect.called_once()
 
     def test_get_ec_for_pipeline(self):
         """


### PR DESCRIPTION

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
