### PR TITLE
BOM-1641 | Removed caniusepython3 from edx-enterprise

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 --------------------
 
+[3.2.16] - 2020-05-27
+---------------------
+
+* Removing caniusepython3 as it is no longer needed since python3 upgrade.
+
 [3.2.15] - 2020-05-26
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "3.2.15"
+__version__ = "3.2.16"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/pylintrc
+++ b/pylintrc
@@ -55,7 +55,7 @@
 [MASTER]
 ignore = migrations
 persistent = yes
-load-plugins = caniusepython3.pylint_checker,edx_lint.pylint,pylint_django,pylint_celery
+load-plugins = edx_lint.pylint,pylint_django,pylint_celery
 no-docstring-rgx = (__.*__)|Meta
 
 [MESSAGES CONTROL]

--- a/pylintrc_tweaks
+++ b/pylintrc_tweaks
@@ -1,5 +1,5 @@
 # pylintrc tweaks for use with edx_lint.
 [MASTER]
 ignore = migrations
-load-plugins = caniusepython3.pylint_checker,edx_lint.pylint,pylint_django,pylint_celery
+load-plugins = edx_lint.pylint,pylint_django,pylint_celery
 no-docstring-rgx=(__.*__)|Meta

--- a/requirements/check_pins.py
+++ b/requirements/check_pins.py
@@ -6,8 +6,6 @@ one in the second one.
 
 from __future__ import absolute_import, print_function, unicode_literals
 
-# pylint: disable=open-builtin
-
 import re
 import sys
 

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -5,7 +5,6 @@
 -r doc.txt
 -r test.txt
 
-caniusepython3            # Additional Python 3 compatibility pylint checks
 futures; python_version == "2.7" # Used by caniusepython3, only needed for Python 2
 edx-lint                  # edX pylint rules and plugins
 edx-i18n-tools            # For i18n_tool dummy

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,20 +4,16 @@
 #
 #    make upgrade
 #
-
 alabaster==0.7.12         # via -r requirements/doc.txt, sphinx
 amqp==1.4.9               # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, kombu
 aniso8601==8.0.0          # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-tincan-py35
 anyjson==0.3.3            # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, kombu
 appdirs==1.4.4            # via virtualenv
-argparse==1.4.0           # via caniusepython3
 astroid==2.3.3            # via pylint, pylint-celery
 attrs==19.3.0             # via -r requirements/test.txt, pytest
 babel==2.8.0              # via -r requirements/doc.txt, sphinx
-backports.functools-lru-cache==1.6.1  # via caniusepython3
 billiard==3.3.0.23        # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, celery
 bleach==3.1.5             # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, readme-renderer
-caniusepython3==7.2.0     # via -r requirements/dev.in
 celery==3.1.26.post2      # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
 certifi==2020.4.5.1       # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, requests
 cffi==1.14.0              # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, cryptography
@@ -30,7 +26,7 @@ cryptography==2.9.2       # via -r requirements/doc.txt, -r requirements/test-ma
 ddt==1.3.1                # via -r requirements/test.txt
 defusedxml==0.6.0         # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, djangorestframework-xml
 diff-cover==2.6.1         # via -r requirements/test.txt
-distlib==0.3.0            # via caniusepython3, virtualenv
+distlib==0.3.0            # via virtualenv
 django-config-models==2.0.2  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
 django-countries==5.5     # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
 django-crum==0.7.6        # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-rbac
@@ -54,7 +50,7 @@ edx-i18n-tools==0.5.3     # via -r requirements/dev.in
 edx-lint==1.4.1           # via -r requirements/dev.in
 edx-opaque-keys[django]==2.1.0  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-drf-extensions
 edx-rbac==1.2.1           # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
-edx-rest-api-client==5.2.0  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+edx-rest-api-client==5.2.1  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
 edx-sphinx-theme==1.5.0   # via -r requirements/doc.txt
 edx-tincan-py35==0.0.5    # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
 factory-boy==2.12.0       # via -r requirements/test.txt
@@ -64,8 +60,7 @@ freezegun==0.3.14         # via -c requirements/constraints.txt, -r requirements
 future==0.18.2            # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, pyjwkest
 idna==2.9                 # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, requests
 imagesize==1.2.0          # via -r requirements/doc.txt, sphinx
