### PR TITLE
update the catalog preview url to use the catalog service

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 --------------------
 
+[3.2.19] - 2020-06-01
+---------------------
+
+* Updating the catalog preview URL to use the Catalog Service
+
+
 [3.2.18] - 2020-05-28
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "3.2.18"
+__version__ = "3.2.19"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api_client/enterprise_catalog.py
+++ b/enterprise/api_client/enterprise_catalog.py
@@ -83,6 +83,14 @@ class EnterpriseCatalogApiClient(JwtLmsApiClient):
             )
             return {}
 
+    @staticmethod
+    def get_content_metadata_url(uuid):
+        """
+        Get the url for the preview information for an enterprise catalog
+        """
+        return EnterpriseCatalogApiClient.API_BASE_URL + \
+            EnterpriseCatalogApiClient.GET_CONTENT_METADATA_ENDPOINT.format(uuid)
+
     @JwtLmsApiClient.refresh_token
     def update_enterprise_catalog(self, catalog_uuid, **kwargs):
         """Updates an enterprise catalog."""

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -25,7 +25,6 @@ from django.http import Http404
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.dateparse import parse_datetime
-from django.utils.html import format_html
 from django.utils.text import slugify
 from django.utils.translation import ugettext as _
 from django.utils.translation import ungettext
@@ -41,11 +40,6 @@ try:
     from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 except ImportError:
     configuration_helpers = None
-
-try:
-    from openedx.core.djangoapps.catalog.models import CatalogIntegration
-except ImportError:
-    CatalogIntegration = None
 
 try:
     from lms.djangoapps.branding.api import get_url
@@ -1015,31 +1009,6 @@ def _get_service_worker(service_worker_username):
         return User.objects.get(username=service_worker_username)
     except User.DoesNotExist:
         return None
-
-
-def discovery_query_url(content_filter, html_format=True):
-    """
-    Return discovery url for preview.
-    """
-    if CatalogIntegration is None:
-        raise NotConnectedToOpenEdX(
-            _(
-                'To get a CatalogIntegration object, this package must be '
-                'installed in an Open edX environment.'
-            )
-        )
-    discovery_root_url = CatalogIntegration.current().get_internal_api_url()
-    disc_url = '{discovery_root_url}{search_all_endpoint}?{query_string}'.format(
-        discovery_root_url=discovery_root_url,
-        search_all_endpoint='search/all/',
-        query_string=urlencode(content_filter, doseq=True)
-    )
-    if html_format:
-        return format_html(
-            '<a href="{url}" target="_blank">Preview</a>',
-            url=disc_url
-        )
-    return disc_url
 
 
 def can_use_enterprise_catalog(enterprise_uuid):

--- a/tests/test_admin/test_forms.py
+++ b/tests/test_admin/test_forms.py
@@ -575,8 +575,9 @@ class EnterpriseCustomerCatalogAdminFormTest(unittest.TestCase):
                 'enterprise_customer_catalogs-0-content_filter': json.dumps({'field_0': 'value_0'}),
                 'enterprise_customer_catalogs-1-content_filter': json.dumps(dummy_content_filter_data),
                 'enterprise_customer_catalogs-2-content_filter': json.dumps({'field_2': 'value_2'}),
+                'enterprise_customer_catalogs-1-uuid': 'CFDF8161-5225-4278-9479-9331A6A16C33'
             },
-            'enterprise_customer_catalogs-1-preview_button'
+            'CFDF8161-5225-4278-9479-9331A6A16C33'
         ),
         (
             {
@@ -586,49 +587,35 @@ class EnterpriseCustomerCatalogAdminFormTest(unittest.TestCase):
             },
             None
         ),
+        (
+            {
+                'enterprise_customer_catalogs-1-preview_button': 'Preview',
+                'enterprise_customer_catalogs-0-content_filter': json.dumps({'field_0': 'value_0'}),
+                'enterprise_customer_catalogs-1-content_filter': json.dumps(dummy_content_filter_data),
+                'enterprise_customer_catalogs-2-content_filter': json.dumps({'field_2': 'value_2'}),
+                'enterprise_customer_catalogs-1-uuid': '3DEC72FD-6BF6-4F8E-91AD-40C119F1BE3B',
+                'enterprise_customer_catalogs-2-uuid': '839F392C-CB03-4116-A3D5-41F2FEBF5853'
+            },
+            '3DEC72FD-6BF6-4F8E-91AD-40C119F1BE3B'
+        )
     )
-    def test_get_enterprise_customer_catalog_preview_button(self, post_data, catalog_preview_button):
-        assert self.form.get_enterprise_customer_catalog_preview_button(post_data) == catalog_preview_button
+    def test_get_enterprise_customer_catalog_uuid(self, post_data, expected_result):
+        assert self.form.get_catalog_preview_uuid(post_data) == expected_result
 
     @ddt.unpack
     @ddt.data(
         (
             {
                 'enterprise_customer_catalogs-1-preview_button': 'Preview',
+                'enterprise_customer_catalogs-2-preview_button': 'Preview',
                 'enterprise_customer_catalogs-0-content_filter': json.dumps({'field_0': 'value_0'}),
                 'enterprise_customer_catalogs-1-content_filter': json.dumps(dummy_content_filter_data),
                 'enterprise_customer_catalogs-2-content_filter': json.dumps({'field_2': 'value_2'}),
-            },
-            dummy_content_filter_data
-        ),
-        # content filter from catalog query
-        (
-            {
-                'enterprise_customer_catalogs-1-preview_button': 'Preview',
-                'enterprise_customer_catalogs-0-content_filter': json.dumps({'field_0': 'value_0'}),
-                'enterprise_customer_catalogs-1-enterprise_catalog_query': '1',
-                'enterprise_customer_catalogs-1-content_filter': json.dumps({'field_1': 'value_1'}),
-                'enterprise_customer_catalogs-2-content_filter': json.dumps({'field_2': 'value_2'}),
-            },
-            catalog_query_content_filter
-        ),
-        # not clicked catalog_preview_button
-        (
-            {
-                'enterprise_customer_catalogs-0-content_filter': json.dumps({'field_0': 'value_0'}),
-                'enterprise_customer_catalogs-1-content_filter': json.dumps(dummy_content_filter_data),
-                'enterprise_customer_catalogs-2-content_filter': json.dumps({'field_2': 'value_2'}),
-            },
-            None
-        ),
-        # missing content filter
-        (
-            {
-                'enterprise_customer_catalogs-1-preview_button': 'Preview',
+                'enterprise_customer_catalogs-1-uuid': '3DEC72FD-6BF6-4F8E-91AD-40C119F1BE3B',
+                'enterprise_customer_catalogs-2-uuid': '839F392C-CB03-4116-A3D5-41F2FEBF5853'
             },
             None
         )
-
     )
-    def test_get_preview_content_filter(self, post_data, content_filter):
-        assert self.form.get_clicked_preview_content_filter(post_data) == content_filter
+    def test_get_catalog_with_two_preview_buttons(self, post_data, expected_result):
+        assert self.form.get_catalog_preview_uuid(post_data) == expected_result


### PR DESCRIPTION
ENT-2577

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
