### PR TITLE
ENT-2964 | Added status key to default content filter for Enter…

### DIFF
--- a/enterprise/constants.py
+++ b/enterprise/constants.py
@@ -86,7 +86,8 @@ DEFAULT_CATALOG_CONTENT_FILTER = {
         'Current',
         'Starting Soon',
         'Upcoming'
-    ]
+    ],
+    'status': 'published'
 }
 
 # Django groups specific to granting permission to enterprise admins.

--- a/enterprise/settings/test.py
+++ b/enterprise/settings/test.py
@@ -196,7 +196,8 @@ ENTERPRISE_CUSTOMER_CATALOG_DEFAULT_CONTENT_FILTER = {
         'Current',
         'Starting Soon',
         'Upcoming'
-    ]
+    ],
+    'status': 'published'
 }
 
 # For testing edx-rbac rules. This is not the actual value of the setting in prod.

--- a/tests/test_enterprise/test_signals.py
+++ b/tests/test_enterprise/test_signals.py
@@ -212,7 +212,8 @@ class TestDefaultContentFilter(unittest.TestCase):
                     'Current',
                     'Starting Soon',
                     'Upcoming'
-                ]
+                ],
+                'status': 'published'
             },
             {
                 'content_type': 'course',
@@ -224,7 +225,8 @@ class TestDefaultContentFilter(unittest.TestCase):
                     'Current',
                     'Starting Soon',
                     'Upcoming'
-                ]
+                ],
+                'status': 'published'
             }
         ),
         # if the value is not set is settings, it picks default value from constant.

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -45,7 +45,7 @@ from enterprise.models import (
     SystemWideEnterpriseUserRoleAssignment,
     logo_path,
 )
-from enterprise.utils import CourseEnrollmentDowngradeError
+from enterprise.utils import CourseEnrollmentDowngradeError, get_default_catalog_content_filter
 from integrated_channels.integrated_channel.models import EnterpriseCustomerPluginConfiguration
 from test_utils import assert_url, assert_url_contains_query_parameters, factories, fake_catalog_api
 
@@ -1276,11 +1276,9 @@ class TestEnterpriseCustomerCatalog(unittest.TestCase):
         mock_catalog_api = mock_catalog_api_class.return_value
         enterprise_catalog = factories.EnterpriseCustomerCatalogFactory()
         enterprise_catalog.get_paginated_content(QueryDict())
-        mock_catalog_api.get_catalog_results.assert_called_with({
-            u'partner': u'edx',
-            u'level_type': [u'Introductory', u'Intermediate', u'Advanced'],
-            u'availability': [u'Current', u'Starting Soon', u'Upcoming'],
-            u'content_type': u'course'}, {"exclude_expired_course_run": True})
+        default_catalog_content_filter = get_default_catalog_content_filter()
+        query_param = {"exclude_expired_course_run": True}
+        mock_catalog_api.get_catalog_results.assert_called_with(default_catalog_content_filter, query_param)
 
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     def test_contains_programs(self, mock_catalog_api_class):


### PR DESCRIPTION
…priseCustomerCatalog.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
