### PR TITLE
ENT-2721 | Added extra logging in 'create_enterprise_course_enrollmen…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 --------------------
 
+[3.2.7] - 2020-05-07
+--------------------
+
+* Added extra logging in 'create_enterprise_course_enrollments' management command.
+
+
 [3.2.6] - 2020-05-06
 --------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "3.2.6"
+__version__ = "3.2.7"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/management/commands/create_enterprise_course_enrollments.py
+++ b/enterprise/management/commands/create_enterprise_course_enrollments.py
@@ -37,6 +37,7 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
+        LOGGER.info("Command has started...")
         enterprise_customer_uuid_filter = options.get('enterprise_customer_uuid')
         records_created = 0
         records_failed = 0
@@ -139,6 +140,7 @@ class Command(BaseCommand):
         and the enterprise. It also excludes learners with edx.org email addresses in order to
         filter out test users.
         """
+        LOGGER.info("Trying to fetch the data from Database with enterprise customer [%s]", enterprise_customer_uuid)
         query = '''
             SELECT
                 au.id as user_id,


### PR DESCRIPTION
…ts' management command.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
