### PR TITLE
ENT-2912: Added enterprise course enrollment rollback

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ Change Log
 
 Unreleased
 --------------------
+[3.2.22] - 2020-06-09
+---------------------
+
+* Added rollback for EnterpriseCourseEnrollment enroll
 
 [3.2.21] - 2020-06-03
 ---------------------

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "3.2.21"
+__version__ = "3.2.22"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -821,7 +821,7 @@ class EnterpriseCustomerUser(TimeStampedModel):
                 raise CourseEnrollmentPermissionError("Auto-cohorting is not enabled for this enterprise")
 
             try:
-                EnterpriseCourseEnrollment.objects.get_or_create(
+                enterprise_course_enrollment, created = EnterpriseCourseEnrollment.objects.get_or_create(
                     enterprise_customer_user=self,
                     course_id=course_run_id,
                     defaults={
@@ -847,6 +847,8 @@ class EnterpriseCustomerUser(TimeStampedModel):
                 enrollment_api_client.enroll_user_in_course(self.username, course_run_id, mode, cohort=cohort)
             except HttpClientError as exc:
                 succeeded = False
+                if created:
+                    enterprise_course_enrollment.delete()
                 default_message = 'No error message provided'
                 try:
                     error_message = json.loads(exc.content.decode()).get('message', default_message)


### PR DESCRIPTION
JIRA: https://openedx.atlassian.net/browse/ENT-2912, https://openedx.atlassian.net/browse/ENT-2559

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
