### PR TITLE
Travis and Tox Update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,21 +4,19 @@ language: python
 
 python:
   - 3.5
-  - 3.6
+  - 3.8
 
 env:
-  - TOXENV=django20
-  - TOXENV=django21
   - TOXENV=django22
   - TOXENV=quality
+  - TOXENV=docs
+  - TOXENV=pii-annotations
 
 services:
     - xvfb
 
 matrix:
   include:
-    - python: 3.6
-      env: TOXENV=docs
     - python: 3.5
       env:
         - TOXENV=jasmine
@@ -34,9 +32,6 @@ matrix:
     - python: 3.5
       env:
         - RUNJSHINT=true
-    - python: 3.6
-      env: TOXENV=pii-annotations
-
 cache:
   - directories:
     - node_modules

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,8 @@ Unreleased
 [3.2.3] - 2020-05-06
 --------------------
 
+* Removed support for Django<2.2 & Python3.6
+* Added support for python3.8.
 * Changes to use catalog query content filter if defined instead of catalog content filter.
 
 [3.2.2] - 2020-05-05

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -24,3 +24,7 @@ mock==3.0.5
 # sphinx has dropped support for python 3.5, latest version requires at least python3.6
 # see https://www.sphinx-doc.org/en/master/intro.html#prerequisites
 sphinx==2.4.1
+
+# freezegun>0.3.14 requires python-dateutil>2.8.1 to pass the tests which is a dependency of edx-platform
+and edx-drf-extensions.
+freezegun==0.3.14

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -15,7 +15,7 @@ attrs==19.3.0             # via -r requirements/test.txt, pytest
 babel==2.8.0              # via -r requirements/doc.txt, sphinx
 backports.functools-lru-cache==1.6.1  # via caniusepython3
 billiard==3.3.0.23        # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, celery
-bleach==3.1.5             # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, readme-renderer
+bleach==3.1.4             # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, readme-renderer
 caniusepython3==7.2.0     # via -r requirements/dev.in
 celery==3.1.26.post2      # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
 certifi==2020.4.5.1       # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, requests
@@ -48,10 +48,10 @@ doc8==0.8.0               # via -r requirements/doc.txt
 docutils==0.16            # via -r requirements/doc.txt, doc8, readme-renderer, restructuredtext-lint, sphinx
 drf-jwt==1.14.0           # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-drf-extensions
 edx-django-utils==3.2.1   # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, django-config-models, edx-drf-extensions, edx-rest-api-client
-edx-drf-extensions==5.1.0  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-rbac
+edx-drf-extensions==5.0.2  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-rbac
 edx-i18n-tools==0.5.0     # via -r requirements/dev.in
 edx-lint==1.4.1           # via -r requirements/dev.in
-edx-opaque-keys[django]==2.1.0  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-drf-extensions
+edx-opaque-keys[django]==2.0.2  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-drf-extensions
 edx-rbac==1.1.3           # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
 edx-rest-api-client==5.1.0  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
 edx-sphinx-theme==1.5.0   # via -r requirements/doc.txt
@@ -59,11 +59,12 @@ edx-tincan-py35==0.0.5    # via -r requirements/doc.txt, -r requirements/test-ma
 factory-boy==2.12.0       # via -r requirements/test.txt
 faker==4.0.3              # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via tox, virtualenv
-freezegun==0.3.15         # via -r requirements/test.txt
+freezegun==0.3.14         # via -c requirements/constraints.txt, -r requirements/test.txt
 future==0.18.2            # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, pyjwkest
 idna==2.9                 # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, requests
 imagesize==1.2.0          # via -r requirements/doc.txt, sphinx
-importlib-metadata==1.6.0  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, inflect, path, pluggy, pytest, tox, virtualenv
+importlib-metadata==1.6.0  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, importlib-resources, inflect, path, pluggy, pytest, tox, virtualenv
+importlib-resources==1.5.0  # via virtualenv
 inflect==3.0.2            # via -c requirements/constraints.txt, -r requirements/test.txt, jinja2-pluralize
 isort==4.3.21             # via -r requirements/dev.in, pylint
 jinja2-pluralize==0.3.0   # via -r requirements/test.txt, diff-cover
@@ -77,12 +78,13 @@ mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.txt
 more-itertools==8.2.0     # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, pytest, zipp
 newrelic==5.12.0.140      # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-django-utils
