### PR TITLE
Adding blackboard course integration customization

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,11 @@ Change Log
 
 Unreleased
 
+[3.9.3]
+--------
+
+* Adding integrated course customization for Blackboard courses.
+
 [3.9.2]
 --------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.9.2"
+__version__ = "3.9.3"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/tests/test_integrated_channels/test_blackboard/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_blackboard/test_exporters/test_content_metadata.py
@@ -62,13 +62,43 @@ class TestBlackboardContentMetadataExporter(unittest.TestCase, EnterpriseMockMix
                 .issubset(set(item.channel_metadata.keys()))
             )
 
-    def test_transform_description(self):
+    def test_transform_course_metadata(self):
         content_metadata_item = {
+            'title': 'test title',
+            'key': 'test key',
             'enrollment_url': 'http://some/enrollment/url/',
             'short_description': 'short desc',
         }
         exporter = BlackboardContentMetadataExporter('fake-user', self.config)
-        description = exporter.transform_enrollment_url(content_metadata_item)
-        expected_description = exporter.DESCRIPTION_TEXT_TEMPLATE.format(
-            enrollment_url='http://some/enrollment/url/')
+        description = exporter.transform_course_metadata(content_metadata_item)
+        expected_description = {
+            'description': exporter.DESCRIPTION_TEXT_TEMPLATE.format(enrollment_url='http://some/enrollment/url/'),
+            'name': content_metadata_item['title'],
+            'externalId': content_metadata_item['key'],
+        }
+
+        assert description == expected_description
+
+    def test_transform_course_child_content_metadata(self):
+        content_metadata_item = {
+            'title': 'test title',
+            'enrollment_url': 'http://some/enrollment/url/',
+            'full_description': 'short desc',
+            'image_url': 'image_url',
+        }
+        exporter = BlackboardContentMetadataExporter('fake-user', self.config)
+        description = exporter.transform_course_child_content_metadata(content_metadata_item)
+        expected_description = {
+            'title': content_metadata_item.get('title'),
+            'availability': 'Yes',
+            'contentHandler': {
+                'id': 'resource/x-bb-externallink',
+                'url': content_metadata_item.get('enrollment_url', None),
+            },
+            'body': '<div>{title}</div><div>{description}</div><img src={image_url} />'.format(
+                title=content_metadata_item.get('title'),
+                description=content_metadata_item.get('full_description', None),
+                image_url=content_metadata_item.get('image_url', None),
+            )
+        }
         assert description == expected_description


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.

This PR adds: 
- Refactored exported content metadata so that it contains both solo the enrollment url as well as the embedded html element. This is to ensure that the description in course discovery keeps it's `go to edX page` hyper link, as well as have the course content page title be the same embedded link. 
- The course content creation method now has the additional process of creating a content object associated with the newly made course, as well as posts the HTML body to the course content's child. 

Outstanding q's:
- How do we want the course content's child to be formatted? It's a simplified HTML markdown language so we are restricted but there is a reasonable amount of customization todo here.

- Is testing required? 