### PR TITLE
BOM-1982 : Unpin django-ipware

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Change Log
 Unreleased
 ----------
 
+[3.17.41]
+---------
+
+* Upgrade django-ipware to version 3.0.2
+
 [3.17.40]
 ---------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,5 +2,5 @@
 Your project description goes here.
 """
 
-__version__ = "3.17.40"
+__version__ = "3.17.41"
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -13,7 +13,7 @@ import pytz
 import waffle
 from dateutil.parser import parse
 from edx_rest_api_client.exceptions import HttpClientError
-from ipware.ip import get_ip
+from ipware.ip import get_client_ip
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from six.moves.urllib.parse import parse_qs, urlencode, urljoin, urlsplit, urlunsplit  # pylint: disable=import-error
@@ -1823,7 +1823,8 @@ class CourseEnrollmentView(NonAtomicView):
 
         """
         # Check to see if access to the course run is restricted for this user.
-        embargo_url = EmbargoApiClient.redirect_if_blocked([course_id], request.user, get_ip(request), request.path)
+        embargo_url = EmbargoApiClient.redirect_if_blocked(
+            [course_id], request.user, get_client_ip(request)[0], request.path)
         if embargo_url:
             return redirect(embargo_url)
 
@@ -2201,7 +2202,8 @@ class ProgramEnrollmentView(NonAtomicView):
         for course in program_details['courses']:
             for course_run in course['course_runs']:
                 course_run_ids.append(course_run['key'])
-        embargo_url = EmbargoApiClient.redirect_if_blocked(course_run_ids, request.user, get_ip(request), request.path)
+        embargo_url = EmbargoApiClient.redirect_if_blocked(
+            course_run_ids, request.user, get_client_ip(request)[0], request.path)
         if embargo_url:
             return redirect(embargo_url)
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -166,7 +166,7 @@ django-filter==2.4.0
     #   -r requirements/doc.txt
     #   -r requirements/test-master.txt
     #   -r requirements/test.txt
-django-ipware==2.1.0
+django-ipware==3.0.2
     # via
     #   -r requirements/doc.txt
     #   -r requirements/test-master.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -87,7 +87,7 @@ django-fernet-fields==0.6
     # via -r requirements/test-master.txt
 django-filter==2.4.0
     # via -r requirements/test-master.txt
-django-ipware==2.1.0
+django-ipware==3.0.2
     # via -r requirements/test-master.txt
 django-model-utils==4.1.1
     # via

--- a/requirements/edx-platform-constraints.txt
+++ b/requirements/edx-platform-constraints.txt
@@ -40,7 +40,7 @@ django-countries==5.5     # via -c requirements/edx/../constraints.txt, -r requi
 django-crum==0.7.9        # via -r requirements/edx/base.in, edx-django-utils, edx-enterprise, edx-proctoring, edx-rbac, edx-toggles, super-csv
 django-fernet-fields==0.6  # via -r requirements/edx/base.in, edx-enterprise, edx-event-routing-backends, edxval
 django-filter==2.4.0      # via -r requirements/edx/base.in, edx-enterprise, lti-consumer-xblock
-django-ipware==2.1.0      # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, edx-enterprise, edx-proctoring
+django-ipware==3.0.2      # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, edx-enterprise, edx-proctoring
 django-js-asset==1.2.2    # via django-mptt
 django-method-override==1.0.4  # via -r requirements/edx/base.in
 django-model-utils==4.1.1  # via -r requirements/edx/base.in, django-user-tasks, edx-bulk-grades, edx-celeryutils, edx-completion, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-rbac, edx-submissions, edx-when, edxval, ora2, super-csv

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -83,7 +83,7 @@ django-filter==2.4.0
     # via
     #   -c requirements/edx-platform-constraints.txt
     #   -r requirements/base.in
-django-ipware==2.1.0
+django-ipware==3.0.2
     # via
     #   -c requirements/edx-platform-constraints.txt
     #   -r requirements/base.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -84,7 +84,7 @@ django-fernet-fields==0.6
     # via -r requirements/test-master.txt
 django-filter==2.4.0
     # via -r requirements/test-master.txt
-django-ipware==2.1.0
+django-ipware==3.0.2
     # via -r requirements/test-master.txt
 django-model-utils==4.1.1
     # via


### PR DESCRIPTION
Manually changed the django-ipware version because it is pinned in platform, and platform needs updated version in enterprise to work. 
Relevant JIRA : https://openedx.atlassian.net/browse/BOM-1982