-importlib-metadata==1.6.0  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, importlib-resources, inflect, path, pluggy, pytest, tox, virtualenv
-importlib-resources==1.5.0  # via virtualenv
+importlib-metadata==1.6.0  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, inflect, path, pluggy, pytest, tox, virtualenv
 inflect==3.0.2            # via -c requirements/constraints.txt, -r requirements/test.txt, jinja2-pluralize
 isort==4.3.21             # via -r requirements/dev.in, pylint
 jinja2-pluralize==0.3.0   # via -r requirements/test.txt, diff-cover
@@ -77,12 +72,11 @@ lazy-object-proxy==1.4.3  # via astroid
 markupsafe==1.1.1         # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, jinja2
 mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.txt
-more-itertools==8.2.0     # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, pytest, zipp
+more-itertools==8.3.0     # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, pytest, zipp
 newrelic==5.12.1.141      # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-django-utils
-packaging==20.3           # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, bleach, caniusepython3, pytest, sphinx, tox
+packaging==20.3           # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, bleach, pytest, sphinx, tox
 path.py==12.4.0           # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-i18n-tools
 path==13.1.0              # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, path.py
-pathlib2==2.3.5           # via -r requirements/test.txt, pytest
 pbr==5.4.5                # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, stevedore
 pillow==7.1.2             # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
 pip-tools==5.1.2          # via -r requirements/dev.in
@@ -115,13 +109,13 @@ pytz==2020.1              # via -r requirements/doc.txt, -r requirements/test-ma
 pyyaml==5.3.1             # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, code-annotations, edx-i18n-tools
 readme-renderer==26.0     # via -r requirements/doc.txt
 requests-toolbelt==0.9.1  # via twine
-requests==2.23.0          # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, caniusepython3, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-toolbelt, responses, slumber, sphinx, twine
+requests==2.23.0          # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-toolbelt, responses, slumber, sphinx, twine
 responses==0.10.14        # via -r requirements/test.txt
 rest-condition==1.0.3     # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-drf-extensions
 restructuredtext-lint==1.3.0  # via -r requirements/doc.txt, doc8
 rules==2.2                # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
 semantic-version==2.8.5   # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-drf-extensions
-six==1.14.0               # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, astroid, bleach, cryptography, diff-cover, django-countries, django-simple-history, doc8, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-rbac, edx-sphinx-theme, freezegun, mock, packaging, pathlib2, pip-tools, pockets, pyjwkest, python-dateutil, readme-renderer, responses, sphinxcontrib-napoleon, stevedore, tox, virtualenv
+six==1.14.0               # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, astroid, bleach, cryptography, diff-cover, django-countries, django-simple-history, doc8, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-rbac, edx-sphinx-theme, freezegun, mock, packaging, pip-tools, pockets, pyjwkest, python-dateutil, readme-renderer, responses, sphinxcontrib-napoleon, stevedore, tox, virtualenv
 slumber==0.7.1            # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via -r requirements/doc.txt, pydocstyle, sphinx
 sphinx==2.4.1             # via -c requirements/constraints.txt, -r requirements/doc.txt, edx-sphinx-theme
@@ -138,18 +132,18 @@ testfixtures==6.14.1      # via -r requirements/dev.in, -r requirements/doc.txt,
 text-unidecode==1.3       # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, faker, python-slugify
 toml==0.10.1              # via tox
 tox-battery==0.5.1        # via -r requirements/dev.in
-tox==3.15.0               # via -r requirements/dev.in, tox-battery
+tox==3.15.1               # via -r requirements/dev.in, tox-battery
 tqdm==4.46.0              # via twine
 twine==1.11.0             # via -r requirements/dev.in
 typed-ast==1.4.1          # via astroid
 unicodecsv==0.14.1        # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
 urllib3==1.25.9           # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, requests
-virtualenv==20.0.20       # via tox
+virtualenv==20.0.21       # via tox
 wcwidth==0.1.9            # via -r requirements/test.txt, pytest
 webencodings==0.5.1       # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, bleach
 wheel==0.34.2             # via -r requirements/dev.in
 wrapt==1.11.2             # via astroid
