### PR TITLE
ENT-3411: Canvas discovery improvements (final touches before MVP)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 --------------------
 
+[3.8.1] 2020-09-10
+-------------------
+
+* Canvas channel discovery improvements assorted changes.
+
 [3.8.0] 2020-09-09
 -------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.8.0"
+__version__ = "3.8.1"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/canvas/client.py
+++ b/integrated_channels/canvas/client.py
@@ -186,6 +186,10 @@ class CanvasAPIClient(IntegratedChannelApiClient):
         self.session = session
 
     def _update_course_details(self, course_id, serialized_data):
+        """
+        Update a course for image_url (and possibly other settings in future)
+        This is used only for settings that are not settable in the initial course creation
+        """
         try:
             # there is no way to do this in a single request during create
             # https://canvas.instructure.com/doc/api/all_resources.html#method.courses.update

--- a/integrated_channels/canvas/exporters/content_metadata.py
+++ b/integrated_channels/canvas/exporters/content_metadata.py
@@ -32,7 +32,7 @@ class CanvasContentMetadataExporter(ContentMetadataExporter):
         This will display in the Syllabus tab in Canvas.
         """
         enrollment_url = content_metadata_item.get('enrollment_url', None)
-        base_description = "<a href={enrollment_url}>To edX Course Page</a><br />".format(
+        base_description = "<a href={enrollment_url}>Go to edX course page</a><br />".format(
             enrollment_url=enrollment_url)
         full_description = content_metadata_item.get('full_description') or None
         if full_description and len(full_description + enrollment_url) <= self.LONG_STRING_LIMIT:

--- a/integrated_channels/canvas/exporters/content_metadata.py
+++ b/integrated_channels/canvas/exporters/content_metadata.py
@@ -22,6 +22,8 @@ class CanvasContentMetadataExporter(ContentMetadataExporter):
         'syllabus_body': 'description',
         'default_view': 'default_view',
         'image_url': 'image_url',
+        'is_public': 'is_public',
+        'self_enrollment': 'self_enrollment',
     }
 
     LONG_STRING_LIMIT = 2000
@@ -55,3 +57,15 @@ class CanvasContentMetadataExporter(ContentMetadataExporter):
         Sets the Home page view in Canvas. We're using Syllabus.
         """
         return 'syllabus'
+
+    def transform_is_public(self, content_metadata_item): # pylint: disable=unused-argument
+        """
+        Whether to make the course visible in the public Canvas index by default.
+        """
+        return True
+
+    def transform_self_enrollment(self, content_metadata_item): # pylint: disable=unused-argument
+        """
+        Whether to allow students to self enroll. Helps students enroll via link or enroll button.
+        """
+        return True

--- a/integrated_channels/canvas/exporters/content_metadata.py
+++ b/integrated_channels/canvas/exporters/content_metadata.py
@@ -28,16 +28,6 @@ class CanvasContentMetadataExporter(ContentMetadataExporter):
 
     LONG_STRING_LIMIT = 2000
 
-    def transform_key(self, content_metadata_item):
-        """
-        IntegrationId is set to edx_{account_id}_{key} which allows multiple accounts to hold the same
-        courses
-        """
-        return "edx_{}_{}".format(
-            self.enterprise_configuration.canvas_account_id,
-            content_metadata_item.get('key', '')
-        )
-
     def transform_description(self, content_metadata_item):
         """
         Return the course description and enrollment url as Canvas' syllabus body attribute.

--- a/integrated_channels/canvas/exporters/content_metadata.py
+++ b/integrated_channels/canvas/exporters/content_metadata.py
@@ -35,7 +35,7 @@ class CanvasContentMetadataExporter(ContentMetadataExporter):
         """
         return "edx_{}_{}".format(
             self.enterprise_configuration.canvas_account_id,
-            content_metadata_item.get('key','')
+            content_metadata_item.get('key', '')
         )
 
     def transform_description(self, content_metadata_item):

--- a/integrated_channels/canvas/exporters/content_metadata.py
+++ b/integrated_channels/canvas/exporters/content_metadata.py
@@ -28,6 +28,16 @@ class CanvasContentMetadataExporter(ContentMetadataExporter):
 
     LONG_STRING_LIMIT = 2000
 
