### PR TITLE
ENH: Adding update and deleting capabilities to the canvas integrated…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,11 +14,15 @@ Change Log
 Unreleased
 --------------------
 
+[3.6.8] 2020-08-26
+-------------------
+
+* Added course update and deletion capabilities to the canvas integrated channel.
+
 [3.6.7] 2020-08-26
 -------------------
 
 * Changed strings in Manage Learners DSC view.
-
 
 [3.6.6] 2020-08-24
 -------------------
@@ -29,7 +33,6 @@ Unreleased
 -------------------
 
 * Added course mode in ecommerce manual enrollment API.
-
 
 [3.6.4] 2020-08-18
 -------------------

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.6.7"
+__version__ = "3.6.8"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/exceptions.py
+++ b/integrated_channels/exceptions.py
@@ -8,3 +8,13 @@ class ClientError(Exception):
     """
     Indicate a problem when interacting with an integrated channel.
     """
+
+
+class CanvasClientError(ClientError):
+    """
+    Exception for specific Canvas integrated channel client problems.
+    """
+
+    def __init__(self, message):
+        """Add a Canvas client identifier to the beginning of the error message."""
+        super().__init__("Canvas Client Error: " + message)

--- a/tests/test_integrated_channels/test_canvas/test_client.py
+++ b/tests/test_integrated_channels/test_canvas/test_client.py
@@ -4,6 +4,7 @@ Tests for clients in integrated_channels.
 """
 
 import datetime
+import json
 import unittest
 
 import pytest
@@ -14,7 +15,7 @@ from six.moves.urllib.parse import urljoin  # pylint: disable=import-error
 from django.utils import timezone
 
 from integrated_channels.canvas.client import CanvasAPIClient
-from integrated_channels.exceptions import ClientError
+from integrated_channels.exceptions import CanvasClientError, ClientError
 from test_utils import factories
 
 NOW = datetime.datetime(2017, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
@@ -30,14 +31,16 @@ class TestCanvasApiClient(unittest.TestCase):
 
     def setUp(self):
         super(TestCanvasApiClient, self).setUp()
-        self.url_base = "http://betatest.instructure.com/"
-        self.oauth_token_auth_path = "login/oauth2/token"
+        self.account_id = 2000
+        self.url_base = "http://betatest.instructure.com"
+        self.oauth_token_auth_path = "/login/oauth2/token"
         self.oauth_url = urljoin(self.url_base, self.oauth_token_auth_path)
-        self.course_api_path = "api/v1/provider/content/course"
+        self.update_url = urljoin(self.url_base, "/api/v1/courses/")
+        self.get_all_courses_url = urljoin(self.url_base, "/api/v1/accounts/{}/courses/".format(self.account_id))
+        self.course_api_path = "/api/v1/provider/content/course"
         self.course_url = urljoin(self.url_base, self.course_api_path)
         self.client_id = "client_id"
         self.client_secret = "client_secret"
-        self.account_id = 2000
         self.access_token = "access_token"
         self.expected_token_response_body = {
             "expires_in": "",
@@ -51,6 +54,100 @@ class TestCanvasApiClient(unittest.TestCase):
             canvas_base_url=self.url_base,
             refresh_token=self.refresh_token,
         )
+        self.integration_id = 'course-v1:test+TEST101'
+
+    def update_fails_with_poorly_formatted_data(self, request_type):
+        """
+        Helper method to test error handling with poorly formatted data
+        """
+        poorly_formatted_data = 'this is a string, not a bytearray'
+        canvas_api_client = CanvasAPIClient(self.enterprise_config)
+
+        with pytest.raises(CanvasClientError) as client_error:
+            with responses.RequestsMock() as request_mock:
+                request_mock.add(
+                    responses.POST,
+                    self.oauth_url,
+                    json={'access_token': self.access_token},
+                    status=200
+                )
+                transmitter_method = getattr(canvas_api_client, request_type)
+                transmitter_method(poorly_formatted_data)
+
+        assert client_error.value.__str__() == 'Canvas Client Error: Unable to decode data.'
+
+    def update_fails_with_poorly_constructed_data(self, request_type):
+        """
+        Helper method to test error handling with poorly constructed data
+        """
+        bad_course_to_update = '{"course": {"name": "test_course"}}'.encode()
+        canvas_api_client = CanvasAPIClient(self.enterprise_config)
+
+        with pytest.raises(CanvasClientError) as client_error:
+            with responses.RequestsMock() as request_mock:
+                request_mock.add(
+                    responses.POST,
+                    self.oauth_url,
+                    json={'access_token': self.access_token},
+                    status=200
+                )
+                transmitter_method = getattr(canvas_api_client, request_type)
+                transmitter_method(bad_course_to_update)
+
+        assert client_error.value.__str__() == 'Canvas Client Error: ' \
+                                               'Could not transmit data, no integration ID present.'
+
+    def update_fails_when_course_id_not_found(self, request_type):
+        """
+        Helper method to test error handling when no course ID is found
+        """
+        course_to_update = '{{"course": {{"integration_id": "{}", "name": "test_course"}}}}'.format(
+            self.integration_id
+        ).encode()
+        mock_all_courses_resp = [
+            {'name': 'wrong course', 'integration_id': 'wrong integration id', 'id': 2}
+        ]
+        canvas_api_client = CanvasAPIClient(self.enterprise_config)
+
+        with pytest.raises(CanvasClientError) as client_error:
+            with responses.RequestsMock() as request_mock:
+                request_mock.add(
+                    responses.GET,
+                    self.get_all_courses_url,
+                    json=mock_all_courses_resp,
+                    status=200
+                )
+                request_mock.add(
+                    responses.POST,
+                    self.oauth_url,
+                    json={'access_token': self.access_token},
+                    status=200
+                )
+                transmitter_method = getattr(canvas_api_client, request_type)
+                transmitter_method(course_to_update)
+
+        assert client_error.value.__str__() == 'Canvas Client Error: No Canvas courses found' \
+                                               ' with associated integration ID: {}.'.format(self.integration_id)
+
+    def transmission_with_empty_data(self, request_type):
+        """
+        Helper method to test error handling with empty data
+        """
+        empty_data = ''
+        canvas_api_client = CanvasAPIClient(self.enterprise_config)
+
+        with pytest.raises(CanvasClientError) as client_error:
+            with responses.RequestsMock() as request_mock:
+                request_mock.add(
+                    responses.POST,
+                    self.oauth_url,
+                    json={'access_token': self.access_token},
+                    status=200
+                )
+                transmitter_method = getattr(canvas_api_client, request_type)
+                transmitter_method(empty_data)
+
+        assert client_error.value.__str__() == 'Canvas Client Error: No data to transmit.'
 
     def test_create_client_session_with_oauth_access_key(self):
         """ Test instantiating the client will fetch and set the session's oauth access key"""
