### PR TITLE
ENT-2996 Restoring enterprise catalog functionality back to where it was originally

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 --------------------
 
+[3.3.11] - 2020-06-25
+---------------------
+
+* Restore EnterpriseCatalogQuery functionality to previous state.
+
 [3.3.10] - 2020-06-24
 ---------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "3.3.10"
+__version__ = "3.3.11"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/admin/__init__.py
+++ b/enterprise/admin/__init__.py
@@ -55,7 +55,7 @@ from enterprise.models import (
     PendingEnterpriseCustomerUser,
     SystemWideEnterpriseUserRoleAssignment,
 )
-from enterprise.utils import get_all_field_names, get_default_catalog_content_filter
+from enterprise.utils import discovery_query_url, get_all_field_names, get_default_catalog_content_filter
 
 try:
     from enterprise.api_client.enterprise_catalog import EnterpriseCatalogApiClient
@@ -592,22 +592,18 @@ class EnterpriseCatalogQueryAdmin(admin.ModelAdmin):
 
     list_display = (
         'title',
-        'preview_catalog_url'
+        'discovery_query_url'
     )
 
-    def preview_catalog_url(self, obj):
+    def discovery_query_url(self, obj):
         """
-        Return enterprise catalog url for preview.
+        Return discovery url for preview.
         """
-        catalog_content_metadata_url = \
-            EnterpriseCatalogApiClient.get_content_metadata_url(obj.uuid)
-        return format_html(
-            '<a href="{url}" target="_blank">Preview</a>',
-            url=catalog_content_metadata_url
-        )
+        return discovery_query_url(obj.content_filter)
 
-    readonly_fields = ('preview_catalog_url',)
-    preview_catalog_url.short_description = 'Preview Catalog Courses'
+    readonly_fields = ('discovery_query_url',)
+    discovery_query_url.allow_tags = True
+    discovery_query_url.short_description = 'Preview Catalog Courses'
 
 
 @admin.register(EnterpriseCustomerCatalog)
@@ -619,6 +615,9 @@ class EnterpriseCustomerCatalogAdmin(admin.ModelAdmin):
 
     class Meta:
         model = EnterpriseCustomerCatalog
