### PR TITLE
ENT-3472: blackboard exporter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,11 @@ Change Log
 
 Unreleased
 
+[3.8.28]
+--------
+
+* Blackboard exporter
+
 [3.8.27]
 --------
 

--- a/integrated_channels/blackboard/exporters/content_metadata.py
+++ b/integrated_channels/blackboard/exporters/content_metadata.py
@@ -28,8 +28,4 @@ class BlackboardContentMetadataExporter(ContentMetadataExporter):
         """
         enrollment_url = content_metadata_item.get('enrollment_url', None)
         url_link = self.DESCRIPTION_TEXT_TEMPLATE.format(enrollment_url=enrollment_url)
-        short_description = content_metadata_item.get(
-            'short_description', content_metadata_item.get('title', '')
-        )
-        description = "<p>{}</p><p>{}</p>".format(short_description, url_link)
-        return description
+        return url_link

--- a/integrated_channels/blackboard/exporters/content_metadata.py
+++ b/integrated_channels/blackboard/exporters/content_metadata.py
@@ -16,6 +16,20 @@ class BlackboardContentMetadataExporter(ContentMetadataExporter):
     DATA_TRANSFORM_MAPPING = {
         'name': 'title',
         'externalId': 'key',
-        'description': 'full_description',
+        'description': 'description',
         'courseId': 'key',
     }
+
+    DESCRIPTION_TEXT_TEMPLATE = "<a href={enrollment_url}>Go to edX course page</a><br />"
+
+    def transform_description(self, content_metadata_item):
+        """
+        This will show a link to edX course on blackboard course description
+        """
+        enrollment_url = content_metadata_item.get('enrollment_url', None)
+        url_link = self.DESCRIPTION_TEXT_TEMPLATE.format(enrollment_url=enrollment_url)
+        short_description = content_metadata_item.get(
+            'short_description', content_metadata_item.get('title', '')
+        )
+        description = "<p>{}</p><p>{}</p>".format(short_description, url_link)
+        return description

--- a/integrated_channels/blackboard/exporters/content_metadata.py
+++ b/integrated_channels/blackboard/exporters/content_metadata.py
@@ -12,17 +12,22 @@ LOGGER = getLogger(__name__)
 class BlackboardContentMetadataExporter(ContentMetadataExporter):
     """
         Blackboard implementation of ContentMetadataExporter.
+        The odd choice of making enrollment_url into description with a link is best explained as:
+            Blackboard does not show description by default on home page.
+            However, description shows on the course search page.
+            This seems to be the only place to visibly place a link for now for learners to
+            find and visit the edX course page. But this can change as we explore blackboard more.
     """
     DATA_TRANSFORM_MAPPING = {
         'name': 'title',
         'externalId': 'key',
-        'description': 'description',
+        'description': 'enrollment_url',
         'courseId': 'key',
     }
 
     DESCRIPTION_TEXT_TEMPLATE = "<a href={enrollment_url}>Go to edX course page</a><br />"
 
-    def transform_description(self, content_metadata_item):
+    def transform_enrollment_url(self, content_metadata_item):
         """
         This will show a link to edX course on blackboard course description
         """

--- a/integrated_channels/blackboard/exporters/content_metadata.py
+++ b/integrated_channels/blackboard/exporters/content_metadata.py
@@ -13,3 +13,9 @@ class BlackboardContentMetadataExporter(ContentMetadataExporter):
     """
         Blackboard implementation of ContentMetadataExporter.
     """
+    DATA_TRANSFORM_MAPPING = {
+        'name': 'title',
+        'externalId': 'key',
+        'description': 'full_description',
+        'courseId': 'key',
+    }

--- a/tests/test_integrated_channels/test_blackboard/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_blackboard/test_exporters/test_content_metadata.py
@@ -7,7 +7,6 @@ import unittest
 from collections import OrderedDict
 
 import mock
-import responses
 from pytest import mark
 
 from integrated_channels.blackboard.exporters.content_metadata import BlackboardContentMetadataExporter

--- a/tests/test_integrated_channels/test_blackboard/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_blackboard/test_exporters/test_content_metadata.py
@@ -61,3 +61,15 @@ class TestBlackboardContentMetadataExporter(unittest.TestCase, EnterpriseMockMix
                 set(expected_keys)
                 .issubset(set(item.channel_metadata.keys()))
             )
+
+    def test_transform_description(self):
+        content_metadata_item = {
+            'enrollment_url': 'http://some/enrollment/url/',
+            'short_description': 'short desc',
+        }
+        exporter = BlackboardContentMetadataExporter('fake-user', self.config)
+        description = exporter.transform_description(content_metadata_item)
+        expected_description = exporter.DESCRIPTION_TEXT_TEMPLATE.format(
+            enrollment_url='http://some/enrollment/url/')
+        self.assertIn(expected_description, description)
+        self.assertIn('short desc', description)

--- a/tests/test_integrated_channels/test_blackboard/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_blackboard/test_exporters/test_content_metadata.py
@@ -71,5 +71,4 @@ class TestBlackboardContentMetadataExporter(unittest.TestCase, EnterpriseMockMix
         description = exporter.transform_description(content_metadata_item)
         expected_description = exporter.DESCRIPTION_TEXT_TEMPLATE.format(
             enrollment_url='http://some/enrollment/url/')
-        self.assertIn(expected_description, description)
-        self.assertIn('short desc', description)
+        assert description == expected_description

--- a/tests/test_integrated_channels/test_blackboard/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_blackboard/test_exporters/test_content_metadata.py
@@ -11,7 +11,7 @@ import responses
 from pytest import mark
 
 from integrated_channels.blackboard.exporters.content_metadata import BlackboardContentMetadataExporter
-from test_utils import FAKE_UUIDS, factories
+from test_utils import factories
 from test_utils.fake_catalog_api import FAKE_COURSE, FAKE_COURSE_RUN
 from test_utils.fake_enterprise_api import EnterpriseMockMixin
 
@@ -56,7 +56,7 @@ class TestBlackboardContentMetadataExporter(unittest.TestCase, EnterpriseMockMix
             FAKE_COURSE['key'],
         ])
 
-        expected_keys = [field for field in exporter.DATA_TRANSFORM_MAPPING.keys()]
+        expected_keys = exporter.DATA_TRANSFORM_MAPPING.keys()
         for item in content_items.values():
             self.assertTrue(
                 set(expected_keys)

--- a/tests/test_integrated_channels/test_blackboard/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_blackboard/test_exporters/test_content_metadata.py
@@ -4,16 +4,15 @@ Tests for Blackboard content metadata exporters.
 """
 
 import unittest
