### PR TITLE
ENT-3139 New viewset/endpoint to create PendingEnterpriseCustomerUser records

### DIFF
--- a/enterprise/api/v1/urls.py
+++ b/enterprise/api/v1/urls.py
@@ -14,6 +14,7 @@ router.register("enterprise_catalogs", views.EnterpriseCustomerCatalogViewSet, '
 router.register("enterprise-course-enrollment", views.EnterpriseCourseEnrollmentViewSet, 'enterprise-course-enrollment')
 router.register("enterprise-customer", views.EnterpriseCustomerViewSet, 'enterprise-customer')
 router.register("enterprise-learner", views.EnterpriseCustomerUserViewSet, 'enterprise-learner')
+router.register("pending-enterprise-learner", views.PendingEnterpriseCustomerUserViewSet, 'pending-enterprise-learner')
 router.register(
     "enterprise-customer-branding",
     views.EnterpriseCustomerBrandingConfigurationViewSet,

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -12,7 +12,7 @@ from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthenticat
 from rest_framework import filters, permissions, status, viewsets
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.decorators import detail_route, list_route
-from rest_framework.exceptions import NotFound
+from rest_framework.exceptions import NotFound, ValidationError
 from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 from rest_framework.status import HTTP_200_OK, HTTP_400_BAD_REQUEST, HTTP_404_NOT_FOUND, HTTP_500_INTERNAL_SERVER_ERROR
@@ -263,6 +263,50 @@ class EnterpriseCustomerUserViewSet(EnterpriseReadWriteModelViewSet):
         if self.request.method in ('GET',):
             return serializers.EnterpriseCustomerUserReadOnlySerializer
         return serializers.EnterpriseCustomerUserWriteSerializer
+
+
+class PendingEnterpriseCustomerUserViewSet(EnterpriseReadWriteModelViewSet):
+    """
+    API views for the ``pending-enterprise-learner`` API endpoint.
+    """
+
+    queryset = models.PendingEnterpriseCustomerUser.objects.all()
+    filter_backends = (filters.OrderingFilter, DjangoFilterBackend)
+    serializer_class = serializers.PendingEnterpriseCustomerUserSerializer
+    permission_classes = (permissions.IsAuthenticated, permissions.IsAdminUser)
+
+    FIELDS = (
+        'enterprise_customer', 'user_email',
+    )
+    filterset_fields = FIELDS
+    ordering_fields = FIELDS
+
+    def create(self, request, *args, **kwargs):
+        serializer = self.get_serializer(data=request.data)
+        try:
+            serializer.is_valid(raise_exception=True)
+        except ValidationError as validation_error:
+            return_status = None
+            if 'user_email' in serializer.errors:
+                for error in serializer.errors['user_email']:
+                    # This error indicates that a PendingEnterpriseCustomerUser already exists.
+                    if error.code == 'unique':
+                        return_status = status.HTTP_204_NO_CONTENT
+                        break
+            elif 'non_field_errors' in serializer.errors:
+                for error in serializer.errors['non_field_errors']:
+                    # This error indicates that an EnterpriseCustomerUser already exists.
+                    if str(error) == 'EnterpriseCustomerUser record already exists':
+                        return_status = status.HTTP_204_NO_CONTENT
+                        break
+
+            if not return_status:
+                raise validation_error
+        else:
+            created = serializer.save()
+            return_status = status.HTTP_201_CREATED if created else status.HTTP_204_NO_CONTENT
+        headers = self.get_success_headers(serializer.data)
+        return Response(serializer.data, status=return_status, headers=headers)
 
 
 class EnterpriseCustomerBrandingConfigurationViewSet(EnterpriseReadOnlyModelViewSet):


### PR DESCRIPTION
This viewset has some special logic to ensure that if the endpoint is called with data that already exists as either a PendingEnterpriseCustomerUser or EnterpriseCustomerUser, we return a 204 No Content. Without this, DRF would just return 400.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
