### PR TITLE
ENT-3388: post course image to canvas once course created

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ Change Log
 Unreleased
 --------------------
 
-[3.6.10] 2020-08-28
+[3.7.1] 2020-08-28
 -------------------
 
 * Also send course image_url to Canvas when creating course.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,7 +24,6 @@ Unreleased
 
 * Fixed Duplicate Calls to OCN API.
 
-
 [3.6.9] 2020-08-26
 -------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,10 +14,16 @@ Change Log
 Unreleased
 --------------------
 
+[3.6.10] 2020-08-28
+-------------------
+
+* Also send course image_url to Canvas when creating course.
+
 [3.7.0] 2020-08-27
 -------------------
 
 * Fixed Duplicate Calls to OCN API.
+
 
 [3.6.9] 2020-08-26
 -------------------

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.7.0"
+__version__ = "3.7.1"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/canvas/client.py
+++ b/integrated_channels/canvas/client.py
@@ -100,7 +100,8 @@ class CanvasAPIClient(IntegratedChannelApiClient):
                 self._put(url, json.dumps({
                     'course' : {'image_url': content_metadata['image_url']}
                 }).encode('utf-8'))
-        except: # we do not want course image update to cause failures
+        except Exception:
+            # we do not want course image update to cause failures
             pass
 
         return status_code, response_text

--- a/integrated_channels/canvas/client.py
+++ b/integrated_channels/canvas/client.py
@@ -50,6 +50,16 @@ class CanvasAPIClient(IntegratedChannelApiClient):
         self.session = None
         self.expires_at = None
 
+    @staticmethod
+    def course_create_endpoint(canvas_base_url, canvas_account_id):
+        """
+        Returns endpoint to POST to for course creation
+        """
+        return '{}/api/v1/accounts/{}/courses'.format(
+            canvas_base_url,
+            canvas_account_id,
+        )
+
     def create_course_completion(self, user_id, payload):  # pylint: disable=unused-argument
         pass
 
@@ -60,9 +70,9 @@ class CanvasAPIClient(IntegratedChannelApiClient):
         self._create_session()
 
         # step 1: create the course
-        url = '{}/api/v1/accounts/{}/courses'.format(
+        url = CanvasAPIClient.course_create_endpoint(
             self.enterprise_configuration.canvas_base_url,
-            self.enterprise_configuration.canvas_account_id,
+            self.enterprise_configuration.canvas_account_id
         )
         status_code, response_text = self._post(url, serialized_data)
 

--- a/integrated_channels/canvas/client.py
+++ b/integrated_channels/canvas/client.py
@@ -60,6 +60,16 @@ class CanvasAPIClient(IntegratedChannelApiClient):
             canvas_account_id,
         )
 
+    @staticmethod
+    def course_update_endpoint(canvas_base_url, course_id):
+        """
+        Returns endpoint to PUT to for course update
+        """
+        return '{}/api/v1/courses/{}'.format(
+            canvas_base_url,
+            course_id,
+        )
+
     def create_course_completion(self, user_id, payload):  # pylint: disable=unused-argument
         pass
 
@@ -81,14 +91,14 @@ class CanvasAPIClient(IntegratedChannelApiClient):
             # there is no way to do this in a single request during create
             # https://canvas.instructure.com/doc/api/all_resources.html#method.courses.update
             created_course_id = json.loads(response_text)['id']
-            content_metadata = json.loads(serialized_data.decode("utf-8"))['course']
+            content_metadata = json.loads(serialized_data.decode('utf-8'))['course']
             if "image_url" in content_metadata:
