### PR TITLE
ENT-3199 | Added course mode in ecommerce manual enrollment API.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 --------------------
 
+[3.6.5] 2020-08-24
+-------------------
+
+* Added course mode in ecommerce manual enrollment API.
+
+
 [3.6.4] 2020-08-18
 -------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.6.4"
+__version__ = "3.6.5"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/admin/views.py
+++ b/enterprise/admin/views.py
@@ -826,6 +826,7 @@ class EnterpriseCustomerManageLearnersView(BaseEnterpriseCustomerView):
                 "discount_percentage": float(discount),
                 "enterprise_customer_name": enterprise_customer.name,
                 "enterprise_customer_uuid": str(enterprise_customer.uuid),
+                "mode": mode,
                 "sales_force_id": sales_force_id,
             } for success in succeeded]
             EcommerceApiClient(get_ecommerce_worker_user()).create_manual_enrollment_orders(enrollments)

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -908,7 +908,7 @@ class EnterpriseCustomerUser(TimeStampedModel):
                 )
                 if mode in paid_modes:
                     # create an ecommerce order for the course enrollment
-                    self.create_order_for_enrollment(course_run_id, discount_percentage, sales_force_id)
+                    self.create_order_for_enrollment(course_run_id, discount_percentage, mode, sales_force_id)
         elif enrolled_in_course and course_enrollment.get('mode') in paid_modes and mode in audit_modes:
             # This enrollment is attempting to "downgrade" the user from a paid track they are already in.
             raise CourseEnrollmentDowngradeError(
@@ -936,7 +936,7 @@ class EnterpriseCustomerUser(TimeStampedModel):
         """
         request.session['enterprise_customer'] = self.enterprise_customer.serialized
 
-    def create_order_for_enrollment(self, course_run_id, discount_percentage, sales_force_id):
+    def create_order_for_enrollment(self, course_run_id, discount_percentage, mode, sales_force_id):
         """
         Create an order on the Ecommerce side for tracking the course enrollment of a enterprise customer user.
         """
@@ -962,6 +962,7 @@ class EnterpriseCustomerUser(TimeStampedModel):
                     'username': self.username,
                     'email': self.user_email,
                     'course_run_key': course_run_id,
+                    'mode': mode,
                     "enterprise_customer_name": self.enterprise_customer.name,
                     "enterprise_customer_uuid": str(self.enterprise_customer.uuid),
                     "discount_percentage": float(discount_percentage),

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -584,6 +584,7 @@ class TestEnterpriseCustomerUser(unittest.TestCase):
         """
         discount = 10.0
         sales_force_id = 'dummy-sales_force_id'
+        mode = "verified"
         user = factories.UserFactory()
         utils_mock.return_value = user
         enterprise_customer_user = factories.EnterpriseCustomerUserFactory()
@@ -597,13 +598,14 @@ class TestEnterpriseCustomerUser(unittest.TestCase):
         )
 
         with LogCapture(level=logging.DEBUG) as log_capture:
-            enterprise_customer_user.create_order_for_enrollment(course_run_id, discount, sales_force_id)
+            enterprise_customer_user.create_order_for_enrollment(course_run_id, discount, mode, sales_force_id)
             assert expected_msg in log_capture.records[0].getMessage()
 
     @mock.patch('enterprise.models.get_ecommerce_worker_user')
     def test_create_order_error_cannot_retrieve_service_worker(self, utils_mock):
         discount = 100.0
         sales_force_id = 'other-sales_force_id'
+        mode = "verified"
         utils_mock.return_value = None
         enterprise_customer_user = factories.EnterpriseCustomerUserFactory()
         course_run_id = 'course-v1:edX+DemoX+Demo_Course'
@@ -623,7 +625,7 @@ class TestEnterpriseCustomerUser(unittest.TestCase):
         ]
 
         with LogCapture(level=logging.DEBUG) as log_capture:
-            enterprise_customer_user.create_order_for_enrollment(course_run_id, discount, sales_force_id)
+            enterprise_customer_user.create_order_for_enrollment(course_run_id, discount, mode, sales_force_id)
             for index, message in enumerate(expected_messages):
                 assert message in log_capture.records[index].getMessage()
 
@@ -632,6 +634,7 @@ class TestEnterpriseCustomerUser(unittest.TestCase):
         discount = 0.0
         sales_force_id = 'another-sales_force_id'
         user = factories.UserFactory()
+        mode = "verified"
         utils_mock.return_value = user
         enterprise_customer_user = factories.EnterpriseCustomerUserFactory()
         course_run_id = 'course-v1:edX+DemoX+Demo_Course'
@@ -650,7 +653,7 @@ class TestEnterpriseCustomerUser(unittest.TestCase):
         ]
 
         with LogCapture(level=logging.DEBUG) as log_capture:
-            enterprise_customer_user.create_order_for_enrollment(course_run_id, discount, sales_force_id)
+            enterprise_customer_user.create_order_for_enrollment(course_run_id, discount, mode, sales_force_id)
             for index, message in enumerate(expected_messages):
                 assert message in log_capture.records[index].getMessage()
 


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