+    def transform_key(self, content_metadata_item):
+        """
+        IntegrationId is set to edx_{account_id}_{key} which allows multiple accounts to hold the same
+        courses
+        """
+        return "edx_{}_{}".format(
+            self.enterprise_configuration.canvas_account_id,
+            content_metadata_item.get('key','')
+        )
+
     def transform_description(self, content_metadata_item):
         """
         Return the course description and enrollment url as Canvas' syllabus body attribute.

--- a/integrated_channels/canvas/exporters/content_metadata.py
+++ b/integrated_channels/canvas/exporters/content_metadata.py
@@ -24,6 +24,7 @@ class CanvasContentMetadataExporter(ContentMetadataExporter):
         'image_url': 'image_url',
         'is_public': 'is_public',
         'self_enrollment': 'self_enrollment',
+        'course_code': 'course_code',
     }
 
     LONG_STRING_LIMIT = 2000
@@ -79,3 +80,9 @@ class CanvasContentMetadataExporter(ContentMetadataExporter):
         Whether to allow students to self enroll. Helps students enroll via link or enroll button.
         """
         return True
+
+    def transform_course_code(self, content_metadata_item): # pylint: disable=unused-argument
+        """
+        Course code is same as integration id for now
+        """
+        return content_metadata_item.get('key', 'edx course')

--- a/integrated_channels/canvas/exporters/content_metadata.py
+++ b/integrated_channels/canvas/exporters/content_metadata.py
@@ -15,7 +15,6 @@ class CanvasContentMetadataExporter(ContentMetadataExporter):
     """
     DATA_TRANSFORM_MAPPING = {
         'name': 'title',
-        'course_code': 'number',
         'start_at': 'start',
         'end_at': 'end',
         'integration_id': 'key',
@@ -24,7 +23,7 @@ class CanvasContentMetadataExporter(ContentMetadataExporter):
         'image_url': 'image_url',
         'is_public': 'is_public',
         'self_enrollment': 'self_enrollment',
-        'course_code': 'course_code',
+        'course_code': 'key',
     }
 
     LONG_STRING_LIMIT = 2000
@@ -80,9 +79,3 @@ class CanvasContentMetadataExporter(ContentMetadataExporter):
         Whether to allow students to self enroll. Helps students enroll via link or enroll button.
         """
         return True
-
-    def transform_course_code(self, content_metadata_item): # pylint: disable=unused-argument
-        """
-        Course code is same as integration id for now
-        """
-        return content_metadata_item.get('key', 'edx course')

--- a/integrated_channels/canvas/exporters/content_metadata.py
+++ b/integrated_channels/canvas/exporters/content_metadata.py
@@ -68,13 +68,13 @@ class CanvasContentMetadataExporter(ContentMetadataExporter):
         """
         return 'syllabus'
 
-    def transform_is_public(self, content_metadata_item): # pylint: disable=unused-argument
+    def transform_is_public(self, content_metadata_item):  # pylint: disable=unused-argument
         """
         Whether to make the course visible in the public Canvas index by default.
         """
         return True
 
-    def transform_self_enrollment(self, content_metadata_item): # pylint: disable=unused-argument
+    def transform_self_enrollment(self, content_metadata_item):  # pylint: disable=unused-argument
         """
         Whether to allow students to self enroll. Helps students enroll via link or enroll button.
         """

--- a/tests/test_integrated_channels/test_canvas/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_canvas/test_exporters/test_content_metadata.py
@@ -135,3 +135,16 @@ class TestCanvasContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):
         content_metadata_item = GENERIC_CONTENT_METADATA_ITEM
         exporter = CanvasContentMetadataExporter('fake-user', self.config)
         assert exporter.transform_self_enrollment(content_metadata_item) is True
+
+    @responses.activate
+    def test_transform_key(self):
+        """
+        `CanvasContentMetadataExporter``'s ``transform_key` returns edx_acctID_key.
+        """
+        content_metadata_item = GENERIC_CONTENT_METADATA_ITEM
+        exporter = CanvasContentMetadataExporter('fake-user', self.config)
+        expected_id = "edx_{}_{}".format(
+            self.config.canvas_account_id,
+            content_metadata_item.get("key")
+        )
+        assert exporter.transform_key(content_metadata_item) == expected_id

--- a/tests/test_integrated_channels/test_canvas/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_canvas/test_exporters/test_content_metadata.py
@@ -139,16 +139,3 @@ class TestCanvasContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):
         content_metadata_item = GENERIC_CONTENT_METADATA_ITEM
         exporter = CanvasContentMetadataExporter('fake-user', self.config)
         assert exporter.transform_self_enrollment(content_metadata_item) is True
-
-    @responses.activate
-    def test_transform_key(self):
-        """
-        `CanvasContentMetadataExporter``'s ``transform_key` returns edx_acctID_key.
-        """
-        content_metadata_item = GENERIC_CONTENT_METADATA_ITEM
-        exporter = CanvasContentMetadataExporter('fake-user', self.config)
-        expected_id = "edx_{}_{}".format(
-            self.config.canvas_account_id,
-            content_metadata_item.get("key")
-        )
-        assert exporter.transform_key(content_metadata_item) == expected_id

--- a/tests/test_integrated_channels/test_canvas/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_canvas/test_exporters/test_content_metadata.py
@@ -125,7 +125,7 @@ class TestCanvasContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):
         """
         content_metadata_item = GENERIC_CONTENT_METADATA_ITEM
         exporter = CanvasContentMetadataExporter('fake-user', self.config)
