### PR TITLE
ENT-2724 | removed get_cache_key and using it from edx-django-utils.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 --------------------
 
+[3.1.1] - 2020-04-20
+--------------------
+
+* removed get_cache_key and using it from edx-django-utils.
+
 [3.1.0] - 2020-04-14
 --------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "3.1.0"
+__version__ = "3.1.1"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/admin/__init__.py
+++ b/enterprise/admin/__init__.py
@@ -175,12 +175,12 @@ class EnterpriseCustomerAdmin(DjangoObjectActions, SimpleHistoryAdmin):
             extra_context=extra_context
         )
 
-    def get_form(self, request, obj=None, **kwargs):
+    def get_form(self, request, obj=None, change=False, **kwargs):
         """
         Retrieve the appropriate form to use, saving the request user
         into the form for use in loading catalog details
         """
-        form = super(EnterpriseCustomerAdmin, self).get_form(request, obj, **kwargs)
+        form = super(EnterpriseCustomerAdmin, self).get_form(request, obj, change, **kwargs)
         form.user = request.user
         return form
 
@@ -629,8 +629,8 @@ class EnterpriseCustomerCatalogAdmin(admin.ModelAdmin):
         return format_html('<span style="white-space: nowrap;">{uuid}</span>'.format(uuid=obj.uuid))
     uuid_nowrap.short_description = 'UUID'
 
-    def get_form(self, request, obj=None, **kwargs):
-        form = super(EnterpriseCustomerCatalogAdmin, self).get_form(request, obj, **kwargs)
+    def get_form(self, request, obj=None, change=False, **kwargs):
+        form = super(EnterpriseCustomerCatalogAdmin, self).get_form(request, obj, change, **kwargs)
         form.base_fields['content_filter'].initial = json.dumps(get_default_catalog_content_filter())
         return form
 

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -5,14 +5,13 @@ Utility functions for enterprise app.
 from __future__ import absolute_import, division, unicode_literals
 
 import datetime
-import hashlib
 import logging
 import re
 from uuid import UUID
 
 import bleach
 import pytz
-from six import iteritems  # pylint: disable=ungrouped-imports
+from edx_django_utils.cache import get_cache_key as get_django_cache_key
 # pylint: disable=import-error,wrong-import-order,ungrouped-imports
 from six.moves.urllib.parse import parse_qs, urlencode, urlparse, urlsplit, urlunsplit
 
@@ -519,26 +518,9 @@ def clean_html_for_template_rendering(text):
 
 def get_cache_key(**kwargs):
     """
-    Get MD5 encoded cache key for given arguments.
-
-    Here is the format of key before MD5 encryption.
-        key1:value1__key2:value2 ...
-
-    Example:
-        >>> get_cache_key(site_domain="example.com", resource="enterprise")
-        # Here is key format for above call
-        # "site_domain:example.com__resource:enterprise"
-        a54349175618ff1659dee0978e3149ca
-
-    Arguments:
-        **kwargs: Key word arguments that need to be present in cache key.
-
-    Returns:
-         An MD5 encoded key uniquely identified by the key word arguments.
+    Wrapper method on edx_django_utils get_cache_key utility.
     """
-    key = '__'.join(['{}:{}'.format(item, value) for item, value in iteritems(kwargs)])
-
-    return hashlib.md5(key.encode('utf-8')).hexdigest()
+    return get_django_cache_key(**kwargs)
 
 
 def traverse_pagination(response, endpoint):

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -20,3 +20,7 @@ jsonfield2==3.0.3
 
 # mock has dropped support for python 3.5 after 3.0.5
 mock==3.0.5
+
+# sphinx has dropped support for python 3.5, latest version requires at least python3.6
+# see https://www.sphinx-doc.org/en/master/intro.html#prerequisites
+sphinx==2.4.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,150 +4,151 @@
 #
 #    make upgrade
 #
-alabaster==0.7.12
-amqp==1.4.9
-aniso8601==8.0.0
-anyjson==0.3.3
+alabaster==0.7.12         # via -r requirements/doc.txt, sphinx
+amqp==1.4.9               # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, kombu
+aniso8601==8.0.0          # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-tincan-py35
+anyjson==0.3.3            # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, kombu
 appdirs==1.4.3            # via virtualenv
 argparse==1.4.0           # via caniusepython3
 astroid==2.3.3            # via pylint, pylint-celery
-attrs==19.3.0
-babel==2.8.0
+attrs==19.3.0             # via -r requirements/test.txt, pytest
+babel==2.8.0              # via -r requirements/doc.txt, sphinx
 backports.functools-lru-cache==1.6.1  # via caniusepython3
-billiard==3.3.0.23
-bleach==3.1.0
-caniusepython3==7.2.0
-celery==3.1.25
-certifi==2019.11.28
-cffi==1.14.0
-chardet==3.0.4
+billiard==3.3.0.23        # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, celery
+bleach==3.1.4             # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, readme-renderer
+caniusepython3==7.2.0     # via -r requirements/dev.in
+celery==3.1.26.post2      # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+certifi==2020.4.5.1       # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, requests
+cffi==1.14.0              # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, cryptography
+chardet==3.0.4            # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, doc8, requests
 click-log==0.3.2          # via edx-lint
-click==7.0
-code-annotations==0.3.3
-coverage==5.0.3
-cryptography==2.8
-ddt==1.2.2
-defusedxml==0.5.0
-diff-cover==2.6.0
+click==7.1.1              # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, click-log, code-annotations, edx-lint, pip-tools
+code-annotations==0.3.3   # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+coverage==5.1             # via -r requirements/test.txt, pytest-cov
+cryptography==2.9         # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, django-fernet-fields
+ddt==1.3.1                # via -r requirements/test.txt
+defusedxml==0.5.0         # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, djangorestframework-xml
+diff-cover==2.6.1         # via -r requirements/test.txt
 distlib==0.3.0            # via caniusepython3, virtualenv
-django-config-models==2.0.0
-django-countries==5.5
-django-crum==0.7.5
-django-fernet-fields==0.6
-django-filter==2.2.0
-django-ipware==2.1.0
-django-model-utils==3.0.0
-django-multi-email-field==0.6.1
-django-object-actions==2.0.0
-django-simple-history==2.8.0
-django-waffle==0.18.0
-django==1.11.28
-djangorestframework-jwt==1.11.0
-djangorestframework-xml==1.4.0
-djangorestframework==3.9.4
-doc8==0.8.0
-docutils==0.16
-edx-django-utils==2.0.4
-edx-drf-extensions==2.4.6
-edx-i18n-tools==0.5.0
-edx-lint==1.4.1
-edx-opaque-keys[django]==2.0.1
-edx-rbac==1.0.5
-edx-rest-api-client==3.0.2
-edx-sphinx-theme==1.5.0
-edx-tincan-py35==0.0.5
-factory-boy==2.12.0
-faker==4.0.0
+django-config-models==2.0.0  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+django-countries==5.5     # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+django-crum==0.7.5        # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-rbac
+django-fernet-fields==0.6  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+django-filter==2.2.0      # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+django-ipware==2.1.0      # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+django-model-utils==3.2.0  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-rbac
+django-multi-email-field==0.6.1  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+django-object-actions==2.0.0  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+django-simple-history==2.8.0  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+django-waffle==0.18.0     # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-django-utils, edx-drf-extensions
+django==2.2.12            # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, code-annotations, django-config-models, django-crum, django-fernet-fields, django-filter, django-model-utils, django-multi-email-field, drf-jwt, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-opaque-keys, edx-rbac, jsonfield2, rest-condition
+djangorestframework-xml==1.4.0  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+djangorestframework==3.9.4  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, django-config-models, drf-jwt, edx-drf-extensions, rest-condition
+doc8==0.8.0               # via -r requirements/doc.txt
+docutils==0.16            # via -r requirements/doc.txt, doc8, readme-renderer, restructuredtext-lint, sphinx
+drf-jwt==1.14.0           # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-drf-extensions
+edx-django-utils==3.2.1   # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, django-config-models, edx-drf-extensions, edx-rest-api-client
+edx-drf-extensions==5.0.2  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-rbac
+edx-i18n-tools==0.5.0     # via -r requirements/dev.in
+edx-lint==1.4.1           # via -r requirements/dev.in
+edx-opaque-keys[django]==2.0.2  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-drf-extensions
+edx-rbac==1.1.2           # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+edx-rest-api-client==5.1.0  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+edx-sphinx-theme==1.5.0   # via -r requirements/doc.txt
+edx-tincan-py35==0.0.5    # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+factory-boy==2.12.0       # via -r requirements/test.txt
+faker==4.0.3              # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via tox, virtualenv
-freezegun==0.3.14
-future==0.18.2
-idna==2.8
-imagesize==1.2.0
-importlib-metadata==1.5.0
-importlib-resources==1.0.2  # via virtualenv
-inflect==3.0.2
-isort==4.3.21
-jinja2-pluralize==0.3.0
-jinja2==2.11.1
-jsondiff==1.2.0
-jsonfield2==3.0.3
-kombu==3.0.37
+freezegun==0.3.14         # via -c requirements/constraints.txt, -r requirements/test.txt
+future==0.18.2            # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, pyjwkest
+idna==2.9                 # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, requests
+imagesize==1.2.0          # via -r requirements/doc.txt, sphinx
+importlib-metadata==1.6.0  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, importlib-resources, inflect, path, pluggy, pytest, tox, virtualenv
+importlib-resources==1.4.0  # via virtualenv
+inflect==3.0.2            # via -c requirements/constraints.txt, -r requirements/test.txt, jinja2-pluralize
+isort==4.3.21             # via -r requirements/dev.in, pylint
+jinja2-pluralize==0.3.0   # via -r requirements/test.txt, diff-cover
+jinja2==2.11.1            # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, code-annotations, diff-cover, jinja2-pluralize, sphinx
+jsondiff==1.2.0           # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+kombu==3.0.37             # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, celery
 lazy-object-proxy==1.4.3  # via astroid
-markupsafe==1.1.1
+markupsafe==1.1.1         # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, jinja2
 mccabe==0.6.1             # via pylint
