### PR TITLE
ENT-2969 Add marked_done to endpoint

### DIFF
--- a/enterprise_learner_portal/api/v1/serializers.py
+++ b/enterprise_learner_portal/api/v1/serializers.py
@@ -72,6 +72,8 @@ class EnterpriseCourseEnrollmentSerializer(serializers.Serializer):  # pylint: d
         representation['pacing'] = course_overview['pacing']
         representation['org_name'] = course_overview['display_org_with_default']
 
+        representation['marked_done'] = instance.marked_done
+
         return representation
 
     def _get_course_overview(self, course_run_id):


### PR DESCRIPTION
Needed to support extra logic in UI to render manually archived courses differently from regular completed courses

**Merge checklist:**
- [X] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [X] `make static` has been run to update webpack bundling if any static content was updated N/A
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [X] Translations updated N/A

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
