### PR TITLE
Re-direct to success url, not dashboard

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 --------------------
 
+[3.3.13] - 2020-06-29
+---------------------
+
+* Changed GrantDataSharingPermission to redirect to the intended course instead of dashboard, if consent is not required
+
 [3.3.12] - 2020-06-27
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.3.12"
+__version__ = "3.3.13"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -690,7 +690,8 @@ class GrantDataSharingPermissions(View):
                     )
                 )
                 LOGGER.info(log_message)
-                return redirect(LMS_DASHBOARD_URL)
+                redirect_url = success_url if success_url is not None else LMS_DASHBOARD_URL
+                return redirect(redirect_url)
             enterprise_customer = consent_record.enterprise_customer
         elif not request.user.is_staff:
             raise PermissionDenied()

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -690,7 +690,7 @@ class GrantDataSharingPermissions(View):
                     )
                 )
                 LOGGER.info(log_message)
-                redirect_url = success_url if success_url is not None else LMS_DASHBOARD_URL
+                redirect_url = success_url if success_url else LMS_DASHBOARD_URL
                 return redirect(redirect_url)
             enterprise_customer = consent_record.enterprise_customer
         elif not request.user.is_staff:


### PR DESCRIPTION
Rather than redirect to the dashboard if consent is not required
for a course, instead redirect to the success url, as if consent
had been granted. Otherwise, the course is inaccessible.

ENT-3049

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [x] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
