### PR TITLE
pull platform sync migration test to enterprise.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,11 @@ Change Log
 
 Unreleased
 
+[3.8.19] 2020-09-24
+-------------------
+
+* Copy test from edx-platform over to enterprise to test migrations early.
+
 [3.8.18] 2020-09-23
 -------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.8.18"
+__version__ = "3.8.19"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -3,68 +3,19 @@
 Tests for migrations, especially potentially risky data migrations.
 """
 
-from django.db import connection
-from django.db.migrations.executor import MigrationExecutor
-from django.test.testcases import TransactionTestCase
+from django.core.management import call_command
+from django.test.testcases import TestCase
+from django.test.utils import override_settings
+from django.utils.six import StringIO
 
 
-class MigrationTestCase(TransactionTestCase):
+class MigrationTests(TestCase):
     """
-    A base test case class for migration test cases.
+    Runs migration tests using Django Command interface.
     """
-
-    migrate_origin = None
-    migrate_dest = None
-    model = None
-
-    def setUp(self):
-        super(MigrationTestCase, self).setUp()
-        self.executor = MigrationExecutor(connection)
-        self.executor.migrate(self.migrate_origin)
-
-    def migrate_to_origin(self):
-        """
-        Performs the migration to the designated origin.
-
-        This only really does anything if you have migrated forward
-        in some way or no migrations were performed at all.
-        """
-        self.executor.loader.build_graph()
-        self.executor.migrate(self.migrate_origin)
-
-    def migrate_to_dest(self):
-        """
-        Performs the migration to the designated destination.
-        """
-        self.executor.loader.build_graph()
-        self.executor.migrate(self.migrate_dest)
-
-    def migrate_to_dest_then_origin(self):
-        """
-        Migrates to the destination and back to the origin.
-
-        Can be used as a shortcut to test a forward- and backward-migration in one-go.
-        """
-        self.migrate_to_dest()
-        self.migrate_to_origin()
-
-    @property
-    def old_apps(self):
-        """
-        Returns the app in its original state -- the one that'd exist before migration.
-        """
-        return self.executor.loader.project_state(self.migrate_origin).apps
-
-    @property
-    def new_apps(self):
-        """
-        Returns the app in a future state -- the one that'd exist after migration.
-        """
-        return self.executor.loader.project_state(self.migrate_dest).apps
-
-    @property
-    def model_label(self):
-        """
-        Returns the label of the ``model``.
-        """
-        return self.model._meta.get_field('name')
+    @override_settings(MIGRATION_MODULES={})
+    def test_migrations_are_in_sync(self):
+        out = StringIO()
+        call_command("makemigrations", dry_run=True, verbosity=3, stdout=out)
+        output = out.getvalue()
+        self.assertIn("No changes detected", output)


### PR DESCRIPTION
Trying to prevent the dreaded successful merge to master > fail in edx-platform pipeline.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
