### PR TITLE
ENT-3557: improve exception reporting for authfailure blackboard

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,11 @@ Change Log
 
 Unreleased
 
+[3.8.43]
+--------
+
+* ENT-3557: Improve blackboard view logging to better report root cause of auth failure.
+
 [3.8.42]
 --------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.8.42"
+__version__ = "3.8.43"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/blackboard/views.py
+++ b/integrated_channels/blackboard/views.py
@@ -3,7 +3,6 @@ Views containing APIs for Blackboard integrated channel
 """
 
 import base64
-
 import requests
 from rest_framework import generics
 from rest_framework.exceptions import APIException, NotFound, ParseError
@@ -109,8 +108,19 @@ class BlackboardCompleteOAuthView(generics.ListAPIView):
         try:
             data = auth_response.json()
             refresh_token = data['refresh_token']
-        except (KeyError, ValueError):
-            raise requests.RequestException(response=auth_response)
+        except KeyError as exception:
+            raise ParseError(
+                "BLACKBOARD: failed to find refresh_token in auth response. "
+                "Auth response text: {}, Response code: {}, JSON response: {}".format(
+                    auth_response.text,
+                    auth_response.status_code,
+                    data,
+                )
+            ) from exception
+        except ValueError as exception:
+            raise ParseError(
+                "BLACKBOARD: auth response is invalid json. auth_response: {}".format(auth_response)
+            )
 
         enterprise_config.refresh_token = refresh_token
         enterprise_config.save()

--- a/integrated_channels/blackboard/views.py
+++ b/integrated_channels/blackboard/views.py
@@ -3,6 +3,7 @@ Views containing APIs for Blackboard integrated channel
 """
 
 import base64
+
 import requests
 from rest_framework import generics
 from rest_framework.exceptions import APIException, NotFound, ParseError

--- a/integrated_channels/blackboard/views.py
+++ b/integrated_channels/blackboard/views.py
@@ -121,7 +121,7 @@ class BlackboardCompleteOAuthView(generics.ListAPIView):
         except ValueError as exception:
             raise ParseError(
                 "BLACKBOARD: auth response is invalid json. auth_response: {}".format(auth_response)
-            )
+            ) from exception
 
         enterprise_config.refresh_token = refresh_token
         enterprise_config.save()


### PR DESCRIPTION
WHY?

Since today's exception reporting actually fails during the raise line meaning we don't actually get to see what the `auth_response` details were. I am getting a failure in staging that does not reproduce locally for me and it's great to be able to see the status_text, response of the response object at least

also handles the two cases KeyError and ValueError differently since they are for different reasons and have different pieces of info available in except blocks

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