-        assert exporter.transform_is_public(content_metadata_item) == True
+        assert exporter.transform_is_public(content_metadata_item) is True
 
     @responses.activate
     def test_transform_self_enrollment(self):
@@ -134,4 +134,4 @@ class TestCanvasContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):
         """
         content_metadata_item = GENERIC_CONTENT_METADATA_ITEM
         exporter = CanvasContentMetadataExporter('fake-user', self.config)
-        assert exporter.transform_self_enrollment(content_metadata_item) == True
+        assert exporter.transform_self_enrollment(content_metadata_item) is True

--- a/tests/test_integrated_channels/test_canvas/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_canvas/test_exporters/test_content_metadata.py
@@ -23,6 +23,7 @@ GENERIC_CONTENT_METADATA_ITEM = {
     'content_type': 'course',
 }
 
+
 @mark.django_db
 @ddt.ddt
 class TestCanvasContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):

--- a/tests/test_integrated_channels/test_canvas/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_canvas/test_exporters/test_content_metadata.py
@@ -74,14 +74,16 @@ class TestCanvasContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):
                 'short_description': 'Some short description.',
                 'full_description': 'Detailed description of edx demo course.',
             },
-            '<a href=http://some/enrollment/url/>Go to edX course page</a><br />Detailed description of edx demo course.'
+            '<a href=http://some/enrollment/url/>Go to edX course page</a><br />'
+            'Detailed description of edx demo course.'
         ),
         (
             {
                 'enrollment_url': 'http://some/enrollment/url/',
                 'title': 'edX Demonstration Course',
             },
-            '<a href=http://some/enrollment/url/>Go to edX course page</a><br />edX Demonstration Course'
+            '<a href=http://some/enrollment/url/>Go to edX course page</a><br />'
+            'edX Demonstration Course'
         ),
         (
             {
@@ -89,7 +91,8 @@ class TestCanvasContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):
                 'title': 'edX Demonstration Course',
                 'short_description': 'Some short description.',
             },
-            '<a href=http://some/enrollment/url/>Go to edX course page</a><br />Some short description.'
+            '<a href=http://some/enrollment/url/>Go to edX course page</a><br />'
+            'Some short description.'
         ),
         (
             {

--- a/tests/test_integrated_channels/test_canvas/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_canvas/test_exporters/test_content_metadata.py
@@ -151,15 +151,3 @@ class TestCanvasContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):
             content_metadata_item.get("key")
         )
         assert exporter.transform_key(content_metadata_item) == expected_id
-
-
-    @responses.activate
-    def test_transform_course_code(self):
-        """
-        `CanvasContentMetadataExporter``'s ``course_code` returns key.
-        """
-        content_metadata_item = GENERIC_CONTENT_METADATA_ITEM
-        exporter = CanvasContentMetadataExporter('fake-user', self.config)
-        assert exporter.transform_course_code(
-            content_metadata_item
-        ) == content_metadata_item.get('key')

--- a/tests/test_integrated_channels/test_canvas/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_canvas/test_exporters/test_content_metadata.py
@@ -151,3 +151,15 @@ class TestCanvasContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):
             content_metadata_item.get("key")
         )
         assert exporter.transform_key(content_metadata_item) == expected_id
+
+
+    @responses.activate
+    def test_transform_course_code(self):
+        """
+        `CanvasContentMetadataExporter``'s ``course_code` returns key.
+        """
+        content_metadata_item = GENERIC_CONTENT_METADATA_ITEM
+        exporter = CanvasContentMetadataExporter('fake-user', self.config)
+        assert exporter.transform_course_code(
+            content_metadata_item
+        ) == content_metadata_item.get('key')

--- a/tests/test_integrated_channels/test_canvas/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_canvas/test_exporters/test_content_metadata.py
@@ -15,6 +15,13 @@ from test_utils import FAKE_UUIDS, factories
 from test_utils.fake_catalog_api import get_fake_content_metadata
 from test_utils.fake_enterprise_api import EnterpriseMockMixin
 
+GENERIC_CONTENT_METADATA_ITEM = {
+    'enrollment_url': 'http://some/enrollment/url/',
+    'aggregation_key': 'course:edX+DemoX',
+    'title': 'edX Demonstration Course',
+    'key': 'edX+DemoX',
+    'content_type': 'course',
+}
 
 @mark.django_db
 @ddt.ddt
@@ -107,12 +114,24 @@ class TestCanvasContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):
         """
         `CanvasContentMetadataExporter``'s ``transform_default_view` returns syllabus as value.
         """
-        content_metadata_item = {
-            'enrollment_url': 'http://some/enrollment/url/',
-            'aggregation_key': 'course:edX+DemoX',
-            'title': 'edX Demonstration Course',
-            'key': 'edX+DemoX',
-            'content_type': 'course',
-        }
+        content_metadata_item = GENERIC_CONTENT_METADATA_ITEM
         exporter = CanvasContentMetadataExporter('fake-user', self.config)
         assert exporter.transform_default_view(content_metadata_item) == 'syllabus'
+
+    @responses.activate
+    def test_transform_is_public(self):
+        """
+        `CanvasContentMetadataExporter``'s ``transform_is_public_view` returns True.
+        """
+        content_metadata_item = GENERIC_CONTENT_METADATA_ITEM
+        exporter = CanvasContentMetadataExporter('fake-user', self.config)
+        assert exporter.transform_is_public(content_metadata_item) == True
+
+    @responses.activate
+    def test_transform_self_enrollment(self):
+        """
+        `CanvasContentMetadataExporter``'s ``transform_self_enrollment` returns True.
+        """
+        content_metadata_item = GENERIC_CONTENT_METADATA_ITEM
+        exporter = CanvasContentMetadataExporter('fake-user', self.config)
+        assert exporter.transform_self_enrollment(content_metadata_item) == True

--- a/tests/test_integrated_channels/test_canvas/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_canvas/test_exporters/test_content_metadata.py
@@ -67,14 +67,14 @@ class TestCanvasContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):
                 'short_description': 'Some short description.',
                 'full_description': 'Detailed description of edx demo course.',
             },
-            '<a href=http://some/enrollment/url/>To edX Course Page</a><br />Detailed description of edx demo course.'
+            '<a href=http://some/enrollment/url/>Go to edX course page</a><br />Detailed description of edx demo course.'
         ),
         (
             {
                 'enrollment_url': 'http://some/enrollment/url/',
                 'title': 'edX Demonstration Course',
             },
-            '<a href=http://some/enrollment/url/>To edX Course Page</a><br />edX Demonstration Course'
+            '<a href=http://some/enrollment/url/>Go to edX course page</a><br />edX Demonstration Course'
         ),
         (
             {
@@ -82,13 +82,13 @@ class TestCanvasContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):
                 'title': 'edX Demonstration Course',
                 'short_description': 'Some short description.',
             },
-            '<a href=http://some/enrollment/url/>To edX Course Page</a><br />Some short description.'
+            '<a href=http://some/enrollment/url/>Go to edX course page</a><br />Some short description.'
         ),
         (
             {
                 'enrollment_url': 'http://some/enrollment/url/'
             },
-            '<a href=http://some/enrollment/url/>To edX Course Page</a><br />'
+            '<a href=http://some/enrollment/url/>Go to edX course page</a><br />'
         )
 
     )


### PR DESCRIPTION
Ok, this PR will address the following changes:

- [x]  Visibility: public (canvas default is course)
- [x] ”Let students self-enroll by sharing with them a secret URL”: true (false by default)
- [x] Course start and end dates should be displayed in Canvas syllabus page (there is a section but it’s empty right now)
    - This one is interesting because course content_type does not have start field so we don't post it. But even if I send a PUT to update the course start date, it only shows on the settings page but not on the syllabus page. So this is a different issue going on. We do send start/end dates when the field is available (such as for course_runs content type)
- [x] Course code should be set to a reasonably unique default value (right now it seems canvas auto sets it to some value that usually does not make sense)
- [x] Change link text to ‘Go to edX Course’


It will not address the following changes since I cannot find a way to do that (will check with instructure tomorrow as well)

* “Include this course in the public course index”: true (is false by default)
* ”Add a "Join this Course" link to the course home page”: true (in the UI this only shows up once the prior setting is turned on)
* Publish course: do no think this can be done via our system (or should be done). It seems this would be an institution action. Publish is needed for course to show up in public index but is not needed if instructor wants to send enrollment url


Decided not to do this one since there is no compelling rasosn right now and can cause issues with update/delete

- [] Course integration_id should be {account_id}_{key} instead of just {key}. This is not part of visibility but helps with multi account setups


**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
