### PR TITLE
Fix data sharing consent test to actually test enrolling a learner wh…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,11 @@ Change Log
 
 Unreleased
 
+[3.9.6]
+--------
+
+* Fix DSC tests to verify enrolling a learner with a license_uuid
+
 [3.9.5]
 --------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.9.5"
+__version__ = "3.9.6"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -585,7 +585,7 @@ class GrantDataSharingPermissions(View):
         if created:
             track_enrollment('data-consent-page-enrollment', request.user.id, course_id, request.path)
 
-    def _enroll_leaner_in_course(
+    def _enroll_learner_in_course(
             self,
             request,
             enterprise_customer,
@@ -636,27 +636,27 @@ class GrantDataSharingPermissions(View):
                         )
                     )
                     raise
-                try:
-                    self.create_enterprise_course_enrollment(request, enterprise_customer, course_id, license_uuid)
-                except IntegrityError:
-                    error_code = 'ENTGDS009'
-                    log_message = (
-                        '[Enterprise DSC API] IntegrityError while creating EnterpriseCourseEnrollment.'
-                        'Course: {course_id}, '
-                        'Program: {program_uuid}, '
-                        'EnterpriseCustomer: {enterprise_customer_uuid}, '
-                        'User: {user_id}, '
-                        'License UUID: {license_uuid}, '
-                        'ErrorCode: {error_code}'.format(
-                            course_id=course_id,
-                            program_uuid=program_uuid,
-                            enterprise_customer_uuid=enterprise_customer.uuid,
-                            user_id=request.user.id,
-                            license_uuid=license_uuid,
-                            error_code=error_code,
-                        )
+            try:
+                self.create_enterprise_course_enrollment(request, enterprise_customer, course_id, license_uuid)
+            except IntegrityError:
+                error_code = 'ENTGDS009'
+                log_message = (
+                    '[Enterprise DSC API] IntegrityError while creating EnterpriseCourseEnrollment.'
+                    'Course: {course_id}, '
+                    'Program: {program_uuid}, '
+                    'EnterpriseCustomer: {enterprise_customer_uuid}, '
+                    'User: {user_id}, '
+                    'License UUID: {license_uuid}, '
+                    'ErrorCode: {error_code}'.format(
+                        course_id=course_id,
+                        program_uuid=program_uuid,
+                        enterprise_customer_uuid=enterprise_customer.uuid,
+                        user_id=request.user.id,
+                        license_uuid=license_uuid,
+                        error_code=error_code,
                     )
-                    LOGGER.exception(log_message)
+                )
+                LOGGER.exception(log_message)
 
     @method_decorator(login_required)
     def get(self, request):  # pylint: disable=too-many-statements
@@ -718,7 +718,7 @@ class GrantDataSharingPermissions(View):
             # If DSC is entirely disabled proceed to enroll the learner in the course
             if not enterprise_customer.requests_data_sharing_consent:
                 try:
-                    self._enroll_leaner_in_course(
+                    self._enroll_learner_in_course(
                         request=request,
                         enterprise_customer=enterprise_customer,
                         course_id=course_id,
@@ -974,7 +974,7 @@ class GrantDataSharingPermissions(View):
         consent_provided = bool(request.POST.get('data_sharing_consent', False))
         if defer_creation is None and consent_record.consent_required() and consent_provided:
             try:
-                self._enroll_leaner_in_course(
+                self._enroll_learner_in_course(
                     request=request,
                     enterprise_customer=enterprise_customer,
                     course_id=course_id,


### PR DESCRIPTION
…o consented

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
