### PR TITLE
Admin dashboard rules predicates now pass an object into the edx-rbac utility functions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 --------------------
 
+[3.3.18] - 2020-07-07
+---------------------
+* Admin dashboard rules predicates now pass an object into the edx-rbac utility functions.
+
 [3.3.17] - 2020-07-07
 ---------------------
 * Created LicensedEnterpriseCourseEnrollment.

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.3.17"
+__version__ = "3.3.18"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/rules.py
+++ b/enterprise/rules.py
@@ -22,18 +22,26 @@ def has_implicit_access_to_dashboard(user, obj):  # pylint: disable=unused-argum
     """
     Check that if request user has implicit access to `ENTERPRISE_DASHBOARD_ADMIN_ROLE` feature role.
 
+    Params:
+        user: An ``auth.User`` instance.
+        obj: An ``EnterpriseCustomer`` instance.
+
     Returns:
         boolean: whether the request user has access or not
     """
     request = crum.get_current_request()
     decoded_jwt = get_decoded_jwt(request) or get_decoded_jwt_from_auth(request)
-    return request_user_has_implicit_access_via_jwt(decoded_jwt, ENTERPRISE_DASHBOARD_ADMIN_ROLE)
+    return request_user_has_implicit_access_via_jwt(decoded_jwt, ENTERPRISE_DASHBOARD_ADMIN_ROLE, obj)
 
 
 @rules.predicate
-def has_explicit_access_to_dashboard(user, obj):  # pylint: disable=unused-argument
+def has_explicit_access_to_dashboard(user, obj):
     """
     Check that if request user has explicit access to `ENTERPRISE_DASHBOARD_ADMIN_ROLE` feature role.
+
+    Params:
+        user: An ``auth.User`` instance.
+        obj: An ``EnterpriseCustomer`` instance.
 
     Returns:
         boolean: whether the request user has access or not
@@ -41,7 +49,8 @@ def has_explicit_access_to_dashboard(user, obj):  # pylint: disable=unused-argum
     return user_has_access_via_database(
         user,
         ENTERPRISE_DASHBOARD_ADMIN_ROLE,
-        EnterpriseFeatureUserRoleAssignment
+        EnterpriseFeatureUserRoleAssignment,
+        obj,
     )
 
 
@@ -49,6 +58,10 @@ def has_explicit_access_to_dashboard(user, obj):  # pylint: disable=unused-argum
 def has_implicit_access_to_catalog(user, obj):  # pylint: disable=unused-argument
     """
     Check that if request user has implicit access to `ENTERPRISE_CATALOG_ADMIN_ROLE` feature role.
+
+    Params:
+        user: An ``auth.User`` instance.
+        obj: An ``EnterpriseCustomer`` instance.
 
     Returns:
         boolean: whether the request user has access or not
@@ -63,6 +76,10 @@ def has_explicit_access_to_catalog(user, obj):
     """
     Check that if request user has explicit access to `ENTERPRISE_CATALOG_ADMIN_ROLE` feature role.
 
+    Params:
+        user: An ``auth.User`` instance.
+        obj: An ``EnterpriseCustomer`` instance.
+
     Returns:
         boolean: whether the request user has access or not
     """
@@ -70,7 +87,7 @@ def has_explicit_access_to_catalog(user, obj):
         user,
         ENTERPRISE_CATALOG_ADMIN_ROLE,
         EnterpriseFeatureUserRoleAssignment,
-        obj
+        obj,
     )
 
 
@@ -78,6 +95,10 @@ def has_explicit_access_to_catalog(user, obj):
 def has_implicit_access_to_enrollment_api(user, obj):  # pylint: disable=unused-argument
     """
     Check that if request user has implicit access to `ENTERPRISE_ENROLLMENT_API_ADMIN_ROLE` feature role.
+
+    Params:
+        user: An ``auth.User`` instance.
+        obj: An ``EnterpriseCustomer`` instance.
 
     Returns:
         boolean: whether the request user has access or not
@@ -92,6 +113,10 @@ def has_explicit_access_to_enrollment_api(user, obj):
     """
     Check that if request user has explicit access to `ENTERPRISE_ENROLLMENT_API_ADMIN_ROLE` feature role.
 
+    Params:
+        user: An ``auth.User`` instance.
+        obj: An ``EnterpriseCustomer`` instance.
+
     Returns:
         boolean: whether the request user has access or not
     """
@@ -99,7 +124,7 @@ def has_explicit_access_to_enrollment_api(user, obj):
         user,
         ENTERPRISE_ENROLLMENT_API_ADMIN_ROLE,
         EnterpriseFeatureUserRoleAssignment,
-        obj
+        obj,
     )
 
 
@@ -107,6 +132,10 @@ def has_explicit_access_to_enrollment_api(user, obj):
 def has_implicit_access_to_reporting_api(user, obj):  # pylint: disable=unused-argument
     """
     Check that if request user has implicit access to `ENTERPRISE_REPORTING_CONFIG_ADMIN_ROLE` feature role.
+
+    Params:
+        user: An ``auth.User`` instance.
+        obj: An ``EnterpriseCustomer`` instance.
 
     Returns:
         boolean: whether the request user has access or not
@@ -121,6 +150,10 @@ def has_explicit_access_to_reporting_api(user, obj):
     """
     Check that if request user has explicit access to `ENTERPRISE_REPORTING_CONFIG_ADMIN_ROLE` feature role.
 
+    Params:
+        user: An ``auth.User`` instance.
+        obj: An ``EnterpriseCustomer`` instance.
+
     Returns:
         boolean: whether the request user has access or not
     """
@@ -128,7 +161,7 @@ def has_explicit_access_to_reporting_api(user, obj):
         user,
         ENTERPRISE_REPORTING_CONFIG_ADMIN_ROLE,
         EnterpriseFeatureUserRoleAssignment,
-        obj
+        obj,
     )
 
 


### PR DESCRIPTION
We have other mechanisms for restricting the set of objects visible to an enterprise-linked user; for example, on the enterprise catalog endpoint, there is a filter that only returns results of enterprises the user is linked to, and returns everything if they're staff.  This change should help us not have to worry about doing that kind of filtering in other views that require the `can_access_admin_dashboard` permission.

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [x] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
