### PR TITLE
moodle - update to preferred format.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,11 @@ Change Log
 
 Unreleased
 
+[3.9.4]
+--------
+
+* Style/UX changes for Moodle integration.
+
 [3.9.3]
 --------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.9.3"
+__version__ = "3.9.4"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/tests/test_integrated_channels/test_moodle/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_moodle/test_exporters/test_content_metadata.py
@@ -104,7 +104,7 @@ class TestMoodleContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):
     @responses.activate
     def test_transform_start(self):
         """
-        `MoodleContentMetadataExporter``'s ``transform_start` returns int timestamp.
+        `MoodleContentMetadataExporter``'s ``transform_start`` returns int timestamp.
         """
         content_metadata_item = {
             'title': 'edX Demonstration Course',
@@ -119,7 +119,7 @@ class TestMoodleContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):
     @responses.activate
     def test_transform_end(self):
         """
-        `MoodleContentMetadataExporter``'s ``transform_start` returns int timestamp.
+        `MoodleContentMetadataExporter``'s ``transform_end`` returns int timestamp.
         """
         content_metadata_item = {
             'title': 'edX Demonstration Course',
@@ -130,3 +130,37 @@ class TestMoodleContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):
         }
         exporter = MoodleContentMetadataExporter('fake-user', self.config)
         assert exporter.transform_end(content_metadata_item) == 1898553600  # Jan 1, 2030 UTC
+
+    @responses.activate
+    def test_transform_shortname(self):
+        """
+        `MoodleContentMetadataExporter``'s ``transform_shortname`` returns
+        a str combination  of title and key.
+        """
+        content_metadata_item = {
+            'title': 'edX Demonstration Course',
+            'key': 'edX+DemoXT0220'
+        }
+        expected_name = '{} ({})'.format(content_metadata_item['title'], content_metadata_item['key'])
+        exporter = MoodleContentMetadataExporter('fake-user', self.config)
+        assert exporter.transform_shortname(content_metadata_item) == expected_name
+
+    @responses.activate
+    def test_transform_title(self):
+        """
+        `MoodleContentMetadataExporter``'s ``transform_title`` returns a str
+        featuring the title and partners/organizations
+        """
+        content_metadata_item = {
+            'title': 'edX Demonstration Course',
+            'organizations': [
+                'HarvardX:Harvard University',
+                'MIT:MIT'
+            ]
+        }
+        expected_title = '{} ({})'.format(
+            content_metadata_item['title'],
+            ', '.join(content_metadata_item['organizations'])
+        )
+        exporter = MoodleContentMetadataExporter('fake-user', self.config)
+        assert exporter.transform_title(content_metadata_item) == expected_title


### PR DESCRIPTION
### Description
- Adds transformations for shortname and title (known as fullname in Moodle)

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