-packaging==20.3           # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, bleach, caniusepython3, pytest, sphinx, tox
+packaging==20.3           # via -r requirements/doc.txt, -r requirements/test.txt, caniusepython3, pytest, sphinx, tox
 path.py==12.4.0           # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-i18n-tools
 path==13.1.0              # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, path.py
+pathlib2==2.3.5           # via -r requirements/test.txt, pytest
 pbr==5.4.5                # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, stevedore
 pillow==7.1.2             # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
-pip-tools==5.1.1          # via -r requirements/dev.in
+pip-tools==5.1.0          # via -r requirements/dev.in
 pkginfo==1.5.0.1          # via twine
 pluggy==0.13.1            # via -r requirements/test.txt, diff-cover, pytest, tox
 pockets==0.9.1            # via -r requirements/doc.txt, sphinxcontrib-napoleon
@@ -101,7 +103,7 @@ pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
 pylint==2.4.2             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.9.0            # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-opaque-keys
-pyparsing==2.2.0          # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, packaging
+pyparsing==2.4.7          # via -r requirements/doc.txt, -r requirements/test.txt, packaging
 pytest-catchlog==1.2.2    # via -r requirements/test.txt
 pytest-cov==2.8.1         # via -r requirements/test.txt
 pytest-django==3.9.0      # via -r requirements/test.txt
@@ -118,7 +120,7 @@ rest-condition==1.0.3     # via -r requirements/doc.txt, -r requirements/test-ma
 restructuredtext-lint==1.3.0  # via -r requirements/doc.txt, doc8
 rules==2.2                # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
 semantic-version==2.8.5   # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-drf-extensions
-six==1.14.0               # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, astroid, bleach, cryptography, diff-cover, django-countries, django-simple-history, doc8, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-rbac, edx-sphinx-theme, freezegun, mock, packaging, pip-tools, pockets, pyjwkest, python-dateutil, readme-renderer, responses, sphinxcontrib-napoleon, stevedore, tox, virtualenv
+six==1.14.0               # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, astroid, bleach, cryptography, diff-cover, django-countries, django-simple-history, doc8, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-rbac, edx-sphinx-theme, freezegun, mock, packaging, pathlib2, pip-tools, pockets, pyjwkest, python-dateutil, readme-renderer, responses, sphinxcontrib-napoleon, stevedore, tox, virtualenv
 slumber==0.7.1            # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via -r requirements/doc.txt, pydocstyle, sphinx
 sphinx==2.4.1             # via -c requirements/constraints.txt, -r requirements/doc.txt, edx-sphinx-theme
@@ -135,18 +137,18 @@ testfixtures==6.14.1      # via -r requirements/dev.in, -r requirements/doc.txt,
 text-unidecode==1.3       # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, faker, python-slugify
 toml==0.10.0              # via tox
 tox-battery==0.5.1        # via -r requirements/dev.in
-tox==3.15.0               # via -r requirements/dev.in, tox-battery
-tqdm==4.46.0              # via twine
+tox==3.14.6               # via -r requirements/dev.in, tox-battery
+tqdm==4.45.0              # via twine
 twine==1.11.0             # via -r requirements/dev.in
 typed-ast==1.4.1          # via astroid
 unicodecsv==0.14.1        # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
 urllib3==1.25.9           # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, requests
-virtualenv==20.0.20       # via tox
+virtualenv==20.0.18       # via tox
 wcwidth==0.1.9            # via -r requirements/test.txt, pytest
 webencodings==0.5.1       # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, bleach
 wheel==0.34.2             # via -r requirements/dev.in
 wrapt==1.11.2             # via astroid
-zipp==1.0.0               # via -c requirements/constraints.txt, -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, importlib-metadata
+zipp==1.0.0               # via -c requirements/constraints.txt, -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -10,7 +10,7 @@ aniso8601==8.0.0          # via -r requirements/test-master.txt, edx-tincan-py35
 anyjson==0.3.3            # via -r requirements/test-master.txt, kombu
 babel==2.8.0              # via sphinx
 billiard==3.3.0.23        # via -r requirements/test-master.txt, celery
