### PR TITLE
ENT-3050 | Added Audit grade for Audit mode enrollments in integrated…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,12 @@ Change Log
 
 Unreleased
 
+[3.8.23] 2020-10-01
+-------------------
+
+* Added Audit grade for Audit mode enrollments in integrated channels.
+
+
 [3.8.22]
 --------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.8.22"
+__version__ = "3.8.23"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/tests/test_integrated_channels/test_cornerstone/test_exporters/test_learner_data.py
+++ b/tests/test_integrated_channels/test_cornerstone/test_exporters/test_learner_data.py
@@ -150,6 +150,16 @@ class TestCornerstoneLearnerExporter(unittest.TestCase):
             }
         )
 
+        # Enrollment API
+        responses.add(
+            responses.GET,
+            urljoin(
+                lms_api.EnrollmentApiClient.API_BASE_URL,
+                "enrollment/{username},{course_id}".format(username=self.user.username, course_id=self.course_id),
+            ),
+            json=dict(mode='verified')
+        )
+
         # Certificates API user's grade response
         responses.add(
             responses.GET,
@@ -191,7 +201,7 @@ class TestCornerstoneLearnerExporter(unittest.TestCase):
     @mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
     def test_transmit_single_learner_data_performs_only_one_transmission(self):
         """
-        Test sending single user's data sould only update one `CornerstoneLearnerDataTransmissionAudit` entry
+        Test sending single user's data should only update one `CornerstoneLearnerDataTransmissionAudit` entry
         """
         course_id = 'course-v1:edX+NmX+Demo_Course_2'
         course_key = 'edX+NmX'
@@ -209,6 +219,16 @@ class TestCornerstoneLearnerExporter(unittest.TestCase):
                 "pacing": "instructor",
                 "end": "2038-06-21T12:58:17.428373Z",
             }
+        )
+
+        # Enrollment API
+        responses.add(
+            responses.GET,
+            urljoin(
+                lms_api.EnrollmentApiClient.API_BASE_URL,
+                "enrollment/{username},{course_id}".format(username=self.user.username, course_id=course_id),
+            ),
+            json=dict(mode='verified')
         )
 
         # Certificates API user's grade response


### PR DESCRIPTION
… channels.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
