### PR TITLE
Add Fullstory to enterprise admin pages

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 --------------------
 
+[3.2.1] - 2020-04-28
+--------------------
+
+* Add Fullstory javascript to enterprise admin pages.
+
+
 [3.2.0] - 2020-04-23
 --------------------
 

--- a/enterprise/admin/__init__.py
+++ b/enterprise/admin/__init__.py
@@ -106,8 +106,18 @@ class EnterpriseCustomerCatalogInline(admin.TabularInline):
         return formset
 
 
+class EnterpriseModelAdmin(admin.ModelAdmin):
+    """
+    Base class for model admin classes for enterprise. Adds the Fullstory script to their admin pages to enable
+    user analytics. ENT-2620
+    """
+
+    class Media:
+        js = ("enterprise/js/fullstory.js",)
+
+
 @admin.register(EnterpriseCustomerType)
-class EnterpriseCustomerTypeAdmin(admin.ModelAdmin):
+class EnterpriseCustomerTypeAdmin(EnterpriseModelAdmin):
     """
     Django admin model for EnterpriseCustomerType.
     """
@@ -162,6 +172,9 @@ class EnterpriseCustomerAdmin(DjangoObjectActions, SimpleHistoryAdmin):
 
     class Meta:
         model = EnterpriseCustomer
+
+    class Media:
+        js = ("enterprise/js/fullstory.js",)
 
     def change_view(self, request, object_id, form_url='', extra_context=None):
         preview_content_filter = EnterpriseCustomerCatalogAdminForm.get_clicked_preview_content_filter(request.POST)
@@ -404,7 +417,7 @@ class EnterpriseCustomerUserAdmin(admin.ModelAdmin):
 
 
 @admin.register(PendingEnterpriseCustomerUser)
-class PendingEnterpriseCustomerUserAdmin(admin.ModelAdmin):
+class PendingEnterpriseCustomerUserAdmin(EnterpriseModelAdmin):
     """
     Django admin model for PendingEnterpriseCustomerUser
     """
@@ -426,7 +439,7 @@ class PendingEnterpriseCustomerUserAdmin(admin.ModelAdmin):
 
 
 @admin.register(EnrollmentNotificationEmailTemplate)
-class EnrollmentNotificationEmailTemplateAdmin(DjangoObjectActions, admin.ModelAdmin):
+class EnrollmentNotificationEmailTemplateAdmin(DjangoObjectActions, EnterpriseModelAdmin):
     """
     Django admin for EnrollmentNotificationEmailTemplate model
     """
@@ -480,7 +493,7 @@ class EnrollmentNotificationEmailTemplateAdmin(DjangoObjectActions, admin.ModelA
 
 
 @admin.register(EnterpriseCourseEnrollment)
-class EnterpriseCourseEnrollmentAdmin(admin.ModelAdmin):
+class EnterpriseCourseEnrollmentAdmin(EnterpriseModelAdmin):
     """
     Django admin model for EnterpriseCourseEnrollment
     """
@@ -516,7 +529,7 @@ class EnterpriseCourseEnrollmentAdmin(admin.ModelAdmin):
 
 
 @admin.register(PendingEnrollment)
-class PendingEnrollmentAdmin(admin.ModelAdmin):
+class PendingEnrollmentAdmin(EnterpriseModelAdmin):
     """
     Django admin model for PendingEnrollment
     """
@@ -552,7 +565,7 @@ class PendingEnrollmentAdmin(admin.ModelAdmin):
 
 
 @admin.register(EnterpriseCatalogQuery)
-class EnterpriseCatalogQueryAdmin(admin.ModelAdmin):
+class EnterpriseCatalogQueryAdmin(EnterpriseModelAdmin):
     """
     Django admin model for EnterpriseCatalogQuery.
     """
@@ -577,7 +590,7 @@ class EnterpriseCatalogQueryAdmin(admin.ModelAdmin):
 
 
 @admin.register(EnterpriseCustomerCatalog)
-class EnterpriseCustomerCatalogAdmin(admin.ModelAdmin):
+class EnterpriseCustomerCatalogAdmin(EnterpriseModelAdmin):
     """
     Django admin model for EnterpriseCustomerCatalog.
     """
@@ -587,7 +600,8 @@ class EnterpriseCustomerCatalogAdmin(admin.ModelAdmin):
         model = EnterpriseCustomerCatalog
 
     class Media:
-        js = ('enterprise/admin/enterprise_customer_catalog.js', )
+        js = ('enterprise/admin/enterprise_customer_catalog.js',
+              "enterprise/js/fullstory.js",)
 
     list_display = (
         'uuid_nowrap',
@@ -689,7 +703,7 @@ class EnterpriseCustomerCatalogAdmin(admin.ModelAdmin):
 
 
 @admin.register(EnterpriseCustomerReportingConfiguration)
-class EnterpriseCustomerReportingConfigurationAdmin(admin.ModelAdmin):
+class EnterpriseCustomerReportingConfigurationAdmin(EnterpriseModelAdmin):
     """
     Django admin model for EnterpriseCustomerReportingConfiguration.
     """

--- a/enterprise/static/enterprise/js/fullstory.js
+++ b/enterprise/static/enterprise/js/fullstory.js
@@ -1,0 +1,17 @@
+window['_fs_debug'] = false;
+window['_fs_host'] = 'fullstory.com';
+window['_fs_script'] = 'edge.fullstory.com/s/fs.js';
+window['_fs_org'] = 'CWDGA';
+window['_fs_namespace'] = 'FS';
+(function(m,n,e,t,l,o,g,y){
+    if (e in m) {if(m.console && m.console.log) { m.console.log('FullStory namespace conflict. Please set window["_fs_namespace"].');} return;}
+    g=m[e]=function(a,b,s){g.q?g.q.push([a,b,s]):g._api(a,b,s);};g.q=[];
+    o=n.createElement(t);o.async=1;o.crossOrigin='anonymous';o.src='https://'+_fs_script;
+    y=n.getElementsByTagName(t)[0];y.parentNode.insertBefore(o,y);
+    g.identify=function(i,v,s){g(l,{uid:i},s);if(v)g(l,v,s)};g.setUserVars=function(v,s){g(l,v,s)};g.event=function(i,v,s){g('event',{n:i,p:v},s)};
+    g.shutdown=function(){g("rec",!1)};g.restart=function(){g("rec",!0)};
+    g.log = function(a,b) { g("log", [a,b]) };
+    g.consent=function(a){g("consent",!arguments.length||a)};
+    g.identifyAccount=function(i,v){o='account';v=v||{};v.acctId=i;g(o,v)};
+    g.clearUserCookie=function(){};
+})(window,document,window['_fs_namespace'],'script','user');

--- a/enterprise/static/enterprise/js/fullstory.js
+++ b/enterprise/static/enterprise/js/fullstory.js
@@ -1,17 +1,17 @@
-window['_fs_debug'] = false;
-window['_fs_host'] = 'fullstory.com';
-window['_fs_script'] = 'edge.fullstory.com/s/fs.js';
-window['_fs_org'] = 'CWDGA';
-window['_fs_namespace'] = 'FS';
+window._fs_debug = false;
+window._fs_host = 'fullstory.com';
+window._fs_script = 'edge.fullstory.com/s/fs.js';
+window._fs_org = 'CWDGA';
+window._fs_namespace = 'FS';
 (function(m,n,e,t,l,o,g,y){
     if (e in m) {if(m.console && m.console.log) { m.console.log('FullStory namespace conflict. Please set window["_fs_namespace"].');} return;}
     g=m[e]=function(a,b,s){g.q?g.q.push([a,b,s]):g._api(a,b,s);};g.q=[];
     o=n.createElement(t);o.async=1;o.crossOrigin='anonymous';o.src='https://'+_fs_script;
     y=n.getElementsByTagName(t)[0];y.parentNode.insertBefore(o,y);
-    g.identify=function(i,v,s){g(l,{uid:i},s);if(v)g(l,v,s)};g.setUserVars=function(v,s){g(l,v,s)};g.event=function(i,v,s){g('event',{n:i,p:v},s)};
-    g.shutdown=function(){g("rec",!1)};g.restart=function(){g("rec",!0)};
-    g.log = function(a,b) { g("log", [a,b]) };
-    g.consent=function(a){g("consent",!arguments.length||a)};
-    g.identifyAccount=function(i,v){o='account';v=v||{};v.acctId=i;g(o,v)};
+    g.identify=function(i,v,s){g(l,{uid:i},s);if(v)g(l,v,s);};g.setUserVars=function(v,s){g(l,v,s);};g.event=function(i,v,s){g('event',{n:i,p:v},s);};
+    g.shutdown=function(){g("rec",!1);};g.restart=function(){g("rec",!0);};
+    g.log = function(a,b) { g("log", [a,b]); };
+    g.consent=function(a){g("consent",!arguments.length||a);};
+    g.identifyAccount=function(i,v){o='account';v=v||{};v.acctId=i;g(o,v);};
     g.clearUserCookie=function(){};
-})(window,document,window['_fs_namespace'],'script','user');
+})(window,document,window._fs_namespace,'script','user');

