### PR TITLE
fixing traversal of results

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 --------------------
 
+[3.0.14] - 2020-04-10
+---------------------
+
+* Fixing the traversal of results in get_content_metadata for the enterprise-catalog API client
+
+
 [3.0.13] - 2020-04-10
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "3.0.13"
+__version__ = "3.0.14"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api_client/enterprise_catalog.py
+++ b/enterprise/api_client/enterprise_catalog.py
@@ -135,7 +135,7 @@ class EnterpriseCatalogApiClient(JwtLmsApiClient):
                 )
                 response = {}
 
-            for item in response:
+            for item in response['results']:
                 content_id = utils.get_content_metadata_item_id(item)
                 content_metadata[content_id] = item
 

--- a/enterprise/api_client/enterprise_catalog.py
+++ b/enterprise/api_client/enterprise_catalog.py
@@ -136,7 +136,7 @@ class EnterpriseCatalogApiClient(JwtLmsApiClient):
                     'Failed to get content metadata for Catalog [%s] in enterprise-catalog due to: [%s]',
                     catalog_uuid, str(exc)
                 )
-        
+
         return list(content_metadata.values())
 
     @JwtLmsApiClient.refresh_token

--- a/enterprise/api_client/enterprise_catalog.py
+++ b/enterprise/api_client/enterprise_catalog.py
@@ -128,17 +128,15 @@ class EnterpriseCatalogApiClient(JwtLmsApiClient):
             endpoint = getattr(self.client, self.GET_CONTENT_METADATA_ENDPOINT.format(catalog_uuid))
             try:
                 response = endpoint.get()
+                for item in response['results']:
+                    content_id = utils.get_content_metadata_item_id(item)
+                    content_metadata[content_id] = item
             except (SlumberBaseException, ConnectionError, Timeout) as exc:
                 LOGGER.exception(
                     'Failed to get content metadata for Catalog [%s] in enterprise-catalog due to: [%s]',
                     catalog_uuid, str(exc)
                 )
-                response = {}
-
-            for item in response['results']:
-                content_id = utils.get_content_metadata_item_id(item)
-                content_metadata[content_id] = item
-
+        
         return list(content_metadata.values())
 
     @JwtLmsApiClient.refresh_token


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