-mock==3.0.5
-more-itertools==8.2.0
-newrelic==5.6.0.135
-packaging==20.1
-path.py==12.4.0
-path==13.1.0
-pathlib2==2.3.5
-pbr==5.4.4
-pillow==7.0.0
-pip-tools==4.4.1
+mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.txt
+more-itertools==8.2.0     # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, pytest, zipp
+newrelic==5.10.0.138      # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-django-utils
+packaging==20.3           # via -r requirements/doc.txt, -r requirements/test.txt, caniusepython3, pytest, sphinx, tox
+path.py==12.4.0           # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-i18n-tools
+path==13.1.0              # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, path.py
+pathlib2==2.3.5           # via -r requirements/test.txt, pytest
+pbr==5.4.5                # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, stevedore
+pillow==7.1.1             # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+pip-tools==4.5.1          # via -r requirements/dev.in
 pkginfo==1.5.0.1          # via twine
-pluggy==0.13.1
-pockets==0.9.1
+pluggy==0.13.1            # via -r requirements/test.txt, diff-cover, pytest, tox
+pockets==0.9.1            # via -r requirements/doc.txt, sphinxcontrib-napoleon
 polib==1.1.0              # via edx-i18n-tools
-psutil==1.2.1
-py==1.8.1
-pycodestyle==2.5.0
-pycparser==2.19
-pycryptodomex==3.9.6
-pydocstyle==5.0.2
-pygments==2.5.2
-pyjwkest==1.3.2
-pyjwt==1.5.2
+psutil==1.2.1             # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-django-utils
+py==1.8.1                 # via -r requirements/test.txt, pytest, pytest-catchlog, tox
+pycodestyle==2.5.0        # via -r requirements/dev.in
+pycparser==2.20           # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, cffi
+pycryptodomex==3.9.7      # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, pyjwkest
+pydocstyle==5.0.2         # via -r requirements/dev.in
+pygments==2.6.1           # via -r requirements/doc.txt, -r requirements/test.txt, diff-cover, readme-renderer, sphinx
+pyjwkest==1.4.2           # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-drf-extensions
+pyjwt==1.5.2              # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, drf-jwt, edx-rest-api-client
 pylint-celery==0.3        # via edx-lint
 pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
 pylint==2.4.2             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pymongo==3.9.0
-pyparsing==2.4.6
-pytest-catchlog==1.2.2
-pytest-cov==2.8.1
-pytest-django==3.8.0
-pytest==5.3.5
-python-dateutil==2.4.0
-python-slugify==4.0.0
-pytz==2019.3
-pyyaml==5.3
-readme-renderer==24.0
+pymongo==3.9.0            # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-opaque-keys
+pyparsing==2.4.7          # via -r requirements/doc.txt, -r requirements/test.txt, packaging
+pytest-catchlog==1.2.2    # via -r requirements/test.txt
+pytest-cov==2.8.1         # via -r requirements/test.txt
+pytest-django==3.9.0      # via -r requirements/test.txt
+pytest==5.4.1             # via -r requirements/test.txt, pytest-catchlog, pytest-cov, pytest-django
+python-dateutil==2.4.0    # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-drf-extensions, faker, freezegun
+python-slugify==4.0.0     # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, code-annotations
+pytz==2019.3              # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, babel, celery, django, edx-tincan-py35
+pyyaml==5.3.1             # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, code-annotations, edx-i18n-tools
+readme-renderer==25.0     # via -r requirements/doc.txt
 requests-toolbelt==0.9.1  # via twine
-requests==2.22.0
-responses==0.10.9
-rest-condition==1.0.3
-restructuredtext-lint==1.3.0
-rules==2.2
-semantic-version==2.8.4
-six==1.14.0
-slumber==0.7.1
-snowballstemmer==2.0.0
-sphinx==2.4.1
-sphinxcontrib-applehelp==1.0.1
-sphinxcontrib-devhelp==1.0.1
-sphinxcontrib-htmlhelp==1.0.2
-sphinxcontrib-jsmath==1.0.1
-sphinxcontrib-napoleon==0.6.1
-sphinxcontrib-qthelp==1.0.2
-sphinxcontrib-serializinghtml==1.1.3
-stevedore==1.31.0
-testfixtures==6.12.0
-text-unidecode==1.3
+requests==2.23.0          # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, caniusepython3, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-toolbelt, responses, slumber, sphinx, twine
+responses==0.10.12        # via -r requirements/test.txt
+rest-condition==1.0.3     # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-drf-extensions
+restructuredtext-lint==1.3.0  # via -r requirements/doc.txt, doc8
+rules==2.2                # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+semantic-version==2.8.4   # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-drf-extensions
+six==1.14.0               # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, astroid, bleach, cryptography, diff-cover, django-countries, django-simple-history, doc8, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-rbac, edx-sphinx-theme, freezegun, mock, packaging, pathlib2, pip-tools, pockets, pyjwkest, python-dateutil, readme-renderer, responses, sphinxcontrib-napoleon, stevedore, tox, virtualenv
+slumber==0.7.1            # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-rest-api-client
+snowballstemmer==2.0.0    # via -r requirements/doc.txt, pydocstyle, sphinx
+sphinx==2.4.1             # via -c requirements/constraints.txt, -r requirements/doc.txt, edx-sphinx-theme
+sphinxcontrib-applehelp==1.0.2  # via -r requirements/doc.txt, sphinx
+sphinxcontrib-devhelp==1.0.2  # via -r requirements/doc.txt, sphinx
+sphinxcontrib-htmlhelp==1.0.3  # via -r requirements/doc.txt, sphinx
+sphinxcontrib-jsmath==1.0.1  # via -r requirements/doc.txt, sphinx
+sphinxcontrib-napoleon==0.6.1  # via -r requirements/doc.txt
+sphinxcontrib-qthelp==1.0.3  # via -r requirements/doc.txt, sphinx
+sphinxcontrib-serializinghtml==1.1.4  # via -r requirements/doc.txt, sphinx
+sqlparse==0.3.1           # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, django
+stevedore==1.32.0         # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, code-annotations, doc8, edx-opaque-keys
+testfixtures==6.14.0      # via -r requirements/dev.in, -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+text-unidecode==1.3       # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, faker, python-slugify
 toml==0.10.0              # via tox
-tox-battery==0.5.1
-tox==3.14.3
-tqdm==4.42.1              # via twine
-twine==1.11.0
+tox-battery==0.5.1        # via -r requirements/dev.in
+tox==3.14.6               # via -r requirements/dev.in, tox-battery
+tqdm==4.45.0              # via twine
+twine==1.11.0             # via -r requirements/dev.in
 typed-ast==1.4.1          # via astroid
-unicodecsv==0.14.1
-urllib3==1.25.8
-virtualenv==20.0.2        # via tox
-wcwidth==0.1.8
-webencodings==0.5.1
-wheel==0.34.2
+unicodecsv==0.14.1        # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+urllib3==1.25.8           # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, requests
+virtualenv==20.0.17       # via tox
+wcwidth==0.1.9            # via -r requirements/test.txt, pytest
+webencodings==0.5.1       # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, bleach
+wheel==0.34.2             # via -r requirements/dev.in
 wrapt==1.11.2             # via astroid
-zipp==1.0.0
+zipp==1.0.0               # via -c requirements/constraints.txt, -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -1,1 +1,1 @@
-django==1.11.28
+django==2.2.12            # via -r requirements/test-master.txt, code-annotations, django-config-models, django-crum, django-fernet-fields, django-filter, django-model-utils, django-multi-email-field, drf-jwt, edx-django-utils, edx-drf-extensions, edx-opaque-keys, edx-rbac, jsonfield2, rest-condition

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -5,97 +5,98 @@
 #    make upgrade
 #
 alabaster==0.7.12         # via sphinx
-amqp==1.4.9
-aniso8601==8.0.0
-anyjson==0.3.3
+amqp==1.4.9               # via -r requirements/test-master.txt, kombu
+aniso8601==8.0.0          # via -r requirements/test-master.txt, edx-tincan-py35
+anyjson==0.3.3            # via -r requirements/test-master.txt, kombu
 babel==2.8.0              # via sphinx
