### PR TITLE
Add enterprise proxy login view

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 --------------------
 
+[3.4.26] 2020-07-20
+-------------------
+
+* Adds proxy login view to allow unauthenticated enterprise learners to login via existing flow from the learner portal.
+
 [3.3.26] 2020-07-17
 -------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.3.26"
+__version__ = "3.4.26"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/urls.py
+++ b/enterprise/urls.py
@@ -8,7 +8,13 @@ from django.conf.urls import include, url
 
 from enterprise.constants import COURSE_KEY_URL_PATTERN
 from enterprise.heartbeat.views import heartbeat
-from enterprise.views import EnterpriseLoginView, EnterpriseSelectionView, GrantDataSharingPermissions, RouterView
+from enterprise.views import (
+    EnterpriseLoginView,
+    EnterpriseProxyLoginView,
+    EnterpriseSelectionView,
+    GrantDataSharingPermissions,
+    RouterView,
+)
 
 ENTERPRISE_ROUTER = RouterView.as_view()
 
@@ -27,6 +33,11 @@ urlpatterns = [
         r'^enterprise/login',
         EnterpriseLoginView.as_view(),
         name='enterprise_slug_login'
+    ),
+    url(
+        r'^enterprise/proxy-login',
+        EnterpriseProxyLoginView.as_view(),
+        name='enterprise_proxy_login'
     ),
     url(
         r'^enterprise/handle_consent_enrollment/(?P<enterprise_uuid>[^/]+)/course/{}/$'.format(

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -21,6 +21,7 @@ from django.contrib.auth.models import User
 from django.core import mail
 from django.core.exceptions import ObjectDoesNotExist
 from django.http import Http404
+from django.shortcuts import get_object_or_404
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.dateparse import parse_datetime
@@ -361,6 +362,13 @@ def send_email_notification_message(user, enrolled_in, enterprise_customer, emai
     )
 
 
+def enterprise_customer_model():
+    """
+    Returns the ``EnterpriseCustomer`` class.
+    """
+    return apps.get_model('enterprise', 'EnterpriseCustomer')  # pylint: disable=invalid-name
+
+
 def get_enterprise_customer(uuid):
     """
     Get the ``EnterpriseCustomer`` instance associated with ``uuid``.
@@ -368,7 +376,7 @@ def get_enterprise_customer(uuid):
     :param uuid: The universally unique ID of the enterprise customer.
     :return: The ``EnterpriseCustomer`` instance, or ``None`` if it doesn't exist.
     """
-    EnterpriseCustomer = apps.get_model('enterprise', 'EnterpriseCustomer')  # pylint: disable=invalid-name
+    EnterpriseCustomer = enterprise_customer_model()  # pylint: disable=invalid-name
     try:
         return EnterpriseCustomer.objects.get(uuid=uuid)  # pylint: disable=no-member
     except EnterpriseCustomer.DoesNotExist:
@@ -518,13 +526,29 @@ def get_enterprise_customer_or_404(enterprise_uuid):
         (EnterpriseCustomer): The EnterpriseCustomer given the UUID.
 
     """
-    EnterpriseCustomer = apps.get_model('enterprise', 'EnterpriseCustomer')  # pylint: disable=invalid-name
+    EnterpriseCustomer = enterprise_customer_model()  # pylint: disable=invalid-name
     try:
         enterprise_uuid = UUID(enterprise_uuid)
         return EnterpriseCustomer.objects.get(uuid=enterprise_uuid)  # pylint: disable=no-member
     except (TypeError, ValueError, EnterpriseCustomer.DoesNotExist):
         LOGGER.error('Unable to find enterprise customer for UUID: [%s]', enterprise_uuid)
         raise Http404
+
+
+def get_enterprise_customer_by_slug_or_404(slug):
+    """
+    Given an EnterpriseCustomer slug, return the corresponding EnterpriseCustomer or raise a 404.
+
+    Arguments:
+        slug (str): The unique slug (a string) identifying the customer.
+
+    Returns:
+        (EnterpriseCustomer): The EnterpriseCustomer given the slug.
+    """
+    return get_object_or_404(
+        enterprise_customer_model(),
+        slug=slug,
+    )
 
 
 def clean_html_for_template_rendering(text):

--- a/tests/test_enterprise/views/test_enterprise_proxy_login_view.py
+++ b/tests/test_enterprise/views/test_enterprise_proxy_login_view.py
@@ -1,0 +1,78 @@
+"""
+Tests for the ``EnterpriseProxyLoginView`` view of the Enterprise app.
+"""
+
+import ddt
+
+from django.http import QueryDict
+from django.test import Client, TestCase
+from django.urls import reverse
+
+from enterprise.views import LMS_LOGIN_URL
+from test_utils.factories import EnterpriseCustomerFactory, EnterpriseCustomerIdentityProviderFactory
+
+
+@ddt.ddt
+class TestEnterpriseProxyLoginView(TestCase):
+    """
+    Test EnterpriseProxyLoginView class.
+    """
+    base_url = reverse('enterprise_proxy_login')
+    next_url = 'http://localhost:18000'
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.client = Client()
+        cls.enterprise_customer = EnterpriseCustomerFactory()
+        cls.identity_provider = EnterpriseCustomerIdentityProviderFactory(enterprise_customer=cls.enterprise_customer)
+
+    def _get_url_with_params(self, use_enterprise_slug=True, use_next=True, enterprise_slug_override=None,
+                             next_override=None):
+        """
+        Helper to add the appropriate query parameters if specified and assert the correct response status.
+        """
+        query_params = QueryDict(mutable=True)
+        if use_enterprise_slug:
+            query_params['enterprise_slug'] = enterprise_slug_override or self.enterprise_customer.slug
+        if use_next:
+            query_params['next'] = next_override or self.next_url
+        url = self.base_url + '/?' + query_params.urlencode()
+        return url
+
+    @ddt.data(
+        {'use_enterprise_slug': False, 'enterprise_slug': None},
+        {'use_enterprise_slug': True, 'enterprise_slug': 'missing-slug'},
+    )
+    @ddt.unpack
+    def test_missing_slug(self, use_enterprise_slug, enterprise_slug):
+        """
+        Verify the view 404s if no slug or a slug not associated with an enterprise customer is used.
+        """
+        url = self._get_url_with_params(
+            use_enterprise_slug=use_enterprise_slug,
+            enterprise_slug_override=enterprise_slug,
+        )
+        response = self.client.get(url)
+        assert response.status_code == 404
+
+    def test_redirect_no_tpa(self):
+        """
+        Verify the view redirects without tpa_hint if the enterprise has no identity provider.
+        """
+        customer_without_tpa = EnterpriseCustomerFactory()
+        url = self._get_url_with_params(enterprise_slug_override=customer_without_tpa.slug, use_next=False)
+        response = self.client.get(url)
+        self.assertRedirects(response, LMS_LOGIN_URL, fetch_redirect_response=False)
+
+    def test_tpa_redirect(self):
+        """
+        Verify the view adds the next param and the tpa_hint to the redirect if the enterprise has an identity provider.
+        """
+        url = self._get_url_with_params()
+        response = self.client.get(url)
+        query_params = QueryDict(mutable=True)
+        query_params['next'] = self.next_url
+        query_params['tpa_hint'] = self.enterprise_customer.identity_provider
+        expected_url = LMS_LOGIN_URL + '?' + query_params.urlencode()
+        self.assertRedirects(response, expected_url, fetch_redirect_response=False)


### PR DESCRIPTION
This view exists to allow redirecting unauthenticated learners from the
enterprise learner portal through the appropriate logistration page
while taking advantage of the existing SSO we already have in place.

ENT-3141


**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [x] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