-bleach==3.1.5             # via -r requirements/test-master.txt, readme-renderer
+bleach==3.1.4             # via -r requirements/test-master.txt, readme-renderer
 celery==3.1.26.post2      # via -r requirements/test-master.txt
 certifi==2020.4.5.1       # via -r requirements/test-master.txt, requests
 cffi==1.14.0              # via -r requirements/test-master.txt, cryptography
@@ -37,8 +37,8 @@ doc8==0.8.0               # via -r requirements/doc.in
 docutils==0.16            # via -r requirements/doc.in, doc8, readme-renderer, restructuredtext-lint, sphinx
 drf-jwt==1.14.0           # via -r requirements/test-master.txt, edx-drf-extensions
 edx-django-utils==3.2.1   # via -r requirements/test-master.txt, django-config-models, edx-drf-extensions, edx-rest-api-client
-edx-drf-extensions==5.1.0  # via -r requirements/test-master.txt, edx-rbac
-edx-opaque-keys[django]==2.1.0  # via -r requirements/test-master.txt, edx-drf-extensions
+edx-drf-extensions==5.0.2  # via -r requirements/test-master.txt, edx-rbac
+edx-opaque-keys[django]==2.0.2  # via -r requirements/test-master.txt, edx-drf-extensions
 edx-rbac==1.1.3           # via -r requirements/test-master.txt
 edx-rest-api-client==5.1.0  # via -r requirements/test-master.txt
 edx-sphinx-theme==1.5.0   # via -r requirements/doc.in
@@ -54,7 +54,7 @@ kombu==3.0.37             # via -r requirements/test-master.txt, celery
 markupsafe==1.1.1         # via -r requirements/test-master.txt, jinja2
 more-itertools==8.2.0     # via -r requirements/test-master.txt, zipp
 newrelic==5.12.0.140      # via -r requirements/test-master.txt, edx-django-utils
-packaging==20.3           # via -r requirements/test-master.txt, bleach, sphinx
+packaging==20.3           # via sphinx
 path.py==12.4.0           # via -r requirements/test-master.txt
 path==13.1.0              # via -r requirements/test-master.txt, path.py
 pbr==5.4.5                # via -r requirements/test-master.txt, stevedore
@@ -67,7 +67,7 @@ pygments==2.6.1           # via readme-renderer, sphinx
 pyjwkest==1.4.2           # via -r requirements/test-master.txt, edx-drf-extensions
 pyjwt==1.5.2              # via -r requirements/test-master.txt, drf-jwt, edx-rest-api-client
 pymongo==3.9.0            # via -r requirements/test-master.txt, edx-opaque-keys
-pyparsing==2.2.0          # via -r requirements/test-master.txt, packaging
+pyparsing==2.4.7          # via packaging
 python-dateutil==2.4.0    # via -r requirements/test-master.txt, edx-drf-extensions
 python-slugify==4.0.0     # via -r requirements/test-master.txt, code-annotations
 pytz==2020.1              # via -r requirements/test-master.txt, babel, celery, django, edx-tincan-py35

--- a/requirements/edx-platform-constraints.txt
+++ b/requirements/edx-platform-constraints.txt
@@ -14,7 +14,7 @@ attrs==19.3.0             # via -r requirements/edx/base.in, edx-ace
 babel==2.8.0              # via -r requirements/edx/base.in, django-babel, django-babel-underscore
 beautifulsoup4==4.9.0     # via pynliner
 billiard==3.3.0.23        # via celery
-bleach==3.1.5             # via -r requirements/edx/base.in, edx-enterprise, lti-consumer-xblock, ora2
+bleach==3.1.4             # via -r requirements/edx/base.in, edx-enterprise, lti-consumer-xblock, ora2
 boto3==1.4.8              # via -r requirements/edx/base.in, fs-s3fs
 boto==2.39.0              # via -r requirements/edx/base.in, django-ses, edxval, ora2
 botocore==1.8.17          # via -r requirements/edx/base.in, boto3, s3transfer
@@ -63,7 +63,7 @@ django-require==1.0.11    # via -r requirements/edx/base.in
 django-sekizai==1.1.0     # via -r requirements/edx/base.in, django-wiki
 django-ses==0.8.14        # via -r requirements/edx/base.in
 django-simple-history==2.10.0  # via -r requirements/edx/base.in, edx-enterprise, edx-organizations, ora2