-zipp==1.0.0               # via -c requirements/constraints.txt, -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, importlib-metadata, importlib-resources
+zipp==1.0.0               # via -c requirements/constraints.txt, -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -4,7 +4,6 @@
 #
 #    make upgrade
 #
-
 alabaster==0.7.12         # via sphinx
 amqp==1.4.9               # via -r requirements/test-master.txt, kombu
 aniso8601==8.0.0          # via -r requirements/test-master.txt, edx-tincan-py35
@@ -41,7 +40,7 @@ edx-django-utils==3.2.2   # via -r requirements/test-master.txt, django-config-m
 edx-drf-extensions==6.0.0  # via -r requirements/test-master.txt, edx-rbac
 edx-opaque-keys[django]==2.1.0  # via -r requirements/test-master.txt, edx-drf-extensions
 edx-rbac==1.2.1           # via -r requirements/test-master.txt
-edx-rest-api-client==5.2.0  # via -r requirements/test-master.txt
+edx-rest-api-client==5.2.1  # via -r requirements/test-master.txt
 edx-sphinx-theme==1.5.0   # via -r requirements/doc.in
 edx-tincan-py35==0.0.5    # via -r requirements/test-master.txt
 future==0.18.2            # via -r requirements/test-master.txt, pyjwkest
@@ -53,7 +52,7 @@ jsondiff==1.2.0           # via -r requirements/test-master.txt
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/test-master.txt
 kombu==3.0.37             # via -r requirements/test-master.txt, celery
 markupsafe==1.1.1         # via -r requirements/test-master.txt, jinja2
-more-itertools==8.2.0     # via -r requirements/test-master.txt, zipp
+more-itertools==8.3.0     # via -r requirements/test-master.txt, zipp
 newrelic==5.12.1.141      # via -r requirements/test-master.txt, edx-django-utils
 packaging==20.3           # via -r requirements/test-master.txt, bleach, sphinx
 path.py==12.4.0           # via -r requirements/test-master.txt

--- a/requirements/edx-platform-constraints.txt
+++ b/requirements/edx-platform-constraints.txt
@@ -12,7 +12,7 @@ anyjson==0.3.3            # via kombu
 appdirs==1.4.4            # via fs
 attrs==19.3.0             # via -r requirements/edx/base.in, edx-ace
 babel==2.8.0              # via -r requirements/edx/base.in, django-babel, django-babel-underscore
-beautifulsoup4==4.9.0     # via pynliner
+beautifulsoup4==4.9.1     # via pynliner
 billiard==3.3.0.23        # via celery
 bleach==3.1.5             # via -r requirements/edx/base.in, edx-enterprise, lti-consumer-xblock, ora2
 boto3==1.4.8              # via -r requirements/edx/base.in, fs-s3fs
@@ -48,7 +48,7 @@ django-fernet-fields==0.6  # via -r requirements/edx/base.in, edx-enterprise, ed
 django-filter==2.2.0      # via -r requirements/edx/base.in, edx-enterprise
 django-ipware==2.1.0      # via -r requirements/edx/base.in, edx-enterprise, edx-proctoring
 django-js-asset==1.2.2    # via django-mptt
-git+https://gitlab.com/Ayub-khan/django-method-override.git@5270af321be2e576d8e8b3c4191711a19975c356#egg=django-method-override==1.0.4  # via -r requirements/edx/github.in
+django-method-override==1.0.4  # via -r requirements/edx/base.in
 django-model-utils==4.0.0  # via -r requirements/edx/base.in, django-user-tasks, edx-bulk-grades, edx-celeryutils, edx-completion, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-rbac, edx-submissions, edx-when, edxval, ora2, super-csv
 django-mptt==0.11.0       # via -r requirements/edx/base.in, django-wiki
 django-mysql==3.5.0       # via -r requirements/edx/base.in
