### PR TITLE
reduce log exceptions that aren't really errors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,13 @@ Change Log
 Unreleased
 --------------------
 
+[3.2.20] - 2020-06-01
+---------------------
+
+* Suppress the 404 exception in get_enterprise_catalog when we expect it
+* Add enterprise_customer_uuid to an error message to be more informative
+
+
 [3.2.19] - 2020-06-01
 ---------------------
 

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -697,9 +697,11 @@ class EnterpriseCustomerCourseEnrollmentsSerializer(serializers.Serializer):
 
         if not enterprise_customer.catalog_contains_course(value):
             error_message = ('[Enterprise API] The course run id is not in the catalog for the Enterprise Customer.'
-                             ' EnterpriseCustomer: {enterprise_customer}, CourseRun: {course_run_id}').format(
+                             ' EnterpriseCustomer: {enterprise_uuid}, EnterpriseName: {enterprise_name},'
+                             ' CourseRun: {course_run_id}').format(
                                  course_run_id=value,
-                                 enterprise_customer=enterprise_customer.name)
+                                 enterprise_uuid=enterprise_customer.uuid,
+                                 enterprise_name=enterprise_customer.name)
             LOGGER.error(error_message)
             raise serializers.ValidationError(
                 'The course run id {course_run_id} is not in the catalog '

--- a/enterprise/api_client/enterprise_catalog.py
+++ b/enterprise/api_client/enterprise_catalog.py
@@ -71,16 +71,27 @@ class EnterpriseCatalogApiClient(JwtLmsApiClient):
             return {}
 
     @JwtLmsApiClient.refresh_token
-    def get_enterprise_catalog(self, catalog_uuid):
-        """Gets an enterprise catalog."""
+    def get_enterprise_catalog(self, catalog_uuid, should_raise_exception=True):
+        """
+        Gets an enterprise catalog.
+
+        Arguments:
+            catalog_uuid (uuid): The uuid of an EnterpriseCatalog instance
+            should_raise_exception (bool): Whether an exception should be logged if
+                a catalog does not yet exist in enterprise-catalog. Defaults to True.
+
+        Returns:
+            dict: a dictionary representing an enterprise catalog
+        """
         endpoint = getattr(self.client, self.ENTERPRISE_CATALOG_ENDPOINT)(catalog_uuid)
         try:
             return endpoint.get()
         except (SlumberBaseException, ConnectionError, Timeout) as exc:
-            LOGGER.exception(
-                'Failed to get EnterpriseCustomer Catalog [%s] in enterprise-catalog due to: [%s]',
-                catalog_uuid, str(exc)
-            )
+            if should_raise_exception:
+                LOGGER.exception(
+                    'Failed to get EnterpriseCustomer Catalog [%s] in enterprise-catalog due to: [%s]',
+                    catalog_uuid, str(exc)
+                )
             return {}
 
     @staticmethod

--- a/enterprise/management/commands/migrate_enterprise_catalogs.py
+++ b/enterprise/management/commands/migrate_enterprise_catalogs.py
@@ -57,7 +57,12 @@ class Command(BaseCommand):
         for enterprise_catalog in queryset:
             LOGGER.info('Migrating Enterprise Catalog {}'.format(enterprise_catalog.uuid))
             try:
-                response = client.get_enterprise_catalog(enterprise_catalog.uuid)
+                response = client.get_enterprise_catalog(
+                    catalog_uuid=enterprise_catalog.uuid,
+                    # Suppress 404 exception since we do not expect the catalog to exist
+                    # in enterprise-catalog if it is a new catalog
+                    should_raise_exception=False,
+                )
                 if not response:
                     # catalog with matching uuid does NOT exist in enterprise-catalog
                     # service, so we should create a new catalog

--- a/enterprise/signals.py
+++ b/enterprise/signals.py
@@ -144,7 +144,15 @@ def update_enterprise_catalog_data(sender, instance, **kwargs):     # pylint: di
     catalog_uuid = instance.uuid
     try:
         catalog_client = EnterpriseCatalogApiClient()
-        response = catalog_client.get_enterprise_catalog(catalog_uuid)
+        if kwargs['created']:
+            response = catalog_client.get_enterprise_catalog(
+                catalog_uuid=catalog_uuid,
+                # Suppress 404 exception on create since we do not expect the catalog
+                # to exist yet in enterprise-catalog
+                should_raise_exception=False,
+            )
+        else:
+            response = catalog_client.get_enterprise_catalog(catalog_uuid=catalog_uuid)
     except NotConnectedToOpenEdX as exc:
         logger.exception('Unable to update Enterprise Catalog {}'.format(str(catalog_uuid)), exc)
     else:


### PR DESCRIPTION
There is a signal for `post_save` on the `EnterpriseCustomerCatalog` model. It is triggered when a catalog gets created or updated (e.g., by ECS). In the signal, we attempt to get a catalog with no assumption that it actually exists yet in enterprise-catalog. If it 404s, we know it doesn't exist and we should create a new catalog in the service.

Since we expect to get a 404 when a catalog is first created in the LMS, we should no longer log it as an exception to avoid seeing false positives for the error in the email alerts.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
