### PR TITLE
ENT-2711: Fixed HTML tags bug in course short_description

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 --------------------
 
+[3.0.15] - 2020-04-14
+---------------------
+
+* Fixed HTML tags bug from short course description in enterprise course enrollment page
+
+
 [3.0.14] - 2020-04-10
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "3.0.14"
+__version__ = "3.0.15"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/templates/enterprise/enterprise_course_enrollment_page.html
+++ b/enterprise/templates/enterprise/enterprise_course_enrollment_page.html
@@ -52,7 +52,7 @@
               <i class="fa fa-clock-o" aria-hidden="true"></i>
               <span>{{ starts_at_text }} {{ course_start_date }} &nbsp;| &nbsp; {{ course_pacing }}</span>
             </div>
-            {{ course_short_description }}
+            {{ course_short_description | striptags }}
             {{ view_course_details_text|link_to_modal:0 }}
           </div>
           {% if course_enrollable %}


### PR DESCRIPTION
Fixes: https://openedx.atlassian.net/browse/ENT-2711

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
