### PR TITLE
override enrollment attributes for enterprise learners

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 --------------------
 
+[3.3.8] - 2020-06-23
+---------------------
+
+* Add support to override enrollment attributes for learners
+
 [3.3.7] - 2020-06-19
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "3.3.7"
+__version__ = "3.3.8"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/admin/utils.py
+++ b/enterprise/admin/utils.py
@@ -81,6 +81,34 @@ class ValidationMessages:
     )
 
 
+def validate_csv(file_stream, expected_columns=None):
+    """
+    Validate csv file for encoding and expected header.
+
+    Args:
+        file_stream: input file
+        expected_columns: list of column names that are expected to be present in csv
+
+    Returns:
+       reader: an iterable for csv datat if csv passes the validation
+
+    Raises:
+        ValidationError
+    """
+    try:
+        reader = unicodecsv.DictReader(file_stream, encoding="utf-8")
+        reader_fieldnames = reader.fieldnames
+    except (unicodecsv.Error, UnicodeDecodeError):
+        raise ValidationError(ValidationMessages.INVALID_ENCODING)
+
+    if expected_columns and set(expected_columns) - set(reader_fieldnames):
+        raise ValidationError(ValidationMessages.MISSING_EXPECTED_COLUMNS.format(
+            expected_columns=", ".join(expected_columns), actual_columns=", ".join(reader.fieldnames)
+        ))
+
+    return reader
+
+
 def parse_csv(file_stream, expected_columns=None):
     """
     Parse csv file and return a stream of dictionaries representing each row.
@@ -94,16 +122,7 @@ def parse_csv(file_stream, expected_columns=None):
     Yields:
         dict: CSV line parsed into a dictionary.
     """
-    try:
-        reader = unicodecsv.DictReader(file_stream, encoding="utf-8")
-        reader_fieldnames = reader.fieldnames
-    except (unicodecsv.Error, UnicodeDecodeError):
-        raise ValidationError(ValidationMessages.INVALID_ENCODING)
-
-    if expected_columns and set(expected_columns) - set(reader_fieldnames):
-        raise ValidationError(ValidationMessages.MISSING_EXPECTED_COLUMNS.format(
-            expected_columns=", ".join(expected_columns), actual_columns=", ".join(reader.fieldnames)
-        ))
+    reader = validate_csv(file_stream, expected_columns)
 
     # "yield from reader" would be nicer, but we're on python2.7 yet.
     for row in reader:

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -1251,6 +1251,8 @@ class EnterpriseCourseEnrollment(TimeStampedModel):
     class Meta:
         unique_together = (('enterprise_customer_user', 'course_id',),)
         app_label = 'enterprise'
+        verbose_name = _('Enterprise Course Enrollment')
+        verbose_name_plural = _('Enterprise Course Enrollments')
         ordering = ['created']
 
     enterprise_customer_user = models.ForeignKey(

--- a/enterprise/templates/enterprise/admin/enterprise_course_enrollments_list.html
+++ b/enterprise/templates/enterprise/admin/enterprise_course_enrollments_list.html
@@ -1,0 +1,8 @@
+{% extends 'admin/change_list.html' %}
+
+{% block object-tools-items %}
+    {% if attr_override_button %}
+      <li><a href="override_attributes/">Override Enrollment Attributes</a></li>
+    {% endif %}
+    {{ block.super }}
+{% endblock %}


### PR DESCRIPTION
**Description:** Provides a way to override enrollment attributes for learners.

**JIRA:** [ENT-2998](https://openedx.atlassian.net/browse/ENT-2998)

**Dependency:** https://github.com/edx/edx-platform/pull/24283 

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
- [ ] Version pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
