### PR TITLE
delete enterprise_learner role assignment on soft delete of EnterpriseCustomerUser records

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Unreleased
 
 * Suppress the 404 exception in get_enterprise_catalog when we expect it
 * Add enterprise_customer_uuid to an error message to be more informative
+* Delete "enterprise_learner" role assignment when an EnterpriseCustomerUser record is soft deleted (i.e., `linked` attribute is False)
 
 
 [3.2.19] - 2020-06-01

--- a/tests/test_enterprise/test_signals.py
+++ b/tests/test_enterprise/test_signals.py
@@ -332,7 +332,7 @@ class TestEnterpriseLearnerRoleSignals(unittest.TestCase):
 
         if should_learner_role_exist:
             # Verify that learner_role_assignment is not modified again when making a
-            # usual update, i.e. it is still the same time when the object was created.
+            # normal update, i.e. modified time is the same as when the object was created.
             learner_role_assignment = SystemWideEnterpriseUserRoleAssignment.objects.get(
                 user=self.learner_user,
                 role=self.enterprise_learner_role


### PR DESCRIPTION
The email alerts for enterprise often contain errors related to a user having an `enterprise_learner` system-wide role but not being linked to an enterprise, e.g.:

> May 30 13:17:16 ip-10-2-11-166 [service_variant=lms][enterprise.models][env:prod-edx-edxapp] WARNING [ip-10-2-11-166  23459] [user 4570228] [models.py:2113] - User 4570228 has a <class 'enterprise.models.SystemWideEnterpriseUserRoleAssignment'> of "enterprise_learner" but is not linked to an enterprise. (ID: 135504)

After some digging, I realized a change was implemented (via [ENT-2538](https://openedx.atlassian.net/browse/ENT-2538)) to soft delete `EnterpriseCustomerUser` records by setting `linked = False` instead of doing a full delete of records.

We previously had a signal that triggers the deletion of the `enterprise_learner` role assignment when an `EnterpriseCustomerUser` record is fully deleted. However, since we now soft-delete those records, the `post_delete` signal is never received.

We should handle both full and soft deletions of `EnterpriseCustomerUser` records to see a large reduction in the number of errors such as the one above.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