-django-splash==0.2.9      # via -r requirements/edx/base.in
+django-splash==0.2.7      # via -r requirements/edx/base.in
 django-statici18n==1.9.0  # via -r requirements/edx/base.in
 django-storages==1.8      # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, edxval
 django-user-tasks==1.0.0  # via -r requirements/edx/base.in
@@ -82,30 +82,30 @@ edx-api-doc-tools==1.2.0  # via -r requirements/edx/base.in
 edx-bulk-grades==0.6.8    # via -r requirements/edx/base.in, staff-graded-xblock
 edx-ccx-keys==1.0.1       # via -r requirements/edx/base.in
 edx-celeryutils==0.5.0    # via -r requirements/edx/base.in, super-csv
-edx-completion==3.2.0     # via -r requirements/edx/base.in
-edx-django-release-util==0.4.4  # via -r requirements/edx/base.in
-edx-django-sites-extensions==2.5.0  # via -r requirements/edx/base.in
+edx-completion==3.1.1     # via -r requirements/edx/base.in
+edx-django-release-util==0.4.2  # via -r requirements/edx/base.in
+edx-django-sites-extensions==2.4.3  # via -r requirements/edx/base.in
 edx-django-utils==3.2.1   # via -r requirements/edx/base.in, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-when
-edx-drf-extensions==5.1.0  # via -r requirements/edx/base.in, edx-completion, edx-enterprise, edx-organizations, edx-proctoring, edx-rbac, edx-when, edxval
-edx-enterprise==3.2.1     # via -r requirements/edx/base.in
+edx-drf-extensions==5.0.2  # via -r requirements/edx/base.in, edx-completion, edx-enterprise, edx-organizations, edx-proctoring, edx-rbac, edx-when, edxval
+edx-enterprise==3.2.0     # via -r requirements/edx/base.in
 edx-i18n-tools==0.5.0     # via ora2
-edx-milestones==0.3.0     # via -r requirements/edx/base.in
-edx-opaque-keys[django]==2.1.0  # via -r requirements/edx/paver.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, xmodule
-edx-organizations==5.2.0  # via -r requirements/edx/base.in
+edx-milestones==0.2.6     # via -r requirements/edx/base.in
+edx-opaque-keys[django]==2.0.2  # via -r requirements/edx/paver.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, xmodule
+edx-organizations==5.1.0  # via -r requirements/edx/base.in
 edx-proctoring-proctortrack==1.0.5  # via -r requirements/edx/base.in
-edx-proctoring==2.4.0     # via -r requirements/edx/base.in, edx-proctoring-proctortrack
+edx-proctoring==2.3.3     # via -r requirements/edx/base.in, edx-proctoring-proctortrack
 edx-rbac==1.1.3           # via edx-enterprise
 edx-rest-api-client==5.1.0  # via -r requirements/edx/base.in, edx-enterprise, edx-proctoring
 edx-search==1.3.4         # via -r requirements/edx/base.in
 edx-sga==0.10.0           # via -r requirements/edx/base.in
-edx-submissions==3.1.3    # via -r requirements/edx/base.in, ora2
+edx-submissions==3.1.2    # via -r requirements/edx/base.in, ora2
 edx-tincan-py35==0.0.5    # via edx-enterprise
 edx-user-state-client==1.1.2  # via -r requirements/edx/base.in
-edx-when==1.2.3           # via -r requirements/edx/base.in, edx-proctoring
-edxval==1.3.4             # via -r requirements/edx/base.in
+edx-when==1.2.1           # via -r requirements/edx/base.in, edx-proctoring
+edxval==1.3.2             # via -r requirements/edx/base.in
 elasticsearch==1.9.0      # via edx-search
 enum34==1.1.10            # via edxval
-event-tracking==0.3.1     # via -r requirements/edx/base.in, edx-proctoring, edx-search
+event-tracking==0.3.0     # via -r requirements/edx/base.in, edx-proctoring, edx-search
 fs-s3fs==0.1.8            # via -r requirements/edx/base.in, django-pyfs
 fs==2.0.18                # via -r requirements/edx/base.in, django-pyfs, fs-s3fs, xblock
 future==0.18.2            # via django-ses, edx-celeryutils, edx-enterprise, pycontracts, pyjwkest
