### PR TITLE
Use waffle sample instead of waffle flag for using enterprise-catalog service

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,15 @@ Unreleased
 --------------------
 Removed all auto-generated fields (e.g: id's) from factories to stop initializing them using `fake.random_int()`
 
+[3.0.11] - 2020-04-10
+---------------------
+
+* Add USE_ENTERPRISE_CATALOG waffle sample, and remove USE_ENTERPRISE_CATALOG waffle flag
+* Switch the use of waffle.flag_is_active to waffle.sample_is_active
+* Updates the EnterpriseCatalogApiClient to make the user argument optional. If the user argument is not provided, it will use the "enterprise_worker" user instead
+* No longer passes user to the EnterpriseCatalogApiClient during initialization in places where a request and/or user object doesn't already exist
+
+
 [3.0.10] - 2020-04-08
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "3.0.10"
+__version__ = "3.0.11"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api_client/enterprise_catalog.py
+++ b/enterprise/api_client/enterprise_catalog.py
@@ -30,6 +30,10 @@ class EnterpriseCatalogApiClient(JwtLmsApiClient):
     GET_CONTENT_METADATA_ENDPOINT = ENTERPRISE_CATALOG_ENDPOINT + '/{}/get_content_metadata'
     APPEND_SLASH = True
 
+    def __init__(self, user=None):
+        user = user if user else utils.get_enterprise_worker_user()
+        super(EnterpriseCatalogApiClient, self).__init__(user)
+
     @JwtLmsApiClient.refresh_token
     def create_enterprise_catalog(
             self,

--- a/enterprise/migrations/0094_add_use_enterprise_catalog_sample.py
+++ b/enterprise/migrations/0094_add_use_enterprise_catalog_sample.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+from enterprise.constants import USE_ENTERPRISE_CATALOG
+
+
+def create_sample(apps, schema_editor):
+    """Create the `use_enterprise_catalog` sample if it does not already exist."""
+    Sample = apps.get_model('waffle', 'Sample')
+    Sample.objects.get_or_create(
+        name=USE_ENTERPRISE_CATALOG,
+        defaults={'percent': 0},
+    )
+
+
+def delete_sample(apps, schema_editor):
+    """Delete the `use_enterprise_catalog` sample if one exists."""
+    Sample = apps.get_model('waffle', 'Sample')
+    Sample.objects.filter(name=USE_ENTERPRISE_CATALOG).delete()
+
+
+def create_flag(apps, schema_editor):
+    """Create the `use_enterprise_catalog` flag if it does not already exist."""
+    Flag = apps.get_model('waffle', 'Flag')
+    Flag.objects.get_or_create(
+        name=USE_ENTERPRISE_CATALOG,
+        defaults={'everyone': None, 'superusers': False},
+    )
+
+
+def delete_flag(apps, schema_editor):
+    """Delete the `use_enterprise_catalog` flag if one exists."""
+    Flag = apps.get_model('waffle', 'Flag')
+    Flag.objects.filter(name=USE_ENTERPRISE_CATALOG).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('enterprise', '0093_add_use_enterprise_catalog_flag'),
+    ]
+
+    operations = [
+        migrations.RunPython(delete_flag, create_flag),
+        migrations.RunPython(create_sample, delete_sample)
+    ]

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -11,7 +11,6 @@ from decimal import Decimal
 from logging import getLogger
 from uuid import uuid4
 
-import crum
 import six
 import waffle
 from django_countries.fields import CountryField
@@ -1579,10 +1578,9 @@ class EnterpriseCustomerCatalog(TimeStampedModel):
         Return:
             dict: The course metadata.
         """
-        request = crum.get_current_request()
-        # Temporarily gate enterprise catalog api usage behind waffle flag
-        if request and waffle.flag_is_active(request, USE_ENTERPRISE_CATALOG):
-            if not EnterpriseCatalogApiClient(user=request.user).contains_content_items(self.uuid, [course_key]):
+        # Temporarily gate enterprise catalog api usage behind waffle sample
+        if waffle.sample_is_active(USE_ENTERPRISE_CATALOG):
+            if not EnterpriseCatalogApiClient().contains_content_items(self.uuid, [course_key]):
                 return None
         else:
             if not self.contains_courses([course_key]):
@@ -1600,10 +1598,9 @@ class EnterpriseCustomerCatalog(TimeStampedModel):
         Return:
             dict: The course run metadata.
         """
-        request = crum.get_current_request()
-        # Temporarily gate enterprise catalog api usage behind waffle flag
-        if request and waffle.flag_is_active(request, USE_ENTERPRISE_CATALOG):
-            if not EnterpriseCatalogApiClient(user=request.user).contains_content_items(self.uuid, [course_run_id]):
+        # Temporarily gate enterprise catalog api usage behind waffle sample
+        if waffle.sample_is_active(USE_ENTERPRISE_CATALOG):
+            if not EnterpriseCatalogApiClient().contains_content_items(self.uuid, [course_run_id]):
                 return None
         else:
             if not self.contains_courses([course_run_id]):
@@ -1625,10 +1622,9 @@ class EnterpriseCustomerCatalog(TimeStampedModel):
             ImproperlyConfigured: Missing or invalid catalog integration.
 
         """
-        request = crum.get_current_request()
-        # Temporarily gate enterprise catalog api usage behind waffle flag
-        if request and waffle.flag_is_active(request, USE_ENTERPRISE_CATALOG):
-            if not EnterpriseCatalogApiClient(user=request.user).contains_content_items(self.uuid, [course_run_id]):
+        # Temporarily gate enterprise catalog api usage behind waffle sample
+        if waffle.sample_is_active(USE_ENTERPRISE_CATALOG):
+            if not EnterpriseCatalogApiClient().contains_content_items(self.uuid, [course_run_id]):
                 return None, None
         else:
             if not self.contains_courses([course_run_id]):
@@ -1648,10 +1644,9 @@ class EnterpriseCustomerCatalog(TimeStampedModel):
         Return:
             dict: The program metadata.
         """
-        request = crum.get_current_request()
-        # Temporarily gate enterprise catalog api usage behind waffle flag
-        if request and waffle.flag_is_active(request, USE_ENTERPRISE_CATALOG):
-            if not EnterpriseCatalogApiClient(user=request.user).contains_content_items(self.uuid, [program_uuid]):
+        # Temporarily gate enterprise catalog api usage behind waffle sample
+        if waffle.sample_is_active(USE_ENTERPRISE_CATALOG):
+            if not EnterpriseCatalogApiClient().contains_content_items(self.uuid, [program_uuid]):
                 return None
         else:
             if not self.contains_programs([program_uuid]):

--- a/integrated_channels/integrated_channel/exporters/content_metadata.py
+++ b/integrated_channels/integrated_channel/exporters/content_metadata.py
@@ -13,7 +13,6 @@ import json
 from collections import OrderedDict
 from logging import getLogger
 
-import crum
 import waffle
 
 from enterprise.api_client.enterprise import EnterpriseApiClient
@@ -82,8 +81,7 @@ class ContentMetadataExporter(Exporter):
         Return the exported and transformed content metadata as a dictionary.
         """
         content_metadata_export = {}
-        request = crum.get_current_request()
-        if request and waffle.flag_is_active(request, USE_ENTERPRISE_CATALOG):
+        if waffle.sample_is_active(USE_ENTERPRISE_CATALOG):
             content_metadata_items = self.enterprise_catalog_api.get_content_metadata(
                 self.enterprise_customer,
                 enterprise_catalogs=self.enterprise_configuration.customer_catalogs_to_transmit

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -24,7 +24,6 @@ from django.core.files import File
 from django.core.files.storage import Storage
 from django.db.utils import IntegrityError
 from django.http import QueryDict
-from django.test.client import RequestFactory
 from django.test.testcases import TransactionTestCase
 from django.urls import reverse
 
@@ -922,8 +921,6 @@ class TestEnterpriseCustomerCatalog(unittest.TestCase):
         self.catalog_uuid = self.faker.uuid4()  # pylint: disable=no-member
         self.enterprise_uuid = self.faker.uuid4()  # pylint: disable=no-member
         self.enterprise_name = 'enterprisewithacatalog'
-        self.request = RequestFactory()
-        self.request.user = factories.UserFactory()
         super(TestEnterpriseCustomerCatalog, self).setUp()
 
     @ddt.data(str, repr)
@@ -1112,58 +1109,46 @@ class TestEnterpriseCustomerCatalog(unittest.TestCase):
         enterprise_customer_catalog = factories.EnterpriseCustomerCatalogFactory()
         assert enterprise_customer_catalog.get_course_and_course_run('fake-course-run-id') == (None, None)
 
-    @mock.patch('enterprise.rules.crum.get_current_request')
     @mock.patch('enterprise.models.EnterpriseCatalogApiClient', return_value=mock.MagicMock())
-    @mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
-    def test_get_course_and_course_run_no_content_items_waffle_flag(self, api_client_mock, get_current_request_mock):
+    def test_get_course_and_course_run_no_content_items_waffle_sample(self, api_client_mock):
         """
-        Verify the `get_course_and_course_run` method returns the same tuple with the enterprise catalog flag active.
+        Verify the `get_course_and_course_run` method returns the same tuple with the enterprise catalog sample active.
         """
         with override_sample(USE_ENTERPRISE_CATALOG, active=True):
             api_client_mock.return_value.contains_content_items.return_value = False
-            get_current_request_mock.return_value = self.request
 
             enterprise_customer_catalog = factories.EnterpriseCustomerCatalogFactory()
             assert enterprise_customer_catalog.get_course_and_course_run('fake-course-run-id') == (None, None)
 
-    @mock.patch('enterprise.rules.crum.get_current_request')
     @mock.patch('enterprise.models.EnterpriseCatalogApiClient', return_value=mock.MagicMock())
-    @mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
-    def test_get_course_no_content_items_waffle_flag(self, api_client_mock, get_current_request_mock):
+    def test_get_course_no_content_items_waffle_sample(self, api_client_mock):
         """
-        Verify the `get_course` method returns None with the enterprise catalog flag active if no content items exist.
+        Verify the `get_course` method returns None with the enterprise catalog sample active if no content items exist.
         """
         with override_sample(USE_ENTERPRISE_CATALOG, active=True):
             api_client_mock.return_value.contains_content_items.return_value = False
-            get_current_request_mock.return_value = self.request
 
             enterprise_customer_catalog = factories.EnterpriseCustomerCatalogFactory()
             assert enterprise_customer_catalog.get_course('fake-course-key') is None
 
-    @mock.patch('enterprise.rules.crum.get_current_request')
     @mock.patch('enterprise.models.EnterpriseCatalogApiClient', return_value=mock.MagicMock())
-    @mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
-    def test_get_course_run_no_content_items_waffle_flag(self, api_client_mock, get_current_request_mock):
+    def test_get_course_run_no_content_items_waffle_sample(self, api_client_mock):
         """
-        Verify the `get_course_run` method returns None with the catalog flag active if no content items exist.
+        Verify the `get_course_run` method returns None with the catalog sample active if no content items exist.
         """
         with override_sample(USE_ENTERPRISE_CATALOG, active=True):
             api_client_mock.return_value.contains_content_items.return_value = False
-            get_current_request_mock.return_value = self.request
 
             enterprise_customer_catalog = factories.EnterpriseCustomerCatalogFactory()
             assert enterprise_customer_catalog.get_course_run('fake-course-run-id') is None
 
-    @mock.patch('enterprise.rules.crum.get_current_request')
     @mock.patch('enterprise.models.EnterpriseCatalogApiClient', return_value=mock.MagicMock())
-    @mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
-    def test_get_program_no_content_items_waffle_flag(self, api_client_mock, get_current_request_mock):
+    def test_get_program_no_content_items_waffle_sample(self, api_client_mock):
         """
-        Verify the `get_program` method returns None with the catalog flag active if no content items exist.
+        Verify the `get_program` method returns None with the catalog sample active if no content items exist.
         """
         with override_sample(USE_ENTERPRISE_CATALOG, active=True):
             api_client_mock.return_value.contains_content_items.return_value = False
-            get_current_request_mock.return_value = self.request
 
             enterprise_customer_catalog = factories.EnterpriseCustomerCatalogFactory()
             assert enterprise_customer_catalog.get_program('fake-program-uuid') is None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -16,7 +16,7 @@ from faker import Factory as FakerFactory
 from opaque_keys.edx.keys import CourseKey
 from pytest import mark, raises
 from testfixtures import LogCapture
-from waffle.testutils import override_flag
+from waffle.testutils import override_sample
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
@@ -1119,7 +1119,7 @@ class TestEnterpriseCustomerCatalog(unittest.TestCase):
         """
         Verify the `get_course_and_course_run` method returns the same tuple with the enterprise catalog flag active.
         """
-        with override_flag(USE_ENTERPRISE_CATALOG, active=True):
+        with override_sample(USE_ENTERPRISE_CATALOG, active=True):
             api_client_mock.return_value.contains_content_items.return_value = False
             get_current_request_mock.return_value = self.request
 
@@ -1133,7 +1133,7 @@ class TestEnterpriseCustomerCatalog(unittest.TestCase):
         """
         Verify the `get_course` method returns None with the enterprise catalog flag active if no content items exist.
         """
-        with override_flag(USE_ENTERPRISE_CATALOG, active=True):
+        with override_sample(USE_ENTERPRISE_CATALOG, active=True):
             api_client_mock.return_value.contains_content_items.return_value = False
             get_current_request_mock.return_value = self.request
 
@@ -1147,7 +1147,7 @@ class TestEnterpriseCustomerCatalog(unittest.TestCase):
         """
         Verify the `get_course_run` method returns None with the catalog flag active if no content items exist.
         """
-        with override_flag(USE_ENTERPRISE_CATALOG, active=True):
+        with override_sample(USE_ENTERPRISE_CATALOG, active=True):
             api_client_mock.return_value.contains_content_items.return_value = False
             get_current_request_mock.return_value = self.request
 
@@ -1161,7 +1161,7 @@ class TestEnterpriseCustomerCatalog(unittest.TestCase):
         """
         Verify the `get_program` method returns None with the catalog flag active if no content items exist.
         """
-        with override_flag(USE_ENTERPRISE_CATALOG, active=True):
+        with override_sample(USE_ENTERPRISE_CATALOG, active=True):
             api_client_mock.return_value.contains_content_items.return_value = False
             get_current_request_mock.return_value = self.request
 


### PR DESCRIPTION
**Description**

This PR primarily swaps over the waffle flag to be a waffle sample. The reason for this is because waffle flags have a dependency on the `request` object to determine if the flag is active for a particular user/request. However, 2 of the places that we are migrating to the enterprise-catalog service are triggered by a management command, which inherently does not have any knowledge of a `request` object. As such, the conditional for `waffle.flag_is_active` will always be false in those cases.

By switching to a waffle sample, we will still be able to incrementally increase the percentage of traffic that hits the enterprise-catalog service, without needing to manage both a flag and sample.

https://waffle.readthedocs.io/en/stable/types/sample.html

**Summary**
1. Adds a migration to create the waffle sample object. It also removes the waffle flag that was previously created.
2. Swaps over existing uses of `waffle.flag_is_active` to use `waffle.switch_is_active`.
3. Updates the `EnterpriseCatalogApiClient` to make the `user` argument optional. If the `user` argument is not provided, it will instead get the "enterprise_worker" user instead.
4. No longer passes `user` to the `EnterpriseCatalogApiClient` during initialization in places where a request and/or user object doesn't already exist (particularly in "enterprise/models.py").

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
