### PR TITLE
Fix version bump and CHANGELOG entry for waffle sample rollout

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,19 +14,19 @@ Change Log
 Unreleased
 --------------------
 
-[3.0.11] - 2020-04-10
----------------------
-
-* Fix issue with matching urls for redirect to enterprise selection page
-
-
-[3.0.11] - 2020-04-10
+[3.0.12] - 2020-04-10
 ---------------------
 
 * Add USE_ENTERPRISE_CATALOG waffle sample, and remove USE_ENTERPRISE_CATALOG waffle flag
 * Switch the use of waffle.flag_is_active to waffle.sample_is_active
 * Updates the EnterpriseCatalogApiClient to make the user argument optional. If the user argument is not provided, it will use the "enterprise_worker" user instead
 * No longer passes user to the EnterpriseCatalogApiClient during initialization in places where a request and/or user object doesn't already exist
+
+
+[3.0.11] - 2020-04-10
+---------------------
+
+* Fix issue with matching urls for redirect to enterprise selection page
 
 
 [3.0.10] - 2020-04-08

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "3.0.11"
+__version__ = "3.0.12"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
