### PR TITLE
ENT-2819 | Enterprise's slug login backend changes.

### DIFF
--- a/enterprise/admin/forms.py
+++ b/enterprise/admin/forms.py
@@ -306,6 +306,7 @@ class EnterpriseCustomerAdminForm(forms.ModelForm):
             "enable_portal_subscription_management_screen",
             "enable_learner_portal",
             "enable_portal_reporting_config_screen",
+            "enable_slug_login",
             "contact_email",
         )
 

--- a/enterprise/forms.py
+++ b/enterprise/forms.py
@@ -8,10 +8,18 @@ from django import forms
 from django.utils.translation import ugettext as _
 
 from enterprise.models import EnterpriseCustomer, EnterpriseCustomerUser
+from enterprise.utils import get_enterprise_customer_idp
 
 ENTERPRISE_SELECT_SUBTITLE = _(
     u'You have access to multiple organizations. Select the organization that you will use '
     'to sign up for courses. If you want to change organizations, sign out and sign back in.'
+)
+ENTERPRISE_LOGIN_TITLE = _(u'Enter the organization name')
+ENTERPRISE_LOGIN_SUBTITLE = _(
+    u'Have an account through your company, school, or organization? Enter your organization’s name below to sign in.'
+)
+ERROR_MESSAGE_FOR_SLUG_LOGIN = _(
+    "The attempt to login with this organization name was not successful. Please try again, or contact our support."
 )
 
 
@@ -49,4 +57,35 @@ class EnterpriseSelectionForm(forms.Form):
         if not EnterpriseCustomerUser.objects.filter(enterprise_customer=enterprise, user_id=self._user_id).exists():
             raise forms.ValidationError(_("Wrong Enterprise"))
 
+        return cleaned_data
+
+
+class EnterpriseLoginForm(forms.Form):
+    """
+    Enterprise Slug Login Form.
+    """
+
+    enterprise_slug = forms.CharField(label='Company Name')
+
+    def clean(self):
+        """
+        Validate POST data.
+        """
+        cleaned_data = super(EnterpriseLoginForm, self).clean()
+        enterprise_slug = cleaned_data['enterprise_slug']
+
+        # verify that given slug has any associated enterprise customer.
+        try:
+            enterprise_customer = EnterpriseCustomer.objects.get(slug=enterprise_slug)
+        except EnterpriseCustomer.DoesNotExist:
+            raise forms.ValidationError(ERROR_MESSAGE_FOR_SLUG_LOGIN)
+
+        # verify that enterprise customer has enabled the slug login feature.
+        if not enterprise_customer.enable_slug_login:
+            raise forms.ValidationError(ERROR_MESSAGE_FOR_SLUG_LOGIN)
+
+        # verify that a valid idp is linked to the enterprise customer.
+        enterprise_customer_idp = get_enterprise_customer_idp(enterprise_slug)
+        if enterprise_customer_idp is None or enterprise_customer_idp.identity_provider is None:
+            raise forms.ValidationError(ERROR_MESSAGE_FOR_SLUG_LOGIN)
         return cleaned_data

--- a/enterprise/templates/enterprise/enterprise_customer_login_page.html
+++ b/enterprise/templates/enterprise/enterprise_customer_login_page.html
@@ -1,0 +1,51 @@
+
+{% extends 'enterprise/base.html' %}
+
+{% load i18n staticfiles enterprise %}
+
+{% block extrahead %}
+  <script type="text/javascript" src="{% static 'js/vendor/jquery.cookie.js' %}"></script>
+  <script type="text/javascript" src="{% static 'enterprise/js/enterprise_login_page.js' %}"></script>
+{% endblock %}
+
+{% block contents %}
+  <main>
+    <div class="enterprise-container">
+      <div class="enterprise-login-container">
+
+          <h2 class="enterprise-login-title">{{ enterprise_login_title_message|safe }}</h2>
+          <div class="enterprise-login-message">
+            <p>{{ enterprise_login_subtitle_message|safe }}</p>
+          </div>
+
+          <form action="" method="POST" id="enterprise-login-form">
+            {% csrf_token %}
+
+            <div
+              role="alert"
+              aria-live="assertive"
+              class="enterprise-login errorlist is-hidden"
+              id="enterprise-login-form-error">
+            </div>
+
+            {% for field in form.visible_fields %}
+              <div>
+              {{ field.errors }}
+              {{ field }}
+              {{ field.help_text }}
+              </div>
+            {% endfor %}
+
+            <button
+              type="submit"
+              class="background-input enterprise-login-submit-button"
+              id="enterprise-login-submit">
+              {% trans "Login" %}
+            </button>
+            <span id="activate-progress-icon" class="icon fa fa-spinner fa-spin is-hidden" aria-hidden="true"></span>
+          </form>
+
+      </div>
+    </div>
+  </main>
+{% endblock %}