@@ -86,3 +183,61 @@ class TestCanvasApiClient(unittest.TestCase):
             canvas_api_client = CanvasAPIClient(self.enterprise_config)
             canvas_api_client._create_session()  # pylint: disable=protected-access
         assert client_error.value.__str__() == "Failed to generate oauth access token: Refresh token required."
+
+    def test_course_delete_fails_with_empty_data(self):
+        self.transmission_with_empty_data("delete_content_metadata")
+
+    def test_course_update_fails_with_empty_data(self):
+        self.transmission_with_empty_data("update_content_metadata")
+
+    def test_course_delete_fails_with_poorly_formatted_data(self):
+        self.update_fails_with_poorly_formatted_data("delete_content_metadata")
+
+    def test_course_update_fails_with_poorly_formatted_data(self):
+        self.update_fails_with_poorly_formatted_data("update_content_metadata")
+
+    def test_course_delete_fails_with_poorly_constructed_data(self):
+        self.update_fails_with_poorly_constructed_data("delete_content_metadata")
+
+    def test_course_update_fails_with_poorly_constructed_data(self):
+        self.update_fails_with_poorly_constructed_data("update_content_metadata")
+
+    def test_course_delete_fails_when_course_id_not_found(self):
+        self.update_fails_when_course_id_not_found("delete_content_metadata")
+
+    def test_course_update_fails_when_course_id_not_found(self):
+        self.update_fails_when_course_id_not_found("update_content_metadata")
+
+    def test_successful_client_update(self):
+        """
+        Test the full workflow of a Canvas integrated channel client update request
+        """
+        course_to_update = json.dumps({
+            "course": {"integration_id": self.integration_id, "name": "test_course"}
+        }).encode()
+        course_id = 1
+        mock_all_courses_resp = [
+            {'name': 'test course', 'integration_id': self.integration_id, 'id': course_id},
+            {'name': 'wrong course', 'integration_id': 'wrong integration id', 'id': 2}
+        ]
+        canvas_api_client = CanvasAPIClient(self.enterprise_config)
+
+        with responses.RequestsMock() as request_mock:
+            request_mock.add(
+                responses.GET,
+                self.get_all_courses_url,
+                json=mock_all_courses_resp,
+                status=200
+            )
+            request_mock.add(
+                responses.POST,
+                self.oauth_url,
+                json={'access_token': self.access_token},
+                status=200
+            )
+            request_mock.add(
+                responses.PUT,
+                self.update_url + str(course_id),
+                body=b'Mock update response text'
+            )
+            canvas_api_client.update_content_metadata(course_to_update)


### PR DESCRIPTION
… channels

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [x] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.


First draft of using the "Fetch all courses for account" solution to implementing update and delete to the canvas integrated channel. WIP TESTING AND EDGE CASE HANDLING TO BE ADDED DO NOT MERGE YET. Some questions posed inline in comments, more to come.

To test locally:
- Follow steps to create a course through our canvas client (be able to run `./manage.py lms transmit_content_metadata --catalog_user enterprise_openedx_operator` from the lms shell and then see a course on the Canvas local instance) & (See Binod's notes?/other canvas PR's for setting up oauth and data locally)
   - This is a rather large step to simply say "do it" so if you have any questions, I would refer to https://github.com/edx/edx-enterprise/pull/918 (The PR that implements the base transmitter + post capabilities) or https://github.com/edx/edx-enterprise/pull/926 and https://github.com/edx/edx-enterprise/pull/917 (creating Canvas integration configs and setting up + completing the oauth process) 
- In the enterprise catalog admin, change the content metadata associated with the posted course.
   - to test an update, all you have to do is change something like the `full_description` within the `json metadata`
![Screen Shot 2020-08-24 at 6 09 26 PM](https://user-images.githubusercontent.com/67655836/91101495-32e8e380-e635-11ea-8ea7-861514f5221c.png)

   - to test a delete, all you have to do is change the `content key` and associated `key` field within the json metadata to be different. The way I do this is increment the int at the end of the key.
 
![Screen Shot 2020-08-24 at 6 12 27 PM](https://user-images.githubusercontent.com/67655836/91101697-9ecb4c00-e635-11ea-87cd-acf30636c1cb.png)

Once either of these things are done and the settings are saved, you can run the above `./manage.py lms transmit_content_metadata --catalog_user enterprise_openedx_operator` command from the lms shell and it should trigger either an update or delete respectfully. 
