### PR TITLE
Update catalog_contains_course to use enterprise-catalog service if waffle sample is active

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,12 @@ Unreleased
 [3.0.12] - 2020-04-10
 ---------------------
 
+* Switch catalog_contains_course method to use enterprise catalog service behind waffle sample
+
+
+[3.0.11] - 2020-04-10
+---------------------
+
 * Add USE_ENTERPRISE_CATALOG waffle sample, and remove USE_ENTERPRISE_CATALOG waffle flag
 * Switch the use of waffle.flag_is_active to waffle.sample_is_active
 * Updates the EnterpriseCatalogApiClient to make the user argument optional. If the user argument is not provided, it will use the "enterprise_worker" user instead

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,13 +14,13 @@ Change Log
 Unreleased
 --------------------
 
-[3.0.12] - 2020-04-10
+[3.0.13] - 2020-04-10
 ---------------------
 
 * Switch catalog_contains_course method to use enterprise catalog service behind waffle sample
 
 
-[3.0.11] - 2020-04-10
+[3.0.12] - 2020-04-10
 ---------------------
 
 * Add USE_ENTERPRISE_CATALOG waffle sample, and remove USE_ENTERPRISE_CATALOG waffle flag

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "3.0.12"
+__version__ = "3.0.13"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api_client/enterprise_catalog.py
+++ b/enterprise/api_client/enterprise_catalog.py
@@ -28,6 +28,7 @@ class EnterpriseCatalogApiClient(JwtLmsApiClient):
     API_BASE_URL = settings.ENTERPRISE_CATALOG_INTERNAL_ROOT_URL + '/api/v1/'
     ENTERPRISE_CATALOG_ENDPOINT = 'enterprise-catalogs'
     GET_CONTENT_METADATA_ENDPOINT = ENTERPRISE_CATALOG_ENDPOINT + '/{}/get_content_metadata'
+    ENTERPRISE_CUSTOMER_ENDPOINT = 'enterprise-customer'
     APPEND_SLASH = True
 
     def __init__(self, user=None):
@@ -150,4 +151,16 @@ class EnterpriseCatalogApiClient(JwtLmsApiClient):
         """
         query_params = {'course_run_ids': content_ids}
         endpoint = getattr(self.client, self.ENTERPRISE_CATALOG_ENDPOINT)(catalog_uuid)
+        return endpoint.contains_content_items.get(**query_params)['contains_content_items']
+
+    @JwtLmsApiClient.refresh_token
+    def enterprise_customer_contains_content_items(self, enterprise_uuid, content_ids):
+        """
+        Checks whether an enterprise customer has any catalogs that contain the provided content ids.
+
+        The endpoint does not differentiate between course_run_ids and program_uuids so they can be used
+        interchangeably. The two query parameters are left in for backwards compatability with edx-enterprise.
+        """
+        query_params = {'course_run_ids': content_ids}
+        endpoint = getattr(self.client, self.ENTERPRISE_CUSTOMER_ENDPOINT)(enterprise_uuid)
         return endpoint.contains_content_items.get(**query_params)['contains_content_items']

--- a/enterprise/api_client/enterprise_catalog.py
+++ b/enterprise/api_client/enterprise_catalog.py
@@ -154,7 +154,7 @@ class EnterpriseCatalogApiClient(JwtLmsApiClient):
         return endpoint.contains_content_items.get(**query_params)['contains_content_items']
 
     @JwtLmsApiClient.refresh_token
-    def enterprise_customer_contains_content_items(self, enterprise_uuid, content_ids):
+    def enterprise_contains_content_items(self, enterprise_uuid, content_ids):
         """
         Checks whether an enterprise customer has any catalogs that contain the provided content ids.
 

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -432,9 +432,14 @@ class EnterpriseCustomer(TimeStampedModel):
         Returns:
             bool: Whether the enterprise catalog includes the given course run.
         """
-        for catalog in self.enterprise_customer_catalogs.all():
-            if catalog.contains_courses([course_run_id]):
+        # Temporarily gate enterprise catalog api usage behind waffle flag
+        if waffle.sample_is_active(USE_ENTERPRISE_CATALOG):
+            if EnterpriseCatalogApiClient().enterprise_customer_contains_content_items(self.uuid, [course_run_id]):
                 return True
+        else:
+            for catalog in self.enterprise_customer_catalogs.all():
+                if catalog.contains_courses([course_run_id]):
+                    return True
 
         return False
 

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -432,9 +432,9 @@ class EnterpriseCustomer(TimeStampedModel):
         Returns:
             bool: Whether the enterprise catalog includes the given course run.
         """
-        # Temporarily gate enterprise catalog api usage behind waffle flag
+        # Temporarily gate enterprise catalog api usage behind waffle sample
         if waffle.sample_is_active(USE_ENTERPRISE_CATALOG):
-            if EnterpriseCatalogApiClient().enterprise_customer_contains_content_items(self.uuid, [course_run_id]):
+            if EnterpriseCatalogApiClient().enterprise_contains_content_items(self.uuid, [course_run_id]):
                 return True
         else:
             for catalog in self.enterprise_customer_catalogs.all():

--- a/tests/test_enterprise/api_client/test_enterprise_catalog.py
+++ b/tests/test_enterprise/api_client/test_enterprise_catalog.py
@@ -141,9 +141,10 @@ def test_contains_content_items():
     actual_response = client.contains_content_items(TEST_ENTERPRISE_CATALOG_UUID, ['demoX'])
     assert actual_response == expected_response['contains_content_items']
 
+
 @responses.activate
 @mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