-billiard==3.3.0.23
-bleach==3.1.0
-celery==3.1.25
-certifi==2019.11.28
-cffi==1.14.0
-chardet==3.0.4
-click==7.0
-code-annotations==0.3.3
-cryptography==2.8
-defusedxml==0.5.0
-django-config-models==2.0.0
-django-countries==5.5
-django-crum==0.7.5
-django-fernet-fields==0.6
-django-filter==2.2.0
-django-ipware==2.1.0
-django-model-utils==3.0.0
-django-multi-email-field==0.6.1
-django-object-actions==2.0.0
-django-simple-history==2.8.0
-django-waffle==0.18.0
-django==1.11.28
-djangorestframework-jwt==1.11.0
-djangorestframework-xml==1.4.0
-djangorestframework==3.9.4
-doc8==0.8.0
-docutils==0.16
-edx-django-utils==2.0.4
-edx-drf-extensions==2.4.6
-edx-opaque-keys[django]==2.0.1
-edx-rbac==1.0.5
-edx-rest-api-client==3.0.2
-edx-sphinx-theme==1.5.0
-edx-tincan-py35==0.0.5
-future==0.18.2
-idna==2.8
+billiard==3.3.0.23        # via -r requirements/test-master.txt, celery
+bleach==3.1.4             # via -r requirements/test-master.txt, readme-renderer
+celery==3.1.26.post2      # via -r requirements/test-master.txt
+certifi==2020.4.5.1       # via -r requirements/test-master.txt, requests
+cffi==1.14.0              # via -r requirements/test-master.txt, cryptography
+chardet==3.0.4            # via -r requirements/test-master.txt, doc8, requests
+click==7.1.1              # via -r requirements/test-master.txt, code-annotations
+code-annotations==0.3.3   # via -r requirements/test-master.txt
+cryptography==2.9         # via -r requirements/test-master.txt, django-fernet-fields
+defusedxml==0.5.0         # via -r requirements/test-master.txt, djangorestframework-xml
+django-config-models==2.0.0  # via -r requirements/test-master.txt
+django-countries==5.5     # via -r requirements/test-master.txt
+django-crum==0.7.5        # via -r requirements/test-master.txt, edx-rbac
+django-fernet-fields==0.6  # via -r requirements/test-master.txt
+django-filter==2.2.0      # via -r requirements/test-master.txt
+django-ipware==2.1.0      # via -r requirements/test-master.txt
+django-model-utils==3.2.0  # via -r requirements/test-master.txt, edx-rbac
+django-multi-email-field==0.6.1  # via -r requirements/test-master.txt
+django-object-actions==2.0.0  # via -r requirements/test-master.txt
+django-simple-history==2.8.0  # via -r requirements/test-master.txt
+django-waffle==0.18.0     # via -r requirements/test-master.txt, edx-django-utils, edx-drf-extensions
+django==2.2.12            # via -r requirements/test-master.txt, code-annotations, django-config-models, django-crum, django-fernet-fields, django-filter, django-model-utils, django-multi-email-field, drf-jwt, edx-django-utils, edx-drf-extensions, edx-opaque-keys, edx-rbac, jsonfield2, rest-condition
+djangorestframework-xml==1.4.0  # via -r requirements/test-master.txt
+djangorestframework==3.9.4  # via -r requirements/test-master.txt, django-config-models, drf-jwt, edx-drf-extensions, rest-condition
+doc8==0.8.0               # via -r requirements/doc.in
+docutils==0.16            # via -r requirements/doc.in, doc8, readme-renderer, restructuredtext-lint, sphinx
+drf-jwt==1.14.0           # via -r requirements/test-master.txt, edx-drf-extensions
+edx-django-utils==3.2.1   # via -r requirements/test-master.txt, django-config-models, edx-drf-extensions, edx-rest-api-client
+edx-drf-extensions==5.0.2  # via -r requirements/test-master.txt, edx-rbac
+edx-opaque-keys[django]==2.0.2  # via -r requirements/test-master.txt, edx-drf-extensions
+edx-rbac==1.1.2           # via -r requirements/test-master.txt
+edx-rest-api-client==5.1.0  # via -r requirements/test-master.txt
+edx-sphinx-theme==1.5.0   # via -r requirements/doc.in
+edx-tincan-py35==0.0.5    # via -r requirements/test-master.txt
+future==0.18.2            # via -r requirements/test-master.txt, pyjwkest
+idna==2.9                 # via -r requirements/test-master.txt, requests
 imagesize==1.2.0          # via sphinx
-importlib-metadata==1.5.0
-jinja2==2.11.1
-jsondiff==1.2.0
-jsonfield2==3.0.3
-kombu==3.0.37
-markupsafe==1.1.1
-more-itertools==8.2.0
-newrelic==5.6.0.135
-packaging==20.1           # via sphinx
-path.py==12.4.0
-path==13.1.0
-pbr==5.4.4
-pillow==7.0.0
+importlib-metadata==1.6.0  # via -r requirements/test-master.txt, path
+jinja2==2.11.1            # via -r requirements/test-master.txt, code-annotations, sphinx
+jsondiff==1.2.0           # via -r requirements/test-master.txt
+jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/test-master.txt
+kombu==3.0.37             # via -r requirements/test-master.txt, celery
+markupsafe==1.1.1         # via -r requirements/test-master.txt, jinja2
+more-itertools==8.2.0     # via -r requirements/test-master.txt, zipp
+newrelic==5.10.0.138      # via -r requirements/test-master.txt, edx-django-utils
+packaging==20.3           # via sphinx
+path.py==12.4.0           # via -r requirements/test-master.txt
+path==13.1.0              # via -r requirements/test-master.txt, path.py
+pbr==5.4.5                # via -r requirements/test-master.txt, stevedore
+pillow==7.1.1             # via -r requirements/test-master.txt
 pockets==0.9.1            # via sphinxcontrib-napoleon
-psutil==1.2.1
-pycparser==2.19
-pycryptodomex==3.9.6
-pygments==2.5.2           # via readme-renderer, sphinx
-pyjwkest==1.3.2
-pyjwt==1.5.2
-pymongo==3.9.0
-pyparsing==2.4.6          # via packaging
-python-dateutil==2.4.0
-python-slugify==4.0.0
-pytz==2019.3
-pyyaml==5.3
-readme-renderer==24.0
-requests==2.22.0
-rest-condition==1.0.3
+psutil==1.2.1             # via -r requirements/test-master.txt, edx-django-utils
+pycparser==2.20           # via -r requirements/test-master.txt, cffi
+pycryptodomex==3.9.7      # via -r requirements/test-master.txt, pyjwkest
+pygments==2.6.1           # via readme-renderer, sphinx
+pyjwkest==1.4.2           # via -r requirements/test-master.txt, edx-drf-extensions
+pyjwt==1.5.2              # via -r requirements/test-master.txt, drf-jwt, edx-rest-api-client
+pymongo==3.9.0            # via -r requirements/test-master.txt, edx-opaque-keys
+pyparsing==2.4.7          # via packaging
+python-dateutil==2.4.0    # via -r requirements/test-master.txt, edx-drf-extensions
+python-slugify==4.0.0     # via -r requirements/test-master.txt, code-annotations
+pytz==2019.3              # via -r requirements/test-master.txt, babel, celery, django, edx-tincan-py35
+pyyaml==5.3.1             # via -r requirements/test-master.txt, code-annotations
+readme-renderer==25.0     # via -r requirements/doc.in
+requests==2.23.0          # via -r requirements/test-master.txt, edx-drf-extensions, edx-rest-api-client, pyjwkest, slumber, sphinx
+rest-condition==1.0.3     # via -r requirements/test-master.txt, edx-drf-extensions
 restructuredtext-lint==1.3.0  # via doc8
-rules==2.2
-semantic-version==2.8.4
-six==1.14.0
-slumber==0.7.1
+rules==2.2                # via -r requirements/test-master.txt
+semantic-version==2.8.4   # via -r requirements/test-master.txt, edx-drf-extensions
+six==1.14.0               # via -r requirements/test-master.txt, bleach, cryptography, django-countries, django-simple-history, doc8, edx-drf-extensions, edx-opaque-keys, edx-rbac, edx-sphinx-theme, packaging, pockets, pyjwkest, python-dateutil, readme-renderer, sphinxcontrib-napoleon, stevedore
+slumber==0.7.1            # via -r requirements/test-master.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via sphinx
-sphinx==2.4.1
-sphinxcontrib-applehelp==1.0.1  # via sphinx
-sphinxcontrib-devhelp==1.0.1  # via sphinx
-sphinxcontrib-htmlhelp==1.0.2  # via sphinx
+sphinx==2.4.1             # via -c requirements/constraints.txt, -r requirements/doc.in, edx-sphinx-theme
+sphinxcontrib-applehelp==1.0.2  # via sphinx
+sphinxcontrib-devhelp==1.0.2  # via sphinx
+sphinxcontrib-htmlhelp==1.0.3  # via sphinx
 sphinxcontrib-jsmath==1.0.1  # via sphinx
-sphinxcontrib-napoleon==0.6.1
-sphinxcontrib-qthelp==1.0.2  # via sphinx
-sphinxcontrib-serializinghtml==1.1.3  # via sphinx
-stevedore==1.31.0
-testfixtures==6.12.0
-text-unidecode==1.3
-unicodecsv==0.14.1
-urllib3==1.25.8
-webencodings==0.5.1
-zipp==1.0.0
+sphinxcontrib-napoleon==0.6.1  # via -r requirements/doc.in
+sphinxcontrib-qthelp==1.0.3  # via sphinx
+sphinxcontrib-serializinghtml==1.1.4  # via sphinx
+sqlparse==0.3.1           # via -r requirements/test-master.txt, django
+stevedore==1.32.0         # via -r requirements/test-master.txt, code-annotations, doc8, edx-opaque-keys
+testfixtures==6.14.0      # via -r requirements/test-master.txt
+text-unidecode==1.3       # via -r requirements/test-master.txt, python-slugify
+unicodecsv==0.14.1        # via -r requirements/test-master.txt
+urllib3==1.25.8           # via -r requirements/test-master.txt, requests
+webencodings==0.5.1       # via -r requirements/test-master.txt, bleach
+zipp==1.0.0               # via -c requirements/constraints.txt, -r requirements/test-master.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/edx-platform-constraints.txt
+++ b/requirements/edx-platform-constraints.txt
@@ -6,238 +6,234 @@
 #    make upgrade
 #
 amqp==1.4.9               # via kombu
-analytics-python==1.2.9
+analytics-python==1.2.9   # via -r requirements/edx/base.in
 aniso8601==8.0.0          # via edx-tincan-py35
 anyjson==0.3.3            # via kombu
 appdirs==1.4.3            # via fs
-attrs==19.3.0
-babel==2.8.0
-beautifulsoup4==4.8.2     # via pynliner
+attrs==19.3.0             # via -r requirements/edx/base.in, edx-ace
+babel==2.8.0              # via -r requirements/edx/base.in, django-babel, django-babel-underscore
+beautifulsoup4==4.9.0     # via pynliner
 billiard==3.3.0.23        # via celery
-bleach==3.1.0
-boto3==1.4.8
-boto==2.39.0
-botocore==1.8.17
-git+https://github.com/edx/bridgekeeper.git@2423e8d8788c2132ebeec509e1a7b17e1f5b9364#egg=bridgekeeper==0.0
-git+https://github.com/edx/openedx-calc.git@e9b698c85ad1152002bc0868f475f153dce88952#egg=calc==0.4
-celery==3.1.25
-certifi==2019.11.28
-cffi==1.14.0
-chardet==3.0.4
-git+https://github.com/edx/openedx-chem.git@ff4e3a03d3c7610e47a9af08eb648d8aabe2eb18#egg=chem==1.0.0
-click==7.0                # via code-annotations, user-util
+bleach==3.1.4             # via -r requirements/edx/base.in, edx-enterprise, lti-consumer-xblock, ora2
+boto3==1.4.8              # via -r requirements/edx/base.in, fs-s3fs
+boto==2.39.0              # via -r requirements/edx/base.in, django-ses, edxval, ora2
+botocore==1.8.17          # via -r requirements/edx/base.in, boto3, s3transfer
+git+https://github.com/edx/bridgekeeper.git@2423e8d8788c2132ebeec509e1a7b17e1f5b9364#egg=bridgekeeper==0.0  # via -r requirements/edx/github.in
+celery==3.1.26.post2      # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, django-celery, django-user-tasks, edx-celeryutils, edx-enterprise
+certifi==2020.4.5.1       # via -r requirements/edx/paver.txt, requests
+cffi==1.14.0              # via -r requirements/edx/../edx-sandbox/shared.txt, cryptography
+chardet==3.0.4            # via -r requirements/edx/paver.txt, pdfminer.six, pysrt, requests
+git+https://github.com/edx/openedx-chem.git@ff4e3a03d3c7610e47a9af08eb648d8aabe2eb18#egg=chem==1.0.0  # via -r requirements/edx/github.in
+click==7.1.1              # via code-annotations, user-util
 code-annotations==0.3.3   # via edx-enterprise
