### PR TITLE
Consider course run status when determining availability and enrollability

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 --------------------
 
+[3.3.3] - 2020-06-12
+---------------------
+
+* Exclude unpublished course runs when determining available/enrollable status
+
+
 [3.3.2] - 2020-06-10
 ---------------------
 
@@ -24,6 +30,7 @@ Unreleased
 ---------------------
 
 * Added marked_done field in /enterprise_course_enrollments/ response
+
 
 [3.3.0] - 2020-06-09
 ---------------------

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "3.3.2"
+__version__ = "3.3.3"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/tests/test_integrated_channels/test_sap_success_factors/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_sap_success_factors/test_exporters/test_content_metadata.py
@@ -136,14 +136,16 @@ class TestSapSuccessFactorsContentMetadataExporter(unittest.TestCase, Enterprise
             'pacing_type': 'instructor_paced',
             'availability': 'Current',
             'title': 'edX Demonstration Course',
-            'content_language': 'English'
+            'content_language': 'English',
+            'status': 'published'
         },
         {
             'start': '2013-02-05T05:00:00Z',
             'pacing_type': 'self_paced',
             'availability': 'Current',
             'title': 'edX Demonstration Course',
-            'content_language': 'English'
+            'content_language': 'English',
+            'status': 'published'
         }
     )
     @responses.activate
@@ -337,6 +339,7 @@ class TestSapSuccessFactorsContentMetadataExporter(unittest.TestCase, Enterprise
                         'end': '2050-12-31T18:00:00Z',
                         'pacing_type': 'instructor_paced',
                         'availability': 'Current',
+                        'status': 'published',
                     }
                 ],
                 'short_description': 'Watch the rabbits roam.',
@@ -354,6 +357,7 @@ class TestSapSuccessFactorsContentMetadataExporter(unittest.TestCase, Enterprise
                         'end': '2151-12-31T18:00:00Z',
                         'pacing_type': 'self_paced',
                         'availability': 'Archived',
+                        'status': 'published'
                     }
                 ],
                 'short_description': 'The bunnies are delighted.',
@@ -368,6 +372,7 @@ class TestSapSuccessFactorsContentMetadataExporter(unittest.TestCase, Enterprise
                     {
                         'pacing_type': 'instructor_paced',
                         'availability': 'Archived',
+                        'status': 'published',
                     }
                 ],
                 'full_description': 'In depth discussion of rabbit care and feeding.',
@@ -382,6 +387,7 @@ class TestSapSuccessFactorsContentMetadataExporter(unittest.TestCase, Enterprise
                         'start': '2216-02-05T05:00:00Z',
                         'pacing_type': 'instructor_paced',
                         'availability': 'Current',
+                        'status': 'published'
                     }
                 ],
                 'short_description': 'Learn to grow this colorful veggie.',
