### PR TITLE
don't return enterprise customer if learner is not linked

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 --------------------
 
+[3.6.9] 2020-08-26
+-------------------
+
+* Return requested user's linked enterprises only. For staff user return all enterprises.
+
 [3.6.8] 2020-08-26
 -------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.6.8"
+__version__ = "3.6.9"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/filters.py
+++ b/enterprise/api/filters.py
@@ -54,3 +54,25 @@ class EnterpriseCustomerUserFilterBackend(filters.BaseFilterBackend):
             queryset = queryset.filter(user_id=request.user.id)
 
         return queryset
+
+
+class EnterpriseLinkedUserFilterBackend(filters.BaseFilterBackend):
+    """
+    Filter backend to return user's linked enterprises only
+
+    * Staff users will bypass this filter.
+    * Non-staff users will receive only their linked enterprises.
+    """
+
+    def filter_queryset(self, request, queryset, view):
+        """
+        Filter out enterprise customer if learner is not linked
+        """
+        if not request.user.is_staff:
+            filter_kwargs = {
+                view.USER_ID_FILTER: request.user.id,
+                'enterprise_customer_users__linked': 1
+            }
+            queryset = queryset.filter(**filter_kwargs)
+
+        return queryset

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -29,7 +29,11 @@ from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext as _
 
 from enterprise import models
-from enterprise.api.filters import EnterpriseCustomerUserFilterBackend, UserFilterBackend
+from enterprise.api.filters import (
+    EnterpriseCustomerUserFilterBackend,
+    EnterpriseLinkedUserFilterBackend,
+    UserFilterBackend,
+)
 from enterprise.api.throttles import ServiceUserThrottle
 from enterprise.api.utils import (
     create_message_body,
@@ -115,6 +119,7 @@ class EnterpriseCustomerViewSet(EnterpriseReadWriteModelViewSet):
 
     queryset = models.EnterpriseCustomer.active_customers.all()
     serializer_class = serializers.EnterpriseCustomerSerializer
+    filter_backends = EnterpriseReadWriteModelViewSet.filter_backends + (EnterpriseLinkedUserFilterBackend,)
 
     USER_ID_FILTER = 'enterprise_customer_users__user_id'
     FIELDS = (


### PR DESCRIPTION
**Description:** Currently an enterprise learner can still view the enterprise's Learner Portal if the learner was linked to the enterprise, and then unlinked. After these changes, learner will be able to view the learner portal.

**JIRA:** https://openedx.atlassian.net/browse/ENT-3251

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