-contextlib2==0.6.0.post1
+contextlib2==0.6.0.post1  # via -r requirements/edx/base.in
 coreapi==2.3.3            # via drf-yasg
 coreschema==0.0.4         # via coreapi, drf-yasg
-git+https://github.com/edx/crowdsourcehinter.git@a7ffc85b134b7d8909bf1fefd23dbdb8eb28e467#egg=crowdsourcehinter-xblock==0.2
-cryptography==2.8
+git+https://github.com/edx/crowdsourcehinter.git@2178ac72891392106ffef389651aef374177d294#egg=crowdsourcehinter-xblock==0.4  # via -r requirements/edx/github.in
+cryptography==2.9         # via -r requirements/edx/../edx-sandbox/shared.txt, django-fernet-fields, edx-enterprise, social-auth-core
 cssutils==1.0.2           # via pynliner
-ddt==1.2.2
-decorator==4.4.1          # via pycontracts
-defusedxml==0.5.0
-git+https://github.com/django-compressor/django-appconf@1526a842ee084b791aa66c931b3822091a442853#egg=django-appconf
-django-babel-underscore==0.5.2
-django-babel==0.6.2       # via django-babel-underscore
-git+https://github.com/edx/django-celery.git@756cb57aad765cb2b0d37372c1855b8f5f37e6b0#egg=django-celery==3.2.1+edx.2
+ddt==1.3.1                # via xblock-drag-and-drop-v2, xblock-poll
+decorator==4.4.2          # via pycontracts
+defusedxml==0.5.0         # via -r requirements/edx/base.in, djangorestframework-xml, ora2, python3-openid, python3-saml, safe-lxml, social-auth-core
+git+https://github.com/django-compressor/django-appconf@1526a842ee084b791aa66c931b3822091a442853#egg=django-appconf  # via -r requirements/edx/github.in, django-statici18n
+git+https://github.com/edx/django-babel-underscore.git@37705f7377a4d0a4e673f1431895ce28a8860cd7#egg=django-babel-underscore==0.6.0  # via -r requirements/edx/github.in
+git+https://github.com/Zegocover/enmerkar.git@dbc113798aa4beabdfa2d00e6fef48248eb0f185#egg=django-babel==0.6.3.dev0  # via -r requirements/edx/github.in
+django-celery==3.3.1      # via -r requirements/edx/base.in
 django-classy-tags==1.0.0  # via django-sekizai
-django-config-models==2.0.0
-django-cors-headers==2.5.3
-django-countries==5.5
-django-crum==0.7.5
-django-fernet-fields==0.6
-django-filter==2.2.0
-django-ipware==2.1.0
+django-config-models==2.0.0  # via -r requirements/edx/base.in, edx-enterprise
+django-cors-headers==2.5.3  # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
+django-countries==5.5     # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, edx-enterprise
+django-crum==0.7.5        # via -r requirements/edx/base.in, edx-enterprise, edx-proctoring, edx-rbac, super-csv
+django-fernet-fields==0.6  # via -r requirements/edx/base.in, edx-enterprise, edxval
+django-filter==2.2.0      # via -r requirements/edx/base.in, edx-enterprise
+django-ipware==2.1.0      # via -r requirements/edx/base.in, edx-enterprise, edx-proctoring
 django-js-asset==1.2.2    # via django-mptt
-git+https://gitlab.com/Ayub-khan/django-method-override.git@5270af321be2e576d8e8b3c4191711a19975c356#egg=django-method-override==1.0.4
-django-model-utils==3.0.0
-django-mptt==0.11.0
+git+https://gitlab.com/Ayub-khan/django-method-override.git@5270af321be2e576d8e8b3c4191711a19975c356#egg=django-method-override==1.0.4  # via -r requirements/edx/github.in
+django-model-utils==3.2.0  # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, django-user-tasks, edx-bulk-grades, edx-celeryutils, edx-completion, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-rbac, edx-submissions, edx-when, edxval, ora2, super-csv
+django-mptt==0.11.0       # via -r requirements/edx/base.in, django-wiki
 django-multi-email-field==0.6.1  # via edx-enterprise
-django-mysql==3.3.0
-git+https://github.com/edx/django-oauth-plus.git@b9b64a3ac24fd11f471763c88462bbf3c53e46e6#egg=django-oauth-plus==2.2.9.edx-4
-django-oauth-toolkit==1.1.3
+django-mysql==3.3.0       # via -r requirements/edx/base.in
+django-oauth-toolkit==1.3.2  # via -r requirements/edx/base.in
 django-object-actions==2.0.0  # via edx-enterprise
-django-pipeline==1.7.0
-django-pyfs==2.1
-django-ratelimit-backend==2.0
-django-require==1.0.11
-django-sekizai==1.1.0
-django-ses==0.8.14
-django-simple-history==2.8.0
-django-splash==0.2.6
-django-statici18n==1.9.0
-django-storages==1.8
-django-user-tasks==0.3.0
-django-waffle==0.18.0
-django-webpack-loader==0.6.0
-django==1.11.28
-djangorestframework-jwt==1.11.0
-git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4bc70c03de308a277197c#egg=djangorestframework-oauth==1.1.1
+django-pipeline==1.7.0    # via -r requirements/edx/base.in
+django-pyfs==2.1          # via -r requirements/edx/base.in
+django-ratelimit-backend==2.0  # via -r requirements/edx/base.in
+django-require==1.0.11    # via -r requirements/edx/base.in
+django-sekizai==1.1.0     # via -r requirements/edx/base.in, django-wiki
+django-ses==0.8.14        # via -r requirements/edx/base.in
+django-simple-history==2.8.0  # via -r requirements/edx/base.in, edx-enterprise, edx-organizations, ora2
+django-splash==0.2.7      # via -r requirements/edx/base.in
+django-statici18n==1.9.0  # via -r requirements/edx/base.in
+django-storages==1.8      # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, edxval
+django-user-tasks==1.0.0  # via -r requirements/edx/base.in
+django-waffle==0.18.0     # via -r requirements/edx/base.in, edx-django-utils, edx-drf-extensions, edx-enterprise, edx-proctoring
+django-webpack-loader==0.7.0  # via -r requirements/edx/base.in, edx-proctoring
+django==2.2.12            # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, code-annotations, django-appconf, django-babel, django-babel-underscore, django-celery, django-classy-tags, django-config-models, django-cors-headers, django-crum, django-fernet-fields, django-filter, django-method-override, django-model-utils, django-mptt, django-multi-email-field, django-mysql, django-oauth-toolkit, django-pyfs, django-ratelimit-backend, django-sekizai, django-splash, django-statici18n, django-storages, django-user-tasks, django-wiki, drf-jwt, drf-yasg, edx-ace, edx-api-doc-tools, edx-bulk-grades, edx-celeryutils, edx-completion, edx-django-release-util, edx-django-sites-extensions, edx-django-utils, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-milestones, edx-opaque-keys, edx-organizations, edx-proctoring, edx-rbac, edx-search, edx-submissions, edx-when, edxval, event-tracking, help-tokens, jsonfield2, ora2, rest-condition, super-csv, xss-utils
 djangorestframework-xml==1.4.0  # via edx-enterprise
-djangorestframework==3.9.4
-docopt==0.6.2
+djangorestframework==3.9.4  # via -r requirements/edx/base.in, django-config-models, django-user-tasks, drf-jwt, drf-yasg, edx-api-doc-tools, edx-completion, edx-drf-extensions, edx-enterprise, edx-organizations, edx-proctoring, edx-submissions, ora2, rest-condition, super-csv
+docopt==0.6.2             # via xmodule
 docutils==0.16            # via botocore
-drf-yasg==1.17.0          # via edx-api-doc-tools
-edx-ace==0.1.13
-edx-analytics-data-api-client==0.15.3
-edx-api-doc-tools==1.0.2
-edx-bulk-grades==0.6.6
-edx-ccx-keys==1.0.0
-edx-celeryutils==0.3.2
-edx-completion==3.0.2
-edx-django-oauth2-provider==1.3.5
-edx-django-release-util==0.3.6
-edx-django-sites-extensions==2.4.3
-edx-django-utils==2.0.4
-edx-drf-extensions==2.4.6
-edx-enterprise==2.3.8
-edx-i18n-tools==0.5.0
-edx-milestones==0.2.6
-edx-oauth2-provider==1.3.1
-edx-opaque-keys[django]==2.0.1
-edx-organizations==2.2.1
-edx-proctoring-proctortrack==1.0.5
-edx-proctoring==2.2.6
-edx-rbac==1.0.5           # via edx-enterprise
-edx-rest-api-client==3.0.2
-edx-search==1.2.2
-edx-sga==0.10.0
-edx-submissions==3.0.4
+drf-jwt==1.14.0           # via -c requirements/edx/../constraints.txt, edx-drf-extensions
+drf-yasg==1.17.0          # via -c requirements/edx/../constraints.txt, edx-api-doc-tools
+edx-ace==0.1.14           # via -r requirements/edx/base.in
+edx-analytics-data-api-client==0.15.5  # via -r requirements/edx/base.in
+edx-api-doc-tools==1.2.0  # via -r requirements/edx/base.in
+edx-bulk-grades==0.6.8    # via -r requirements/edx/base.in, staff-graded-xblock
+edx-ccx-keys==1.0.1       # via -r requirements/edx/base.in
+edx-celeryutils==0.5.0    # via -r requirements/edx/base.in, super-csv
+edx-completion==3.1.1     # via -r requirements/edx/base.in
+edx-django-release-util==0.4.2  # via -r requirements/edx/base.in
+edx-django-sites-extensions==2.4.3  # via -r requirements/edx/base.in
+edx-django-utils==3.2.1   # via -r requirements/edx/base.in, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-when
+edx-drf-extensions==5.0.2  # via -r requirements/edx/base.in, edx-completion, edx-enterprise, edx-organizations, edx-proctoring, edx-rbac, edx-when, edxval
+edx-enterprise==3.0.14    # via -r requirements/edx/base.in
+edx-i18n-tools==0.5.0     # via ora2
+edx-milestones==0.2.6     # via -r requirements/edx/base.in
+edx-opaque-keys[django]==2.0.2  # via -r requirements/edx/paver.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, xmodule
+edx-organizations==5.1.0  # via -r requirements/edx/base.in
+edx-proctoring-proctortrack==1.0.5  # via -r requirements/edx/base.in
+edx-proctoring==2.3.3     # via -r requirements/edx/base.in, edx-proctoring-proctortrack
+edx-rbac==1.1.2           # via edx-enterprise
+edx-rest-api-client==5.1.0  # via -r requirements/edx/base.in, edx-enterprise, edx-proctoring
+edx-search==1.3.4         # via -r requirements/edx/base.in
+edx-sga==0.10.0           # via -r requirements/edx/base.in
+edx-submissions==3.0.7    # via -r requirements/edx/base.in, ora2
 edx-tincan-py35==0.0.5    # via edx-enterprise