--- a/enterprise/static/enterprise/js/fullstory.js
+++ b/enterprise/static/enterprise/js/fullstory.js
@@ -5,6 +5,7 @@ window._fs_org = 'CWDGA';
 window._fs_namespace = 'FS';
 (function(m,n,e,t,l,o,g,y){
     if (e in m) {if(m.console && m.console.log) { m.console.log('FullStory namespace conflict. Please set window["_fs_namespace"].');} return;}
+    /*jshint -W030 */
     g=m[e]=function(a,b,s){g.q?g.q.push([a,b,s]):g._api(a,b,s);};g.q=[];
     o=n.createElement(t);o.async=1;o.crossOrigin='anonymous';o.src='https://'+_fs_script;
     y=n.getElementsByTagName(t)[0];y.parentNode.insertBefore(o,y);

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -25,9 +25,9 @@ click-log==0.3.2          # via edx-lint
 click==7.1.1              # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, click-log, code-annotations, edx-lint, pip-tools
 code-annotations==0.3.3   # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
 coverage==5.1             # via -r requirements/test.txt, pytest-cov
-cryptography==2.9         # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, django-fernet-fields
+cryptography==2.9.2       # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, django-fernet-fields
 ddt==1.3.1                # via -r requirements/test.txt
-defusedxml==0.5.0         # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, djangorestframework-xml
+defusedxml==0.6.0         # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, djangorestframework-xml
 diff-cover==2.6.1         # via -r requirements/test.txt
 distlib==0.3.0            # via caniusepython3, virtualenv
 django-config-models==2.0.0  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
@@ -39,10 +39,10 @@ django-ipware==2.1.0      # via -r requirements/doc.txt, -r requirements/test-ma
 django-model-utils==3.2.0  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-rbac
 django-multi-email-field==0.6.1  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
 django-object-actions==2.0.0  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
-django-simple-history==2.8.0  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+django-simple-history==2.9.0  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
 django-waffle==0.18.0     # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-django-utils, edx-drf-extensions
 django==2.2.12            # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, code-annotations, django-config-models, django-crum, django-fernet-fields, django-filter, django-model-utils, django-multi-email-field, drf-jwt, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-opaque-keys, edx-rbac, jsonfield2, rest-condition
-djangorestframework-xml==1.4.0  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+djangorestframework-xml==2.0.0  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
 djangorestframework==3.9.4  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, django-config-models, drf-jwt, edx-drf-extensions, rest-condition
 doc8==0.8.0               # via -r requirements/doc.txt
 docutils==0.16            # via -r requirements/doc.txt, doc8, readme-renderer, restructuredtext-lint, sphinx
@@ -52,23 +52,22 @@ edx-drf-extensions==5.0.2  # via -r requirements/doc.txt, -r requirements/test-m
 edx-i18n-tools==0.5.0     # via -r requirements/dev.in
 edx-lint==1.4.1           # via -r requirements/dev.in
 edx-opaque-keys[django]==2.0.2  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-drf-extensions
-edx-rbac==1.1.2           # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+edx-rbac==1.1.3           # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
 edx-rest-api-client==5.1.0  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
 edx-sphinx-theme==1.5.0   # via -r requirements/doc.txt
 edx-tincan-py35==0.0.5    # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
 factory-boy==2.12.0       # via -r requirements/test.txt
 faker==4.0.3              # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via tox, virtualenv
-freezegun==0.3.14         # via -c requirements/constraints.txt, -r requirements/test.txt
+freezegun==0.3.14         # via -r requirements/test.txt
 future==0.18.2            # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, pyjwkest
 idna==2.9                 # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, requests
 imagesize==1.2.0          # via -r requirements/doc.txt, sphinx
-importlib-metadata==1.6.0  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, importlib-resources, inflect, path, pluggy, pytest, tox, virtualenv
-importlib-resources==1.4.0  # via virtualenv
+importlib-metadata==1.6.0  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, inflect, path, pluggy, pytest, tox, virtualenv
 inflect==3.0.2            # via -c requirements/constraints.txt, -r requirements/test.txt, jinja2-pluralize
 isort==4.3.21             # via -r requirements/dev.in, pylint
 jinja2-pluralize==0.3.0   # via -r requirements/test.txt, diff-cover
-jinja2==2.11.1            # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, code-annotations, diff-cover, jinja2-pluralize, sphinx
+jinja2==2.11.2            # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, code-annotations, diff-cover, jinja2-pluralize, sphinx
 jsondiff==1.2.0           # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
 kombu==3.0.37             # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, celery
@@ -77,14 +76,13 @@ markupsafe==1.1.1         # via -r requirements/doc.txt, -r requirements/test-ma
 mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.txt
 more-itertools==8.2.0     # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, pytest, zipp
-newrelic==5.10.0.138      # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-django-utils
+newrelic==5.12.0.140      # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-django-utils
 packaging==20.3           # via -r requirements/doc.txt, -r requirements/test.txt, caniusepython3, pytest, sphinx, tox
 path.py==12.4.0           # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-i18n-tools
 path==13.1.0              # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, path.py
-pathlib2==2.3.5           # via -r requirements/test.txt, pytest
 pbr==5.4.5                # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, stevedore
-pillow==7.1.1             # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
-pip-tools==4.5.1          # via -r requirements/dev.in
+pillow==7.1.2             # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+pip-tools==5.1.0          # via -r requirements/dev.in
 pkginfo==1.5.0.1          # via twine
 pluggy==0.13.1            # via -r requirements/test.txt, diff-cover, pytest, tox
 pockets==0.9.1            # via -r requirements/doc.txt, sphinxcontrib-napoleon
@@ -112,15 +110,15 @@ python-dateutil==2.4.0    # via -r requirements/doc.txt, -r requirements/test-ma
 python-slugify==4.0.0     # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, code-annotations
 pytz==2019.3              # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, babel, celery, django, edx-tincan-py35
 pyyaml==5.3.1             # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, code-annotations, edx-i18n-tools
-readme-renderer==25.0     # via -r requirements/doc.txt
+readme-renderer==26.0     # via -r requirements/doc.txt
 requests-toolbelt==0.9.1  # via twine
 requests==2.23.0          # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, caniusepython3, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-toolbelt, responses, slumber, sphinx, twine
-responses==0.10.12        # via -r requirements/test.txt
+responses==0.10.14        # via -r requirements/test.txt
 rest-condition==1.0.3     # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-drf-extensions
 restructuredtext-lint==1.3.0  # via -r requirements/doc.txt, doc8
 rules==2.2                # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
 semantic-version==2.8.4   # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-drf-extensions
-six==1.14.0               # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, astroid, bleach, cryptography, diff-cover, django-countries, django-simple-history, doc8, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-rbac, edx-sphinx-theme, freezegun, mock, packaging, pathlib2, pip-tools, pockets, pyjwkest, python-dateutil, readme-renderer, responses, sphinxcontrib-napoleon, stevedore, tox, virtualenv
+six==1.14.0               # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, astroid, bleach, cryptography, diff-cover, django-countries, django-simple-history, doc8, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-rbac, edx-sphinx-theme, freezegun, mock, packaging, pip-tools, pockets, pyjwkest, python-dateutil, readme-renderer, responses, sphinxcontrib-napoleon, stevedore, tox, virtualenv
 slumber==0.7.1            # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via -r requirements/doc.txt, pydocstyle, sphinx
 sphinx==2.4.1             # via -c requirements/constraints.txt, -r requirements/doc.txt, edx-sphinx-theme
@@ -133,7 +131,7 @@ sphinxcontrib-qthelp==1.0.3  # via -r requirements/doc.txt, sphinx
 sphinxcontrib-serializinghtml==1.1.4  # via -r requirements/doc.txt, sphinx
 sqlparse==0.3.1           # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, django
 stevedore==1.32.0         # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, code-annotations, doc8, edx-opaque-keys
-testfixtures==6.14.0      # via -r requirements/dev.in, -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+testfixtures==6.14.1      # via -r requirements/dev.in, -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
 text-unidecode==1.3       # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, faker, python-slugify
 toml==0.10.0              # via tox
 tox-battery==0.5.1        # via -r requirements/dev.in
@@ -142,13 +140,14 @@ tqdm==4.45.0              # via twine
 twine==1.11.0             # via -r requirements/dev.in
 typed-ast==1.4.1          # via astroid
 unicodecsv==0.14.1        # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
-urllib3==1.25.8           # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, requests
-virtualenv==20.0.17       # via tox
+urllib3==1.25.9           # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, requests
+virtualenv==20.0.18       # via tox
 wcwidth==0.1.9            # via -r requirements/test.txt, pytest
 webencodings==0.5.1       # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, bleach
 wheel==0.34.2             # via -r requirements/dev.in
 wrapt==1.11.2             # via astroid
-zipp==1.0.0               # via -c requirements/constraints.txt, -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, importlib-metadata, importlib-resources
+zipp==1.0.0               # via -c requirements/constraints.txt, -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
+# pip
 # setuptools

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -17,8 +17,8 @@ cffi==1.14.0              # via -r requirements/test-master.txt, cryptography
 chardet==3.0.4            # via -r requirements/test-master.txt, doc8, requests
 click==7.1.1              # via -r requirements/test-master.txt, code-annotations
 code-annotations==0.3.3   # via -r requirements/test-master.txt
-cryptography==2.9         # via -r requirements/test-master.txt, django-fernet-fields
-defusedxml==0.5.0         # via -r requirements/test-master.txt, djangorestframework-xml
+cryptography==2.9.2       # via -r requirements/test-master.txt, django-fernet-fields
+defusedxml==0.6.0         # via -r requirements/test-master.txt, djangorestframework-xml
 django-config-models==2.0.0  # via -r requirements/test-master.txt
 django-countries==5.5     # via -r requirements/test-master.txt
 django-crum==0.7.5        # via -r requirements/test-master.txt, edx-rbac
@@ -28,10 +28,10 @@ django-ipware==2.1.0      # via -r requirements/test-master.txt
 django-model-utils==3.2.0  # via -r requirements/test-master.txt, edx-rbac
 django-multi-email-field==0.6.1  # via -r requirements/test-master.txt
 django-object-actions==2.0.0  # via -r requirements/test-master.txt
-django-simple-history==2.8.0  # via -r requirements/test-master.txt
+django-simple-history==2.9.0  # via -r requirements/test-master.txt
 django-waffle==0.18.0     # via -r requirements/test-master.txt, edx-django-utils, edx-drf-extensions
 django==2.2.12            # via -r requirements/test-master.txt, code-annotations, django-config-models, django-crum, django-fernet-fields, django-filter, django-model-utils, django-multi-email-field, drf-jwt, edx-django-utils, edx-drf-extensions, edx-opaque-keys, edx-rbac, jsonfield2, rest-condition
-djangorestframework-xml==1.4.0  # via -r requirements/test-master.txt
+djangorestframework-xml==2.0.0  # via -r requirements/test-master.txt
 djangorestframework==3.9.4  # via -r requirements/test-master.txt, django-config-models, drf-jwt, edx-drf-extensions, rest-condition
 doc8==0.8.0               # via -r requirements/doc.in
 docutils==0.16            # via -r requirements/doc.in, doc8, readme-renderer, restructuredtext-lint, sphinx
@@ -39,7 +39,7 @@ drf-jwt==1.14.0           # via -r requirements/test-master.txt, edx-drf-extensi
 edx-django-utils==3.2.1   # via -r requirements/test-master.txt, django-config-models, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==5.0.2  # via -r requirements/test-master.txt, edx-rbac
 edx-opaque-keys[django]==2.0.2  # via -r requirements/test-master.txt, edx-drf-extensions
-edx-rbac==1.1.2           # via -r requirements/test-master.txt
+edx-rbac==1.1.3           # via -r requirements/test-master.txt
 edx-rest-api-client==5.1.0  # via -r requirements/test-master.txt
 edx-sphinx-theme==1.5.0   # via -r requirements/doc.in
 edx-tincan-py35==0.0.5    # via -r requirements/test-master.txt
@@ -47,18 +47,18 @@ future==0.18.2            # via -r requirements/test-master.txt, pyjwkest
 idna==2.9                 # via -r requirements/test-master.txt, requests
 imagesize==1.2.0          # via sphinx
 importlib-metadata==1.6.0  # via -r requirements/test-master.txt, path
-jinja2==2.11.1            # via -r requirements/test-master.txt, code-annotations, sphinx
+jinja2==2.11.2            # via -r requirements/test-master.txt, code-annotations, sphinx
 jsondiff==1.2.0           # via -r requirements/test-master.txt
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/test-master.txt
 kombu==3.0.37             # via -r requirements/test-master.txt, celery
 markupsafe==1.1.1         # via -r requirements/test-master.txt, jinja2
 more-itertools==8.2.0     # via -r requirements/test-master.txt, zipp
-newrelic==5.10.0.138      # via -r requirements/test-master.txt, edx-django-utils
+newrelic==5.12.0.140      # via -r requirements/test-master.txt, edx-django-utils
 packaging==20.3           # via sphinx
 path.py==12.4.0           # via -r requirements/test-master.txt
 path==13.1.0              # via -r requirements/test-master.txt, path.py
 pbr==5.4.5                # via -r requirements/test-master.txt, stevedore
-pillow==7.1.1             # via -r requirements/test-master.txt
+pillow==7.1.2             # via -r requirements/test-master.txt
 pockets==0.9.1            # via sphinxcontrib-napoleon
 psutil==1.2.1             # via -r requirements/test-master.txt, edx-django-utils
 pycparser==2.20           # via -r requirements/test-master.txt, cffi
@@ -72,7 +72,7 @@ python-dateutil==2.4.0    # via -r requirements/test-master.txt, edx-drf-extensi
 python-slugify==4.0.0     # via -r requirements/test-master.txt, code-annotations
 pytz==2019.3              # via -r requirements/test-master.txt, babel, celery, django, edx-tincan-py35
 pyyaml==5.3.1             # via -r requirements/test-master.txt, code-annotations
-readme-renderer==25.0     # via -r requirements/doc.in
+readme-renderer==26.0     # via -r requirements/doc.in
 requests==2.23.0          # via -r requirements/test-master.txt, edx-drf-extensions, edx-rest-api-client, pyjwkest, slumber, sphinx
 rest-condition==1.0.3     # via -r requirements/test-master.txt, edx-drf-extensions
 restructuredtext-lint==1.3.0  # via doc8
@@ -91,10 +91,10 @@ sphinxcontrib-qthelp==1.0.3  # via sphinx
 sphinxcontrib-serializinghtml==1.1.4  # via sphinx
 sqlparse==0.3.1           # via -r requirements/test-master.txt, django
 stevedore==1.32.0         # via -r requirements/test-master.txt, code-annotations, doc8, edx-opaque-keys
-testfixtures==6.14.0      # via -r requirements/test-master.txt
+testfixtures==6.14.1      # via -r requirements/test-master.txt
 text-unidecode==1.3       # via -r requirements/test-master.txt, python-slugify
 unicodecsv==0.14.1        # via -r requirements/test-master.txt
-urllib3==1.25.8           # via -r requirements/test-master.txt, requests
+urllib3==1.25.9           # via -r requirements/test-master.txt, requests
 webencodings==0.5.1       # via -r requirements/test-master.txt, bleach
 zipp==1.0.0               # via -c requirements/constraints.txt, -r requirements/test-master.txt, importlib-metadata
 

--- a/requirements/edx-platform-constraints.txt
+++ b/requirements/edx-platform-constraints.txt
@@ -24,23 +24,24 @@ certifi==2020.4.5.1       # via -r requirements/edx/paver.txt, requests
 cffi==1.14.0              # via -r requirements/edx/../edx-sandbox/shared.txt, cryptography
 chardet==3.0.4            # via -r requirements/edx/paver.txt, pdfminer.six, pysrt, requests
 git+https://github.com/edx/openedx-chem.git@ff4e3a03d3c7610e47a9af08eb648d8aabe2eb18#egg=chem==1.0.0  # via -r requirements/edx/github.in
-click==7.1.1              # via code-annotations, user-util
+click==7.1.1              # via -r requirements/edx/../edx-sandbox/shared.txt, code-annotations, nltk, user-util
 code-annotations==0.3.3   # via edx-enterprise
 contextlib2==0.6.0.post1  # via -r requirements/edx/base.in
 coreapi==2.3.3            # via drf-yasg
 coreschema==0.0.4         # via coreapi, drf-yasg
 git+https://github.com/edx/crowdsourcehinter.git@2178ac72891392106ffef389651aef374177d294#egg=crowdsourcehinter-xblock==0.4  # via -r requirements/edx/github.in
-cryptography==2.9         # via -r requirements/edx/../edx-sandbox/shared.txt, django-fernet-fields, edx-enterprise, social-auth-core
+cryptography==2.9.2       # via -r requirements/edx/../edx-sandbox/shared.txt, django-fernet-fields, edx-enterprise, social-auth-core
 cssutils==1.0.2           # via pynliner
 ddt==1.3.1                # via xblock-drag-and-drop-v2, xblock-poll
 decorator==4.4.2          # via pycontracts
-defusedxml==0.5.0         # via -r requirements/edx/base.in, djangorestframework-xml, ora2, python3-openid, python3-saml, safe-lxml, social-auth-core
+defusedxml==0.6.0         # via -r requirements/edx/base.in, djangorestframework-xml, ora2, python3-openid, python3-saml, safe-lxml, social-auth-core
 git+https://github.com/django-compressor/django-appconf@1526a842ee084b791aa66c931b3822091a442853#egg=django-appconf  # via -r requirements/edx/github.in, django-statici18n
 git+https://github.com/edx/django-babel-underscore.git@37705f7377a4d0a4e673f1431895ce28a8860cd7#egg=django-babel-underscore==0.6.0  # via -r requirements/edx/github.in
 git+https://github.com/Zegocover/enmerkar.git@dbc113798aa4beabdfa2d00e6fef48248eb0f185#egg=django-babel==0.6.3.dev0  # via -r requirements/edx/github.in
 django-celery==3.3.1      # via -r requirements/edx/base.in
 django-classy-tags==1.0.0  # via django-sekizai
 django-config-models==2.0.0  # via -r requirements/edx/base.in, edx-enterprise
+django-cookies-samesite==0.5.1  # via -r requirements/edx/base.in
 django-cors-headers==2.5.3  # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
 django-countries==5.5     # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, edx-enterprise
 django-crum==0.7.5        # via -r requirements/edx/base.in, edx-enterprise, edx-proctoring, edx-rbac, super-csv
@@ -49,10 +50,10 @@ django-filter==2.2.0      # via -r requirements/edx/base.in, edx-enterprise
 django-ipware==2.1.0      # via -r requirements/edx/base.in, edx-enterprise, edx-proctoring
 django-js-asset==1.2.2    # via django-mptt
 git+https://gitlab.com/Ayub-khan/django-method-override.git@5270af321be2e576d8e8b3c4191711a19975c356#egg=django-method-override==1.0.4  # via -r requirements/edx/github.in
-django-model-utils==3.2.0  # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, django-user-tasks, edx-bulk-grades, edx-celeryutils, edx-completion, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-rbac, edx-submissions, edx-when, edxval, ora2, super-csv
+django-model-utils==3.2.0  # via -r requirements/edx/base.in, django-user-tasks, edx-bulk-grades, edx-celeryutils, edx-completion, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-rbac, edx-submissions, edx-when, edxval, ora2, super-csv
 django-mptt==0.11.0       # via -r requirements/edx/base.in, django-wiki
 django-multi-email-field==0.6.1  # via edx-enterprise
-django-mysql==3.3.0       # via -r requirements/edx/base.in
+django-mysql==3.4.0       # via -r requirements/edx/base.in
 django-oauth-toolkit==1.3.2  # via -r requirements/edx/base.in
 django-object-actions==2.0.0  # via edx-enterprise
 django-pipeline==1.7.0    # via -r requirements/edx/base.in
@@ -61,7 +62,7 @@ django-ratelimit-backend==2.0  # via -r requirements/edx/base.in
 django-require==1.0.11    # via -r requirements/edx/base.in
 django-sekizai==1.1.0     # via -r requirements/edx/base.in, django-wiki
 django-ses==0.8.14        # via -r requirements/edx/base.in
-django-simple-history==2.8.0  # via -r requirements/edx/base.in, edx-enterprise, edx-organizations, ora2
+django-simple-history==2.9.0  # via -r requirements/edx/base.in, edx-enterprise, edx-organizations, ora2
 django-splash==0.2.7      # via -r requirements/edx/base.in
 django-statici18n==1.9.0  # via -r requirements/edx/base.in
 django-storages==1.8      # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, edxval
@@ -69,7 +70,7 @@ django-user-tasks==1.0.0  # via -r requirements/edx/base.in
 django-waffle==0.18.0     # via -r requirements/edx/base.in, edx-django-utils, edx-drf-extensions, edx-enterprise, edx-proctoring
 django-webpack-loader==0.7.0  # via -r requirements/edx/base.in, edx-proctoring
 django==2.2.12            # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, code-annotations, django-appconf, django-babel, django-babel-underscore, django-celery, django-classy-tags, django-config-models, django-cors-headers, django-crum, django-fernet-fields, django-filter, django-method-override, django-model-utils, django-mptt, django-multi-email-field, django-mysql, django-oauth-toolkit, django-pyfs, django-ratelimit-backend, django-sekizai, django-splash, django-statici18n, django-storages, django-user-tasks, django-wiki, drf-jwt, drf-yasg, edx-ace, edx-api-doc-tools, edx-bulk-grades, edx-celeryutils, edx-completion, edx-django-release-util, edx-django-sites-extensions, edx-django-utils, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-milestones, edx-opaque-keys, edx-organizations, edx-proctoring, edx-rbac, edx-search, edx-submissions, edx-when, edxval, event-tracking, help-tokens, jsonfield2, ora2, rest-condition, super-csv, xss-utils
-djangorestframework-xml==1.4.0  # via edx-enterprise
+djangorestframework-xml==2.0.0  # via edx-enterprise
 djangorestframework==3.9.4  # via -r requirements/edx/base.in, django-config-models, django-user-tasks, drf-jwt, drf-yasg, edx-api-doc-tools, edx-completion, edx-drf-extensions, edx-enterprise, edx-organizations, edx-proctoring, edx-submissions, ora2, rest-condition, super-csv
 docopt==0.6.2             # via xmodule
 docutils==0.16            # via botocore
@@ -86,22 +87,22 @@ edx-django-release-util==0.4.2  # via -r requirements/edx/base.in
 edx-django-sites-extensions==2.4.3  # via -r requirements/edx/base.in
 edx-django-utils==3.2.1   # via -r requirements/edx/base.in, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-when
 edx-drf-extensions==5.0.2  # via -r requirements/edx/base.in, edx-completion, edx-enterprise, edx-organizations, edx-proctoring, edx-rbac, edx-when, edxval
-edx-enterprise==3.0.14    # via -r requirements/edx/base.in
+edx-enterprise==3.2.0     # via -r requirements/edx/base.in
 edx-i18n-tools==0.5.0     # via ora2
 edx-milestones==0.2.6     # via -r requirements/edx/base.in
 edx-opaque-keys[django]==2.0.2  # via -r requirements/edx/paver.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, xmodule
 edx-organizations==5.1.0  # via -r requirements/edx/base.in
 edx-proctoring-proctortrack==1.0.5  # via -r requirements/edx/base.in
 edx-proctoring==2.3.3     # via -r requirements/edx/base.in, edx-proctoring-proctortrack
-edx-rbac==1.1.2           # via edx-enterprise
+edx-rbac==1.1.3           # via edx-enterprise
 edx-rest-api-client==5.1.0  # via -r requirements/edx/base.in, edx-enterprise, edx-proctoring
 edx-search==1.3.4         # via -r requirements/edx/base.in
 edx-sga==0.10.0           # via -r requirements/edx/base.in
-edx-submissions==3.0.7    # via -r requirements/edx/base.in, ora2
+edx-submissions==3.1.1    # via -r requirements/edx/base.in, ora2
 edx-tincan-py35==0.0.5    # via edx-enterprise
 edx-user-state-client==1.1.2  # via -r requirements/edx/base.in
-edx-when==1.2.0           # via -r requirements/edx/base.in, edx-proctoring
-edxval==1.2.9             # via -r requirements/edx/base.in
+edx-when==1.2.1           # via -r requirements/edx/base.in, edx-proctoring
+edxval==1.3.2             # via -r requirements/edx/base.in
 elasticsearch==1.9.0      # via edx-search
 enum34==1.1.10            # via edxval
 event-tracking==0.3.0     # via -r requirements/edx/base.in, edx-proctoring, edx-search
@@ -113,16 +114,17 @@ glob2==0.7                # via -r requirements/edx/base.in
 gunicorn==20.0.4          # via -r requirements/edx/base.in
 help-tokens==1.0.5        # via -r requirements/edx/base.in
 html5lib==1.0.1           # via -r requirements/edx/base.in, ora2
-httplib2==0.17.1          # via oauth2
+httplib2==0.17.3          # via oauth2
 icalendar==4.0.5          # via -r requirements/edx/base.in
 idna==2.9                 # via -r requirements/edx/paver.txt, requests
 importlib-metadata==1.6.0  # via -r requirements/edx/paver.txt, path
 inflection==0.4.0         # via drf-yasg
 ipaddress==1.0.23         # via -r requirements/edx/base.in
 isodate==0.6.0            # via python3-saml
-itypes==1.1.0             # via coreapi
-jinja2==2.11.1            # via code-annotations, coreschema
+itypes==1.2.0             # via coreapi
+jinja2==2.11.2            # via code-annotations, coreschema
 jmespath==0.9.5           # via boto3, botocore
+joblib==0.14.1            # via -r requirements/edx/../edx-sandbox/shared.txt, nltk
 jsondiff==1.2.0           # via edx-enterprise
 jsonfield2==3.0.3         # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, edx-celeryutils, edx-enterprise, edx-proctoring, edx-submissions, ora2
 kombu==3.0.37             # via celery
@@ -131,7 +133,7 @@ lazy==1.4                 # via -r requirements/edx/paver.txt, acid-xblock, ora2
 lepl==5.1.3               # via rfc6266-parser
 libsass==0.10.0           # via -r requirements/edx/paver.txt, ora2
 loremipsum==1.0.5         # via ora2
-git+https://github.com/edx/xblock-lti-consumer.git@v1.2.5#egg=lti_consumer-xblock==1.2.5  # via -r requirements/edx/github.in
+git+https://github.com/edx/xblock-lti-consumer.git@v1.2.6#egg=lti_consumer-xblock==1.2.6  # via -r requirements/edx/github.in
 lxml==4.5.0               # via -r requirements/edx/../edx-sandbox/shared.txt, capa, edxval, lti-consumer-xblock, ora2, safe-lxml, xblock, xmlsec
 mailsnake==1.6.4          # via -r requirements/edx/base.in
 mako==1.0.2               # via -r requirements/edx/base.in, acid-xblock, lti-consumer-xblock, xblock-google-drive, xblock-utils
@@ -144,11 +146,11 @@ git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752
 mongoengine==0.10.0       # via -r requirements/edx/base.in
 more-itertools==8.2.0     # via -r requirements/edx/paver.txt, zipp
 mpmath==1.1.0             # via sympy
-mysqlclient==1.4.6        # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
-newrelic==5.10.0.138      # via -r requirements/edx/base.in, edx-django-utils
-nltk==3.4.5               # via -r requirements/edx/../edx-sandbox/shared.txt, chem
+mysqlclient==1.4.6        # via -r requirements/edx/base.in
+newrelic==5.12.0.140      # via -r requirements/edx/base.in, edx-django-utils
+nltk==3.5                 # via -r requirements/edx/../edx-sandbox/shared.txt, chem
 nodeenv==1.3.5            # via -r requirements/edx/base.in
-numpy==1.18.2             # via chem, openedx-calc, scipy
+numpy==1.18.3             # via chem, openedx-calc, scipy
 git+https://github.com/joestump/python-oauth2.git@b94f69b1ad195513547924e380d9265133e995fa#egg=oauth2  # via -r requirements/edx/github.in
 oauthlib==3.0.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, django-oauth-toolkit, lti-consumer-xblock, requests-oauthlib, social-auth-core
 openedx-calc==1.0.7       # via -r requirements/edx/base.in
@@ -161,12 +163,12 @@ paver==1.3.4              # via -r requirements/edx/paver.txt
 pbr==5.4.5                # via -r requirements/edx/paver.txt, stevedore
 pdfminer.six==20200402    # via -r requirements/edx/base.in
 piexif==1.1.3             # via -r requirements/edx/base.in
-pillow==7.1.1             # via -r requirements/edx/base.in, edx-enterprise, edx-organizations
+pillow==7.1.2             # via -r requirements/edx/base.in, edx-enterprise, edx-organizations
 pkgconfig==1.5.1          # via xmlsec
 polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1             # via -r requirements/edx/paver.txt, edx-django-utils
 py2neo==3.1.2             # via -r requirements/edx/base.in
-pycontracts==1.8.12       # via -r requirements/edx/base.in, edx-user-state-client
+pycontracts==1.8.14       # via -r requirements/edx/base.in, edx-user-state-client
 pycountry==19.8.18        # via -r requirements/edx/base.in
 pycparser==2.20           # via -r requirements/edx/../edx-sandbox/shared.txt, cffi
 pycryptodome==3.9.7       # via pdfminer.six
@@ -184,13 +186,14 @@ python-memcached==1.59    # via -r requirements/edx/paver.txt
 python-slugify==4.0.0     # via code-annotations
 python-swiftclient==3.9.0  # via ora2
 python3-openid==3.1.0 ; python_version >= "3"  # via -r requirements/edx/base.in, social-auth-core
-python3-saml==1.5.0       # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
+python3-saml==1.9.0       # via -r requirements/edx/base.in
 pytz==2019.3              # via -r requirements/edx/base.in, babel, capa, celery, django, django-ses, edx-completion, edx-enterprise, edx-proctoring, edx-submissions, edx-tincan-py35, event-tracking, fs, icalendar, ora2, xblock
 pyuca==1.2                # via -r requirements/edx/base.in
 pyyaml==5.3.1             # via -r requirements/edx/base.in, code-annotations, edx-django-release-util, edx-i18n-tools, xblock
 random2==1.0.1            # via -r requirements/edx/base.in
 recommender-xblock==1.4.5  # via -r requirements/edx/base.in
 redis==2.10.6             # via -r requirements/edx/base.in
+regex==2020.4.4           # via -r requirements/edx/../edx-sandbox/shared.txt, nltk
 requests-oauthlib==1.3.0  # via -r requirements/edx/base.in, social-auth-core
 requests==2.23.0          # via -r requirements/edx/paver.txt, analytics-python, coreapi, django-oauth-toolkit, edx-analytics-data-api-client, edx-bulk-grades, edx-drf-extensions, edx-enterprise, edx-rest-api-client, geoip2, mailsnake, pyjwkest, python-swiftclient, requests-oauthlib, sailthru-client, slumber, social-auth-core
 rest-condition==1.0.3     # via -r requirements/edx/base.in, edx-drf-extensions
@@ -204,7 +207,7 @@ scipy==1.4.1              # via chem, openedx-calc
 semantic-version==2.8.4   # via edx-drf-extensions
 shapely==1.7.0            # via -r requirements/edx/base.in
 simplejson==3.17.0        # via -r requirements/edx/base.in, sailthru-client, super-csv, xblock-utils
-six==1.14.0               # via -r requirements/edx/../edx-sandbox/shared.txt, -r requirements/edx/base.in, -r requirements/edx/paver.txt, analytics-python, bleach, cryptography, django-appconf, django-classy-tags, django-countries, django-pyfs, django-sekizai, django-simple-history, django-statici18n, drf-yasg, edx-ace, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-milestones, edx-opaque-keys, edx-rbac, edx-search, event-tracking, fs, fs-s3fs, help-tokens, html5lib, isodate, libsass, mock, nltk, openedx-calc, packaging, paver, pycontracts, pyjwkest, python-dateutil, python-memcached, python-swiftclient, social-auth-app-django, social-auth-core, stevedore, xblock
+six==1.14.0               # via -r requirements/edx/../edx-sandbox/shared.txt, -r requirements/edx/base.in, -r requirements/edx/paver.txt, analytics-python, bleach, cryptography, django-appconf, django-classy-tags, django-countries, django-pyfs, django-sekizai, django-simple-history, django-statici18n, drf-yasg, edx-ace, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-milestones, edx-opaque-keys, edx-rbac, edx-search, event-tracking, fs, fs-s3fs, help-tokens, html5lib, isodate, libsass, mock, openedx-calc, packaging, paver, pycontracts, pyjwkest, python-dateutil, python-memcached, python-swiftclient, social-auth-app-django, social-auth-core, stevedore, xblock
 slumber==0.7.1            # via edx-bulk-grades, edx-enterprise, edx-rest-api-client
 social-auth-core==3.3.3   # via -r requirements/edx/base.in, social-auth-app-django
 git+https://github.com/jazzband/sorl-thumbnail.git@13bedfb7d2970809eda597e3ef79318a6fa80ac2#egg=sorl-thumbnail  # via -r requirements/edx/github.in
@@ -215,11 +218,12 @@ staff-graded-xblock==0.7  # via -r requirements/edx/base.in
 stevedore==1.32.0         # via -r requirements/edx/base.in, -r requirements/edx/paver.txt, code-annotations, edx-ace, edx-enterprise, edx-opaque-keys
 super-csv==0.9.7          # via -r requirements/edx/base.in, edx-bulk-grades
 sympy==1.5.1              # via symmath
-testfixtures==6.14.0      # via edx-enterprise
+testfixtures==6.14.1      # via edx-enterprise
 text-unidecode==1.3       # via python-slugify
+tqdm==4.45.0              # via -r requirements/edx/../edx-sandbox/shared.txt, nltk
 unicodecsv==0.14.1        # via -r requirements/edx/base.in, edx-enterprise
 uritemplate==3.0.1        # via coreapi, drf-yasg
-urllib3==1.25.8           # via -r requirements/edx/paver.txt, elasticsearch, geoip2, requests
+urllib3==1.25.9           # via -r requirements/edx/paver.txt, elasticsearch, geoip2, requests
 user-util==0.1.5          # via -r requirements/edx/base.in
 voluptuous==0.11.7        # via ora2
 watchdog==0.10.2          # via -r requirements/edx/paver.txt
@@ -227,7 +231,7 @@ web-fragments==0.3.1      # via -r requirements/edx/base.in, staff-graded-xblock
 webencodings==0.5.1       # via bleach, html5lib
 webob==1.8.6              # via xblock, xmodule
 wrapt==1.11.2             # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.txt
-git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.9#egg=xblock-drag-and-drop-v2==2.2.9  # via -r requirements/edx/github.in
+git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.10#egg=xblock-drag-and-drop-v2==2.2.10  # via -r requirements/edx/github.in
 git+https://github.com/open-craft/xblock-poll@da2d8fd21791a7af128595cf82bee83ee579e00f#egg=xblock-poll==1.9.6  # via -r requirements/edx/github.in
 xblock-utils==2.0.0       # via -r requirements/edx/base.in, edx-sga, lti-consumer-xblock, staff-graded-xblock, xblock-drag-and-drop-v2, xblock-google-drive
 xblock==1.2.9             # via -r requirements/edx/base.in, acid-xblock, crowdsourcehinter-xblock, done-xblock, edx-completion, edx-sga, edx-user-state-client, edx-when, lti-consumer-xblock, ora2, rate-xblock, staff-graded-xblock, xblock-discussion, xblock-drag-and-drop-v2, xblock-google-drive, xblock-poll, xblock-utils

--- a/requirements/js_test.txt
+++ b/requirements/js_test.txt
@@ -5,29 +5,26 @@
 #    make upgrade
 #
 cheroot==8.3.0            # via cherrypy
-cherrypy==18.5.0          # via jasmine
+cherrypy==18.6.0          # via jasmine
 glob2==0.7                # via jasmine-core
-importlib-metadata==1.6.0  # via importlib-resources
-importlib-resources==1.4.0  # via jaraco.text
-jaraco.classes==2.0       # via jaraco.collections
-jaraco.collections==2.1   # via cherrypy
-jaraco.functools==2.0     # via cheroot, jaraco.text, tempora
+jaraco.classes==3.1.0     # via jaraco.collections
+jaraco.collections==3.0.0  # via cherrypy
+jaraco.functools==3.0.1   # via cheroot, jaraco.text, tempora
 jaraco.text==3.2.0        # via jaraco.collections
 jasmine-core==3.1.0       # via jasmine
 jasmine==3.1.0            # via -r requirements/js_test.in
 jinja2==2.11.2            # via jasmine
 markupsafe==1.1.1         # via jinja2
-more-itertools==8.2.0     # via cheroot, cherrypy, jaraco.functools
+more-itertools==8.2.0     # via cheroot, cherrypy, jaraco.classes, jaraco.functools
 ordereddict==1.1          # via jasmine-core
 portend==2.6              # via cherrypy
-pytz==2019.3              # via tempora
+pytz==2020.1              # via tempora
 pyyaml==3.10              # via jasmine
 selenium==3.141.0         # via jasmine
-six==1.14.0               # via cheroot, jaraco.classes, jaraco.collections, jaraco.text, tempora
-tempora==1.14.1           # via portend
-urllib3==1.25.8           # via selenium
+six==1.14.0               # via cheroot, jaraco.collections, jaraco.text
+tempora==3.0.0            # via portend
+urllib3==1.25.9           # via selenium
 zc.lockfile==2.0          # via cherrypy
-zipp==1.2.0               # via importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/js_test.txt
+++ b/requirements/js_test.txt
@@ -7,9 +7,9 @@
 cheroot==8.3.0            # via cherrypy
 cherrypy==18.6.0          # via jasmine
 glob2==0.7                # via jasmine-core
-jaraco.classes==3.1.0     # via jaraco.collections
-jaraco.collections==3.0.0  # via cherrypy
-jaraco.functools==3.0.1   # via cheroot, jaraco.text, tempora
+jaraco.classes==2.0       # via jaraco.collections
+jaraco.collections==2.1   # via cherrypy
+jaraco.functools==2.0     # via cheroot, jaraco.text, tempora
 jaraco.text==3.2.0        # via jaraco.collections
 jasmine-core==3.1.0       # via jasmine
 jasmine==3.1.0            # via -r requirements/js_test.in

--- a/requirements/js_test.txt
+++ b/requirements/js_test.txt
@@ -22,7 +22,7 @@ pytz==2020.1              # via tempora
 pyyaml==3.10              # via jasmine
 selenium==3.141.0         # via jasmine
 six==1.14.0               # via cheroot, jaraco.collections, jaraco.text
-tempora==3.0.0            # via portend
+tempora==1.14.1            # via portend
 urllib3==1.25.9           # via selenium
 zc.lockfile==2.0          # via cherrypy
 

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -15,8 +15,8 @@ cffi==1.14.0              # via -c requirements/edx-platform-constraints.txt, cr
 chardet==3.0.4            # via -c requirements/edx-platform-constraints.txt, requests
 click==7.1.1              # via -c requirements/edx-platform-constraints.txt, code-annotations
 code-annotations==0.3.3   # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
-cryptography==2.9         # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, django-fernet-fields
-defusedxml==0.5.0         # via -c requirements/edx-platform-constraints.txt, djangorestframework-xml
+cryptography==2.9.2       # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, django-fernet-fields
+defusedxml==0.6.0         # via -c requirements/edx-platform-constraints.txt, djangorestframework-xml
 django-config-models==2.0.0  # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
 django-countries==5.5     # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
 django-crum==0.7.5        # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, edx-rbac
@@ -26,32 +26,32 @@ django-ipware==2.1.0      # via -c requirements/edx-platform-constraints.txt, -r
 django-model-utils==3.2.0  # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, edx-rbac
 django-multi-email-field==0.6.1  # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
 django-object-actions==2.0.0  # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
-django-simple-history==2.8.0  # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
+django-simple-history==2.9.0  # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
 django-waffle==0.18.0     # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, edx-django-utils, edx-drf-extensions
 django==2.2.12            # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, code-annotations, django-config-models, django-crum, django-fernet-fields, django-filter, django-model-utils, django-multi-email-field, drf-jwt, edx-django-utils, edx-drf-extensions, edx-opaque-keys, edx-rbac, jsonfield2, rest-condition
-djangorestframework-xml==1.4.0  # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
+djangorestframework-xml==2.0.0  # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
 djangorestframework==3.9.4  # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, django-config-models, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.14.0           # via -c requirements/edx-platform-constraints.txt, edx-drf-extensions
 edx-django-utils==3.2.1   # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, django-config-models, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==5.0.2  # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, edx-rbac
 edx-opaque-keys[django]==2.0.2  # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, edx-drf-extensions
-edx-rbac==1.1.2           # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
+edx-rbac==1.1.3           # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
 edx-rest-api-client==5.1.0  # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
 edx-tincan-py35==0.0.5    # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
 future==0.18.2            # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, pyjwkest
 idna==2.9                 # via -c requirements/edx-platform-constraints.txt, requests
 importlib-metadata==1.6.0  # via -c requirements/edx-platform-constraints.txt, path
-jinja2==2.11.1            # via -c requirements/edx-platform-constraints.txt, code-annotations
+jinja2==2.11.2            # via -c requirements/edx-platform-constraints.txt, code-annotations
 jsondiff==1.2.0           # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
 jsonfield2==3.0.3         # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
 kombu==3.0.37             # via -c requirements/edx-platform-constraints.txt, celery
 markupsafe==1.1.1         # via -c requirements/edx-platform-constraints.txt, jinja2
 more-itertools==8.2.0     # via -c requirements/edx-platform-constraints.txt, zipp
-newrelic==5.10.0.138      # via -c requirements/edx-platform-constraints.txt, edx-django-utils
+newrelic==5.12.0.140      # via -c requirements/edx-platform-constraints.txt, edx-django-utils
 path.py==12.4.0           # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
 path==13.1.0              # via -c requirements/edx-platform-constraints.txt, path.py
 pbr==5.4.5                # via -c requirements/edx-platform-constraints.txt, stevedore
-pillow==7.1.1             # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
+pillow==7.1.2             # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
 psutil==1.2.1             # via -c requirements/edx-platform-constraints.txt, edx-django-utils
 pycparser==2.20           # via -c requirements/edx-platform-constraints.txt, cffi
 pycryptodomex==3.9.7      # via -c requirements/edx-platform-constraints.txt, pyjwkest
@@ -70,9 +70,9 @@ six==1.14.0               # via -c requirements/edx-platform-constraints.txt, -r
 slumber==0.7.1            # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, edx-rest-api-client
 sqlparse==0.3.1           # via -c requirements/edx-platform-constraints.txt, django
 stevedore==1.32.0         # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, code-annotations, edx-opaque-keys
-testfixtures==6.14.0      # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
+testfixtures==6.14.1      # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
 text-unidecode==1.3       # via -c requirements/edx-platform-constraints.txt, python-slugify
 unicodecsv==0.14.1        # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
-urllib3==1.25.8           # via -c requirements/edx-platform-constraints.txt, requests
+urllib3==1.25.9           # via -c requirements/edx-platform-constraints.txt, requests
 webencodings==0.5.1       # via -c requirements/edx-platform-constraints.txt, bleach
 zipp==1.0.0               # via -c requirements/edx-platform-constraints.txt, importlib-metadata

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -17,9 +17,9 @@ chardet==3.0.4            # via -r requirements/test-master.txt, requests
 click==7.1.1              # via -r requirements/test-master.txt, code-annotations
 code-annotations==0.3.3   # via -r requirements/test-master.txt
 coverage==5.1             # via pytest-cov
-cryptography==2.9         # via -r requirements/test-master.txt, django-fernet-fields
+cryptography==2.9.2       # via -r requirements/test-master.txt, django-fernet-fields
 ddt==1.3.1                # via -r requirements/test.in
-defusedxml==0.5.0         # via -r requirements/test-master.txt, djangorestframework-xml
+defusedxml==0.6.0         # via -r requirements/test-master.txt, djangorestframework-xml
 diff-cover==2.6.1         # via -r requirements/test.in
 django-config-models==2.0.0  # via -r requirements/test-master.txt
 django-countries==5.5     # via -r requirements/test-master.txt
@@ -30,39 +30,38 @@ django-ipware==2.1.0      # via -r requirements/test-master.txt
 django-model-utils==3.2.0  # via -r requirements/test-master.txt, -r requirements/test.in, edx-rbac
 django-multi-email-field==0.6.1  # via -r requirements/test-master.txt
 django-object-actions==2.0.0  # via -r requirements/test-master.txt
-django-simple-history==2.8.0  # via -r requirements/test-master.txt
+django-simple-history==2.9.0  # via -r requirements/test-master.txt
 django-waffle==0.18.0     # via -r requirements/test-master.txt, edx-django-utils, edx-drf-extensions
-djangorestframework-xml==1.4.0  # via -r requirements/test-master.txt
+djangorestframework-xml==2.0.0  # via -r requirements/test-master.txt
 djangorestframework==3.9.4  # via -r requirements/test-master.txt, django-config-models, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.14.0           # via -r requirements/test-master.txt, edx-drf-extensions
 edx-django-utils==3.2.1   # via -r requirements/test-master.txt, django-config-models, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==5.0.2  # via -r requirements/test-master.txt, edx-rbac
 edx-opaque-keys[django]==2.0.2  # via -r requirements/test-master.txt, edx-drf-extensions
-edx-rbac==1.1.2           # via -r requirements/test-master.txt
+edx-rbac==1.1.3           # via -r requirements/test-master.txt
 edx-rest-api-client==5.1.0  # via -r requirements/test-master.txt
 edx-tincan-py35==0.0.5    # via -r requirements/test-master.txt
 factory-boy==2.12.0       # via -r requirements/test.in
 faker==4.0.3              # via factory-boy
-freezegun==0.3.14         # via -c requirements/constraints.txt, -r requirements/test.in
+freezegun==0.3.14         # via -r requirements/test.in
 future==0.18.2            # via -r requirements/test-master.txt, pyjwkest
 idna==2.9                 # via -r requirements/test-master.txt, requests
 importlib-metadata==1.6.0  # via -r requirements/test-master.txt, inflect, path, pluggy, pytest
 inflect==3.0.2            # via -c requirements/constraints.txt, jinja2-pluralize
 jinja2-pluralize==0.3.0   # via diff-cover
-jinja2==2.11.1            # via -r requirements/test-master.txt, code-annotations, diff-cover, jinja2-pluralize
+jinja2==2.11.2            # via -r requirements/test-master.txt, code-annotations, diff-cover, jinja2-pluralize
 jsondiff==1.2.0           # via -r requirements/test-master.txt
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/test-master.txt
 kombu==3.0.37             # via -r requirements/test-master.txt, celery
 markupsafe==1.1.1         # via -r requirements/test-master.txt, jinja2
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.in
 more-itertools==8.2.0     # via -r requirements/test-master.txt, pytest, zipp
-newrelic==5.10.0.138      # via -r requirements/test-master.txt, edx-django-utils
+newrelic==5.12.0.140      # via -r requirements/test-master.txt, edx-django-utils
 packaging==20.3           # via pytest
 path.py==12.4.0           # via -r requirements/test-master.txt
 path==13.1.0              # via -r requirements/test-master.txt, path.py
-pathlib2==2.3.5           # via pytest
 pbr==5.4.5                # via -r requirements/test-master.txt, stevedore
-pillow==7.1.1             # via -r requirements/test-master.txt
+pillow==7.1.2             # via -r requirements/test-master.txt
 pluggy==0.13.1            # via diff-cover, pytest
 psutil==1.2.1             # via -r requirements/test-master.txt, edx-django-utils
 py==1.8.1                 # via pytest, pytest-catchlog
@@ -82,18 +81,18 @@ python-slugify==4.0.0     # via -r requirements/test-master.txt, code-annotation
 pytz==2019.3              # via -r requirements/test-master.txt, celery, django, edx-tincan-py35
 pyyaml==5.3.1             # via -r requirements/test-master.txt, code-annotations
 requests==2.23.0          # via -r requirements/test-master.txt, edx-drf-extensions, edx-rest-api-client, pyjwkest, responses, slumber
-responses==0.10.12        # via -r requirements/test.in
+responses==0.10.14        # via -r requirements/test.in
 rest-condition==1.0.3     # via -r requirements/test-master.txt, edx-drf-extensions
 rules==2.2                # via -r requirements/test-master.txt
 semantic-version==2.8.4   # via -r requirements/test-master.txt, edx-drf-extensions
-six==1.14.0               # via -r requirements/test-master.txt, bleach, cryptography, diff-cover, django-countries, django-simple-history, edx-drf-extensions, edx-opaque-keys, edx-rbac, freezegun, mock, packaging, pathlib2, pyjwkest, python-dateutil, responses, stevedore
+six==1.14.0               # via -r requirements/test-master.txt, bleach, cryptography, diff-cover, django-countries, django-simple-history, edx-drf-extensions, edx-opaque-keys, edx-rbac, freezegun, mock, packaging, pyjwkest, python-dateutil, responses, stevedore
 slumber==0.7.1            # via -r requirements/test-master.txt, edx-rest-api-client
 sqlparse==0.3.1           # via -r requirements/test-master.txt, django
 stevedore==1.32.0         # via -r requirements/test-master.txt, code-annotations, edx-opaque-keys
-testfixtures==6.14.0      # via -r requirements/test-master.txt, -r requirements/test.in
+testfixtures==6.14.1      # via -r requirements/test-master.txt, -r requirements/test.in
 text-unidecode==1.3       # via -r requirements/test-master.txt, faker, python-slugify
 unicodecsv==0.14.1        # via -r requirements/test-master.txt
-urllib3==1.25.8           # via -r requirements/test-master.txt, requests
+urllib3==1.25.9           # via -r requirements/test-master.txt, requests
 wcwidth==0.1.9            # via pytest
 webencodings==0.5.1       # via -r requirements/test-master.txt, bleach
 zipp==1.0.0               # via -c requirements/constraints.txt, -r requirements/test-master.txt, importlib-metadata

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -12,8 +12,7 @@ coverage==5.1             # via codecov
 distlib==0.3.0            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
 idna==2.9                 # via requests
-importlib-metadata==1.6.0  # via importlib-resources, pluggy, tox, virtualenv
-importlib-resources==1.4.0  # via virtualenv
+importlib-metadata==1.6.0  # via pluggy, tox, virtualenv
 more-itertools==8.2.0     # via zipp
 packaging==20.3           # via tox
 pluggy==0.13.1            # via tox
@@ -24,6 +23,6 @@ six==1.14.0               # via packaging, tox, virtualenv
 toml==0.10.0              # via tox
 tox-battery==0.5.1        # via -r requirements/travis.in
 tox==3.14.6               # via -r requirements/travis.in, tox-battery
-urllib3==1.25.8           # via requests
-virtualenv==20.0.17       # via tox
-zipp==1.0.0               # via -c requirements/constraints.txt, importlib-metadata, importlib-resources
+urllib3==1.25.9           # via requests
+virtualenv==20.0.18       # via tox
+zipp==1.0.0               # via -c requirements/constraints.txt, importlib-metadata


### PR DESCRIPTION
Added a script to enterprise admin pages to report analytics
to Fullstory.

ENT-2620

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [x] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