@@ -83,17 +83,17 @@ edx-django-release-util==0.4.4  # via -r requirements/edx/base.in
 edx-django-sites-extensions==2.5.1  # via -r requirements/edx/base.in
 edx-django-utils==3.2.2   # via -r requirements/edx/base.in, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-when
 edx-drf-extensions==6.0.0  # via -r requirements/edx/base.in, edx-completion, edx-enterprise, edx-organizations, edx-proctoring, edx-rbac, edx-when, edxval
-edx-enterprise==3.2.12    # via -r requirements/edx/base.in
+edx-enterprise==3.2.14    # via -r requirements/edx/base.in
 edx-i18n-tools==0.5.3     # via ora2
 edx-milestones==0.3.0     # via -r requirements/edx/base.in
 edx-opaque-keys[django]==2.1.0  # via -r requirements/edx/paver.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, xmodule
 edx-organizations==5.2.0  # via -r requirements/edx/base.in
 edx-proctoring-proctortrack==1.0.5  # via -r requirements/edx/base.in
 edx-proctoring==2.4.0     # via -r requirements/edx/base.in, edx-proctoring-proctortrack
-edx-rest-api-client==5.2.0  # via -r requirements/edx/base.in, edx-enterprise, edx-proctoring
+edx-rest-api-client==5.2.1  # via -r requirements/edx/base.in, edx-enterprise, edx-proctoring
 edx-search==1.3.4         # via -r requirements/edx/base.in
-edx-sga==0.10.0           # via -r requirements/edx/base.in
-edx-submissions==3.1.5    # via -r requirements/edx/base.in, ora2
+edx-sga==0.11.0           # via -r requirements/edx/base.in
+edx-submissions==3.1.7    # via -r requirements/edx/base.in, ora2
 edx-user-state-client==1.2.0  # via -r requirements/edx/base.in
 edx-when==1.2.3           # via -r requirements/edx/base.in, edx-proctoring
 edxval==1.3.4             # via -r requirements/edx/base.in
@@ -108,7 +108,6 @@ glob2==0.7                # via -r requirements/edx/base.in
 gunicorn==20.0.4          # via -r requirements/edx/base.in
 help-tokens==1.1.2        # via -r requirements/edx/base.in
 html5lib==1.0.1           # via -r requirements/edx/base.in, ora2
-httplib2==0.17.3          # via oauth2
 icalendar==4.0.6          # via -r requirements/edx/base.in
 idna==2.9                 # via -r requirements/edx/paver.txt, requests
 importlib-metadata==1.6.0  # via -r requirements/edx/paver.txt, path
@@ -118,7 +117,7 @@ isodate==0.6.0            # via python3-saml
 itypes==1.2.0             # via coreapi
 jinja2==2.11.2            # via code-annotations, coreschema
 jmespath==0.10.0          # via boto3, botocore
-joblib==0.14.1            # via -r requirements/edx/../edx-sandbox/shared.txt, nltk
+joblib==0.14.1            # via -c requirements/edx/../constraints.txt, -r requirements/edx/../edx-sandbox/shared.txt, nltk
 jsonfield2==3.0.3         # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, edx-celeryutils, edx-enterprise, edx-proctoring, edx-submissions, ora2
 kombu==3.0.37             # via celery
 laboratory==1.0.2         # via -r requirements/edx/base.in
@@ -137,24 +136,23 @@ maxminddb==1.5.4          # via geoip2
 mock==3.0.5               # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.txt, xblock-drag-and-drop-v2, xblock-poll
 git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a#egg=MongoDBProxy==0.1.0+edx.2  # via -r requirements/edx/github.in
 mongoengine==0.10.0       # via -r requirements/edx/base.in
-more-itertools==8.2.0     # via -r requirements/edx/paver.txt, zipp
+more-itertools==8.3.0     # via -r requirements/edx/paver.txt, zipp
 mpmath==1.1.0             # via sympy
 mysqlclient==1.4.6        # via -r requirements/edx/base.in
 newrelic==5.12.1.141      # via -r requirements/edx/base.in, edx-django-utils
 nltk==3.5                 # via -r requirements/edx/../edx-sandbox/shared.txt, chem
 nodeenv==1.3.5            # via -r requirements/edx/base.in
 numpy==1.18.4             # via chem, openedx-calc, scipy