-edx-user-state-client==1.1.2
-edx-when==0.7.0
-edxval==1.2.3
+edx-user-state-client==1.1.2  # via -r requirements/edx/base.in
+edx-when==1.2.0           # via -r requirements/edx/base.in, edx-proctoring
+edxval==1.2.9             # via -r requirements/edx/base.in
 elasticsearch==1.9.0      # via edx-search
-enum34==1.1.6             # via edxval
-event-tracking==0.3.0
-fs-s3fs==0.1.8
-fs==2.0.18
+enum34==1.1.10            # via edxval
+event-tracking==0.3.0     # via -r requirements/edx/base.in, edx-proctoring, edx-search
+fs-s3fs==0.1.8            # via -r requirements/edx/base.in, django-pyfs
+fs==2.0.18                # via -r requirements/edx/base.in, django-pyfs, fs-s3fs, xblock
 future==0.18.2            # via django-ses, edx-celeryutils, edx-enterprise, pycontracts, pyjwkest
-geoip2==3.0.0
-glob2==0.7
-gunicorn==20.0.4
-help-tokens==1.0.5
-html5lib==1.0.1
-httplib2==0.17.0
-idna==2.8
-importlib-metadata==1.5.0
-inflection==0.3.1         # via drf-yasg
-ipaddress==1.0.23
+geoip2==3.0.0             # via -r requirements/edx/base.in
+glob2==0.7                # via -r requirements/edx/base.in
+gunicorn==20.0.4          # via -r requirements/edx/base.in
+help-tokens==1.0.5        # via -r requirements/edx/base.in
+html5lib==1.0.1           # via -r requirements/edx/base.in, ora2
+httplib2==0.17.1          # via oauth2
+icalendar==4.0.5          # via -r requirements/edx/base.in
+idna==2.9                 # via -r requirements/edx/paver.txt, requests
+importlib-metadata==1.6.0  # via -r requirements/edx/paver.txt, path
+inflection==0.4.0         # via drf-yasg
+ipaddress==1.0.23         # via -r requirements/edx/base.in
 isodate==0.6.0            # via python3-saml
 itypes==1.1.0             # via coreapi
 jinja2==2.11.1            # via code-annotations, coreschema
-jmespath==0.9.4           # via boto3, botocore
+jmespath==0.9.5           # via boto3, botocore
 jsondiff==1.2.0           # via edx-enterprise
-jsonfield2==3.0.3
+jsonfield2==3.0.3         # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, edx-celeryutils, edx-enterprise, edx-proctoring, edx-submissions, ora2
 kombu==3.0.37             # via celery
-laboratory==1.0.2
-lazy==1.4
+laboratory==1.0.2         # via -r requirements/edx/base.in
+lazy==1.4                 # via -r requirements/edx/paver.txt, acid-xblock, ora2
 lepl==5.1.3               # via rfc6266-parser
-libsass==0.10.0
-loremipsum==1.0.5
-git+https://github.com/edx/xblock-lti-consumer.git@v1.2.3#egg=lti_consumer-xblock==1.2.3
-lxml==4.5.0
-mailsnake==1.6.4
-mako==1.0.2
-markdown==2.6.11
+libsass==0.10.0           # via -r requirements/edx/paver.txt, ora2
+loremipsum==1.0.5         # via ora2
+git+https://github.com/edx/xblock-lti-consumer.git@v1.2.5#egg=lti_consumer-xblock==1.2.5  # via -r requirements/edx/github.in
+lxml==4.5.0               # via -r requirements/edx/../edx-sandbox/shared.txt, capa, edxval, lti-consumer-xblock, ora2, safe-lxml, xblock, xmlsec
+mailsnake==1.6.4          # via -r requirements/edx/base.in
+mako==1.0.2               # via -r requirements/edx/base.in, acid-xblock, lti-consumer-xblock, xblock-google-drive, xblock-utils
+markdown==2.6.11          # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, django-wiki, staff-graded-xblock, xblock-poll
 markey==0.8               # via django-babel-underscore
-markupsafe==1.1.1
+markupsafe==1.1.1         # via -r requirements/edx/paver.txt, chem, jinja2, mako, xblock
 maxminddb==1.5.2          # via geoip2
-mock==3.0.5
-git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a#egg=MongoDBProxy==0.1.0+edx.2
-mongoengine==0.10.0
-more-itertools==8.2.0
+mock==3.0.5               # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.txt, xblock-drag-and-drop-v2, xblock-poll
+git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a#egg=MongoDBProxy==0.1.0+edx.2  # via -r requirements/edx/github.in
+mongoengine==0.10.0       # via -r requirements/edx/base.in
+more-itertools==8.2.0     # via -r requirements/edx/paver.txt, zipp
 mpmath==1.1.0             # via sympy
-mysqlclient==1.4.6
-newrelic==5.6.0.135
-nltk==3.4.5
-nodeenv==1.3.5
-numpy==1.18.1             # via scipy
-git+https://github.com/joestump/python-oauth2.git@b94f69b1ad195513547924e380d9265133e995fa#egg=oauth2
-oauthlib==2.1.0
-git+https://github.com/edx/edx-ora2.git@2.6.9#egg=ora2==2.6.9
-packaging==20.1           # via drf-yasg
-path.py==12.4.0           # via edx-enterprise, edx-i18n-tools
-path==13.1.0
-pathtools==0.1.2
-paver==1.3.4
-pbr==5.4.4
-pdfminer.six==20200124
-piexif==1.1.3
-pillow==7.0.0
+mysqlclient==1.4.6        # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
+newrelic==5.10.0.138      # via -r requirements/edx/base.in, edx-django-utils
+nltk==3.4.5               # via -r requirements/edx/../edx-sandbox/shared.txt, chem
+nodeenv==1.3.5            # via -r requirements/edx/base.in
+numpy==1.18.2             # via chem, openedx-calc, scipy
+git+https://github.com/joestump/python-oauth2.git@b94f69b1ad195513547924e380d9265133e995fa#egg=oauth2  # via -r requirements/edx/github.in
+oauthlib==3.0.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, django-oauth-toolkit, lti-consumer-xblock, requests-oauthlib, social-auth-core
+openedx-calc==1.0.7       # via -r requirements/edx/base.in
+git+https://github.com/edx/edx-ora2.git@2.6.25#egg=ora2==2.6.25  # via -r requirements/edx/github.in
+packaging==20.3           # via drf-yasg
+path.py==12.4.0           # via edx-enterprise, edx-i18n-tools, ora2, xmodule
+path==13.1.0              # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.txt, path.py
+pathtools==0.1.2          # via -r requirements/edx/paver.txt, watchdog
+paver==1.3.4              # via -r requirements/edx/paver.txt
+pbr==5.4.5                # via -r requirements/edx/paver.txt, stevedore
+pdfminer.six==20200402    # via -r requirements/edx/base.in
+piexif==1.1.3             # via -r requirements/edx/base.in
+pillow==7.1.1             # via -r requirements/edx/base.in, edx-enterprise, edx-organizations
 pkgconfig==1.5.1          # via xmlsec
 polib==1.1.0              # via edx-i18n-tools
-psutil==1.2.1
-py2neo==3.1.2
-pycontracts==1.8.12
-pycountry==19.8.18
-pycparser==2.19
-pycryptodome==3.9.6       # via pdfminer.six
-pycryptodomex==3.9.6
-pygments==2.5.2
-pyjwkest==1.3.2
-pyjwt==1.5.2
-pymongo==3.9.0
-pynliner==0.8.0
-pyparsing==2.2.0          # via packaging, pycontracts
-pysrt==1.1.2
-python-dateutil==2.4.0
-python-levenshtein==0.12.0
-python-memcached==1.59
+psutil==1.2.1             # via -r requirements/edx/paver.txt, edx-django-utils
+py2neo==3.1.2             # via -r requirements/edx/base.in
+pycontracts==1.8.12       # via -r requirements/edx/base.in, edx-user-state-client
+pycountry==19.8.18        # via -r requirements/edx/base.in
+pycparser==2.20           # via -r requirements/edx/../edx-sandbox/shared.txt, cffi
+pycryptodome==3.9.7       # via pdfminer.six
+pycryptodomex==3.9.7      # via -r requirements/edx/base.in, edx-proctoring, pyjwkest
+pygments==2.6.1           # via -r requirements/edx/base.in
+pyjwkest==1.4.2           # via -r requirements/edx/base.in, edx-drf-extensions
+pyjwt==1.5.2              # via -r requirements/edx/base.in, drf-jwt, edx-rest-api-client, social-auth-core
+pymongo==3.9.0            # via -r requirements/edx/base.in, -r requirements/edx/paver.txt, edx-opaque-keys, event-tracking, mongodbproxy, mongoengine
+pynliner==0.8.0           # via -r requirements/edx/base.in
+pyparsing==2.2.0          # via chem, openedx-calc, packaging, pycontracts
+pysrt==1.1.2              # via -r requirements/edx/base.in, edxval
+python-dateutil==2.4.0    # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, analytics-python, botocore, edx-ace, edx-drf-extensions, edx-enterprise, edx-proctoring, icalendar, ora2, xblock
+python-levenshtein==0.12.0  # via -r requirements/edx/base.in
+python-memcached==1.59    # via -r requirements/edx/paver.txt
 python-slugify==4.0.0     # via code-annotations
