### PR TITLE
Remove field key, part 2 of field rename

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 --------------------
 
+[3.4.39] 2020-08-04
+-------------------
+
+* Remove field 'key' from a canvas integrated_channel model (but not migration yet), step 2/3
+
 [3.4.38] 2020-08-04
 -------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.4.38"
+__version__ = "3.4.39"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/canvas/models.py
+++ b/integrated_channels/canvas/models.py
@@ -77,16 +77,6 @@ class CanvasEnterpriseCustomerConfiguration(EnterpriseCustomerPluginConfiguratio
         )
     )
 
-    key = models.CharField(
-        max_length=255,
-        blank=True,
-        verbose_name="API Client ID",
-        help_text=(
-            "The API Client ID provided to edX by the enterprise customer to be used to make API "
-            "calls to Canvas on behalf of the customer."
-        )
-    )
-
     secret = models.CharField(
         max_length=255,
         blank=True,

--- a/tests/test_integrated_channels/test_canvas/test_client.py
+++ b/tests/test_integrated_channels/test_canvas/test_client.py
@@ -21,6 +21,7 @@ NOW_TIMESTAMP_FORMATTED = NOW.strftime('%F')
 
 @freeze_time(NOW)
 @pytest.mark.django_db
+@pytest.mark.skip('Can only run once key field is removed from db, since it was marked Not Null')
 class TestCanvasApiClient(unittest.TestCase):
     """
     Test Canvas API client methods.
@@ -46,7 +47,7 @@ class TestCanvasApiClient(unittest.TestCase):
             oauth_api_path=self.oauth_api_path,
         )
         self.enterprise_config = canvas_factories.CanvasEnterpriseCustomerConfigurationFactory(
-            key=self.client_id,
+            client_id=self.client_id,
             secret=self.client_secret,
             canvas_company_id=self.company_id,
             canvas_base_url=self.url_base,


### PR DESCRIPTION
This is step 2 of renaming the field 'key', just updating model no migrations here

- [x] Model field 'key' and all its usage (none in this case) removed


**Merge checklist:**
- [x] N/A ::  Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] N/A :: `make static` has been run to update webpack bundling if any static content was updated
- [x] N/A ::`./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [x] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