+from collections import OrderedDict
 
 import mock
 import responses
 from pytest import mark
-from collections import OrderedDict
 
 from integrated_channels.blackboard.exporters.content_metadata import BlackboardContentMetadataExporter
-
 from test_utils import FAKE_UUIDS, factories
-from test_utils.fake_catalog_api import FAKE_COURSE_RUN, FAKE_COURSE
+from test_utils.fake_catalog_api import FAKE_COURSE, FAKE_COURSE_RUN
 from test_utils.fake_enterprise_api import EnterpriseMockMixin
 
 

--- a/tests/test_integrated_channels/test_blackboard/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_blackboard/test_exporters/test_content_metadata.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for Blackboard content metadata exporters.
+"""
+
+import unittest
+
+import mock
+import responses
+from pytest import mark
+from collections import OrderedDict
+
+from integrated_channels.blackboard.exporters.content_metadata import BlackboardContentMetadataExporter
+
+from test_utils import FAKE_UUIDS, factories
+from test_utils.fake_catalog_api import FAKE_COURSE_RUN, FAKE_COURSE
+from test_utils.fake_enterprise_api import EnterpriseMockMixin
+
+
+@mark.django_db
+class TestBlackboardContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):
+    """
+    Tests for the ``BlackboardContentMetadataExporter`` class.
+    """
+
+    def setUp(self):
+        with mock.patch('enterprise.signals.EnterpriseCatalogApiClient'):
+            self.enterprise_customer_catalog = factories.EnterpriseCustomerCatalogFactory()
+
+        self.config = factories.BlackboardEnterpriseCustomerConfigurationFactory(
+            enterprise_customer=self.enterprise_customer_catalog.enterprise_customer,
+        )
+
+        # Mocks
+        self.mock_enterprise_customer_catalogs(str(self.enterprise_customer_catalog.uuid))
+        jwt_builder = mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
+        self.jwt_builder = jwt_builder.start()
+        self.addCleanup(jwt_builder.stop)
+        super(TestBlackboardContentMetadataExporter, self).setUp()
+
+    @mock.patch('enterprise.api_client.enterprise_catalog.EnterpriseCatalogApiClient.get_content_metadata')
+    def test_content_exporter_export(self, mock_get_content_metadata):
+        """
+        ``BlackboardContentMetadataExporter``'s ``export`` produces the expected export.
+        """
+        fake_content_metadata = OrderedDict()
+        fake_content_metadata[FAKE_COURSE_RUN['key']] = FAKE_COURSE_RUN
+        fake_content_metadata[FAKE_COURSE['key']] = FAKE_COURSE
+
+        mock_get_content_metadata.return_value = list(fake_content_metadata.values())
+        exporter = BlackboardContentMetadataExporter('fake-user', self.config)
+        content_items = exporter.export()
+
+        # not testing with program content type yet (it just generates a lot of keyError)
+        assert sorted(list(content_items.keys())) == sorted([
+            FAKE_COURSE_RUN['key'],
+            FAKE_COURSE['key'],
+        ])
+
+        expected_keys = [field for field in exporter.DATA_TRANSFORM_MAPPING.keys()]
+        for item in content_items.values():
+            self.assertTrue(
+                set(expected_keys)
+                .issubset(set(item.channel_metadata.keys()))
+            )

--- a/tests/test_integrated_channels/test_blackboard/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_blackboard/test_exporters/test_content_metadata.py
@@ -68,7 +68,7 @@ class TestBlackboardContentMetadataExporter(unittest.TestCase, EnterpriseMockMix
             'short_description': 'short desc',
         }
         exporter = BlackboardContentMetadataExporter('fake-user', self.config)
-        description = exporter.transform_description(content_metadata_item)
+        description = exporter.transform_enrollment_url(content_metadata_item)
         expected_description = exporter.DESCRIPTION_TEXT_TEMPLATE.format(
             enrollment_url='http://some/enrollment/url/')
         assert description == expected_description


### PR DESCRIPTION
- [X] still need to ensure discovery back from blackboard to edX but otherwise can create a course at least with this json output from exporter
     - Have a temporary solution to this by adding a link to enrollment_url in the description field but I am too psyched about it, will chat with Ken later today and explore ways to make this better. But this basically allows learners to find edX from the search page at least.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
