### PR TITLE
Sync catalog content from saved query during save() method

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,13 @@ Change Log
 Unreleased
 --------------------
 
+[3.7.3] 2020-09-01
+-------------------
+
+* Override the ``EnterpriseContentCatalog.save()`` method to sync the ``content_filter`` from an associated
+  ``EnterpriseCatalogQuery``, if appropriate.
+* Add some logging to the ``update_enterprise_catalog_query`` signal.
+
 [3.7.2] 2020-09-01
 -------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.7.2"
+__version__ = "3.7.3"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -1801,6 +1801,18 @@ class EnterpriseCustomerCatalog(TimeStampedModel):
 
         return utils.update_query_parameters(url, {'catalog': self.uuid})
 
+    def save(self, *args, **kwargs):  # pylint: disable=arguments-differ
+        """
+        Saves this ``EnterpriseCatalogQuery``.
+
+        Copies the ``content_filter`` of a related CatalogQuery into this
+        instance's ``content_filter`` if syncing is allowed.
+        """
+        if self.enterprise_catalog_query and self.sync_enterprise_catalog_query:
+            content_filter_from_query = self.enterprise_catalog_query.content_filter
+            self.content_filter = content_filter_from_query
+        super().save(*args, **kwargs)
+
 
 @python_2_unicode_compatible
 class EnrollmentNotificationEmailTemplate(TimeStampedModel):

--- a/enterprise/signals.py
+++ b/enterprise/signals.py
@@ -158,9 +158,20 @@ def update_enterprise_catalog_query(sender, instance, **kwargs):     # pylint: d
     Sync data changes from Enterprise Catalog Query to the Enterprise Customer Catalog.
     """
     updated_content_filter = instance.content_filter
+    logger.info(
+        'Running update_enterprise_catalog_query for Catalog Query {} with updated_content_filter {}'.format(
+            instance.pk,
+            updated_content_filter
+        )
+    )
     catalogs = instance.enterprise_customer_catalogs.filter(sync_enterprise_catalog_query=True)
 
     for catalog in catalogs:
+        logger.info(
+            'update_enterprise_catalog_query is updating catalog {} with the updated_content_filter.'.format(
+                catalog.uuid
+            )
+        )
         catalog.content_filter = updated_content_filter
         catalog.save()
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2000,3 +2000,39 @@ class TestEnterpriseCatalogQuery(unittest.TestCase):
     def test_save_content_filter_success(self, content_filter):
         catalog_query = EnterpriseCatalogQuery(content_filter=content_filter)
         catalog_query.full_clean()
+
+    @mock.patch('enterprise.signals.EnterpriseCatalogApiClient', return_value=mock.MagicMock())
+    def test_sync_catalog_query_content_filter(self, mock_api_client):  # pylint: disable=unused-argument
+        enterprise_customer = factories.EnterpriseCustomerFactory()
+        catalog = factories.EnterpriseCustomerCatalogFactory(
+            enterprise_customer=enterprise_customer,
+            sync_enterprise_catalog_query=True,
+            enterprise_catalog_query=None,
+            content_filter={'key': 'course-v-one-million:course123'},
+        )
+        catalog.save()
+        expected_content_filter = {'key': 'course-v-one-million:course123'}
+        assert expected_content_filter == catalog.content_filter
+
+        catalog.enterprise_catalog_query = factories.EnterpriseCatalogQueryFactory(
+            content_filter={'key': 'coursev1:course1'}
+        )
+        catalog.save()
+        expected_content_filter = {'key': 'coursev1:course1'}
+        assert expected_content_filter == catalog.content_filter
+
+    @mock.patch('enterprise.signals.EnterpriseCatalogApiClient', return_value=mock.MagicMock())
+    def test_no_sync_of_catalog_query_content_filter(self, mock_api_client):  # pylint: disable=unused-argument
+        enterprise_customer = factories.EnterpriseCustomerFactory()
+        enterprise_catalog_query = factories.EnterpriseCatalogQueryFactory(
+            content_filter={'key': 'coursev1:course1'},
+        )
+        catalog = factories.EnterpriseCustomerCatalogFactory(
+            enterprise_customer=enterprise_customer,
+            sync_enterprise_catalog_query=False,
+            enterprise_catalog_query=enterprise_catalog_query,
+            content_filter={'key': 'course-v-one-million:course123'},
+        )
+        catalog.save()
+        expected_content_filter = {'key': 'course-v-one-million:course123'}
+        assert expected_content_filter == catalog.content_filter

--- a/tox.ini
+++ b/tox.ini
@@ -4,28 +4,6 @@ envlist = py35-django22,py38-django{22,30}
 [doc8]
 max-line-length = 120
 
-[pydocstyle]
-; D101 = Missing docstring in public class
-; D106 = Missing docstring in public nested class
-; D200 = One-line docstring should fit on one line with quotes
-; D203 = 1 blank line required before class docstring
-; D212 = Multi-line docstring summary should start at the first line
-; D213 = Multi-line docstring summary should start at the second line
-; D401 = First line should be in imperative mood (numpy style)
-; D404 = First word of the docstring should not be This (numpy style)
-; D405 = Section name should be properly capitalized (numpy style)
-; D406 = Section name should end with a newline (numpy style)
-; D407 = Missing dashed underline after section (numpy style)
-; D408 = Section underline should be in the line following the section’s name (numpy style)
-; D409 = Section underline should match the length of its name (numpy style)
-; D410 = Missing blank line after section (numpy style)
-; D411 = Missing blank line before section (numpy style)
-; D412 = No blank lines allowed between a section header and its content (numpy style)
-; D413 = Missing blank line after last section (numpy style)
-; D414 = Section has no content (numpy style)
-ignore = D101,D106,D200,D203,D212,D213,D401,D404,D405,D406,D407,D408,D409,D410,D411,D412,D413,D414
-match-dir = (?!migrations)
-
 [pytest]
 DJANGO_SETTINGS_MODULE = enterprise.settings.test
 addopts = --cov enterprise --cov enterprise_learner_portal --cov consent --cov integrated_channels --cov-report term-missing --cov-report xml
@@ -95,7 +73,6 @@ commands =
     pylint -j 0 enterprise enterprise_learner_portal consent integrated_channels tests test_utils requirements/check_pins.py
     rm tests/__init__.py
     pycodestyle enterprise enterprise_learner_portal consent integrated_channels tests test_utils
-    pydocstyle enterprise enterprise_learner_portal consent integrated_channels tests test_utils
     isort --check-only --diff --recursive tests test_utils enterprise enterprise_learner_portal consent integrated_channels manage.py setup.py
 
 [testenv:jasmine]


### PR DESCRIPTION
Overrides the `EnterpriseContentCatalog.save()` method to sync the `content_filter` from an associated `EnterpriseCatalogQuery`, if appropriate.  We do this outside of the `post_save` signal handler because it's
an action that might result in a catalog instance having its data updated, which would (a) be inappropriate in a post-save signal handler, and (b) could result in an infinite loop if we weren't careful.

Also adds some logging to the `update_enterprise_catalog_query` signal.

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [x] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
