### PR TITLE
ENH: Add validation for content filter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 --------------------
 
+[3.3.5] - 2020-06-16
+---------------------
+
+* Add validation for content_filter subfields in EnterpriseCatalogQuery and EnterpriseCustomerCatalog
+
+
 [3.3.4] - 2020-06-15
 ---------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Change Log
 Unreleased
 --------------------
 
+[3.3.6] - 2020-06-17
 ---------------------
 
 * Add validation for content_filter subfields in EnterpriseCatalogQuery and EnterpriseCustomerCatalog

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "3.3.5"
+__version__ = "3.3.6"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "3.3.4"
+__version__ = "3.3.5"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/constants.py
+++ b/enterprise/constants.py
@@ -128,6 +128,7 @@ CONTENT_FILTER_FIELD_TYPES = {
     'first_enrollable_paid_seat_price__lte': {'type': str}
 }
 
+
 def json_serialized_course_modes():
     """
     :return: serialized course modes.

--- a/enterprise/constants.py
+++ b/enterprise/constants.py
@@ -121,6 +121,12 @@ EDX_ORG_NAME = 'edX, Inc'
 # Waffle flag used to switch over edx-enterprise's usage of the enterprise catalog service
 USE_ENTERPRISE_CATALOG = 'use_enterprise_catalog'
 
+# ContentFilter field types for validation.
+CONTENT_FILTER_FIELD_TYPES = {
+    'key': {'type': list, 'subtype': str},
+    'aggregation_key': {'type': list, 'subtype': str},
+    'first_enrollable_paid_seat_price__lte': {'type': str}
+}
 
 def json_serialized_course_modes():
     """

--- a/enterprise/constants.py
+++ b/enterprise/constants.py
@@ -124,7 +124,6 @@ USE_ENTERPRISE_CATALOG = 'use_enterprise_catalog'
 # ContentFilter field types for validation.
 CONTENT_FILTER_FIELD_TYPES = {
     'key': {'type': list, 'subtype': str},
-    'aggregation_key': {'type': list, 'subtype': str},
     'first_enrollable_paid_seat_price__lte': {'type': str}
 }
 

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -56,7 +56,12 @@ from enterprise.utils import (
     get_ecommerce_worker_user,
     get_enterprise_worker_user,
 )
-from enterprise.validators import validate_hex_color, validate_image_extension, validate_image_size
+from enterprise.validators import (
+    validate_hex_color,
+    validate_image_extension,
+    validate_image_size,
+    validate_content_filter_fields
+)
 
 try:
     from lms.djangoapps.email_marketing.tasks import update_user
@@ -1381,7 +1386,8 @@ class EnterpriseCatalogQuery(TimeStampedModel):
             "Query parameters which will be used to filter the discovery service's search/all endpoint results, "
             "specified as a JSON object. An empty JSON object means that all available content items will be "
             "included in the catalog."
-        )
+        ),
+        validators=[validate_content_filter_fields]
     )
 
     class Meta:
@@ -1444,7 +1450,8 @@ class EnterpriseCustomerCatalog(TimeStampedModel):
             "Query parameters which will be used to filter the discovery service's search/all endpoint results, "
             "specified as a Json object. An empty Json object means that all available content items will be "
             "included in the catalog."