-python-swiftclient==3.8.1
-python3-openid==3.1.0 ; python_version >= "3"
-python3-saml==1.5.0
-pytz==2019.3
-pyuca==1.2
-pyyaml==5.3
-random2==1.0.1
-recommender-xblock==1.4.5
-redis==2.10.6
-requests-oauthlib==1.1.0
-requests==2.22.0
-rest-condition==1.0.3
-rfc6266-parser==0.0.6
+python-swiftclient==3.9.0  # via ora2
+python3-openid==3.1.0 ; python_version >= "3"  # via -r requirements/edx/base.in, social-auth-core
+python3-saml==1.5.0       # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
+pytz==2019.3              # via -r requirements/edx/base.in, babel, capa, celery, django, django-ses, edx-completion, edx-enterprise, edx-proctoring, edx-submissions, edx-tincan-py35, event-tracking, fs, icalendar, ora2, xblock
+pyuca==1.2                # via -r requirements/edx/base.in
+pyyaml==5.3.1             # via -r requirements/edx/base.in, code-annotations, edx-django-release-util, edx-i18n-tools, xblock
+random2==1.0.1            # via -r requirements/edx/base.in
+recommender-xblock==1.4.5  # via -r requirements/edx/base.in
+redis==2.10.6             # via -r requirements/edx/base.in
+requests-oauthlib==1.3.0  # via -r requirements/edx/base.in, social-auth-core
+requests==2.23.0          # via -r requirements/edx/paver.txt, analytics-python, coreapi, django-oauth-toolkit, edx-analytics-data-api-client, edx-bulk-grades, edx-drf-extensions, edx-enterprise, edx-rest-api-client, geoip2, mailsnake, pyjwkest, python-swiftclient, requests-oauthlib, sailthru-client, slumber, social-auth-core
+rest-condition==1.0.3     # via -r requirements/edx/base.in, edx-drf-extensions
+rfc6266-parser==0.0.6     # via -r requirements/edx/base.in
 ruamel.yaml.clib==0.2.0   # via ruamel.yaml
-ruamel.yaml==0.16.7       # via drf-yasg
-rules==2.2
+ruamel.yaml==0.16.10      # via drf-yasg
+rules==2.2                # via -r requirements/edx/base.in, edx-enterprise, edx-proctoring
 s3transfer==0.1.13        # via boto3
-sailthru-client==2.2.3
-scipy==1.4.1
+sailthru-client==2.2.3    # via -r requirements/edx/base.in, edx-ace
+scipy==1.4.1              # via chem, openedx-calc
 semantic-version==2.8.4   # via edx-drf-extensions
-shapely==1.7.0
-shortuuid==0.5.0          # via edx-django-oauth2-provider
-simplejson==3.17.0
-six==1.14.0
+shapely==1.7.0            # via -r requirements/edx/base.in
+simplejson==3.17.0        # via -r requirements/edx/base.in, sailthru-client, super-csv, xblock-utils
+six==1.14.0               # via -r requirements/edx/../edx-sandbox/shared.txt, -r requirements/edx/base.in, -r requirements/edx/paver.txt, analytics-python, bleach, cryptography, django-appconf, django-classy-tags, django-countries, django-pyfs, django-sekizai, django-simple-history, django-statici18n, drf-yasg, edx-ace, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-milestones, edx-opaque-keys, edx-rbac, edx-search, event-tracking, fs, fs-s3fs, help-tokens, html5lib, isodate, libsass, mock, nltk, openedx-calc, packaging, paver, pycontracts, pyjwkest, python-dateutil, python-memcached, python-swiftclient, social-auth-app-django, social-auth-core, stevedore, xblock
 slumber==0.7.1            # via edx-bulk-grades, edx-enterprise, edx-rest-api-client
-social-auth-core==3.2.0
-git+https://github.com/jazzband/sorl-thumbnail.git@13bedfb7d2970809eda597e3ef79318a6fa80ac2#egg=sorl-thumbnail
-sortedcontainers==2.1.0
-soupsieve==1.9.5          # via beautifulsoup4
-sqlparse==0.3.0
-staff-graded-xblock==0.6
-stevedore==1.31.0
-super-csv==0.9.6
-sympy==1.5.1
-testfixtures==6.12.0      # via edx-enterprise
+social-auth-core==3.3.3   # via -r requirements/edx/base.in, social-auth-app-django
+git+https://github.com/jazzband/sorl-thumbnail.git@13bedfb7d2970809eda597e3ef79318a6fa80ac2#egg=sorl-thumbnail  # via -r requirements/edx/github.in
+sortedcontainers==2.1.0   # via -r requirements/edx/base.in, pdfminer.six
+soupsieve==2.0            # via beautifulsoup4
+sqlparse==0.3.1           # via -r requirements/edx/base.in, django
+staff-graded-xblock==0.7  # via -r requirements/edx/base.in
+stevedore==1.32.0         # via -r requirements/edx/base.in, -r requirements/edx/paver.txt, code-annotations, edx-ace, edx-enterprise, edx-opaque-keys
+super-csv==0.9.7          # via -r requirements/edx/base.in, edx-bulk-grades
+sympy==1.5.1              # via symmath
+testfixtures==6.14.0      # via edx-enterprise
 text-unidecode==1.3       # via python-slugify
-unicodecsv==0.14.1
+unicodecsv==0.14.1        # via -r requirements/edx/base.in, edx-enterprise
 uritemplate==3.0.1        # via coreapi, drf-yasg
-urllib3==1.25.8
-user-util==0.1.5
-voluptuous==0.11.7
-watchdog==0.10.2
-web-fragments==0.3.1
+urllib3==1.25.8           # via -r requirements/edx/paver.txt, elasticsearch, geoip2, requests
+user-util==0.1.5          # via -r requirements/edx/base.in
+voluptuous==0.11.7        # via ora2
+watchdog==0.10.2          # via -r requirements/edx/paver.txt
+web-fragments==0.3.1      # via -r requirements/edx/base.in, staff-graded-xblock, xblock, xblock-utils
 webencodings==0.5.1       # via bleach, html5lib
-webob==1.8.6              # via xblock
-wrapt==1.11.2
-git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.8#egg=xblock-drag-and-drop-v2==2.2.8
-git+https://github.com/open-craft/xblock-poll@3c7dcaf6c933d914188f0740a60711603f948d26#egg=xblock-poll==1.9.1
-xblock-utils==1.2.4
-xblock==1.2.9
+webob==1.8.6              # via xblock, xmodule
+wrapt==1.11.2             # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.txt
+git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.9#egg=xblock-drag-and-drop-v2==2.2.9  # via -r requirements/edx/github.in
+git+https://github.com/open-craft/xblock-poll@da2d8fd21791a7af128595cf82bee83ee579e00f#egg=xblock-poll==1.9.6  # via -r requirements/edx/github.in
+xblock-utils==2.0.0       # via -r requirements/edx/base.in, edx-sga, lti-consumer-xblock, staff-graded-xblock, xblock-drag-and-drop-v2, xblock-google-drive
+xblock==1.2.9             # via -r requirements/edx/base.in, acid-xblock, crowdsourcehinter-xblock, done-xblock, edx-completion, edx-sga, edx-user-state-client, edx-when, lti-consumer-xblock, ora2, rate-xblock, staff-graded-xblock, xblock-discussion, xblock-drag-and-drop-v2, xblock-google-drive, xblock-poll, xblock-utils
 xmlsec==1.3.3             # via python3-saml
-xss-utils==0.1.2
-zipp==1.0.0
+xss-utils==0.1.2          # via -r requirements/edx/base.in
+zipp==1.0.0               # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/js_test.txt
+++ b/requirements/js_test.txt
@@ -7,14 +7,15 @@
 cheroot==8.3.0            # via cherrypy
 cherrypy==18.5.0          # via jasmine
 glob2==0.7                # via jasmine-core
-importlib-resources==1.0.2  # via jaraco.text
+importlib-metadata==1.6.0  # via importlib-resources
+importlib-resources==1.4.0  # via jaraco.text
 jaraco.classes==2.0       # via jaraco.collections
 jaraco.collections==2.1   # via cherrypy
 jaraco.functools==2.0     # via cheroot, jaraco.text, tempora
 jaraco.text==3.2.0        # via jaraco.collections
 jasmine-core==3.1.0       # via jasmine
-jasmine==3.1.0
-jinja2==2.11.1            # via jasmine
+jasmine==3.1.0            # via -r requirements/js_test.in
+jinja2==2.11.2            # via jasmine
 markupsafe==1.1.1         # via jinja2
 more-itertools==8.2.0     # via cheroot, cherrypy, jaraco.functools
 ordereddict==1.1          # via jasmine-core
@@ -26,6 +27,7 @@ six==1.14.0               # via cheroot, jaraco.classes, jaraco.collections, jar
 tempora==1.14.1           # via portend
 urllib3==1.25.8           # via selenium
 zc.lockfile==2.0          # via cherrypy
+zipp==1.2.0               # via importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -4,74 +4,75 @@
 #
 #    make upgrade
 #
