### PR TITLE
ENT-3288: JSON datetime format error in Cornerstone catalog sync call

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 --------------------
 
+[3.5.4] 2020-08-12
+-------------------
+
+* Fixed date format in Cornerstone catalog sync call
+
+
 [3.5.3] 2020-08-11
 -------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.5.3"
+__version__ = "3.5.4"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/cornerstone/exporters/content_metadata.py
+++ b/integrated_channels/cornerstone/exporters/content_metadata.py
@@ -11,6 +11,7 @@ import pytz
 from django.apps import apps
 
 from enterprise.utils import get_closest_course_run, get_language_code
+from integrated_channels.integrated_channel.constants import ISO_8601_DATE_FORMAT
 from integrated_channels.integrated_channel.exporters.content_metadata import ContentMetadataExporter
 from integrated_channels.utils import (
     get_duration_from_estimated_hours,
@@ -75,7 +76,7 @@ class CornerstoneContentMetadataExporter(ContentMetadataExporter):  # pylint: di
         """
         Return the modified datetime of closest course run`.
         """
-        modified_datetime = datetime.datetime.now(pytz.UTC)
+        modified_datetime = datetime.datetime.now(pytz.UTC).strftime(ISO_8601_DATE_FORMAT)
         course_runs = content_metadata_item.get('course_runs')
         if course_runs:
             closest_course_run = get_closest_course_run(course_runs)

--- a/integrated_channels/integrated_channel/constants.py
+++ b/integrated_channels/integrated_channel/constants.py
@@ -1,0 +1,5 @@
+"""
+Constants used by the integrated channels
+"""
+
+ISO_8601_DATE_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'

--- a/tests/test_integrated_channels/test_cornerstone/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_cornerstone/test_exporters/test_content_metadata.py
@@ -14,6 +14,7 @@ from freezegun import freeze_time
 from pytest import mark
 
 from integrated_channels.cornerstone.exporters.content_metadata import CornerstoneContentMetadataExporter
+from integrated_channels.integrated_channel.constants import ISO_8601_DATE_FORMAT
 from test_utils import FAKE_UUIDS, factories
 from test_utils.fake_catalog_api import FAKE_SEARCH_ALL_COURSE_RESULT_3
 from test_utils.fake_enterprise_api import EnterpriseMockMixin
@@ -294,7 +295,7 @@ class TestCornerstoneContentMetadataExporter(unittest.TestCase, EnterpriseMockMi
             {
                 'course_runs': 'undefined',
             },
-            str(NOW)
+            NOW.strftime(ISO_8601_DATE_FORMAT)
         ),
         (
             {
@@ -312,7 +313,7 @@ class TestCornerstoneContentMetadataExporter(unittest.TestCase, EnterpriseMockMi
                     },
                 ]
             },
-            str(NOW)
+            NOW.strftime(ISO_8601_DATE_FORMAT)
         ),
         (
             {


### PR DESCRIPTION
**JIRA**: https://openedx.atlassian.net/browse/ENT-3288

**Description**:
The modified date coming from CATALOG API is in correct format. However, in case if the modified date of a course_run OR course_run itself does not exist, we use the current datetime as last modified date. This was not being transformed into correct format before transmitting the data. This PR is a fix for it. 

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