-git+https://github.com/joestump/python-oauth2.git@b94f69b1ad195513547924e380d9265133e995fa#egg=oauth2  # via -r requirements/edx/github.in
 oauthlib==3.0.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, django-oauth-toolkit, lti-consumer-xblock, requests-oauthlib, social-auth-core
 openedx-calc==1.0.9       # via -r requirements/edx/base.in
-git+https://github.com/edx/edx-ora2.git@2.6.25#egg=ora2==2.6.25  # via -r requirements/edx/github.in
+git+https://github.com/edx/edx-ora2.git@2.7.6#egg=ora2==2.7.6  # via -r requirements/edx/github.in
 packaging==20.3           # via bleach, drf-yasg
 path.py==12.4.0           # via edx-enterprise, edx-i18n-tools, ora2, xmodule
 path==13.1.0              # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.txt, path.py
 pathtools==0.1.2          # via -r requirements/edx/paver.txt, watchdog
 paver==1.3.4              # via -r requirements/edx/paver.txt
 pbr==5.4.5                # via -r requirements/edx/paver.txt, stevedore
-pdfminer.six==20200402    # via -r requirements/edx/base.in
+pdfminer.six==20200517    # via -r requirements/edx/base.in
 piexif==1.1.3             # via -r requirements/edx/base.in
 pillow==7.1.2             # via -r requirements/edx/base.in, edx-enterprise, edx-organizations
 pkgconfig==1.5.1          # via xmlsec
@@ -186,7 +184,7 @@ pyyaml==5.3.1             # via -r requirements/edx/base.in, code-annotations, e
 random2==1.0.1            # via -r requirements/edx/base.in
 recommender-xblock==1.4.8  # via -r requirements/edx/base.in
 redis==2.10.6             # via -r requirements/edx/base.in
-regex==2020.5.13          # via -r requirements/edx/../edx-sandbox/shared.txt, nltk
+regex==2020.5.14          # via -r requirements/edx/../edx-sandbox/shared.txt, nltk
 requests-oauthlib==1.3.0  # via -r requirements/edx/base.in, social-auth-core
 requests==2.23.0          # via -r requirements/edx/paver.txt, analytics-python, coreapi, django-oauth-toolkit, edx-analytics-data-api-client, edx-bulk-grades, edx-drf-extensions, edx-enterprise, edx-rest-api-client, geoip2, mailsnake, pyjwkest, python-swiftclient, requests-oauthlib, sailthru-client, slumber, social-auth-core
 rest-condition==1.0.3     # via -r requirements/edx/base.in, edx-drf-extensions
@@ -205,7 +203,7 @@ slumber==0.7.1            # via edx-bulk-grades, edx-enterprise, edx-rest-api-cl
 social-auth-core==3.3.3   # via -r requirements/edx/base.in, social-auth-app-django
 git+https://github.com/jazzband/sorl-thumbnail.git@13bedfb7d2970809eda597e3ef79318a6fa80ac2#egg=sorl-thumbnail  # via -r requirements/edx/github.in
 sortedcontainers==2.1.0   # via -r requirements/edx/base.in, pdfminer.six
-soupsieve==2.0            # via beautifulsoup4
+soupsieve==2.0.1          # via beautifulsoup4
 sqlparse==0.3.1           # via -r requirements/edx/base.in, django
 staff-graded-xblock==0.8  # via -r requirements/edx/base.in
 stevedore==1.32.0         # via -r requirements/edx/base.in, -r requirements/edx/paver.txt, code-annotations, edx-ace, edx-enterprise, edx-opaque-keys

--- a/requirements/js_test.txt
+++ b/requirements/js_test.txt
@@ -4,12 +4,9 @@
 #
 #    make upgrade
 #
-
 cheroot==8.3.0            # via cherrypy
 cherrypy==18.6.0          # via jasmine
 glob2==0.7                # via jasmine-core
-importlib-metadata==1.6.0  # via importlib-resources
-importlib-resources==1.5.0  # via jaraco.text
 jaraco.classes==2.0       # via -r requirements/js_test.in, jaraco.collections
 jaraco.collections==2.1   # via -r requirements/js_test.in, cherrypy
 jaraco.functools==2.0     # via -r requirements/js_test.in, cheroot, jaraco.text, tempora