-amqp==1.4.9               # via kombu
-aniso8601==8.0.0          # via edx-tincan-py35
-anyjson==0.3.3            # via kombu
-billiard==3.3.0.23        # via celery
-bleach==3.1.0
-celery==3.1.25
-certifi==2019.11.28       # via requests
-cffi==1.14.0              # via cryptography
-chardet==3.0.4            # via requests
-click==7.0                # via code-annotations
-code-annotations==0.3.3
-cryptography==2.8
-defusedxml==0.5.0         # via djangorestframework-xml
-django-config-models==2.0.0
-django-countries==5.5
-django-crum==0.7.5
-django-fernet-fields==0.6
-django-filter==2.2.0
-django-ipware==2.1.0
-django-model-utils==3.0.0
-django-multi-email-field==0.6.1
-django-object-actions==2.0.0
-django-simple-history==2.8.0
-django-waffle==0.18.0
-django==1.11.28
-djangorestframework-jwt==1.11.0  # via edx-drf-extensions
-djangorestframework-xml==1.4.0
-djangorestframework==3.9.4
-edx-django-utils==2.0.4
-edx-drf-extensions==2.4.6
-edx-opaque-keys[django]==2.0.1
-edx-rbac==1.0.5
-edx-rest-api-client==3.0.2
-edx-tincan-py35==0.0.5
-future==0.18.2
-idna==2.8                 # via requests
-importlib-metadata==1.5.0  # via path
-jinja2==2.11.1            # via code-annotations
-jsondiff==1.2.0
-jsonfield2==3.0.3
-kombu==3.0.37             # via celery
-markupsafe==1.1.1         # via jinja2
-more-itertools==8.2.0     # via zipp
-newrelic==5.6.0.135       # via edx-django-utils
-path.py==12.4.0
-path==13.1.0              # via path.py
-pbr==5.4.4                # via stevedore
-pillow==7.0.0
-psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
-pycparser==2.19           # via cffi
-pycryptodomex==3.9.6      # via pyjwkest
-pyjwkest==1.3.2           # via edx-drf-extensions
-pyjwt==1.5.2              # via djangorestframework-jwt, edx-rest-api-client
-pymongo==3.9.0            # via edx-opaque-keys
-python-dateutil==2.4.0
-python-slugify==4.0.0     # via code-annotations
-pytz==2019.3
-pyyaml==5.3               # via code-annotations
-requests==2.22.0
-rest-condition==1.0.3     # via edx-drf-extensions
-rules==2.2
-semantic-version==2.8.4   # via edx-drf-extensions
-six==1.14.0
-slumber==0.7.1
-stevedore==1.31.0
-testfixtures==6.12.0
-text-unidecode==1.3       # via python-slugify
-unicodecsv==0.14.1
-urllib3==1.25.8           # via requests
-webencodings==0.5.1       # via bleach
-zipp==1.0.0               # via importlib-metadata
+amqp==1.4.9               # via -c requirements/edx-platform-constraints.txt, kombu
+aniso8601==8.0.0          # via -c requirements/edx-platform-constraints.txt, edx-tincan-py35
+anyjson==0.3.3            # via -c requirements/edx-platform-constraints.txt, kombu
+billiard==3.3.0.23        # via -c requirements/edx-platform-constraints.txt, celery
+bleach==3.1.4             # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
+celery==3.1.26.post2      # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
+certifi==2020.4.5.1       # via -c requirements/edx-platform-constraints.txt, requests
+cffi==1.14.0              # via -c requirements/edx-platform-constraints.txt, cryptography
+chardet==3.0.4            # via -c requirements/edx-platform-constraints.txt, requests
+click==7.1.1              # via -c requirements/edx-platform-constraints.txt, code-annotations
+code-annotations==0.3.3   # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
+cryptography==2.9         # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, django-fernet-fields
+defusedxml==0.5.0         # via -c requirements/edx-platform-constraints.txt, djangorestframework-xml
+django-config-models==2.0.0  # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
+django-countries==5.5     # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
+django-crum==0.7.5        # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, edx-rbac
+django-fernet-fields==0.6  # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
+django-filter==2.2.0      # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
+django-ipware==2.1.0      # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
+django-model-utils==3.2.0  # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, edx-rbac
+django-multi-email-field==0.6.1  # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
+django-object-actions==2.0.0  # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
+django-simple-history==2.8.0  # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
+django-waffle==0.18.0     # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, edx-django-utils, edx-drf-extensions
+django==2.2.12            # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, code-annotations, django-config-models, django-crum, django-fernet-fields, django-filter, django-model-utils, django-multi-email-field, drf-jwt, edx-django-utils, edx-drf-extensions, edx-opaque-keys, edx-rbac, jsonfield2, rest-condition
+djangorestframework-xml==1.4.0  # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
+djangorestframework==3.9.4  # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, django-config-models, drf-jwt, edx-drf-extensions, rest-condition
+drf-jwt==1.14.0           # via -c requirements/edx-platform-constraints.txt, edx-drf-extensions
+edx-django-utils==3.2.1   # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, django-config-models, edx-drf-extensions, edx-rest-api-client
+edx-drf-extensions==5.0.2  # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, edx-rbac
+edx-opaque-keys[django]==2.0.2  # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, edx-drf-extensions
+edx-rbac==1.1.2           # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
+edx-rest-api-client==5.1.0  # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
+edx-tincan-py35==0.0.5    # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
+future==0.18.2            # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, pyjwkest
+idna==2.9                 # via -c requirements/edx-platform-constraints.txt, requests
+importlib-metadata==1.6.0  # via -c requirements/edx-platform-constraints.txt, path
+jinja2==2.11.1            # via -c requirements/edx-platform-constraints.txt, code-annotations
+jsondiff==1.2.0           # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
+jsonfield2==3.0.3         # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
+kombu==3.0.37             # via -c requirements/edx-platform-constraints.txt, celery
+markupsafe==1.1.1         # via -c requirements/edx-platform-constraints.txt, jinja2
+more-itertools==8.2.0     # via -c requirements/edx-platform-constraints.txt, zipp
+newrelic==5.10.0.138      # via -c requirements/edx-platform-constraints.txt, edx-django-utils
+path.py==12.4.0           # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
+path==13.1.0              # via -c requirements/edx-platform-constraints.txt, path.py
+pbr==5.4.5                # via -c requirements/edx-platform-constraints.txt, stevedore
+pillow==7.1.1             # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
+psutil==1.2.1             # via -c requirements/edx-platform-constraints.txt, edx-django-utils
+pycparser==2.20           # via -c requirements/edx-platform-constraints.txt, cffi
+pycryptodomex==3.9.7      # via -c requirements/edx-platform-constraints.txt, pyjwkest
+pyjwkest==1.4.2           # via -c requirements/edx-platform-constraints.txt, edx-drf-extensions
+pyjwt==1.5.2              # via -c requirements/edx-platform-constraints.txt, drf-jwt, edx-rest-api-client
+pymongo==3.9.0            # via -c requirements/edx-platform-constraints.txt, edx-opaque-keys
+python-dateutil==2.4.0    # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, edx-drf-extensions
+python-slugify==4.0.0     # via -c requirements/edx-platform-constraints.txt, code-annotations
+pytz==2019.3              # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, celery, django, edx-tincan-py35
+pyyaml==5.3.1             # via -c requirements/edx-platform-constraints.txt, code-annotations
+requests==2.23.0          # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, edx-drf-extensions, edx-rest-api-client, pyjwkest, slumber
+rest-condition==1.0.3     # via -c requirements/edx-platform-constraints.txt, edx-drf-extensions
+rules==2.2                # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
+semantic-version==2.8.4   # via -c requirements/edx-platform-constraints.txt, edx-drf-extensions
+six==1.14.0               # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, bleach, cryptography, django-countries, django-simple-history, edx-drf-extensions, edx-opaque-keys, edx-rbac, pyjwkest, python-dateutil, stevedore
+slumber==0.7.1            # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, edx-rest-api-client
+sqlparse==0.3.1           # via -c requirements/edx-platform-constraints.txt, django
+stevedore==1.32.0         # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, code-annotations, edx-opaque-keys
+testfixtures==6.14.0      # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
+text-unidecode==1.3       # via -c requirements/edx-platform-constraints.txt, python-slugify
+unicodecsv==0.14.1        # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
+urllib3==1.25.8           # via -c requirements/edx-platform-constraints.txt, requests
+webencodings==0.5.1       # via -c requirements/edx-platform-constraints.txt, bleach
+zipp==1.0.0               # via -c requirements/edx-platform-constraints.txt, importlib-metadata

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,95 +4,96 @@
 #
 #    make upgrade
 #
-amqp==1.4.9
-aniso8601==8.0.0
-anyjson==0.3.3
+amqp==1.4.9               # via -r requirements/test-master.txt, kombu
+aniso8601==8.0.0          # via -r requirements/test-master.txt, edx-tincan-py35
+anyjson==0.3.3            # via -r requirements/test-master.txt, kombu
 attrs==19.3.0             # via pytest
