### PR TITLE
Enrollments endpoint updates to optimize client side frontend learner portal

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 --------------------
 
+[3.3.5] - 2020-06-17
+---------------------
+
+* Update processing of marked_done field slightly for cleaner boolean usage in client
+
 [3.3.4] - 2020-06-15
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "3.3.4"
+__version__ = "3.3.5"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise_learner_portal/api/v1/views.py
+++ b/enterprise_learner_portal/api/v1/views.py
@@ -100,7 +100,7 @@ class EnterpriseCourseEnrollmentView(APIView):
             course_id=course_id
         )
 
-        # TODO: For now, this makes the change backward compatible, we will change this to true boolean support 
+        # TODO: For now, this makes the change backward compatible, we will change this to true boolean support
         enterprise_enrollment.marked_done = marked_done.lower() == 'true'
         enterprise_enrollment.save()
 

--- a/enterprise_learner_portal/api/v1/views.py
+++ b/enterprise_learner_portal/api/v1/views.py
@@ -100,7 +100,8 @@ class EnterpriseCourseEnrollmentView(APIView):
             course_id=course_id
         )
 
-        enterprise_enrollment.marked_done = marked_done
+        # TODO: change client to use patch body and then process this as proper boolean
+        enterprise_enrollment.marked_done = marked_done == 'true'
         enterprise_enrollment.save()
 
         course_overviews = get_course_overviews([course_id])

--- a/enterprise_learner_portal/api/v1/views.py
+++ b/enterprise_learner_portal/api/v1/views.py
@@ -100,8 +100,8 @@ class EnterpriseCourseEnrollmentView(APIView):
             course_id=course_id
         )
 
-        # TODO: change client to use patch body and then process this as proper boolean
-        enterprise_enrollment.marked_done = marked_done == 'true'
+        # TODO: For now, this makes the change backward compatible, we will change this to true boolean support 
+        enterprise_enrollment.marked_done = marked_done.lower() == 'true'
         enterprise_enrollment.save()
 
         course_overviews = get_course_overviews([course_id])

--- a/enterprise_learner_portal/utils.py
+++ b/enterprise_learner_portal/utils.py
@@ -43,7 +43,9 @@ def get_course_run_status(course_overview, certificate_info, enterprise_enrollme
     is_certificate_passing = certificate_info.get('is_passing', False)
     certificate_creation_date = certificate_info.get('created', datetime.max)
 
-    if enterprise_enrollment and enterprise_enrollment.marked_done:
+    if enterprise_enrollment and enterprise_enrollment.marked_done is False:
+        return CourseRunProgressStatuses.IN_PROGRESS
+    if enterprise_enrollment and enterprise_enrollment.marked_done is True:
         return CourseRunProgressStatuses.COMPLETED
     if course_overview['pacing'] == 'instructor':
         if course_overview['has_ended']:

--- a/enterprise_learner_portal/utils.py
+++ b/enterprise_learner_portal/utils.py
@@ -43,9 +43,7 @@ def get_course_run_status(course_overview, certificate_info, enterprise_enrollme
     is_certificate_passing = certificate_info.get('is_passing', False)
     certificate_creation_date = certificate_info.get('created', datetime.max)
 
-    if enterprise_enrollment and enterprise_enrollment.marked_done is False:
-        return CourseRunProgressStatuses.IN_PROGRESS
-    if enterprise_enrollment and enterprise_enrollment.marked_done is True:
+    if enterprise_enrollment and enterprise_enrollment.marked_done:
         return CourseRunProgressStatuses.COMPLETED
     if course_overview['pacing'] == 'instructor':
         if course_overview['has_ended']:

--- a/tests/test_enterprise_learner_portal/api/test_views.py
+++ b/tests/test_enterprise_learner_portal/api/test_views.py
@@ -161,7 +161,7 @@ class TestEnterpriseCourseEnrollmentView(TestCase):
         query_params = {
             'enterprise_id': str(self.enterprise_customer.uuid),
             'course_id': self.course_run_id,
-            'marked_done': 'true',
+            'marked_done': True,
         }
 
         assert not self.enterprise_enrollment.marked_done

--- a/tests/test_enterprise_learner_portal/api/test_views.py
+++ b/tests/test_enterprise_learner_portal/api/test_views.py
@@ -161,7 +161,7 @@ class TestEnterpriseCourseEnrollmentView(TestCase):
         query_params = {
             'enterprise_id': str(self.enterprise_customer.uuid),
             'course_id': self.course_run_id,
-            'marked_done': True,
+            'marked_done': 'true',
         }
 
         assert not self.enterprise_enrollment.marked_done
@@ -190,7 +190,7 @@ class TestEnterpriseCourseEnrollmentView(TestCase):
         query_params_full = {
             'enterprise_id': str(self.enterprise_customer.uuid),
             'course_id': self.course_run_id,
-            'marked_done': True,
+            'marked_done': 'true',
         }
         for key in query_params_full:
             query_params = query_params_full.copy()
@@ -218,7 +218,7 @@ class TestEnterpriseCourseEnrollmentView(TestCase):
         query_params = {
             'enterprise_id': str(uuid.uuid4()),
             'course_id': self.course_run_id,
-            'marked_done': True,
+            'marked_done': 'true',
         }
 
         resp = self.client.patch(


### PR DESCRIPTION
This change allows the client learner portal to simply use a boolean field true instead of a string based field, it does come at the cost of an extra string compare in backend but it used to be implicit now I explicitly check for case insensitive 'true' so works for both current and new usages 

## Ephemeral change: Process marked_done as a string 'true' or 'false' which matches the boolean type to be used in client side code.
This change will allow the client side code to be optimized to use boolean for marked_done rather than a string.
This is incremental and in near future we will update it to use patch body and process this field as boolean. right now it gets a string 'true' or 'false' due to string based payload. See https://github.com/edx/frontend-app-learner-portal-enterprise/pull/27



Fixes: ENT-3047

## Blocks
https://github.com/edx/frontend-app-learner-portal-enterprise/pull/27

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files) : N/A
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [X] `make static` has been run to update webpack bundling if any static content was updated N/A
- [X] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [X] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [X] Translations updated N/A

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
