### PR TITLE
ENT-2788 Add more logging around create/update calls to the enterprise catalog service

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 --------------------
 
+[3.2.8] - 2020-05-08
+--------------------
+
+* Added extra logging when syncing Enterprise Catalog data to the Enterprise Catalog Service.
+
 [3.2.7] - 2020-05-07
 --------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "3.2.7"
+__version__ = "3.2.8"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api_client/enterprise_catalog.py
+++ b/enterprise/api_client/enterprise_catalog.py
@@ -57,6 +57,11 @@ class EnterpriseCatalogApiClient(JwtLmsApiClient):
             'publish_audit_enrollment_urls': json.dumps(publish_audit_enrollment_urls),
         }
         try:
+            LOGGER.info(
+                'Creating Enterprise Catalog %s in the Enterprise Catalog Service with params: %s',
+                catalog_uuid,
+                json.dumps(post_data)
+            )
             return endpoint.post(post_data)
         except (SlumberBaseException, ConnectionError, Timeout) as exc:
             LOGGER.exception(
@@ -83,6 +88,11 @@ class EnterpriseCatalogApiClient(JwtLmsApiClient):
         """Updates an enterprise catalog."""
         endpoint = getattr(self.client, self.ENTERPRISE_CATALOG_ENDPOINT)(catalog_uuid)
         try:
+            LOGGER.info(
+                'Updating Enterprise Catalog %s in the Enterprise Catalog Service with params: %s',
+                catalog_uuid,
+                json.dumps(kwargs)
+            )
             return endpoint.put(kwargs)
         except (SlumberBaseException, ConnectionError, Timeout) as exc:
             LOGGER.exception(


### PR DESCRIPTION

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
