### PR TITLE
ENT-2726 Fix issue with matching urls for enterprise selection page

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,12 @@ Change Log
 
 Unreleased
 --------------------
-Removed all auto-generated fields (e.g: id's) from factories to stop initializing them using `fake.random_int()`
+
+[3.0.11] - 2020-04-10
+---------------------
+
+* Fix issue with matching urls for redirect to enterprise selection page
+
 
 [3.0.10] - 2020-04-08
 ---------------------

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "3.0.10"
+__version__ = "3.0.11"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/tpa_pipeline.py
+++ b/enterprise/tpa_pipeline.py
@@ -145,7 +145,7 @@ def handle_redirect_after_social_auth_login(backend, user):
     """
     enterprise_customers_count = EnterpriseCustomerUser.objects.filter(user_id=user.id).count()
     next_url = backend.strategy.session_get('next')
-    using_enrollment_url = re.match(r'/enterprise/.*/course/.*/enroll', next_url)
+    using_enrollment_url = re.match(r'/enterprise/.*/course/.*/enroll', str(next_url))
     if (enterprise_customers_count > 1) and not using_enrollment_url:
         select_enterprise_page_as_redirect_url(backend.strategy)
 


### PR DESCRIPTION
Description: This PR fixes a TypeError issue when matching urls for redirect to the enterprise selection page.

JIRA: https://openedx.atlassian.net/browse/ENT-2726

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
