### PR TITLE
ENT-3520 | Read service usernames from a settings list, if it exists,…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,12 @@ Change Log
 
 Unreleased
 
+[3.8.27]
+--------
+
+* Update ``get_service_usernames()`` to read from a list variable (that may not exist).
+
+
 [3.8.26] 2020-10-05
 -------------------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.8.26"
+__version__ = "3.8.27"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/utils.py
+++ b/enterprise/api/utils.py
@@ -22,6 +22,9 @@ def get_service_usernames():
     """
     Return the set of service usernames that are given extended permissions in the API.
     """
+    if getattr(settings, 'ENTERPRISE_ALL_SERVICE_USERNAMES', None):
+        return set(settings.ENTERPRISE_ALL_SERVICE_USERNAMES)
+
     return {getattr(settings, username, None) for username in SERVICE_USERNAMES}
 
 

--- a/enterprise/settings/test.py
+++ b/enterprise/settings/test.py
@@ -173,6 +173,15 @@ TEST_SERVER = "http://testserver"
 ALLOWED_HOSTS = ["testserver.enterprise"]
 MEDIA_URL = "/"
 
+# Defines the usernames of service users who should be throttled
+# at a higher rate than normal users.
+ENTERPRISE_ALL_SERVICE_USERNAMES = [
+    'ecommerce_worker',
+    'enterprise_worker',
+    'license_manager_worker',
+    'enterprise_catalog_worker',
+]
+
 ECOMMERCE_SERVICE_WORKER_USERNAME = 'ecommerce_worker'
 ENTERPRISE_SERVICE_WORKER_USERNAME = 'enterprise_worker'
 
@@ -269,6 +278,8 @@ app.config_from_object('django.conf:settings')
 CELERY_ALWAYS_EAGER = True
 
 CLEAR_REQUEST_CACHE_ON_TASK_COMPLETION = False
+
+##### END CELERY #####
 
 JWT_AUTH = {
     'JWT_AUDIENCE': 'test-aud',

--- a/pytest.local.ini
+++ b/pytest.local.ini
@@ -1,0 +1,7 @@
+# This makes it easier to get coverage reports for only specific modules
+# when running pytest locally, for example:
+# pytest -c pytest.local.ini tests/test_enterprise/api/test_throttles.py --cov=enterprise.api.throttles
+[pytest]
+DJANGO_SETTINGS_MODULE = enterprise.settings.test
+addopts = --cov-report term-missing -W ignore
+norecursedirs = .* docs requirements node_modules


### PR DESCRIPTION
… when determining API throttle rates.

https://openedx.atlassian.net/browse/ENT-3520

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [x] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