@@ -150,12 +150,12 @@ mysqlclient==1.4.6        # via -r requirements/edx/base.in
 newrelic==5.12.0.140      # via -r requirements/edx/base.in, edx-django-utils
 nltk==3.5                 # via -r requirements/edx/../edx-sandbox/shared.txt, chem
 nodeenv==1.3.5            # via -r requirements/edx/base.in
-numpy==1.18.4             # via chem, openedx-calc, scipy
+numpy==1.18.3             # via chem, openedx-calc, scipy
 git+https://github.com/joestump/python-oauth2.git@b94f69b1ad195513547924e380d9265133e995fa#egg=oauth2  # via -r requirements/edx/github.in
 oauthlib==3.0.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, django-oauth-toolkit, lti-consumer-xblock, requests-oauthlib, social-auth-core
 openedx-calc==1.0.7       # via -r requirements/edx/base.in
 git+https://github.com/edx/edx-ora2.git@2.6.25#egg=ora2==2.6.25  # via -r requirements/edx/github.in
-packaging==20.3           # via bleach, drf-yasg
+packaging==20.3           # via drf-yasg
 path.py==12.4.0           # via edx-enterprise, edx-i18n-tools, ora2, xmodule
 path==13.1.0              # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.txt, path.py
 pathtools==0.1.2          # via -r requirements/edx/paver.txt, watchdog
@@ -214,13 +214,13 @@ git+https://github.com/jazzband/sorl-thumbnail.git@13bedfb7d2970809eda597e3ef793
 sortedcontainers==2.1.0   # via -r requirements/edx/base.in, pdfminer.six
 soupsieve==2.0            # via beautifulsoup4
 sqlparse==0.3.1           # via -r requirements/edx/base.in, django
-staff-graded-xblock==0.8  # via -r requirements/edx/base.in
+staff-graded-xblock==0.7  # via -r requirements/edx/base.in
 stevedore==1.32.0         # via -r requirements/edx/base.in, -r requirements/edx/paver.txt, code-annotations, edx-ace, edx-enterprise, edx-opaque-keys
 super-csv==0.9.7          # via -r requirements/edx/base.in, edx-bulk-grades
 sympy==1.5.1              # via symmath
 testfixtures==6.14.1      # via edx-enterprise
 text-unidecode==1.3       # via python-slugify
-tqdm==4.46.0              # via -r requirements/edx/../edx-sandbox/shared.txt, nltk
+tqdm==4.45.0              # via -r requirements/edx/../edx-sandbox/shared.txt, nltk
 unicodecsv==0.14.1        # via -r requirements/edx/base.in, edx-enterprise
 uritemplate==3.0.1        # via coreapi, drf-yasg
 urllib3==1.25.9           # via -r requirements/edx/paver.txt, elasticsearch, geoip2, requests
@@ -236,7 +236,7 @@ git+https://github.com/open-craft/xblock-poll@da2d8fd21791a7af128595cf82bee83ee5
 xblock-utils==2.0.0       # via -r requirements/edx/base.in, edx-sga, lti-consumer-xblock, staff-graded-xblock, xblock-drag-and-drop-v2, xblock-google-drive
 xblock==1.2.9             # via -r requirements/edx/base.in, acid-xblock, crowdsourcehinter-xblock, done-xblock, edx-completion, edx-sga, edx-user-state-client, edx-when, lti-consumer-xblock, ora2, rate-xblock, staff-graded-xblock, xblock-discussion, xblock-drag-and-drop-v2, xblock-google-drive, xblock-poll, xblock-utils
 xmlsec==1.3.3             # via python3-saml
-xss-utils==0.1.3          # via -r requirements/edx/base.in
+xss-utils==0.1.2          # via -r requirements/edx/base.in
 zipp==1.0.0               # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/js_test.txt
+++ b/requirements/js_test.txt
@@ -7,24 +7,27 @@
 cheroot==8.3.0            # via cherrypy
 cherrypy==18.6.0          # via jasmine
 glob2==0.7                # via jasmine-core
-jaraco.classes==2.0     # via jaraco.collections
-jaraco.collections==2.1  # via cherrypy
-jaraco.functools==2.0   # via cheroot, jaraco.text, tempora
+importlib-metadata==1.6.0  # via importlib-resources
+importlib-resources==1.5.0  # via jaraco.text
+jaraco.classes==2.0       # via jaraco.collections
+jaraco.collections==2.1   # via cherrypy
+jaraco.functools==2.0     # via cheroot, jaraco.text, tempora
 jaraco.text==3.2.0        # via jaraco.collections
 jasmine-core==3.1.0       # via jasmine
 jasmine==3.1.0            # via -r requirements/js_test.in
 jinja2==2.11.2            # via jasmine
 markupsafe==1.1.1         # via jinja2
