### PR TITLE
ENT-2755 | Tests are failing due to UNIQUE constraint failed

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,10 +11,16 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+Unreleased
+--------------------
+Removed all auto-generated fields (e.g: id's) from factories to stop initializing them using `fake.random_int()`
+
+
 [3.0.6] - 2020-04-06
 --------------------
 
 * Added support for bypassing enterprise selection page for enrollment url triggered login
+
 
 [3.0.5] - 2020-03-31
 --------------------

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -1101,16 +1101,6 @@ class EnterpriseCustomerBrandingConfiguration(TimeStampedModel):
         verbose_name_plural = _("Branding Configurations")
         ordering = ['created']
 
-    def save(self, *args, **kwargs):  # pylint: disable=arguments-differ
-        """Save the enterprise customer branding config."""
-        if self.pk is None:
-            logo_image = self.logo
-            self.logo = None
-            super(EnterpriseCustomerBrandingConfiguration, self).save(*args, **kwargs)
-            self.logo = logo_image
-
-        super(EnterpriseCustomerBrandingConfiguration, self).save(*args, **kwargs)
-
     def __str__(self):
         """
         Return human-readable string representation.

--- a/enterprise/settings/test.py
+++ b/enterprise/settings/test.py
@@ -148,8 +148,8 @@ EMAIL_BACKEND = 'django.core.mail.backends.locmem.EmailBackend'
 
 DEFAULT_FROM_EMAIL = 'course_staff@example.com'
 
-USER_THROTTLE_RATE = '90/minute'
-SERVICE_USER_THROTTLE_RATE = '100/minute'
+USER_THROTTLE_RATE = '190/minute'
+SERVICE_USER_THROTTLE_RATE = '200/minute'
 REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
     'PAGE_SIZE': 10,

--- a/test_utils/factories.py
+++ b/test_utils/factories.py
@@ -165,7 +165,6 @@ class UserFactory(factory.DjangoModelFactory):
 
         model = User
 
-    id = factory.LazyAttribute(lambda x: FAKER.random_int(min=1))
     email = factory.LazyAttribute(lambda x: FAKER.email())
     username = factory.LazyAttribute(lambda x: FAKER.user_name())
     first_name = factory.LazyAttribute(lambda x: FAKER.first_name())
@@ -227,7 +226,6 @@ class EnterpriseCustomerBrandingConfigurationFactory(factory.django.DjangoModelF
 
         model = EnterpriseCustomerBrandingConfiguration
 
-    id = factory.LazyAttribute(lambda x: FAKER.random_int(min=1))
     logo = factory.LazyAttribute(lambda x: FAKER.image_url())
     enterprise_customer = factory.SubFactory(EnterpriseCustomerFactory)
     banner_border_color = '#ffffff'
@@ -248,7 +246,6 @@ class EnterpriseCourseEnrollmentFactory(factory.django.DjangoModelFactory):
 
         model = EnterpriseCourseEnrollment
 
-    id = factory.LazyAttribute(lambda x: FAKER.random_int(min=1))
     course_id = factory.LazyAttribute(lambda x: FAKER.slug())
     marked_done = False
     enterprise_customer_user = factory.SubFactory(EnterpriseCustomerUserFactory)
@@ -325,7 +322,6 @@ class EnterpriseCustomerReportingConfigFactory(factory.django.DjangoModelFactory
 
         model = EnterpriseCustomerReportingConfiguration
 
-    id = factory.LazyAttribute(lambda x: FAKER.random_int(min=1))
     active = True
     email = factory.LazyAttribute(lambda x: FAKER.email())
     day_of_month = 1
@@ -370,7 +366,6 @@ class SAPSuccessFactorsGlobalConfigurationFactory(factory.django.DjangoModelFact
 
         model = SAPSuccessFactorsGlobalConfiguration
 
-    id = factory.LazyAttribute(lambda x: FAKER.random_int(min=1))
     completion_status_api_path = factory.LazyAttribute(lambda x: FAKER.file_path())
     course_api_path = factory.LazyAttribute(lambda x: FAKER.file_path())
     oauth_api_path = factory.LazyAttribute(lambda x: FAKER.file_path())
@@ -437,7 +432,6 @@ class DegreedGlobalConfigurationFactory(factory.django.DjangoModelFactory):
 
         model = DegreedGlobalConfiguration
 
-    id = factory.LazyAttribute(lambda x: FAKER.random_int(min=1))
     completion_status_api_path = factory.LazyAttribute(lambda x: FAKER.file_path())
     course_api_path = factory.LazyAttribute(lambda x: FAKER.file_path())
     oauth_api_path = factory.LazyAttribute(lambda x: FAKER.file_path())
@@ -544,7 +538,6 @@ class CornerstoneGlobalConfigurationFactory(factory.django.DjangoModelFactory):
 
         model = CornerstoneGlobalConfiguration
 
-    id = factory.LazyAttribute(lambda x: FAKER.random_int(min=1))
     completion_status_api_path = '/progress'
     key = factory.LazyAttribute(lambda x: FAKER.slug())
     secret = factory.LazyAttribute(lambda x: FAKER.uuid4())

--- a/tests/test_enterprise/api/test_throttles.py
+++ b/tests/test_enterprise/api/test_throttles.py
@@ -49,6 +49,8 @@ class TestEnterpriseAPIThrottling(APITest):
         """
         Make sure throttling works as expected for regular users.
         """
+        self.create_user('test_user', 'QWERTY')
+        self.client.login(username='test_user', password='QWERTY')
         self.exhaust_throttle_limit(throttle_limit=self.USER_THROTTLE_RATE)
         response = self.client.get(self.url)
         assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -1482,7 +1482,7 @@ class TestEnterpriseAPIViews(APITest):
             [{
                 'course_mode': 'audit',
                 'course_run_id': 'course-v1:edX+DemoX+Demo_Course',
-                'lms_user_id': 1,
+                'lms_user_id': 10,
             }],
             [{
                 'non_field_errors': [
@@ -1514,7 +1514,7 @@ class TestEnterpriseAPIViews(APITest):
             [{
                 'course_mode': 'audit',
                 'course_run_id': 'course-v1:edX+DemoX+Demo_Course',
-                'lms_user_id': 1,
+                'lms_user_id': 10,
             }],
             [{
                 'course_run_id': [
@@ -1530,7 +1530,7 @@ class TestEnterpriseAPIViews(APITest):
             [{
                 'course_mode': 'audit',
                 'course_run_id': 'course-v1:edX+DemoX+Demo_Course',
-                'lms_user_id': 1,
+                'lms_user_id': 10,
                 'tpa_user_id': 'abc',
             }],
             [{
@@ -1547,7 +1547,7 @@ class TestEnterpriseAPIViews(APITest):
             [{
                 'course_mode': 'audit',
                 'course_run_id': 'course-v1:edX+DemoX+Demo_Course',
-                'lms_user_id': 1,
+                'lms_user_id': 10,
             }],
             [{
                 'detail': (
@@ -1563,7 +1563,7 @@ class TestEnterpriseAPIViews(APITest):
             [{
                 'course_mode': 'audit',
                 'course_run_id': 'course-v1:edX+DemoX+Demo_Course',
-                'lms_user_id': 1,
+                'lms_user_id': 10,
                 'cohort': 'masters'
             }],
             [{
@@ -1623,7 +1623,7 @@ class TestEnterpriseAPIViews(APITest):
             [{
                 'course_mode': 'audit',
                 'course_run_id': 'course-v1:edX+DemoX+Demo_Course',
-                'lms_user_id': 1,
+                'lms_user_id': 10,
                 'tpa_user_id': 'abc',
                 'user_email': 'abc@test.com',
             }],
@@ -1634,7 +1634,7 @@ class TestEnterpriseAPIViews(APITest):
             [{
                 'course_mode': 'audit',
                 'course_run_id': 'course-v1:edX+DemoX+Demo_Course',
-                'lms_user_id': 1,
+                'lms_user_id': 10,
             }],
         ),
         (
@@ -1661,7 +1661,7 @@ class TestEnterpriseAPIViews(APITest):
             [{
                 'course_mode': 'audit',
                 'course_run_id': 'course-v1:edX+DemoX+Demo_Course',
-                'lms_user_id': 1,
+                'lms_user_id': 10,
                 'email_students': True
             }],
         ),
@@ -1671,7 +1671,7 @@ class TestEnterpriseAPIViews(APITest):
             [{
                 'course_mode': 'audit',
                 'course_run_id': 'course-v1:edX+DemoX+Demo_Course',
-                'lms_user_id': 1,
+                'lms_user_id': 10,
                 'email_students': True,
                 'cohort': 'masters',
             }],
@@ -1693,7 +1693,7 @@ class TestEnterpriseAPIViews(APITest):
             [{
                 'course_mode': 'verified',
                 'course_run_id': 'course-v1:edX+DemoX+Demo_Course',
-                'lms_user_id': 1,
+                'lms_user_id': 10,
             }],
         ),
         (
@@ -1702,7 +1702,7 @@ class TestEnterpriseAPIViews(APITest):
             [{
                 'course_mode': 'verified',
                 'course_run_id': 'course-v1:edX+DemoX+Demo_Course',
-                'lms_user_id': 1,
+                'lms_user_id': 10,
                 'is_active': False,
             }],
         ),
@@ -1840,7 +1840,7 @@ class TestEnterpriseAPIViews(APITest):
         tpa_user_id = 'abc'
         new_user_email = 'abc@test.com'
         pending_email = 'foo@bar.com'
-        lms_user_id = 1
+        lms_user_id = 10
         course_run_id = 'course-v1:edX+DemoX+Demo_Course'
         payload = [
             {

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -408,7 +408,7 @@ class TestEnterpriseCustomerUser(unittest.TestCase):
         enterprise_customer_user = factories.EnterpriseCustomerUserFactory(user_id=user_instance.id)
         assert enterprise_customer_user.user == user_instance
 
-    @ddt.data(1, 42, 1138)
+    @ddt.data(10, 42, 1138)
     def test_user_property_user_missing(self, user_id):
         enterprise_customer_user = factories.EnterpriseCustomerUserFactory(user_id=user_id)
         assert enterprise_customer_user.user is None
@@ -778,10 +778,10 @@ class TestEnterpriseCustomerBrandingConfiguration(unittest.TestCase):
             logo="test1.png"
         )
         configuration.save()
-        self.assertEqual(configuration.logo.url, '/test1.png')
+        self.assertEqual(configuration.logo.url, '/test1.png')  # pylint: disable=no-member
         configuration.logo = 'test2.png'
         configuration.save()
-        self.assertEqual(configuration.logo.url, '/test2.png')
+        self.assertEqual(configuration.logo.url, '/test2.png')  # pylint: disable=no-member
 
     @ddt.data(
         (False, 2048),


### PR DESCRIPTION
Removed all auto-generated fields (e.g: id's) from factories to stop initializing them using `fake.random_int()`


**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
