### PR TITLE
 fix permissions issues with license_revoke endpoint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 --------------------
 
+[3.5.3] 2020-08-11
+-------------------
+
+* Fix permissions issue with license_revoke endpoint in LicensedEnterpriseCourseEnrollmentViewSet.
+
 [3.5.2] 2020-08-11
 -------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.5.2"
+__version__ = "3.5.3"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -253,7 +253,7 @@ class EnterpriseCourseEnrollmentViewSet(EnterpriseReadWriteModelViewSet):
         return serializers.EnterpriseCourseEnrollmentWriteSerializer
 
 
-class LicensedEnterpriseCourseEnrollmentViewSet(EnterpriseReadOnlyModelViewSet):
+class LicensedEnterpriseCourseEnrollmentViewSet(EnterpriseWrapperApiViewSet):
     """
     API views for the ``licensed-enterprise-course-enrollment`` API endpoint.
     """

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -31,6 +31,7 @@ from enterprise.constants import (
     ALL_ACCESS_CONTEXT,
     ENTERPRISE_ADMIN_ROLE,
     ENTERPRISE_DASHBOARD_ADMIN_ROLE,
+    ENTERPRISE_LEARNER_ROLE,
     ENTERPRISE_OPERATOR_ROLE,
     ENTERPRISE_REPORTING_CONFIG_ADMIN_ROLE,
 )
@@ -2305,11 +2306,11 @@ class TestEnterpriseAPIViews(APITest):
             is_revoked,
             status_code,
     ):
-        if has_permissions:
-            permission = Permission.objects.get(name='Can add licensed enterprise course enrollment')
-            self.user.user_permissions.add(permission)
-
         enterprise_customer = factories.EnterpriseCustomerFactory()
+
+        if not has_permissions:
+            self.set_jwt_cookie(ENTERPRISE_LEARNER_ROLE, str(enterprise_customer.uuid))
+
         enterprise_customer_user = factories.EnterpriseCustomerUserFactory(
             user_id=self.user.id,
             enterprise_customer=enterprise_customer,


### PR DESCRIPTION
Previously, `LicensedEnterpriseCourseEnrollmentViewSet` used EnterpriseReadOnlyModelViewSet, which introduced model-level permissions for the endpoint, when we really only want to deal with JWTs.

I noticed an unused `EnterpriseWrapperApiViewSet` and tried using that for `LicensedEnterpriseCourseEnrollmentViewSet`, which fixes the permissions issue of a 403 for non-superusers.

Now, I get a valid 204 response without needing to deal with the model-level permissions.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
