### PR TITLE
ENT-3249 | PendingEnterpriseCustomerUser create action can create an …

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 --------------------
 
+[3.4.31] 2020-07-30
+-------------------
+
+* The PendingEnterpriseCustomerUser create action will create an EnterpriseCustomerUser
+  if an ``auth.User`` record with the given user_email already exists.
+
 [3.4.30] 2020-07-29
 -------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.4.30"
+__version__ = "3.4.31"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -469,9 +469,14 @@ class TestEnterpriseAPIViews(APITest):
         elif status_code == 201:
             response = self.load_json(response.content)
             self.assertDictEqual(data, response)
-            assert PendingEnterpriseCustomerUser.objects.get(
-                user_email=new_user_email, enterprise_customer=enterprise_customer
-            )
+            if not user_exists:
+                assert PendingEnterpriseCustomerUser.objects.get(
+                    user_email=new_user_email, enterprise_customer=enterprise_customer
+                )
+            else:
+                assert EnterpriseCustomerUser.objects.get(
+                    user_id=user.id, enterprise_customer=enterprise_customer, active=user.is_active
+                )
 
     def test_post_pending_enterprise_customer_user_logged_out(self):
         """


### PR DESCRIPTION
…EnterpriseCustomerUser if the User record already exists for the given email.

Helps resolve https://openedx.atlassian.net/browse/ENT-3249

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
