### PR TITLE
switch to logger.warning over logger.error

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 --------------------
 
+[3.2.21] - 2020-06-03
+---------------------
+
+* Downgrade an error log to a warning to reduce alert noise
+
+
 [3.2.20] - 2020-06-01
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "3.2.20"
+__version__ = "3.2.21"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -702,7 +702,7 @@ class EnterpriseCustomerCourseEnrollmentsSerializer(serializers.Serializer):
                                  course_run_id=value,
                                  enterprise_uuid=enterprise_customer.uuid,
                                  enterprise_name=enterprise_customer.name)
-            LOGGER.error(error_message)
+            LOGGER.warning(error_message)
             raise serializers.ValidationError(
                 'The course run id {course_run_id} is not in the catalog '
                 'for Enterprise Customer {enterprise_customer}'.format(


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