-        )
+        ),
+        validators=[validate_content_filter_fields]
     )
     enabled_course_modes = JSONField(
         default=json_serialized_course_modes,

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -57,10 +57,10 @@ from enterprise.utils import (
     get_enterprise_worker_user,
 )
 from enterprise.validators import (
+    validate_content_filter_fields,
     validate_hex_color,
     validate_image_extension,
     validate_image_size,
-    validate_content_filter_fields
 )
 
 try:

--- a/enterprise/validators.py
+++ b/enterprise/validators.py
@@ -13,6 +13,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from enterprise.constants import CONTENT_FILTER_FIELD_TYPES
 
+
 def get_app_config():
     """
     :return Application configuration.
@@ -52,6 +53,9 @@ def validate_image_size(image):
 
 
 def validate_content_filter_fields(content_filter):
+    """
+    Validate particular fields (if present) passed in through content_filter are certain types.
+    """
     for key in CONTENT_FILTER_FIELD_TYPES:
         if key in content_filter.keys():
             if not isinstance(content_filter[key], CONTENT_FILTER_FIELD_TYPES[key]['type']):

--- a/enterprise/validators.py
+++ b/enterprise/validators.py
@@ -11,6 +11,7 @@ from django.apps import apps
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
 
+from enterprise.constants import CONTENT_FILTER_FIELD_TYPES
 
 def get_app_config():
     """
@@ -48,3 +49,19 @@ def validate_image_size(image):
     if config and not image.size <= valid_max_image_size_in_bytes:
         raise ValidationError(
             _("The logo image file size must be less than or equal to %s KB.") % config.valid_max_image_size)
+
+
+def validate_content_filter_fields(content_filter):
+    for key in CONTENT_FILTER_FIELD_TYPES:
+        if key in content_filter.keys():
+            if not isinstance(content_filter[key], CONTENT_FILTER_FIELD_TYPES[key]['type']):
+                raise ValidationError(
+                    "Content filter '%s' must be of type %s" % (key, CONTENT_FILTER_FIELD_TYPES[key]['type'])
+                )
+            if CONTENT_FILTER_FIELD_TYPES[key]['type'] == list:
+                if not all(isinstance(x, str) for x in content_filter[key]):
+                    raise ValidationError(
+                        "Content filter '%s' must contain values of type %s" % (
+                            key, CONTENT_FILTER_FIELD_TYPES[key]['subtype']
+                        )
+                    )

--- a/enterprise/validators.py
+++ b/enterprise/validators.py
@@ -11,7 +11,7 @@ from django.apps import apps
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
 
-from enterprise.constants import CONTENT_FILTER_FIELD_TYPES
+from enterprise.constants import CONTENT_FILTER_FIELD_TYPES as cftypes
 
 
 def get_app_config():
@@ -56,16 +56,16 @@ def validate_content_filter_fields(content_filter):
     """
     Validate particular fields (if present) passed in through content_filter are certain types.
     """
-    for key in CONTENT_FILTER_FIELD_TYPES:
+    for key in cftypes:
         if key in content_filter.keys():
-            if not isinstance(content_filter[key], CONTENT_FILTER_FIELD_TYPES[key]['type']):
+            if not isinstance(content_filter[key], cftypes[key]['type']):
                 raise ValidationError(
-                    "Content filter '%s' must be of type %s" % (key, CONTENT_FILTER_FIELD_TYPES[key]['type'])
+                    "Content filter '%s' must be of type %s" % (key, cftypes[key]['type'])
                 )
-            if CONTENT_FILTER_FIELD_TYPES[key]['type'] == list:
+            if cftypes[key]['type'] == list:
                 if not all(isinstance(x, str) for x in content_filter[key]):
                     raise ValidationError(
                         "Content filter '%s' must contain values of type %s" % (
-                            key, CONTENT_FILTER_FIELD_TYPES[key]['subtype']
+                            key, cftypes[key]['subtype']
                         )
                     )

--- a/enterprise/validators.py
+++ b/enterprise/validators.py
@@ -63,7 +63,7 @@ def validate_content_filter_fields(content_filter):
                     "Content filter '%s' must be of type %s" % (key, cftypes[key]['type'])
                 )
             if cftypes[key]['type'] == list:
