### PR TITLE
Make enrollment reason optional

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 --------------------
 
+[3.2.2] - 2020-05-05
+--------------------
+
+* Made enrollment reason optional when linking learners without enrollment.
+
 [3.2.1] - 2020-05-04
 --------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "3.2.1"
+__version__ = "3.2.2"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/requirements/js_test.txt
+++ b/requirements/js_test.txt
@@ -7,9 +7,9 @@
 cheroot==8.3.0            # via cherrypy
 cherrypy==18.6.0          # via jasmine
 glob2==0.7                # via jasmine-core
-jaraco.classes==3.1.0     # via jaraco.collections
-jaraco.collections==3.0.0  # via cherrypy
-jaraco.functools==3.0.1   # via cheroot, jaraco.text, tempora
+jaraco.classes==2.0     # via jaraco.collections
+jaraco.collections==2.1  # via cherrypy
+jaraco.functools==2.0   # via cheroot, jaraco.text, tempora
 jaraco.text==3.2.0        # via jaraco.collections
 jasmine-core==3.1.0       # via jasmine
 jasmine==3.1.0            # via -r requirements/js_test.in

--- a/requirements/js_test.txt
+++ b/requirements/js_test.txt
@@ -22,7 +22,7 @@ pytz==2020.1              # via tempora
 pyyaml==3.10              # via jasmine
 selenium==3.141.0         # via jasmine
 six==1.14.0               # via cheroot, jaraco.collections, jaraco.text
-tempora==3.0.0            # via portend
+tempora==1.14.1            # via portend
 urllib3==1.25.9           # via selenium
 zc.lockfile==2.0          # via cherrypy
 


### PR DESCRIPTION
Downgrade jaraco versions to fix Travis build

ENT-2568

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