-                url = '{}/api/v1/courses/{}'.format(
+                url = CanvasAPIClient.course_update_endpoint(
                     self.enterprise_configuration.canvas_base_url,
                     created_course_id,
                 )
                 self._put(url, json.dumps({
-                    'course' : { 'image_url': content_metadata['image_url'] }
+                    'course' : {'image_url': content_metadata['image_url']}
                 }).encode('utf-8'))
         except: # we do not want course image update to cause failures
             pass
@@ -101,7 +111,7 @@ class CanvasAPIClient(IntegratedChannelApiClient):
         integration_id = self._get_integration_id_from_transmition_data(serialized_data)
         course_id = self._get_course_id_from_integration_id(integration_id)
 
-        url = '{}/api/v1/courses/{}'.format(
+        url = CanvasAPIClient.course_update_endpoint(
             self.enterprise_configuration.canvas_base_url,
             course_id,
         )

--- a/integrated_channels/canvas/client.py
+++ b/integrated_channels/canvas/client.py
@@ -100,7 +100,7 @@ class CanvasAPIClient(IntegratedChannelApiClient):
                 self._put(url, json.dumps({
                     'course' : {'image_url': content_metadata['image_url']}
                 }).encode('utf-8'))
-        except Exception:
+        except Exception: #pylint: disable=broad-except
             # we do not want course image update to cause failures
             pass
 

--- a/integrated_channels/canvas/client.py
+++ b/integrated_channels/canvas/client.py
@@ -59,11 +59,31 @@ class CanvasAPIClient(IntegratedChannelApiClient):
     def create_content_metadata(self, serialized_data):
         self._create_session()
 
-        url = '{}/api/v1/accounts/{}/courses/'.format(
+        # step 1: create the course
+        url = '{}/api/v1/accounts/{}/courses'.format(
             self.enterprise_configuration.canvas_base_url,
             self.enterprise_configuration.canvas_account_id,
         )
-        return self._post(url, serialized_data)
+        status_code, response_text = self._post(url, serialized_data)
+
+        # step 2: upload image_url if present
+        try:
+            # there is no way to do this in a single request during create
+            # https://canvas.instructure.com/doc/api/all_resources.html#method.courses.update
+            created_course_id = json.loads(response_text)['id']
+            content_metadata = json.loads(serialized_data.decode("utf-8"))['course']
+            if "image_url" in content_metadata:
+                url = '{}/api/v1/courses/{}'.format(
+                    self.enterprise_configuration.canvas_base_url,
+                    created_course_id,
+                )
+                self._put(url, json.dumps({
+                    'course' : { 'image_url': content_metadata['image_url'] }
+                }).encode('utf-8'))
+        except: # we do not want course image update to cause failures
+            pass
+
+        return status_code, response_text
 
     def update_content_metadata(self, serialized_data):
         self._create_session()

--- a/integrated_channels/canvas/client.py
+++ b/integrated_channels/canvas/client.py
@@ -98,9 +98,9 @@ class CanvasAPIClient(IntegratedChannelApiClient):
                     created_course_id,
                 )
                 self._put(url, json.dumps({
-                    'course' : {'image_url': content_metadata['image_url']}
+                    'course': {'image_url': content_metadata['image_url']}
                 }).encode('utf-8'))
-        except Exception: #pylint: disable=broad-except
+        except Exception:  # pylint: disable=broad-except
             # we do not want course image update to cause failures
             pass
 

--- a/integrated_channels/canvas/exporters/content_metadata.py
+++ b/integrated_channels/canvas/exporters/content_metadata.py
@@ -21,6 +21,7 @@ class CanvasContentMetadataExporter(ContentMetadataExporter):
         'integration_id': 'key',
         'syllabus_body': 'description',
         'default_view': 'default_view',
+        'image_url': 'image_url',
     }
 
     LONG_STRING_LIMIT = 2000

--- a/tests/test_integrated_channels/test_canvas/test_client.py
+++ b/tests/test_integrated_channels/test_canvas/test_client.py
@@ -202,7 +202,7 @@ class TestCanvasApiClient(unittest.TestCase):
                 status=200
             )
 
-            expected_resp = '{id: 1}'
+            expected_resp = '{"id": 1}'
             request_mock.add(
                 responses.POST,
                 CanvasAPIClient.course_create_endpoint(self.url_base, self.account_id),
@@ -213,6 +213,39 @@ class TestCanvasApiClient(unittest.TestCase):
             assert status_code == 201
             assert response_text == expected_resp
 
+    def test_create_course_success_with_image_url(self):
+        canvas_api_client = CanvasAPIClient(self.enterprise_config)
+        course_to_create = json.dumps({
+            "course": {
+                "integration_id": self.integration_id,
+                "name": "test_course_create",
+                "image_url": "http://image.one/url.png"
+            }
+        }).encode('utf-8')
+
+        with responses.RequestsMock() as request_mock:
+            request_mock.add(
+                responses.POST,
+                self.oauth_url,
+                json={'access_token': self.access_token},
+                status=200
+            )
+
+            expected_resp = '{"id": 1111}'
+            request_mock.add(
+                responses.POST,
+                CanvasAPIClient.course_create_endpoint(self.url_base, self.account_id),
+                status=201,
+                body=expected_resp
+            )
+            request_mock.add(
+                responses.PUT,
+                CanvasAPIClient.course_update_endpoint(self.url_base, 1111),
+                status=200
+            )
+            status_code, response_text = canvas_api_client.create_content_metadata(course_to_create)
+            assert status_code == 201
+            assert response_text == expected_resp
 
     def test_course_delete_fails_with_empty_data(self):
         self.transmission_with_empty_data("delete_content_metadata")

--- a/tests/test_integrated_channels/test_canvas/test_client.py
+++ b/tests/test_integrated_channels/test_canvas/test_client.py
@@ -56,7 +56,6 @@ class TestCanvasApiClient(unittest.TestCase):
         )
         self.integration_id = 'course-v1:test+TEST101'
 
-
     def update_fails_with_poorly_formatted_data(self, request_type):
         """
         Helper method to test error handling with poorly formatted data


### PR DESCRIPTION
Do an extra PUT to send course image once course is created (only done if image_url is present in content_metadata item)

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