-def test_enterprise_customer_contains_content_items():
+def test_enterprise_contains_content_items():
     url = _url("enterprise-customer/{enterprise_uuid}/contains_content_items/?course_run_ids=demoX".format(
         enterprise_uuid=TEST_ENTERPRISE_ID))
     expected_response = {
@@ -155,5 +156,5 @@ def test_enterprise_customer_contains_content_items():
         json=expected_response,
     )
     client = enterprise_catalog.EnterpriseCatalogApiClient('staff-user-goes-here')
-    actual_response = client.enterprise_customer_contains_content_items(TEST_ENTERPRISE_ID, ['demoX'])
+    actual_response = client.enterprise_contains_content_items(TEST_ENTERPRISE_ID, ['demoX'])
     assert actual_response == expected_response['contains_content_items']

--- a/tests/test_enterprise/api_client/test_enterprise_catalog.py
+++ b/tests/test_enterprise/api_client/test_enterprise_catalog.py
@@ -140,3 +140,20 @@ def test_contains_content_items():
     client = enterprise_catalog.EnterpriseCatalogApiClient('staff-user-goes-here')
     actual_response = client.contains_content_items(TEST_ENTERPRISE_CATALOG_UUID, ['demoX'])
     assert actual_response == expected_response['contains_content_items']
+
+@responses.activate
+@mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
+def test_enterprise_customer_contains_content_items():
+    url = _url("enterprise-customer/{enterprise_uuid}/contains_content_items/?course_run_ids=demoX".format(
+        enterprise_uuid=TEST_ENTERPRISE_ID))
+    expected_response = {
+        'contains_content_items': True,
+    }
+    responses.add(
+        responses.GET,
+        url,
+        json=expected_response,
+    )
+    client = enterprise_catalog.EnterpriseCatalogApiClient('staff-user-goes-here')
+    actual_response = client.enterprise_customer_contains_content_items(TEST_ENTERPRISE_ID, ['demoX'])
+    assert actual_response == expected_response['contains_content_items']

--- a/tests/test_enterprise/api_client/test_enterprise_catalog.py
+++ b/tests/test_enterprise/api_client/test_enterprise_catalog.py
@@ -128,7 +128,8 @@ def test_delete_enterprise_catalog():
 @mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_contains_content_items():
     url = _url("enterprise-catalogs/{catalog_uuid}/contains_content_items/?course_run_ids=demoX".format(
-        catalog_uuid=TEST_ENTERPRISE_CATALOG_UUID))
+        catalog_uuid=TEST_ENTERPRISE_CATALOG_UUID
+    ))
     expected_response = {
         'contains_content_items': True,
     }
@@ -146,7 +147,8 @@ def test_contains_content_items():
 @mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_enterprise_contains_content_items():
     url = _url("enterprise-customer/{enterprise_uuid}/contains_content_items/?course_run_ids=demoX".format(
-        enterprise_uuid=TEST_ENTERPRISE_ID))
+        enterprise_uuid=TEST_ENTERPRISE_ID
+    ))
     expected_response = {
         'contains_content_items': True,
     }

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -200,6 +200,24 @@ class TestEnterpriseCustomer(unittest.TestCase):
         mock_catalog_api.get_course_id.return_value = None
         assert enterprise_customer.catalog_contains_course(fake_catalog_api.FAKE_COURSE_RUN['key']) is False
 
+    @mock.patch('enterprise.models.EnterpriseCatalogApiClient', return_value=mock.MagicMock())
+    def test_catalog_contains_course_with_enterprise_customer_catalog_waffle_sample(self, api_client_mock):
+        """
+        Test EnterpriseCustomer.catalog_contains_course with a related
+        EnterpriseCustomerCatalog when the sample is active.
+        """
+        with override_sample(USE_ENTERPRISE_CATALOG, active=True):
+            enterprise_customer = factories.EnterpriseCustomerFactory()
+            factories.EnterpriseCustomerCatalogFactory(enterprise_customer=enterprise_customer)
+
+            # Test when content is in the enterprise customer's catalog(s)
+            api_client_mock.return_value.enterprise_customer_contains_content_items.return_value = True
+            assert enterprise_customer.catalog_contains_course(fake_catalog_api.FAKE_COURSE_RUN['key']) is True
+            
+            # Test when content is NOT in the enterprise customer's catalog(s)
+            api_client_mock.return_value.enterprise_customer_contains_content_items.return_value = False
+            assert enterprise_customer.catalog_contains_course(fake_catalog_api.FAKE_COURSE_RUN['key']) is False
+
 
 @mark.django_db
 @ddt.ddt

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -211,11 +211,11 @@ class TestEnterpriseCustomer(unittest.TestCase):
             factories.EnterpriseCustomerCatalogFactory(enterprise_customer=enterprise_customer)
 
             # Test when content is in the enterprise customer's catalog(s)
-            api_client_mock.return_value.enterprise_customer_contains_content_items.return_value = True
+            api_client_mock.return_value.enterprise_contains_content_items.return_value = True
             assert enterprise_customer.catalog_contains_course(fake_catalog_api.FAKE_COURSE_RUN['key']) is True
-            
+
             # Test when content is NOT in the enterprise customer's catalog(s)
-            api_client_mock.return_value.enterprise_customer_contains_content_items.return_value = False
+            api_client_mock.return_value.enterprise_contains_content_items.return_value = False
             assert enterprise_customer.catalog_contains_course(fake_catalog_api.FAKE_COURSE_RUN['key']) is False
 
 


### PR DESCRIPTION
**Description**

This PR adds a conditional check to the `catalog_contains_course` method on the `EnterpriseCustomer` model to call the enterprise-catalog service when the `USE_ENTERPRISE_CATALOG` sample is active. If the sample is not active, the method uses the existing implementation.

Ticket: https://openedx.atlassian.net/browse/ENT-2574

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
