### PR TITLE
Fixing the construction of the next param in the proxy login view for SSO

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 -------------------
 
+[3.8.8] 2020-09-15
+-------------------
+
+* Fixing the construction of the next param in the proxy login view for SSO.
+
 [3.8.7] 2020-09-15
 -------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.8.7"
+__version__ = "3.8.8"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -73,6 +73,7 @@ from enterprise.utils import (
     is_course_run_enrollable,
     track_enrollment,
     ungettext_min_max,
+    update_query_parameters,
 )
 from integrated_channels.cornerstone.utils import create_cornerstone_learner_data
 
@@ -1033,8 +1034,10 @@ class EnterpriseProxyLoginView(View):
             # Add the tpa_hint to the redirect's 'next' query parameter
             # Redirect will be to the Enterprise Customer's TPA provider
             tpa_hint = enterprise_customer.identity_provider
-            tpa_next_param = query_dict['next'] + '?tpa_hint=' + tpa_hint
-            query_dict['next'] = tpa_next_param
+            tpa_next_param = {
+                'tpa_hint': tpa_hint,
+            }
+            query_dict['next'] = update_query_parameters(str(query_dict['next']), tpa_next_param)
         else:
             # Add Enterprise Customer UUID and proxy_login to the redirect's query parameters
             # Redirect will be to the edX Logistration with Enterprise Proxy Login sidebar


### PR DESCRIPTION
It was noticed while testing SAPSF enrollment using BestRun on prod that SSO login redirect doesn't work for any LP URLs other than the for the dashboard. That's because of the way that the tpa_hint param was added to the URL used in the next param and how it didn't account for URLs that may already have query params. This PR makes use of the update_query_parameters utility function to replace the previous functionality which naively added "?tpa_hint=blah" to the end of the URL. 

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