-more-itertools==8.2.0     # via cheroot, cherrypy, jaraco.classes, jaraco.functools
+more-itertools==8.2.0     # via cheroot, cherrypy, jaraco.functools
 ordereddict==1.1          # via jasmine-core
 portend==2.6              # via cherrypy
 pytz==2020.1              # via tempora
 pyyaml==3.10              # via jasmine
 selenium==3.141.0         # via jasmine
-six==1.14.0               # via cheroot, jaraco.collections, jaraco.text
-tempora==1.14.1            # via portend
+six==1.14.0               # via cheroot, jaraco.classes, jaraco.collections, jaraco.text, tempora
+tempora==1.14.1           # via portend
 urllib3==1.25.9           # via selenium
 zc.lockfile==2.0          # via cherrypy
+zipp==1.2.0               # via importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -8,7 +8,7 @@ amqp==1.4.9               # via -c requirements/edx-platform-constraints.txt, ko
 aniso8601==8.0.0          # via -c requirements/edx-platform-constraints.txt, edx-tincan-py35
 anyjson==0.3.3            # via -c requirements/edx-platform-constraints.txt, kombu
 billiard==3.3.0.23        # via -c requirements/edx-platform-constraints.txt, celery
-bleach==3.1.5             # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
+bleach==3.1.4             # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
 celery==3.1.26.post2      # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
 certifi==2020.4.5.1       # via -c requirements/edx-platform-constraints.txt, requests
 cffi==1.14.0              # via -c requirements/edx-platform-constraints.txt, cryptography
@@ -33,8 +33,8 @@ djangorestframework-xml==2.0.0  # via -c requirements/edx-platform-constraints.t
 djangorestframework==3.9.4  # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, django-config-models, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.14.0           # via -c requirements/edx-platform-constraints.txt, edx-drf-extensions
 edx-django-utils==3.2.1   # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, django-config-models, edx-drf-extensions, edx-rest-api-client
-edx-drf-extensions==5.1.0  # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, edx-rbac
-edx-opaque-keys[django]==2.1.0  # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, edx-drf-extensions
+edx-drf-extensions==5.0.2  # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, edx-rbac
+edx-opaque-keys[django]==2.0.2  # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, edx-drf-extensions
 edx-rbac==1.1.3           # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
 edx-rest-api-client==5.1.0  # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
 edx-tincan-py35==0.0.5    # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
@@ -48,7 +48,6 @@ kombu==3.0.37             # via -c requirements/edx-platform-constraints.txt, ce
 markupsafe==1.1.1         # via -c requirements/edx-platform-constraints.txt, jinja2
 more-itertools==8.2.0     # via -c requirements/edx-platform-constraints.txt, zipp
 newrelic==5.12.0.140      # via -c requirements/edx-platform-constraints.txt, edx-django-utils
-packaging==20.3           # via -c requirements/edx-platform-constraints.txt, bleach
 path.py==12.4.0           # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
 path==13.1.0              # via -c requirements/edx-platform-constraints.txt, path.py
 pbr==5.4.5                # via -c requirements/edx-platform-constraints.txt, stevedore
@@ -59,7 +58,6 @@ pycryptodomex==3.9.7      # via -c requirements/edx-platform-constraints.txt, py
 pyjwkest==1.4.2           # via -c requirements/edx-platform-constraints.txt, edx-drf-extensions
 pyjwt==1.5.2              # via -c requirements/edx-platform-constraints.txt, drf-jwt, edx-rest-api-client
 pymongo==3.9.0            # via -c requirements/edx-platform-constraints.txt, edx-opaque-keys
-pyparsing==2.2.0          # via -c requirements/edx-platform-constraints.txt, packaging
 python-dateutil==2.4.0    # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, edx-drf-extensions
 python-slugify==4.0.0     # via -c requirements/edx-platform-constraints.txt, code-annotations
 pytz==2020.1              # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, celery, django, edx-tincan-py35