-                if not all(isinstance(x, str) for x in content_filter[key]):
+                if not all(cftypes[key]['subtype'] == type(x) for x in content_filter[key]):
                     raise ValidationError(
                         "Content filter '%s' must contain values of type %s" % (
                             key, cftypes[key]['subtype']

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -34,6 +34,7 @@ from consent.models import DataSharingConsent, ProxyDataSharingConsent
 from enterprise.constants import ENTERPRISE_LEARNER_ROLE, ENTERPRISE_OPERATOR_ROLE, USE_ENTERPRISE_CATALOG
 from enterprise.models import (
     EnrollmentNotificationEmailTemplate,
+    EnterpriseCatalogQuery,
     EnterpriseCourseEnrollment,
     EnterpriseCustomer,
     EnterpriseCustomerBrandingConfiguration,
@@ -1310,6 +1311,32 @@ class TestEnterpriseCustomerCatalog(unittest.TestCase):
         catalog.save()
         self.assertEqual(catalog.get_content_filter(), catalog_query_content_filter)
 
+    @ddt.data(
+        {
+            'content_filter': {'key': 'coursev1:course1'},
+            'error': ["Content filter 'key' must be of type <class 'list'>"]
+        },
+        {
+            'content_filter': {'aggregation_key': 'courserun:course'},
+            'error': ["Content filter 'aggregation_key' must be of type <class 'list'>"],
+        },
+        {
+            'content_filter': {'first_enrollable_paid_seat_price__lte': [12]},
+            'error': ["Content filter 'first_enrollable_paid_seat_price__lte' must be of type <class 'str'>"]
+        },
+        {
+            'content_filter': {'key': [3, 'course']},
+            'error': ["Content filter 'key' must contain values of type <class 'str'>"]
+        }
+    )
+    @ddt.unpack
+    def test_save_content_filter_fail(self, content_filter, error):
+        fail_catalog = factories.EnterpriseCustomerCatalogFactory(content_filter=content_filter)
+        try:
+            fail_catalog.full_clean()
+        except ValidationError as validation_error:
+            assert sorted(validation_error.messages) == sorted(error)
+
 
 @mark.django_db
 @ddt.ddt
@@ -1972,3 +1999,53 @@ class TestSystemWideEnterpriseUserRoleAssignment(unittest.TestCase):
         )
 
         assert enterprise_role_assignment.get_context() == expected_context
+
+
+@mark.django_db
+@ddt.ddt
+class TestEnterpriseCatalogQuery(unittest.TestCase):
+    """
+    Tests for the EnterpriseCatalogQuery model.
+    """
+
+    @ddt.data(
+        {
+            'content_filter': {'key': 'coursev1:course1'},
+            'error': ["Content filter 'key' must be of type <class 'list'>"]
+        },
+        {
+            'content_filter': {'aggregation_key': 'courserun:course'},
+            'error': ["Content filter 'aggregation_key' must be of type <class 'list'>"],
+        },
+        {
+            'content_filter': {'first_enrollable_paid_seat_price__lte': [12]},
+            'error': ["Content filter 'first_enrollable_paid_seat_price__lte' must be of type <class 'str'>"]
+        },
+        {
+            'content_filter': {'key': [3, 'course']},
+            'error': ["Content filter 'key' must contain values of type <class 'str'>"]
+        }
+    )
+    @ddt.unpack
+    def test_save_content_filter_fail(self, content_filter, error):
+        catalog_query = EnterpriseCatalogQuery(content_filter=content_filter)
+        try:
+            catalog_query.full_clean()
+        except ValidationError as validation_error:
+            assert sorted(validation_error.messages) == sorted(error)
+
+    @ddt.data(
+        {
+            'content_filter': {'key': ['coursev1:course1', ]},
+        },
+        {
+            'content_filter': {'aggregation_key': ['courserun:course', ]},
+        },
+        {
+            'content_filter': {'first_enrollable_paid_seat_price__lte': "12"},
+        }
+    )
+    @ddt.unpack
+    def test_save_content_filter_success(self, content_filter):
+        catalog_query = EnterpriseCatalogQuery(content_filter=content_filter)
+        catalog_query.full_clean()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2014,10 +2014,6 @@ class TestEnterpriseCatalogQuery(unittest.TestCase):
             'error': ["Content filter 'key' must be of type <class 'list'>"]
         },
         {
-            'content_filter': {'aggregation_key': 'courserun:course'},
-            'error': ["Content filter 'aggregation_key' must be of type <class 'list'>"],
-        },
-        {
             'content_filter': {'first_enrollable_paid_seat_price__lte': [12]},
             'error': ["Content filter 'first_enrollable_paid_seat_price__lte' must be of type <class 'str'>"]
         },


### PR DESCRIPTION
This adds validation for the content_filter field's subfields (filter keys) in both EnterpriseCatalogQuery and EnterpriseCustomerCatalog.

**WIP** - Tests and the rest of this checklist forthcoming.

This is for ticket [ENT-2828](https://openedx.atlassian.net/browse/ENT-2828) 

**Merge checklist:**
- [X] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files) **_N/A_**
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [X] `make static` has been run to update webpack bundling if any static content was updated **_N/A_**
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)