--- a/enterprise/urls.py
+++ b/enterprise/urls.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from django.conf.urls import include, url
 
 from enterprise.constants import COURSE_KEY_URL_PATTERN
-from enterprise.views import EnterpriseSelectionView, GrantDataSharingPermissions, RouterView
+from enterprise.views import EnterpriseLoginView, EnterpriseSelectionView, GrantDataSharingPermissions, RouterView
 
 ENTERPRISE_ROUTER = RouterView.as_view()
 
@@ -22,6 +22,11 @@ urlpatterns = [
         r'^enterprise/select/active',
         EnterpriseSelectionView.as_view(),
         name='enterprise_select_active'
+    ),
+    url(
+        r'^enterprise/login',
+        EnterpriseLoginView.as_view(),
+        name='enterprise_slug_login'
     ),
     url(
         r'^enterprise/handle_consent_enrollment/(?P<enterprise_uuid>[^/]+)/course/{}/$'.format(

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -417,6 +417,23 @@ def get_enterprise_customer_user(user_id, enterprise_uuid):
         return None
 
 
+def get_enterprise_customer_idp(enterprise_customer_slug):
+    """
+    Return the identity provider for the given enterprise customer's slug if exists otherwise None.
+
+    Arguments:
+        enterprise_customer_slug (str): enterprise customer's slug.
+
+    Returns:
+        (EnterpriseCustomerIdentityProvider): enterprise customer identity provider record.
+    """
+    EnterpriseCustomerIdentityProvider = apps.get_model(    # pylint: disable=invalid-name
+        'enterprise',
+        'EnterpriseCustomerIdentityProvider'
+    )
+    return EnterpriseCustomerIdentityProvider.objects.filter(enterprise_customer__slug=enterprise_customer_slug).first()
+
+
 def get_course_track_selection_url(course_run, query_parameters):
     """
     Return track selection url for the given course.

--- a/test_utils/__init__.py
+++ b/test_utils/__init__.py
@@ -11,6 +11,8 @@ from __future__ import absolute_import, unicode_literals
 import copy
 import json
 import logging
+import os
+import tempfile
 import uuid
 
 import mock
@@ -28,11 +30,11 @@ from six.moves.urllib.parse import (  # pylint: disable=import-error,ungrouped-i
 
 from django.conf import settings
 from django.shortcuts import render
+from django.test import TestCase
 from django.test.client import RequestFactory
 from django.urls import reverse
 
 from enterprise import utils
-from enterprise.constants import ENTERPRISE_ADMIN_ROLE
 from test_utils import factories
 
 FAKE_UUIDS = [str(uuid.uuid4()) for i in range(5)]  # pylint: disable=no-member
@@ -358,3 +360,37 @@ class MockLoggingHandler(logging.Handler):
             'error': [],
             'critical': [],
         }
+
+
+class EnterpriseFormViewTestCase(TestCase):
+    """
+    Base class for TestCase.
+
+    It has support for mocking of rendering the template file for FormView.
+    """
+
+    url = None
+    template_path = None
+
+    def setUp(self):
+        """
+        Mocked the rendering the template file.
+        """
+        super(EnterpriseFormViewTestCase, self).setUp()
+        # create a temporary template file
+        # rendering View's template fails becuase of dependency on edx-platform
+        tpl = tempfile.NamedTemporaryFile(
+            prefix='test_template.',
+            suffix=".html",
+            dir=os.path.join(settings.REPO_ROOT, 'templates/enterprise/'),
+            delete=False,
+        )
+        tpl.close()
+        self.addCleanup(os.remove, tpl.name)
+
+        patcher = mock.patch(
+            self.template_path,
+            mock.PropertyMock(return_value=tpl.name)
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)

--- a/tests/test_enterprise/views/test_enterprise_login_view.py
+++ b/tests/test_enterprise/views/test_enterprise_login_view.py
@@ -1,0 +1,133 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for the ``EnterpriseLoginView`` view of the Enterprise app.
+"""
+
+from __future__ import absolute_import, unicode_literals
+
+import ddt
+import mock
+from pytest import mark
+
+from django.test import Client
+from django.urls import reverse
+
+from enterprise.forms import ENTERPRISE_LOGIN_SUBTITLE, ENTERPRISE_LOGIN_TITLE, ERROR_MESSAGE_FOR_SLUG_LOGIN
+from test_utils import EnterpriseFormViewTestCase
+from test_utils.factories import EnterpriseCustomerFactory, EnterpriseCustomerIdentityProviderFactory
+
+IDENTITY_PROVIDER_PATH = 'enterprise.models.EnterpriseCustomerIdentityProvider.identity_provider'
+GET_PROVIDER_LOGIN_URL_PATH = 'enterprise.views.get_provider_login_url'
+
+
+@mark.django_db
+@ddt.ddt
+class TestEnterpriseLoginView(EnterpriseFormViewTestCase):
+    """
+    Test EnterpriseLoginView class.
+    """
+    url = reverse('enterprise_slug_login')
+    template_path = 'enterprise.views.EnterpriseLoginView.template_name'
+
+    def setUp(self):
+        super(TestEnterpriseLoginView, self).setUp()
+        self.client = Client()
+
+    def test_view_get(self):
+        """
+        Test that view HTTP GET works as expected.
+        """
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        assert response.context['enterprise_login_title_message'] == ENTERPRISE_LOGIN_TITLE
+        assert response.context['enterprise_login_subtitle_message'] == ENTERPRISE_LOGIN_SUBTITLE
+        assert list(response.context['form'].fields.keys())[0] == 'enterprise_slug'
+
+    def _assert_post_request(self, enterprise_slug, expected_status_code, expected_response):
+        """
+        Assert the POST request.
+        """
+        post_data = {
+            'enterprise_slug': enterprise_slug
+        }
+        if expected_status_code == 200:
+            with mock.patch(IDENTITY_PROVIDER_PATH) as mock_identity_provider:
+                with mock.patch(GET_PROVIDER_LOGIN_URL_PATH) as mock_get_provider_login_url:
+                    mock_identity_provider.return_value = 'some-dummy-provider'
+                    mock_get_provider_login_url.return_value = expected_response
+                    response = self.client.post(self.url, post_data)
+                    assert response.status_code == expected_status_code
+                    assert response.json().get('url') == expected_response
+        else:
+            response = self.client.post(self.url, post_data)
+            assert response.status_code == expected_status_code
+            assert response.json().get('errors') == expected_response
+
+    @ddt.unpack
+    @ddt.data(
+        # Raise error if slug is wrong.
+        {
+            'create_enterprise_customer': False,
+            'create_enterprise_customer_idp': False,
+            'enable_slug_login': False,
+            'enterprise_slug': 'incorrect_slug',
+            'expected_response': [ERROR_MESSAGE_FOR_SLUG_LOGIN],
+            'status_code': 400,
+        },
+        # Raise error if enable_slug_login is not enable.
+        {
+            'create_enterprise_customer': True,
+            'create_enterprise_customer_idp': False,
+            'enable_slug_login': False,
+            'enterprise_slug': 'ec_slug',
+            'expected_response': [ERROR_MESSAGE_FOR_SLUG_LOGIN],
+            'status_code': 400,
+        },
+        # Raise error if enterprise_customer is not linked to an idp.
+        {
+            'create_enterprise_customer': True,
+            'create_enterprise_customer_idp': False,
+            'enable_slug_login': True,
+            'enterprise_slug': 'ec_slug_other',
+            'expected_response': [ERROR_MESSAGE_FOR_SLUG_LOGIN],
+            'status_code': 400,
+        },
+        # Raise error if enterprise_customer is linked to an idp which not in the Registry Class.
+        {
+            'create_enterprise_customer': True,
+            'create_enterprise_customer_idp': True,
+            'enable_slug_login': True,
+            'enterprise_slug': 'ec_slug_other',
+            'expected_response': [ERROR_MESSAGE_FOR_SLUG_LOGIN],
+            'status_code': 400,
+        },
+        # Valid request.
+        {
+            'create_enterprise_customer': True,
+            'create_enterprise_customer_idp': True,
+            'enable_slug_login': True,
+            'enterprise_slug': 'ec_slug_other',
+            'expected_response': u'http://provider.login-url.com',
+            'status_code': 200,
+        },
+    )
+    def test_view_post(
+            self,
+            create_enterprise_customer,
+            create_enterprise_customer_idp,
+            enable_slug_login,
+            enterprise_slug,
+            expected_response,
+            status_code
+    ):
+        """
+        Test that view HTTP POST works as expected.
+        """
+        enterprise_customer = None
+        if create_enterprise_customer:
+            enterprise_customer = EnterpriseCustomerFactory(slug=enterprise_slug, enable_slug_login=enable_slug_login)
+
+        if enterprise_customer and create_enterprise_customer_idp:
+            EnterpriseCustomerIdentityProviderFactory(enterprise_customer=enterprise_customer)
+
+        self._assert_post_request(enterprise_slug, status_code, expected_response)

--- a/tests/test_enterprise/views/test_enterprise_selection.py
+++ b/tests/test_enterprise/views/test_enterprise_selection.py
@@ -5,29 +5,27 @@ Tests for the ``EnterpriseSelectionView`` view of the Enterprise app.
 
 from __future__ import absolute_import, unicode_literals
 
-import os
-import tempfile
-
 import ddt
 import mock
 from pytest import mark
 
-from django.conf import settings
-from django.test import Client, TestCase
+from django.test import Client
 from django.urls import reverse
 
 from enterprise.forms import ENTERPRISE_SELECT_SUBTITLE
 from enterprise.models import EnterpriseCustomerUser
+from test_utils import EnterpriseFormViewTestCase
 from test_utils.factories import EnterpriseCustomerFactory, EnterpriseCustomerUserFactory, UserFactory
 
 
 @mark.django_db
 @ddt.ddt
-class TestEnterpriseSelectionView(TestCase):
+class TestEnterpriseSelectionView(EnterpriseFormViewTestCase):
     """
     Test EnterpriseSelectionView.
     """
     url = reverse('enterprise_select_active')
+    template_path = 'enterprise.views.EnterpriseSelectionView.template_name'
 
     def setUp(self):
         self.user = UserFactory.create(is_active=True)
@@ -51,24 +49,6 @@ class TestEnterpriseSelectionView(TestCase):
             'enterprise_customer__uuid', 'enterprise_customer__name'
         )
         self.enterprise_choices = [(str(uuid), name) for uuid, name in enterprises]
-
-        # create a temporary template file
-        # rendering `enterprise/enterprise_customer_select_form.html` fails becuase of dependency on edx-platform
-        tpl = tempfile.NamedTemporaryFile(
-            prefix='test_template.',
-            suffix=".html",
-            dir=settings.REPO_ROOT + '/templates/enterprise/',
-            delete=False,
-        )
-        tpl.close()
-        self.addCleanup(os.remove, tpl.name)
-
-        patcher = mock.patch(
-            'enterprise.views.EnterpriseSelectionView.template_name',
-            mock.PropertyMock(return_value=tpl.name)
-        )
-        patcher.start()
-        self.addCleanup(patcher.stop)
 
     def _login(self):
         """


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
