### PR TITLE
Fix EnterpriseCustomerCatalogAdmin save hook on update

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 --------------------
 
+[3.2.10] - 2020-05-08
+---------------------
+
+* Updated EnterpriseCustomerCatalogAdmin save hook to check if a corresponding catalog exists in the enterprise-catalog service. If it does, the save hook will update the existing catalog; otherwise, a new catalog will be created.
+
+
 [3.2.9] - 2020-05-08
 --------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Unreleased
 ---------------------
 
 * Updated EnterpriseCustomerCatalogAdmin save hook to check if a corresponding catalog exists in the enterprise-catalog service. If it does, the save hook will update the existing catalog; otherwise, a new catalog will be created.
+* Added extra logging when syncing Enterprise Catalog data to the Enterprise Catalog Service.
 
 
 [3.2.9] - 2020-05-08

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "3.2.9"
+__version__ = "3.2.10"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/admin/__init__.py
+++ b/enterprise/admin/__init__.py
@@ -650,15 +650,31 @@ class EnterpriseCustomerCatalogAdmin(admin.ModelAdmin):
         catalog_client = EnterpriseCatalogApiClient(user=request.user)
 
         if change:
-            update_fields = {
-                'enterprise_customer': str(obj.enterprise_customer.uuid),
-                'enterprise_customer_name': obj.enterprise_customer.name,
-                'title': obj.title,
-                'content_filter': obj.content_filter,
-                'enabled_course_modes': obj.enabled_course_modes,
-                'publish_audit_enrollment_urls': obj.publish_audit_enrollment_urls,
-            }
-            catalog_client.update_enterprise_catalog(catalog_uuid, **update_fields)
+            response = catalog_client.get_enterprise_catalog(catalog_uuid)
+            if not response:
+                # catalog with matching uuid does NOT exist in enterprise-catalog
+                # service, so we should create a new catalog
+                catalog_client.create_enterprise_catalog(
+                    str(catalog_uuid),
+                    str(obj.enterprise_customer.uuid),
+                    obj.enterprise_customer.name,
+                    obj.title,
+                    obj.content_filter,
+                    obj.enabled_course_modes,
+                    obj.publish_audit_enrollment_urls,
+                )
+            else:
+                # catalog with matching uuid does exist in enterprise-catalog
+                # service, so we should update the existing catalog
+                update_fields = {
+                    'enterprise_customer': str(obj.enterprise_customer.uuid),
+                    'enterprise_customer_name': obj.enterprise_customer.name,
+                    'title': obj.title,
+                    'content_filter': obj.content_filter,
+                    'enabled_course_modes': obj.enabled_course_modes,
+                    'publish_audit_enrollment_urls': obj.publish_audit_enrollment_urls,
+                }
+                catalog_client.update_enterprise_catalog(catalog_uuid, **update_fields)
         else:
             catalog_client.create_enterprise_catalog(
                 str(catalog_uuid),

--- a/enterprise/api_client/enterprise_catalog.py
+++ b/enterprise/api_client/enterprise_catalog.py
@@ -57,6 +57,11 @@ class EnterpriseCatalogApiClient(JwtLmsApiClient):
             'publish_audit_enrollment_urls': json.dumps(publish_audit_enrollment_urls),
         }
         try:
+            LOGGER.info(
+                'Creating Enterprise Catalog %s in the Enterprise Catalog Service with params: %s',
+                catalog_uuid,
+                json.dumps(post_data)
+            )
             return endpoint.post(post_data)
         except (SlumberBaseException, ConnectionError, Timeout) as exc:
             LOGGER.exception(
@@ -83,6 +88,11 @@ class EnterpriseCatalogApiClient(JwtLmsApiClient):
         """Updates an enterprise catalog."""
         endpoint = getattr(self.client, self.ENTERPRISE_CATALOG_ENDPOINT)(catalog_uuid)
         try:
+            LOGGER.info(
+                'Updating Enterprise Catalog %s in the Enterprise Catalog Service with params: %s',
+                catalog_uuid,
+                json.dumps(kwargs)
+            )
             return endpoint.put(kwargs)
         except (SlumberBaseException, ConnectionError, Timeout) as exc:
             LOGGER.exception(

--- a/tests/test_admin/test_model_admins.py
+++ b/tests/test_admin/test_model_admins.py
@@ -56,8 +56,25 @@ class EnterpriseCustomerCatalogAdminTests(TestCase):
         )
 
     @mock.patch('enterprise.admin.EnterpriseCatalogApiClient')
-    def test_update_catalog(self, api_client_mock):
+    def test_update_catalog_without_existing_service_catalog(self, api_client_mock):
         api_client_mock.return_value = mock.MagicMock()
+        api_client_mock.return_value.get_enterprise_catalog.return_value = False
+        api_client_mock.return_value.create_enterprise_catalog = mock.MagicMock()
+
+        change = True  # True for updating
+        self.catalog_admin.save_model(self.request, self.enterprise_catalog, self.form, change)
+
+        # Verify the API was called and the catalog is the same as there were no real updates
+        api_client_mock.return_value.create_enterprise_catalog.assert_called()
+        self.assertEqual(
+            EnterpriseCustomerCatalog.objects.get(uuid=self.enterprise_catalog_uuid),
+            self.enterprise_catalog
+        )
+
+    @mock.patch('enterprise.admin.EnterpriseCatalogApiClient')
+    def test_update_catalog_with_existing_service_catalog(self, api_client_mock):
+        api_client_mock.return_value = mock.MagicMock()
+        api_client_mock.return_value.get_enterprise_catalog.return_value = True
         api_client_mock.return_value.update_enterprise_catalog = mock.MagicMock()
 
         change = True  # True for updating


### PR DESCRIPTION
This PR modifies the save hook in `EnterpriseCustomerCatalogAdmin` for updating an existing enterprise catalog within the LMS. On an update, the save hook will now attempt to fetch the corresponding catalog in the enterprise-catalog service. If the catalog does not yet exist in the service, a new catalog will be created; otherwise, the existing catalog will be updated.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