@@ -398,6 +404,7 @@ class TestSapSuccessFactorsContentMetadataExporter(unittest.TestCase, Enterprise
                         'end': '2317-02-05T05:00:00Z',
                         'pacing_type': 'instructor_paced',
                         'availability': 'Current',
+                        'status': 'published'
                     }
                 ],
                 'short_description': 'Yep.',

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1119,6 +1119,7 @@ class TestEnterpriseUtils(unittest.TestCase):
     @ddt.data(
         (
             {
+                "status": "published",
                 "end": "3000-10-13T13:11:01Z",
                 "enrollment_start": "2014-10-13T13:11:03Z",
                 "enrollment_end": "2999-10-13T13:11:04Z",
@@ -1126,19 +1127,35 @@ class TestEnterpriseUtils(unittest.TestCase):
             True,
         ),
         (
-            {"end": None, "enrollment_start": "2014-10-13T13:11:03Z", "enrollment_end": "2999-10-13T13:11:04Z"},
-            True,
-        ),
-        (
-            {"end": "3000-10-13T13:11:01Z", "enrollment_start": None, "enrollment_end": "2999-10-13T13:11:04Z"},
-            True,
-        ),
-        (
-            {"end": "3000-10-13T13:11:01Z", "enrollment_start": "2014-10-13T13:11:03Z", "enrollment_end": None},
+            {
+                "status": "published",
+                "end": None,
+                "enrollment_start": "2014-10-13T13:11:03Z",
+                "enrollment_end": "2999-10-13T13:11:04Z"
+            },
             True,
         ),
         (
             {
+                "status": "published",
+                "end": "3000-10-13T13:11:01Z",
+                "enrollment_start": None,
+                "enrollment_end": "2999-10-13T13:11:04Z"
+            },
+            True,
+        ),
+        (
+            {
+                "status": "published",
+                "end": "3000-10-13T13:11:01Z",
+                "enrollment_start": "2014-10-13T13:11:03Z",
+                "enrollment_end": None
+            },
+            True,
+        ),
+        (
+            {
+                "status": "published",
                 "end": "2014-10-13T13:11:01Z",  # end < now
                 "enrollment_start": "2014-10-13T13:11:03Z",
                 "enrollment_end": "2999-10-13T13:11:04Z",
@@ -1147,6 +1164,7 @@ class TestEnterpriseUtils(unittest.TestCase):
         ),
         (
             {
+                "status": "published",
                 "end": "3000-10-13T13:11:01Z",
                 "enrollment_start": "2999-10-13T13:11:03Z",  # enrollment_start > now
                 "enrollment_end": "3000-10-13T13:11:04Z",
@@ -1155,9 +1173,19 @@ class TestEnterpriseUtils(unittest.TestCase):
         ),
         (
             {
+                "status": "published",
                 "end": "3000-10-13T13:11:01Z",
                 "enrollment_start": "2014-10-13T13:11:03Z",
                 "enrollment_end": "2014-10-13T13:11:04Z",  # enrollment_end < now
+            },
+            False,
+        ),
+        (
+            {
+                "status": "unpublished",
+                "end": "3000-10-13T13:11:01Z",
+                "enrollment_start": "2014-10-13T13:11:03Z",
+                "enrollment_end": "3000-10-13T13:11:04Z",  # enrollment_end < now
             },
             False,
         ),
@@ -1171,6 +1199,7 @@ class TestEnterpriseUtils(unittest.TestCase):
         - False on end < now.
         - False on enrollment_end < now.
         - False on enrollment_start > now.
+        - False on is_course_run_published = False
         - True if none of the above plus, optionally, if any of the values are NULL.
         """
         assert utils.is_course_run_enrollable(course_run) == expected_enrollment_eligibility
@@ -1183,12 +1212,14 @@ class TestEnterpriseUtils(unittest.TestCase):
         (
             [
                 {
+                    "status": "published",
                     "availability": "Current",
                     "end": "3000-10-13T13:11:01Z",
                     "enrollment_start": "2999-10-13T13:11:03Z",  # enrollment_start > now
                     "enrollment_end": "3000-10-13T13:11:04Z",
                 },
                 {
+                    "status": "published",
                     "availability": "Current",
                     "end": "3000-10-13T13:11:01Z",
                     "enrollment_start": "2014-10-13T13:11:03Z",
@@ -1200,12 +1231,14 @@ class TestEnterpriseUtils(unittest.TestCase):
         (
             [
                 {
+                    "status": "published",
                     "availability": "Archived",
                     "end": "3000-10-13T13:11:01Z",
                     "enrollment_start": "2014-10-13T13:11:03Z",
                     "enrollment_end": "2999-10-13T13:11:04Z",
                 },
                 {
+                    "status": "published",
                     "availability": "Current",
                     "end": "3000-10-13T13:11:01Z",
                     "enrollment_start": "2014-10-13T13:11:03Z",
@@ -1217,6 +1250,7 @@ class TestEnterpriseUtils(unittest.TestCase):
         (
             [
                 {
+                    "status": "published",
                     "availability": "Current",
                     "end": "3000-10-13T13:11:01Z",
                     "enrollment_start": "2014-10-13T13:11:03Z",
@@ -1228,6 +1262,7 @@ class TestEnterpriseUtils(unittest.TestCase):
         (
             [
                 {
+                    "status": "published",
                     "availability": "Archived",
                     "end": "3000-10-13T13:11:01Z",
                     "enrollment_start": "2014-10-13T13:11:03Z",
@@ -1235,7 +1270,31 @@ class TestEnterpriseUtils(unittest.TestCase):
                 }
             ],
             False,
-        )
+        ),
+        (
+            [
+                {
+                    "status": "published",
+                    "availability": "Current",
+                    "end": "3000-10-13T13:11:01Z",
+                    "enrollment_start": "2014-10-13T13:11:03Z",
+                    "enrollment_end": "2999-10-13T13:11:04Z",
+                }
+            ],
+            True,
+        ),
+        (
+            [
+                {
+                    "status": "unpublished",
+                    "availability": "Current",
+                    "end": "3000-10-13T13:11:01Z",
+                    "enrollment_start": "2014-10-13T13:11:03Z",
+                    "enrollment_end": "2999-10-13T13:11:04Z",
+                }
+            ],
+            False,
+        ),
     )
     @ddt.unpack
     def test_contains_course_run_available_for_enrollment(self, course_runs, expected_enrollment_eligibility):
@@ -1259,6 +1318,18 @@ class TestEnterpriseUtils(unittest.TestCase):
         for an upgrade to the verified track.
         """
         assert utils.is_course_run_upgradeable(course_run) == expected_upgradeability
+
+    @ddt.data(
+        ({"status": "published"}, True),
+        ({"status": "unpublished"}, False)
+    )
+    @ddt.unpack
+    def test_is_course_published(self, course_run, expected_response):
+        """
+        ``is_course_run_published`` returns whether the course run is considered "published"
+        given its metadata structure and values.
+        """
+        assert utils.is_course_run_published(course_run) == expected_response
 
     @ddt.data(
         ({"start": "3000-10-13T13:11:04Z"}, utils.parse_datetime_handle_invalid("3000-10-13T13:11:04Z")),


### PR DESCRIPTION
There are situations where a course run is considered "Current" and included in the API response, however it is flagged as "unpublished".  These runs should not be included in the API response.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