@@ -68,7 +66,7 @@ requests==2.23.0          # via -c requirements/edx-platform-constraints.txt, -r
 rest-condition==1.0.3     # via -c requirements/edx-platform-constraints.txt, edx-drf-extensions
 rules==2.2                # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
 semantic-version==2.8.5   # via -c requirements/edx-platform-constraints.txt, edx-drf-extensions
-six==1.14.0               # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, bleach, cryptography, django-countries, django-simple-history, edx-drf-extensions, edx-opaque-keys, edx-rbac, packaging, pyjwkest, python-dateutil, stevedore
+six==1.14.0               # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, bleach, cryptography, django-countries, django-simple-history, edx-drf-extensions, edx-opaque-keys, edx-rbac, pyjwkest, python-dateutil, stevedore
 slumber==0.7.1            # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, edx-rest-api-client
 sqlparse==0.3.1           # via -c requirements/edx-platform-constraints.txt, django
 stevedore==1.32.0         # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, code-annotations, edx-opaque-keys

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -9,7 +9,7 @@ aniso8601==8.0.0          # via -r requirements/test-master.txt, edx-tincan-py35
 anyjson==0.3.3            # via -r requirements/test-master.txt, kombu
 attrs==19.3.0             # via pytest
 billiard==3.3.0.23        # via -r requirements/test-master.txt, celery
-bleach==3.1.5             # via -r requirements/test-master.txt
+bleach==3.1.4             # via -r requirements/test-master.txt
 celery==3.1.26.post2      # via -r requirements/test-master.txt
 certifi==2020.4.5.1       # via -r requirements/test-master.txt, requests
 cffi==1.14.0              # via -r requirements/test-master.txt, cryptography
@@ -36,17 +36,17 @@ djangorestframework-xml==2.0.0  # via -r requirements/test-master.txt
 djangorestframework==3.9.4  # via -r requirements/test-master.txt, django-config-models, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.14.0           # via -r requirements/test-master.txt, edx-drf-extensions
 edx-django-utils==3.2.1   # via -r requirements/test-master.txt, django-config-models, edx-drf-extensions, edx-rest-api-client
-edx-drf-extensions==5.1.0  # via -r requirements/test-master.txt, edx-rbac
-edx-opaque-keys[django]==2.1.0  # via -r requirements/test-master.txt, edx-drf-extensions
+edx-drf-extensions==5.0.2  # via -r requirements/test-master.txt, edx-rbac
+edx-opaque-keys[django]==2.0.2  # via -r requirements/test-master.txt, edx-drf-extensions
 edx-rbac==1.1.3           # via -r requirements/test-master.txt
 edx-rest-api-client==5.1.0  # via -r requirements/test-master.txt
 edx-tincan-py35==0.0.5    # via -r requirements/test-master.txt
 factory-boy==2.12.0       # via -r requirements/test.in
 faker==4.0.3              # via factory-boy
-freezegun==0.3.14         # via -r requirements/test.in
+freezegun==0.3.14         # via -c requirements/constraints.txt, -r requirements/test.in
 future==0.18.2            # via -r requirements/test-master.txt, pyjwkest
 idna==2.9                 # via -r requirements/test-master.txt, requests
-importlib-metadata==1.6.0  # via -r requirements/test-master.txt, path, pluggy, pytest
+importlib-metadata==1.6.0  # via -r requirements/test-master.txt, inflect, path, pluggy, pytest
 inflect==3.0.2            # via -c requirements/constraints.txt, jinja2-pluralize
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.11.2            # via -r requirements/test-master.txt, code-annotations, diff-cover, jinja2-pluralize
@@ -57,9 +57,10 @@ markupsafe==1.1.1         # via -r requirements/test-master.txt, jinja2
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.in
 more-itertools==8.2.0     # via -r requirements/test-master.txt, pytest, zipp
 newrelic==5.12.0.140      # via -r requirements/test-master.txt, edx-django-utils
-packaging==20.3           # via -r requirements/test-master.txt, bleach, pytest
+packaging==20.3           # via pytest
 path.py==12.4.0           # via -r requirements/test-master.txt
 path==13.1.0              # via -r requirements/test-master.txt, path.py
