### PR TITLE
Present course run as inactive when end date is within 24 hours.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,13 @@ Change Log
 Unreleased
 --------------------
 
+
+[3.1.3] - 2020-04-23
+--------------------
+
+* Revised "end date" window for determinine course active/inactive status in catalog API responses.
+
+
 [3.1.2] - 2020-04-21
 --------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "3.1.2"
+__version__ = "3.1.3"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -719,15 +719,17 @@ def is_course_run_enrollable(course_run):
     Return true if the course run is enrollable, false otherwise.
 
     We look for the following criteria:
-    - end is greater than now OR null
-    - enrollment_start is less than now OR null
-    - enrollment_end is greater than now OR null
+    1. end date is greater than a reasonably-defined enrollment window, or undefined
+       * reasonably-defined enrollment window is 1 day before course run end date
+    2. enrollment_start is less than now, or undefined
+    3. enrollment_end is greater than now, or undefined
     """
     now = datetime.datetime.now(pytz.UTC)
+    reasonable_enrollment_window = now + datetime.timedelta(days=1)
     end = parse_datetime_handle_invalid(course_run.get('end'))
     enrollment_start = parse_datetime_handle_invalid(course_run.get('enrollment_start'))
     enrollment_end = parse_datetime_handle_invalid(course_run.get('enrollment_end'))
-    return (not end or end > now) and \
+    return (not end or end > reasonable_enrollment_window) and \
            (not enrollment_start or enrollment_start < now) and \
            (not enrollment_end or enrollment_end > now)
 


### PR DESCRIPTION
**Merge checklist:**
- [ ] ~Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)~
    - ~`base.in` if needed in production but edx-platform doesn't install it~
    - ~`test-master.in` if edx-platform pins it, with a matching version~
    - ~`make upgrade && make requirements` have been run to regenerate requirements~
- [ ] ~`make static` has been run to update webpack bundling if any static content was updated~
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] ~Translations updated~

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)

Ref #736 