@@ -18,7 +15,7 @@ jasmine-core==3.1.0       # via jasmine
 jasmine==3.1.0            # via -r requirements/js_test.in
 jinja2==2.11.2            # via jasmine
 markupsafe==1.1.1         # via jinja2
-more-itertools==8.2.0     # via cheroot, cherrypy, jaraco.functools, zipp
+more-itertools==8.3.0     # via cheroot, cherrypy, jaraco.functools
 ordereddict==1.1          # via jasmine-core
 portend==2.6              # via cherrypy
 pytz==2020.1              # via tempora
@@ -28,7 +25,6 @@ six==1.14.0               # via cheroot, jaraco.classes, jaraco.collections, jar
 tempora==1.14.1           # via -r requirements/js_test.in, portend
 urllib3==1.25.9           # via selenium
 zc.lockfile==2.0          # via cherrypy
-zipp==1.0.0               # via -c requirements/constraints.txt, importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -4,7 +4,6 @@
 #
 #    make upgrade
 #
-
 amqp==1.4.9               # via -c requirements/edx-platform-constraints.txt, kombu
 aniso8601==8.0.0          # via -c requirements/edx-platform-constraints.txt, edx-tincan-py35
 anyjson==0.3.3            # via -c requirements/edx-platform-constraints.txt, kombu
@@ -37,7 +36,7 @@ edx-django-utils==3.2.2   # via -c requirements/edx-platform-constraints.txt, -r
 edx-drf-extensions==6.0.0  # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, edx-rbac
 edx-opaque-keys[django]==2.1.0  # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, edx-drf-extensions
 edx-rbac==1.2.1           # via -r requirements/base.in
-edx-rest-api-client==5.2.0  # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
+edx-rest-api-client==5.2.1  # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
 edx-tincan-py35==0.0.5    # via -r requirements/base.in
 future==0.18.2            # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, pyjwkest
 idna==2.9                 # via -c requirements/edx-platform-constraints.txt, requests
@@ -47,7 +46,7 @@ jsondiff==1.2.0           # via -r requirements/base.in
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -c requirements/edx-platform-constraints.txt, -r requirements/base.in
 kombu==3.0.37             # via -c requirements/edx-platform-constraints.txt, celery
 markupsafe==1.1.1         # via -c requirements/edx-platform-constraints.txt, jinja2
-more-itertools==8.2.0     # via -c requirements/edx-platform-constraints.txt, zipp
+more-itertools==8.3.0     # via -c requirements/edx-platform-constraints.txt, zipp
 newrelic==5.12.1.141      # via -c requirements/edx-platform-constraints.txt, edx-django-utils
 packaging==20.3           # via -c requirements/edx-platform-constraints.txt, bleach
 path.py==12.4.0           # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,7 +4,6 @@
 #
 #    make upgrade
 #
-
 amqp==1.4.9               # via -r requirements/test-master.txt, kombu
 aniso8601==8.0.0          # via -r requirements/test-master.txt, edx-tincan-py35
 anyjson==0.3.3            # via -r requirements/test-master.txt, kombu
@@ -40,7 +39,7 @@ edx-django-utils==3.2.2   # via -r requirements/test-master.txt, django-config-m
 edx-drf-extensions==6.0.0  # via -r requirements/test-master.txt, edx-rbac
 edx-opaque-keys[django]==2.1.0  # via -r requirements/test-master.txt, edx-drf-extensions
 edx-rbac==1.2.1           # via -r requirements/test-master.txt
-edx-rest-api-client==5.2.0  # via -r requirements/test-master.txt
+edx-rest-api-client==5.2.1  # via -r requirements/test-master.txt
 edx-tincan-py35==0.0.5    # via -r requirements/test-master.txt
 factory-boy==2.12.0       # via -r requirements/test.in
 faker==4.1.0              # via factory-boy
