### PR TITLE
update seed_enterprise_devstack_data command to include name on profiles

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Unreleased
 * Suppress the 404 exception in get_enterprise_catalog when we expect it
 * Add enterprise_customer_uuid to an error message to be more informative
 * Delete "enterprise_learner" role assignment when an EnterpriseCustomerUser record is soft deleted (i.e., `linked` attribute is False)
+* Update seed_enterprise_devstack_data command to include name on user profiles when creating enterprise users
 
 
 [3.2.19] - 2020-06-01

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "3.2.19"
+__version__ = "3.2.20"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/management/commands/seed_enterprise_devstack_data.py
+++ b/enterprise/management/commands/seed_enterprise_devstack_data.py
@@ -138,11 +138,10 @@ class Command(BaseCommand):
         if not UserProfile:
             LOGGER.error('UserProfile module does not exist.')
             return
-
-        user_profile = UserProfile.objects.get_or_create(user=user)
-        if user_profile:
-            user_profile.name = 'Test Enterprise User'
-            user_profile.save()
+        UserProfile.objects.update_or_create(
+            user=user,
+            defaults={'name': 'Test Enterprise User'},
+        )
 
     def _add_user_to_groups(self, user, role):
         """ Adds a user with a given role to the appropriate groups """

--- a/enterprise/management/commands/seed_enterprise_devstack_data.py
+++ b/enterprise/management/commands/seed_enterprise_devstack_data.py
@@ -139,7 +139,7 @@ class Command(BaseCommand):
             LOGGER.error('UserProfile module does not exist.')
             return
 
-        user_profile = UserProfile.objects.get(user=user)
+        user_profile = UserProfile.objects.get_or_create(user=user)
         if user_profile:
             user_profile.name = 'Test Enterprise User'
             user_profile.save()


### PR DESCRIPTION
Update seed_enterprise_devstack_data command to include name on user profiles when creating enterprise users since it's technically a required field (without name, things seem to break).

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