+pathlib2==2.3.5           # via pytest
 pbr==5.4.5                # via -r requirements/test-master.txt, stevedore
 pillow==7.1.2             # via -r requirements/test-master.txt
 pluggy==0.13.1            # via diff-cover, pytest
@@ -71,7 +72,7 @@ pygments==2.6.1           # via diff-cover
 pyjwkest==1.4.2           # via -r requirements/test-master.txt, edx-drf-extensions
 pyjwt==1.5.2              # via -r requirements/test-master.txt, drf-jwt, edx-rest-api-client
 pymongo==3.9.0            # via -r requirements/test-master.txt, edx-opaque-keys
-pyparsing==2.2.0          # via -r requirements/test-master.txt, packaging
+pyparsing==2.4.7          # via packaging
 pytest-catchlog==1.2.2    # via -r requirements/test.in
 pytest-cov==2.8.1         # via -r requirements/test.in
 pytest-django==3.9.0      # via -r requirements/test.in
@@ -85,7 +86,7 @@ responses==0.10.14        # via -r requirements/test.in
 rest-condition==1.0.3     # via -r requirements/test-master.txt, edx-drf-extensions
 rules==2.2                # via -r requirements/test-master.txt
 semantic-version==2.8.5   # via -r requirements/test-master.txt, edx-drf-extensions
-six==1.14.0               # via -r requirements/test-master.txt, bleach, cryptography, diff-cover, django-countries, django-simple-history, edx-drf-extensions, edx-opaque-keys, edx-rbac, freezegun, mock, packaging, pyjwkest, python-dateutil, responses, stevedore
+six==1.14.0               # via -r requirements/test-master.txt, bleach, cryptography, diff-cover, django-countries, django-simple-history, edx-drf-extensions, edx-opaque-keys, edx-rbac, freezegun, mock, packaging, pathlib2, pyjwkest, python-dateutil, responses, stevedore
 slumber==0.7.1            # via -r requirements/test-master.txt, edx-rest-api-client
 sqlparse==0.3.1           # via -r requirements/test-master.txt, django
 stevedore==1.32.0         # via -r requirements/test-master.txt, code-annotations, edx-opaque-keys

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -12,7 +12,8 @@ coverage==5.1             # via codecov
 distlib==0.3.0            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
 idna==2.9                 # via requests
-importlib-metadata==1.6.0  # via pluggy, tox, virtualenv
+importlib-metadata==1.6.0  # via importlib-resources, pluggy, tox, virtualenv
+importlib-resources==1.5.0  # via virtualenv
 more-itertools==8.2.0     # via zipp
 packaging==20.3           # via tox
 pluggy==0.13.1            # via tox
@@ -22,7 +23,7 @@ requests==2.23.0          # via codecov
 six==1.14.0               # via packaging, tox, virtualenv
 toml==0.10.0              # via tox
 tox-battery==0.5.1        # via -r requirements/travis.in
-tox==3.15.0               # via -r requirements/travis.in, tox-battery
+tox==3.14.6               # via -r requirements/travis.in, tox-battery
 urllib3==1.25.9           # via requests
-virtualenv==20.0.20       # via tox
-zipp==1.0.0               # via -c requirements/constraints.txt, importlib-metadata
+virtualenv==20.0.18       # via tox
+zipp==1.0.0               # via -c requirements/constraints.txt, importlib-metadata, importlib-resources

--- a/setup.py
+++ b/setup.py
@@ -113,12 +113,12 @@ setup(
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Framework :: Django",
-        "Framework :: Django :: 1.11",
+        "Framework :: Django :: 2.2",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.8",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{35,36}-django{111,20,21,22}
+envlist = py35-django22,py38-django{22,30}
 
 [doc8]
 max-line-length = 120
@@ -49,10 +49,8 @@ setenv =
     TOXENV={envname}
 deps =
     -r{toxinidir}/requirements/test.txt
-    django111: Django>=1.11,<2.0
-    django20: Django>=2.0,<2.1
-    django21: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3
+    django30: Django>=3.0,<3.1
 commands =
     py.test -Wd {posargs}
 


### PR DESCRIPTION
**Issue:** [BOM-1567](https://openedx.atlassian.net/browse/BOM-1567)

### Changes in Travis and Tox
- Changed `py36` with `py38`.
- Removed `django111`, `django20`, `django21`.
- Added `django30` in **Tox**.
- Updated version to `3.2.3`.