@@ -56,12 +55,11 @@ jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements
 kombu==3.0.37             # via -r requirements/test-master.txt, celery
 markupsafe==1.1.1         # via -r requirements/test-master.txt, jinja2
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.in
-more-itertools==8.2.0     # via -r requirements/test-master.txt, pytest, zipp
+more-itertools==8.3.0     # via -r requirements/test-master.txt, pytest, zipp
 newrelic==5.12.1.141      # via -r requirements/test-master.txt, edx-django-utils
 packaging==20.3           # via -r requirements/test-master.txt, bleach, pytest
 path.py==12.4.0           # via -r requirements/test-master.txt
 path==13.1.0              # via -r requirements/test-master.txt, path.py
-pathlib2==2.3.5           # via pytest
 pbr==5.4.5                # via -r requirements/test-master.txt, stevedore
 pillow==7.1.2             # via -r requirements/test-master.txt
 pluggy==0.13.1            # via diff-cover, pytest

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -4,19 +4,17 @@
 #
 #    make upgrade
 #
-
 appdirs==1.4.4            # via virtualenv
 certifi==2020.4.5.1       # via requests
 chardet==3.0.4            # via requests
-codecov==2.0.22           # via -r requirements/travis.in
+codecov==2.1.1            # via -r requirements/travis.in
 coverage==5.1             # via codecov
 distlib==0.3.0            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
 idna==2.9                 # via requests
-importlib-metadata==1.6.0  # via importlib-resources, pluggy, tox, virtualenv
-importlib-resources==1.5.0  # via virtualenv
-more-itertools==8.2.0     # via zipp
-packaging==20.3           # via tox
+importlib-metadata==1.6.0  # via pluggy, tox, virtualenv
+more-itertools==8.3.0     # via zipp
+packaging==20.4           # via tox
 pluggy==0.13.1            # via tox
 py==1.8.1                 # via tox
 pyparsing==2.4.7          # via packaging
@@ -24,7 +22,7 @@ requests==2.23.0          # via codecov
 six==1.14.0               # via packaging, tox, virtualenv
 toml==0.10.1              # via tox
 tox-battery==0.5.1        # via -r requirements/travis.in
-tox==3.15.0               # via -r requirements/travis.in, tox-battery
+tox==3.15.1               # via -r requirements/travis.in, tox-battery
 urllib3==1.25.9           # via requests
-virtualenv==20.0.20       # via tox
-zipp==1.0.0               # via -c requirements/constraints.txt, importlib-metadata, importlib-resources
+virtualenv==20.0.21       # via tox
+zipp==1.0.0               # via -c requirements/constraints.txt, importlib-metadata

--- a/test_utils/file_helpers.py
+++ b/test_utils/file_helpers.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, unicode_literals
 import six
 import unicodecsv
 
+
 class MakeCsvStreamContextManager:
     """
     Context manager that creates a temporary csv file.

--- a/test_utils/file_helpers.py
+++ b/test_utils/file_helpers.py
@@ -7,8 +7,6 @@ from __future__ import absolute_import, unicode_literals
 import six
 import unicodecsv
 
-
-# pylint: disable=open-builtin
 class MakeCsvStreamContextManager:
     """
     Context manager that creates a temporary csv file.

--- a/tox.ini
+++ b/tox.ini
@@ -93,7 +93,6 @@ deps =
 commands =
     touch tests/__init__.py
     pylint -j 0 enterprise enterprise_learner_portal consent integrated_channels tests test_utils requirements/check_pins.py
-    pylint -j 0 --py3k enterprise enterprise_learner_portal consent integrated_channels tests test_utils
     rm tests/__init__.py
     pycodestyle enterprise enterprise_learner_portal consent integrated_channels tests test_utils
     pydocstyle enterprise enterprise_learner_portal consent integrated_channels tests test_utils


### PR DESCRIPTION
**Background:** Any repositories which have already been updated to drop Python 2.7 support no longer need to depend on or use the caniusepython3 package, but some of them (such as edx-enterprise) still do. (https://openedx.atlassian.net/browse/BOM-1630)

This PR will remove caniusepython3 from edx-enterprise. - https://openedx.atlassian.net/browse/BOM-1641

**Things done:**

- Remove any executions of pylint using the --py3k option
- Remove caniusepython3.pylint_checker from pylintrc_tweaks and pylintrc
- Remove caniusepython3 as a dependency and run make upgrade

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
