### PR TITLE
handle when subjects is a list of dicts or list of strings for Cornerstone content exporter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 --------------------
 
+[3.3.21] - 2020-07-10
+---------------------
+
+* Gracefully handle when list of subjects for content metadata contains either a list of strings and list of dictionaries
+
+
 [3.3.20] - 2020-07-09
 ---------------------
 * Added new SAML Config option to EnterpriseCustomer in Django admin.

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.3.20"
+__version__ = "3.3.21"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/cornerstone/exporters/content_metadata.py
+++ b/integrated_channels/cornerstone/exporters/content_metadata.py
@@ -12,7 +12,11 @@ from django.apps import apps
 
 from enterprise.utils import get_closest_course_run, get_language_code
 from integrated_channels.integrated_channel.exporters.content_metadata import ContentMetadataExporter
-from integrated_channels.utils import get_duration_from_estimated_hours, get_image_url
+from integrated_channels.utils import (
+    get_duration_from_estimated_hours,
+    get_image_url,
+    get_subjects_from_content_metadata,
+)
 
 LOGGER = getLogger(__name__)
 
@@ -130,7 +134,7 @@ class CornerstoneContentMetadataExporter(ContentMetadataExporter):  # pylint: di
         Return the transformed version of the course subject list or default value if no subject found.
         """
         subjects = []
-        course_subjects = content_metadata_item.get('subjects') or []
+        course_subjects = get_subjects_from_content_metadata(content_metadata_item)
         CornerstoneGlobalConfiguration = apps.get_model(  # pylint: disable=invalid-name
             'cornerstone',
             'CornerstoneGlobalConfiguration'

--- a/integrated_channels/utils.py
+++ b/integrated_channels/utils.py
@@ -191,3 +191,31 @@ def get_duration_from_estimated_hours(estimated_hours):
         return duration
 
     return None
+
+
+def get_subjects_from_content_metadata(content_metadata_item):
+    """
+    Returns a list of subject names for the content metadata item. Subjects are represented
+    by either:
+      - list of strings, e.g. ['Communication']
+      - list of objects, e.g. [{'name': 'Communication'}]
+
+    Arguments:
+        - content_metadata_item (dict): a dictionary for the content metadata item
+
+    Returns:
+        - list: a list of subject names as strings
+    """
+    metadata_subjects = content_metadata_item.get('subjects') or []
+    subjects = set()
+
+    for subject in metadata_subjects:
+        if isinstance(subject, str):
+            subjects.add(subject)
+            continue
+
+        subject_name = subject.get('name')
+        if subject_name:
+            subjects.add(subject_name)
+
+    return list(subjects)

--- a/integrated_channels/utils.py
+++ b/integrated_channels/utils.py
@@ -196,7 +196,7 @@ def get_duration_from_estimated_hours(estimated_hours):
 def get_subjects_from_content_metadata(content_metadata_item):
     """
     Returns a list of subject names for the content metadata item.
-    
+
     Subjects in the content metadata item are represented by either:
       - a list of strings, e.g. ['Communication']
       - a list of objects, e.g. [{'name': 'Communication'}]

--- a/integrated_channels/utils.py
+++ b/integrated_channels/utils.py
@@ -195,10 +195,11 @@ def get_duration_from_estimated_hours(estimated_hours):
 
 def get_subjects_from_content_metadata(content_metadata_item):
     """
-    Returns a list of subject names for the content metadata item. Subjects are represented
-    by either:
-      - list of strings, e.g. ['Communication']
-      - list of objects, e.g. [{'name': 'Communication'}]
+    Returns a list of subject names for the content metadata item.
+    
+    Subjects in the content metadata item are represented by either:
+      - a list of strings, e.g. ['Communication']
+      - a list of objects, e.g. [{'name': 'Communication'}]
 
     Arguments:
         - content_metadata_item (dict): a dictionary for the content metadata item

--- a/tests/test_integrated_channels/test_cornerstone/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_cornerstone/test_exporters/test_content_metadata.py
@@ -509,6 +509,17 @@ class TestCornerstoneContentMetadataExporter(unittest.TestCase, EnterpriseMockMi
             },
             ["Industry Specific"]
         ),
+        (
+            {
+                'subjects': [
+                    {'name': 'Computer Science'},
+                    {'name': 'Communication'},
+                    {'name': 'Music'},
+                    {'name': 'Design'},
+                ],
+            },
+            ["Technology", "Business Skills", "Creative"],
+        ),
     )
     @responses.activate
     @ddt.unpack


### PR DESCRIPTION
Ticket: https://openedx.atlassian.net/browse/ENT-3145

There is an error parsing the list of subjects that the LMS gets back from enterprise-catalog when transmitting content metadata to Cornerstone:
```
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/integrated_channels/cornerstone/exporters/content_metadata.py", line 141, in transform_subjects
    if subject.lower() in [edx_subject.lower() for edx_subject in edx_subjects]:
AttributeError: 'dict' object has no attribute 'lower'
```

Cornerstone's integrated channel content exporter parses the metadata it gets back from the `get_content_metadata` endpoint in enterprise-catalog. We store this metadata in the enterprise-catalog DB from Discovery's `/api/v1/search/all` endpoint, which has `subjects` as a list of strings. Then, we "override" the metadata with the full course metadata (from Discovery's `/api/v1/courses` endpoint), which has `subjects` as a list of dicts (not strings).

This means the `get_content_metadata` endpoint in enterprise-catalog now returns `subjects` as a list of objects where edx-enterprise is expecting a list of strings, thus throwing the above exception.

This PR makes the Cornerstone content exporter more flexible by handling when `subjects` is either a list of strings or a list of dicts, which contain a `name` attribute.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