+
+    class Media:
+        js = ('enterprise/admin/enterprise_customer_catalog.js',)
 
     list_display = (
         'uuid_nowrap',

--- a/enterprise/api/v1/urls.py
+++ b/enterprise/api/v1/urls.py
@@ -28,6 +28,11 @@ router.register(
 
 urlpatterns = [
     url(
+        r'^enterprise_catalog_query/(?P<catalog_query_id>[\d]+)/$',
+        views.CatalogQueryView.as_view(),
+        name='enterprise-catalog-query'
+    ),
+    url(
         r'^request_codes$',
         views.CouponCodesView.as_view(),
         name='request-codes'

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -16,7 +16,7 @@ from rest_framework.decorators import detail_route, list_route
 from rest_framework.exceptions import NotFound
 from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
-from rest_framework.status import HTTP_200_OK, HTTP_400_BAD_REQUEST, HTTP_500_INTERNAL_SERVER_ERROR
+from rest_framework.status import HTTP_200_OK, HTTP_400_BAD_REQUEST, HTTP_404_NOT_FOUND, HTTP_500_INTERNAL_SERVER_ERROR
 from rest_framework.views import APIView
 from rest_framework_xml.renderers import XMLRenderer
 from six.moves.urllib.parse import quote_plus, unquote  # pylint: disable=import-error,ungrouped-imports
@@ -488,6 +488,26 @@ class EnterpriseCustomerReportingConfigurationViewSet(EnterpriseReadWriteModelVi
     def destroy(self, request, *args, **kwargs):
         # pylint: disable=no-member
         return super(EnterpriseCustomerReportingConfigurationViewSet, self).destroy(request, *args, **kwargs)
+
+
+class CatalogQueryView(APIView):
+    """
+    View for enterprise catalog query.
+    This will be called from django admin tool to populate `content_filter` field of `EnterpriseCustomerCatalog` model.
+    """
+    authentication_classes = [SessionAuthentication]
+    permission_classes = [permissions.IsAuthenticated, permissions.IsAdminUser]
+    http_method_names = ['get']
+
+    def get(self, request, catalog_query_id):
+        """
+        API endpoint for fetching an enterprise catalog query.
+        """
+        try:
+            catalog_query = models.EnterpriseCatalogQuery.objects.get(pk=catalog_query_id)
+        except models.EnterpriseCatalogQuery.DoesNotExist:
+            return Response({"detail": "Could not find enterprise catalog query."}, status=HTTP_404_NOT_FOUND)
+        return Response(catalog_query.content_filter, status=HTTP_200_OK)
 
 
 class CouponCodesView(APIView):

--- a/enterprise/static/enterprise/admin/enterprise_customer_catalog.js
+++ b/enterprise/static/enterprise/admin/enterprise_customer_catalog.js
@@ -1,0 +1,28 @@
+(function($){
+    $(document).ready(function(){
+        var catalogQueryId,
+            // Django admin does auto form filling once the form is loaded.
+            // We want to ignore the first two "on change event on enterprise_catalog_query dropdown".
+            // The reason to ignore this is for the case when we might have manually updated the
+            // content_filter field and when loading the admin page, Django populates the form, fills the
+            // dropdown field, which will trigger an "on change event on enterprise_catalog_query dropdown".
+            numTriggeredUpdates = 0,
+            catalogQueryApiUrl = '/enterprise/api/v1/enterprise_catalog_query/',
+            $contentFilterEl = $('#id_content_filter');
+
+        $("[name='enterprise_catalog_query']").on("change", function(event){
+            catalogQueryId = $(event.target).val();
+            if (numTriggeredUpdates > 1 && catalogQueryId) {
+                // Extract content_filter for the selected catalogQueryId.
+                $.ajax({
+                    url: catalogQueryApiUrl + catalogQueryId + '/',
+                    method: "get"
+                }).done(function (catalogQueryResponse) {
+                    $contentFilterEl.val(JSON.stringify(catalogQueryResponse));
+                });
+            }
+            // Turn on the logic to extract content_filter.
+            numTriggeredUpdates += 1;
+        }).change();
+    });
+})(jQuery);

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -36,6 +36,7 @@ from enterprise.constants import (
     ENTERPRISE_REPORTING_CONFIG_ADMIN_ROLE,
 )
 from enterprise.models import (
+    EnterpriseCatalogQuery,
     EnterpriseCourseEnrollment,
     EnterpriseCustomerUser,
     EnterpriseEnrollmentSource,
@@ -1971,6 +1972,78 @@ class TestEnterpriseAPIViews(APITest):
 
         response_xml = self.client.get('/enterprise/api/v1/enterprise_catalogs.xml')
         self.assertEqual(response_xml['content-type'], 'application/xml; charset=utf-8')
+
+    def test_get_catalog_query(self):
+        """
+        Test that `CatalogQueryView` returns expected response.
+        """
+        expected_content_filter = {'partner': 'MushiX'}
+        catalog_query = EnterpriseCatalogQuery.objects.create(
+            title='Test Catalog Query',
+            content_filter=expected_content_filter
+        )
+        response = self.client.get(
+            settings.TEST_SERVER + reverse('enterprise-catalog-query', kwargs={'catalog_query_id': catalog_query.id})
+        )
+        assert response.status_code == 200
+        assert response.json() == expected_content_filter
+
+    def test_get_catalog_query_not_found(self):
+        """
+        Test that `CatalogQueryView` returns correct response when enterprise catalog query is not found.
+        """
+        non_existed_id = 100
+        response = self.client.get(
+            settings.TEST_SERVER + reverse('enterprise-catalog-query', kwargs={'catalog_query_id': non_existed_id})
+        )
+        assert response.status_code == 404
+        response = response.json()
+        assert response['detail'] == 'Could not find enterprise catalog query.'
+
+    def test_get_catalog_query_post_method_not_allowed(self):
+        """
+        Test that `CatalogQueryView` does not allow POST method.
+        """
+        response = self.client.post(
+            settings.TEST_SERVER + reverse('enterprise-catalog-query', kwargs={'catalog_query_id': 1}),
+            data=json.dumps({'current_troll_hunter': 'Jim Lake Jr.'}),
+            content_type='application/json'
+        )
+        assert response.status_code == 405
+        response = response.json()
+        assert response['detail'] == 'Method "POST" not allowed.'
+
+    def test_get_catalog_query_not_staff(self):
+        """
+        Test that `CatalogQueryView` does not allow non staff users.
+        """
+        # Creating a non staff user so as to verify the insufficient permission conditions.
+        user = factories.UserFactory(username='test_user', is_active=True, is_staff=False)
+        user.set_password('test_password')  # pylint: disable=no-member
+        user.save()  # pylint: disable=no-member
+
+        client = APIClient()
+        client.login(username='test_user', password='test_password')
+        response = client.get(
+            settings.TEST_SERVER + reverse('enterprise-catalog-query', kwargs={'catalog_query_id': 1})
+        )
+
+        assert response.status_code == 403
+        response = response.json()
+        assert response['detail'] == 'You do not have permission to perform this action.'
+
+    def test_get_catalog_query_not_logged_in(self):
+        """
+        Test that `CatalogQueryView` only allows logged in users.
+        """
+        client = APIClient()
+        # User is not logged in.
+        response = client.get(
+            settings.TEST_SERVER + reverse('enterprise-catalog-query', kwargs={'catalog_query_id': 1})
+        )
+        assert response.status_code == 403
+        response = response.json()
+        assert response['detail'] == 'Authentication credentials were not provided.'
 
     @mock.patch('django.core.mail.send_mail')
     @ddt.data(


### PR DESCRIPTION
Between ENT-2845 and ENT-2577, we've unintentionally broken the saved EnterpriseCatalogQuery functionality.
This PR is selectively restoring it so that it behaves as it did before those changes and
is compatible with the new Enterprise Catalog Service.

**Related PRs:** 
https://github.com/edx/edx-enterprise/pull/776
https://github.com/edx/edx-enterprise/pull/763

**Testing instructions:**
Loading EnterpriseCatalogQuery django admin does not result in a 500 error and behaves normally (ie can create, update, and delete EnterpriseCatalogQueries.
Go to the EnterpriseCustomerCatalog django admin. When creating or updating a catalog from this django admin view (not the inline view for EnterpriseCustomers), you should be able to select an EnterpriseCatalogQuery and see the content filter updated to match that query when selected. You should be able to edit that content filter field if desired. What is entered in the content filter text area is what gets saved to the data model.

Note that this behavior does not happen in the inline catalog form on the EnterpriseCustomer django admin page. After some digging, I'm pretty sure it never worked on that page so I did not attempt to "restore" the functionality there in this PR. This PR merely introduces back selectively code that was removed but previously existed.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as a `make upgrade` in edx-platform will look for the latest version in PyPi.
