### PR TITLE
add action to kick off refreshing catalogs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,11 @@ Change Log
 
 Unreleased
 
+[3.9.5]
+--------
+
+* ENT-2450: Add action to kick off jobs to refresh enterprise catalogs so changes will be immediately visible
+
 [3.9.4]
 --------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.9.4"
+__version__ = "3.9.5"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/admin/__init__.py
+++ b/enterprise/admin/__init__.py
@@ -21,7 +21,7 @@ from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
 
-from enterprise.admin.actions import export_as_csv_action
+from enterprise.admin.actions import export_as_csv_action, refresh_catalog
 from enterprise.admin.forms import (
     EnterpriseCustomerAdminForm,
     EnterpriseCustomerCatalogAdminForm,
@@ -700,6 +700,7 @@ class EnterpriseCustomerCatalogAdmin(admin.ModelAdmin):
     Django admin model for EnterpriseCustomerCatalog.
     """
     ordering = ('enterprise_customer__name', 'title')
+    actions = [refresh_catalog]
 
     class Meta:
         model = EnterpriseCustomerCatalog


### PR DESCRIPTION
**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.


All catalogs are refreshing:
![Screen Shot 2020-10-20 at 11 43 09 AM](https://user-images.githubusercontent.com/17459564/96624147-5b5e2880-12da-11eb-87ba-0145a3491dd0.png)

Catalogs that failed to refresh:
![Screen Shot 2020-10-20 at 11 44 12 AM](https://user-images.githubusercontent.com/17459564/96624152-5dc08280-12da-11eb-8b33-cff03d12a0a7.png)

Mixture of successfully refreshing and failing to refresh catalogs:
![Screen Shot 2020-10-20 at 11 40 31 AM](https://user-images.githubusercontent.com/17459564/96624154-5f8a4600-12da-11eb-93f8-4a85796da16e.png)