-billiard==3.3.0.23
-bleach==3.1.0
-celery==3.1.25
-certifi==2019.11.28
-cffi==1.14.0
-chardet==3.0.4
-click==7.0
-code-annotations==0.3.3
-coverage==5.0.3           # via pytest-cov
-cryptography==2.8
-ddt==1.2.2
-defusedxml==0.5.0
-diff-cover==2.6.0
-django-config-models==2.0.0
-django-countries==5.5
-django-crum==0.7.5
-django-fernet-fields==0.6
-django-filter==2.2.0
-django-ipware==2.1.0
-django-model-utils==3.0.0
-django-multi-email-field==0.6.1
-django-object-actions==2.0.0
-django-simple-history==2.8.0
-django-waffle==0.18.0
-djangorestframework-jwt==1.11.0
-djangorestframework-xml==1.4.0
-djangorestframework==3.9.4
-edx-django-utils==2.0.4
-edx-drf-extensions==2.4.6
-edx-opaque-keys[django]==2.0.1
-edx-rbac==1.0.5
-edx-rest-api-client==3.0.2
-edx-tincan-py35==0.0.5
-factory-boy==2.12.0
-faker==4.0.0              # via factory-boy
-freezegun==0.3.14
-future==0.18.2
-idna==2.8
-importlib-metadata==1.5.0
-inflect==3.0.2            # via jinja2-pluralize
+billiard==3.3.0.23        # via -r requirements/test-master.txt, celery
+bleach==3.1.4             # via -r requirements/test-master.txt
+celery==3.1.26.post2      # via -r requirements/test-master.txt
+certifi==2020.4.5.1       # via -r requirements/test-master.txt, requests
+cffi==1.14.0              # via -r requirements/test-master.txt, cryptography
+chardet==3.0.4            # via -r requirements/test-master.txt, requests
+click==7.1.1              # via -r requirements/test-master.txt, code-annotations
+code-annotations==0.3.3   # via -r requirements/test-master.txt
+coverage==5.1             # via pytest-cov
+cryptography==2.9         # via -r requirements/test-master.txt, django-fernet-fields
+ddt==1.3.1                # via -r requirements/test.in
+defusedxml==0.5.0         # via -r requirements/test-master.txt, djangorestframework-xml
+diff-cover==2.6.1         # via -r requirements/test.in
+django-config-models==2.0.0  # via -r requirements/test-master.txt
+django-countries==5.5     # via -r requirements/test-master.txt
+django-crum==0.7.5        # via -r requirements/test-master.txt, edx-rbac
+django-fernet-fields==0.6  # via -r requirements/test-master.txt
+django-filter==2.2.0      # via -r requirements/test-master.txt
+django-ipware==2.1.0      # via -r requirements/test-master.txt
+django-model-utils==3.2.0  # via -r requirements/test-master.txt, -r requirements/test.in, edx-rbac
+django-multi-email-field==0.6.1  # via -r requirements/test-master.txt
+django-object-actions==2.0.0  # via -r requirements/test-master.txt
+django-simple-history==2.8.0  # via -r requirements/test-master.txt
+django-waffle==0.18.0     # via -r requirements/test-master.txt, edx-django-utils, edx-drf-extensions
+djangorestframework-xml==1.4.0  # via -r requirements/test-master.txt
+djangorestframework==3.9.4  # via -r requirements/test-master.txt, django-config-models, drf-jwt, edx-drf-extensions, rest-condition
+drf-jwt==1.14.0           # via -r requirements/test-master.txt, edx-drf-extensions
+edx-django-utils==3.2.1   # via -r requirements/test-master.txt, django-config-models, edx-drf-extensions, edx-rest-api-client
+edx-drf-extensions==5.0.2  # via -r requirements/test-master.txt, edx-rbac
+edx-opaque-keys[django]==2.0.2  # via -r requirements/test-master.txt, edx-drf-extensions
+edx-rbac==1.1.2           # via -r requirements/test-master.txt
+edx-rest-api-client==5.1.0  # via -r requirements/test-master.txt
+edx-tincan-py35==0.0.5    # via -r requirements/test-master.txt
+factory-boy==2.12.0       # via -r requirements/test.in
+faker==4.0.3              # via factory-boy
+freezegun==0.3.14         # via -c requirements/constraints.txt, -r requirements/test.in
+future==0.18.2            # via -r requirements/test-master.txt, pyjwkest
+idna==2.9                 # via -r requirements/test-master.txt, requests
+importlib-metadata==1.6.0  # via -r requirements/test-master.txt, inflect, path, pluggy, pytest
+inflect==3.0.2            # via -c requirements/constraints.txt, jinja2-pluralize
 jinja2-pluralize==0.3.0   # via diff-cover
-jinja2==2.11.1
-jsondiff==1.2.0
-jsonfield2==3.0.3
-kombu==3.0.37
-markupsafe==1.1.1
-mock==3.0.5
-more-itertools==8.2.0
-newrelic==5.6.0.135
-packaging==20.1           # via pytest
-path.py==12.4.0
-path==13.1.0
+jinja2==2.11.1            # via -r requirements/test-master.txt, code-annotations, diff-cover, jinja2-pluralize
+jsondiff==1.2.0           # via -r requirements/test-master.txt
+jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/test-master.txt
+kombu==3.0.37             # via -r requirements/test-master.txt, celery
+markupsafe==1.1.1         # via -r requirements/test-master.txt, jinja2
+mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.in
+more-itertools==8.2.0     # via -r requirements/test-master.txt, pytest, zipp
+newrelic==5.10.0.138      # via -r requirements/test-master.txt, edx-django-utils
+packaging==20.3           # via pytest
+path.py==12.4.0           # via -r requirements/test-master.txt
+path==13.1.0              # via -r requirements/test-master.txt, path.py
 pathlib2==2.3.5           # via pytest
-pbr==5.4.4
-pillow==7.0.0
+pbr==5.4.5                # via -r requirements/test-master.txt, stevedore
+pillow==7.1.1             # via -r requirements/test-master.txt
 pluggy==0.13.1            # via diff-cover, pytest
-psutil==1.2.1
+psutil==1.2.1             # via -r requirements/test-master.txt, edx-django-utils
 py==1.8.1                 # via pytest, pytest-catchlog
-pycparser==2.19
-pycryptodomex==3.9.6
-pygments==2.5.2           # via diff-cover
-pyjwkest==1.3.2
-pyjwt==1.5.2
-pymongo==3.9.0
-pyparsing==2.4.6          # via packaging
-pytest-catchlog==1.2.2
-pytest-cov==2.8.1
-pytest-django==3.8.0
-pytest==5.3.5             # via pytest-catchlog, pytest-cov, pytest-django
-python-dateutil==2.4.0
-python-slugify==4.0.0
-pytz==2019.3
-pyyaml==5.3
-requests==2.22.0
-responses==0.10.9
-rest-condition==1.0.3
-rules==2.2
-semantic-version==2.8.4
-six==1.14.0
-slumber==0.7.1
-stevedore==1.31.0
-testfixtures==6.12.0
-text-unidecode==1.3
-unicodecsv==0.14.1
-urllib3==1.25.8
-wcwidth==0.1.8            # via pytest
-webencodings==0.5.1
-zipp==1.0.0
+pycparser==2.20           # via -r requirements/test-master.txt, cffi
+pycryptodomex==3.9.7      # via -r requirements/test-master.txt, pyjwkest
+pygments==2.6.1           # via diff-cover
+pyjwkest==1.4.2           # via -r requirements/test-master.txt, edx-drf-extensions
+pyjwt==1.5.2              # via -r requirements/test-master.txt, drf-jwt, edx-rest-api-client
+pymongo==3.9.0            # via -r requirements/test-master.txt, edx-opaque-keys
+pyparsing==2.4.7          # via packaging
+pytest-catchlog==1.2.2    # via -r requirements/test.in
+pytest-cov==2.8.1         # via -r requirements/test.in
+pytest-django==3.9.0      # via -r requirements/test.in
+pytest==5.4.1             # via pytest-catchlog, pytest-cov, pytest-django
+python-dateutil==2.4.0    # via -r requirements/test-master.txt, edx-drf-extensions, faker, freezegun
+python-slugify==4.0.0     # via -r requirements/test-master.txt, code-annotations
+pytz==2019.3              # via -r requirements/test-master.txt, celery, django, edx-tincan-py35
+pyyaml==5.3.1             # via -r requirements/test-master.txt, code-annotations
+requests==2.23.0          # via -r requirements/test-master.txt, edx-drf-extensions, edx-rest-api-client, pyjwkest, responses, slumber
+responses==0.10.12        # via -r requirements/test.in
+rest-condition==1.0.3     # via -r requirements/test-master.txt, edx-drf-extensions
+rules==2.2                # via -r requirements/test-master.txt
+semantic-version==2.8.4   # via -r requirements/test-master.txt, edx-drf-extensions
+six==1.14.0               # via -r requirements/test-master.txt, bleach, cryptography, diff-cover, django-countries, django-simple-history, edx-drf-extensions, edx-opaque-keys, edx-rbac, freezegun, mock, packaging, pathlib2, pyjwkest, python-dateutil, responses, stevedore
+slumber==0.7.1            # via -r requirements/test-master.txt, edx-rest-api-client
+sqlparse==0.3.1           # via -r requirements/test-master.txt, django
+stevedore==1.32.0         # via -r requirements/test-master.txt, code-annotations, edx-opaque-keys
+testfixtures==6.14.0      # via -r requirements/test-master.txt, -r requirements/test.in
+text-unidecode==1.3       # via -r requirements/test-master.txt, faker, python-slugify
+unicodecsv==0.14.1        # via -r requirements/test-master.txt
+urllib3==1.25.8           # via -r requirements/test-master.txt, requests
+wcwidth==0.1.9            # via pytest
+webencodings==0.5.1       # via -r requirements/test-master.txt, bleach
+zipp==1.0.0               # via -c requirements/constraints.txt, -r requirements/test-master.txt, importlib-metadata

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -5,25 +5,25 @@
 #    make upgrade
 #
 appdirs==1.4.3            # via virtualenv
-certifi==2019.11.28       # via requests
+certifi==2020.4.5.1       # via requests
 chardet==3.0.4            # via requests
-codecov==2.0.15
-coverage==5.0.3           # via codecov
+codecov==2.0.22           # via -r requirements/travis.in
+coverage==5.1             # via codecov
 distlib==0.3.0            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
-idna==2.8                 # via requests
-importlib-metadata==1.5.0  # via pluggy, tox, virtualenv
-importlib-resources==1.0.2  # via virtualenv
+idna==2.9                 # via requests
+importlib-metadata==1.6.0  # via importlib-resources, pluggy, tox, virtualenv
+importlib-resources==1.4.0  # via virtualenv
 more-itertools==8.2.0     # via zipp
-packaging==20.1           # via tox
+packaging==20.3           # via tox
 pluggy==0.13.1            # via tox
 py==1.8.1                 # via tox
-pyparsing==2.4.6          # via packaging
-requests==2.22.0          # via codecov
+pyparsing==2.4.7          # via packaging
+requests==2.23.0          # via codecov
 six==1.14.0               # via packaging, tox, virtualenv
 toml==0.10.0              # via tox
-tox-battery==0.5.1
-tox==3.14.3
+tox-battery==0.5.1        # via -r requirements/travis.in
+tox==3.14.6               # via -r requirements/travis.in, tox-battery
 urllib3==1.25.8           # via requests
-virtualenv==20.0.2        # via tox
-zipp==1.0.0               # via importlib-metadata
+virtualenv==20.0.17       # via tox
+zipp==1.0.0               # via -c requirements/constraints.txt, importlib-metadata, importlib-resources


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
