### PR TITLE
ENT-2871 | Makes the data sharing consent template guard against empt…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 --------------------
 
+[3.2.8] - 2020-05-07
+--------------------
+
+* Makes the data sharing consent template guard against empty/null branding configuration logo values.
+
 [3.2.7] - 2020-05-07
 --------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "3.2.7"
+__version__ = "3.2.8"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/templates/enterprise/_enterprise_customer_sidebar.html
+++ b/enterprise/templates/enterprise/_enterprise_customer_sidebar.html
@@ -1,5 +1,5 @@
 {% load enterprise %}
-{% if enterprise_customer.branding_configuration %}
+{% if enterprise_customer.branding_configuration and enterprise_customer.branding_configuration.logo %}
     <img class="enterprise-logo" src="{{ enterprise_customer.branding_configuration.logo.url }}" alt="{{ enterprise_customer.name }}"/>
 {% endif %}
 {% if text_override_available %}


### PR DESCRIPTION
…y/null branding configuration logo values.

https://openedx.atlassian.net/browse/ENT-2871

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
