### PR TITLE
ENT-3334 | SAP SF customer is seeing courses as not open for enrollment when they should be

### DIFF
--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -769,7 +769,7 @@ def is_course_run_enrollable(course_run):
     3. enrollment_end is greater than now, or undefined
     """
     # Check if the course run is unpublished (sometimes these sneak through)
-    if not is_course_run_published(course_run):
+    if is_course_run_unpublished(course_run):
         return False
 
     now = datetime.datetime.now(pytz.UTC)
@@ -822,12 +822,12 @@ def is_course_run_upgradeable(course_run):
     return False
 
 
-def is_course_run_published(course_run):
+def is_course_run_unpublished(course_run):
     """
-    Return True if the course run's status value is "published".
+    Return True if the course run's status value is "unpublished".
     """
     if course_run:
-        if course_run.get('status') == 'published':
+        if course_run.get('status') == 'unpublished':
             return True
     return False
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1328,16 +1328,17 @@ class TestEnterpriseUtils(unittest.TestCase):
         assert utils.is_course_run_upgradeable(course_run) == expected_upgradeability
 
     @ddt.data(
-        ({"status": "published"}, True),
-        ({"status": "unpublished"}, False)
+        ({'key': 'value'}, False),  # test with missing `status` key
+        ({"status": "published"}, False),
+        ({"status": "unpublished"}, True),
     )
     @ddt.unpack
-    def test_is_course_published(self, course_run, expected_response):
+    def test_is_course_unpublished(self, course_run, expected_response):
         """
-        ``is_course_run_published`` returns whether the course run is considered "published"
+        ``is_course_run_unpublished`` returns whether the course run is considered "unpublished"
         given its metadata structure and values.
         """
-        assert utils.is_course_run_published(course_run) == expected_response
+        assert utils.is_course_run_unpublished(course_run) == expected_response
 
     @ddt.data(
         ({"start": "3000-10-13T13:11:04Z"}, utils.parse_datetime_handle_invalid("3000-10-13T13:11:04Z")),


### PR DESCRIPTION
comparing `status` of the course_run with the `unpublished` instead of 'published' to handle cases where unpublished key is missing.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
