### PR TITLE
ENT-3522: Unset learners language so that default_language from enterprise customer may take effect.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,11 @@ Change Log
 
 Unreleased
 
+[3.9.7]
+--------
+
+* Unset learners language so that default_language from enterprise customer may take effect.
+
 [3.9.6]
 --------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.9.6"
+__version__ = "3.9.7"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/admin/__init__.py
+++ b/enterprise/admin/__init__.py
@@ -55,7 +55,12 @@ from enterprise.models import (
     PendingEnterpriseCustomerUser,
     SystemWideEnterpriseUserRoleAssignment,
 )
-from enterprise.utils import discovery_query_url, get_all_field_names, get_default_catalog_content_filter
+from enterprise.utils import (
+    discovery_query_url,
+    get_all_field_names,
+    get_default_catalog_content_filter,
+    unset_language_of_all_enterprise_learners,
+)
 
 try:
     from enterprise.api_client.enterprise_catalog import EnterpriseCatalogApiClient
@@ -192,6 +197,18 @@ class EnterpriseCustomerAdmin(DjangoObjectActions, SimpleHistoryAdmin):
 
     class Meta:
         model = EnterpriseCustomer
+
+    def save_model(self, request, obj, form, change):
+        """
+        Check if `default_language` has changed or not, if it is changed then update language preference of all the
+        learners belonging to this enterprise customer.
+        """
+        super(EnterpriseCustomerAdmin, self).save_model(request, obj, form, change)
+
+        if 'default_language' in form.changed_data and obj.default_language:
+            # Unset the language preference when all the learners linked with the enterprise customer.
+            # The middleware in the enterprise will handle the cases for setting a proper language for the learner.
+            unset_language_of_all_enterprise_learners(obj)
 
     def change_view(self, request, object_id, form_url='', extra_context=None):
         catalog_uuid = EnterpriseCustomerCatalogAdminForm.get_catalog_preview_uuid(request.POST)

--- a/enterprise/middleware.py
+++ b/enterprise/middleware.py
@@ -2,15 +2,13 @@
 Middleware for enterprise app.
 """
 
-from django.conf import settings
 from django.utils.deprecation import MiddlewareMixin
 
 from enterprise.utils import get_enterprise_customer_for_user
 
 try:
-    from openedx.core.djangoapps.lang_pref import COOKIE_DURATION, LANGUAGE_KEY
+    from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
 except ImportError:
-    COOKIE_DURATION = None
     LANGUAGE_KEY = None
 
 try:
@@ -38,7 +36,7 @@ class EnterpriseLanguagePreferenceMiddleware(MiddlewareMixin):
     whenever they are logged in.
     """
 
-    def process_response(self, request, response):
+    def process_request(self, request):
         """
         Perform the following checks
             1. Check that the user is authenticated and belongs to an enterprise customer.
@@ -46,8 +44,10 @@ class EnterpriseLanguagePreferenceMiddleware(MiddlewareMixin):
                 EnterpriseCustomer model.
             3. Check that user has not set a language via its account settings page.
 
-        If all the above checks are satisfied then set the language cookie to the `default_language` of
-        EnterpriseCustomer model instance.
+        If all the above checks are satisfied then set request._anonymous_user_cookie_lang to the `default_language` of
+        EnterpriseCustomer model instance. This attribute will later be used by the `LanguagePreferenceMiddleware`
+        middleware for setting the user preference. Since, this middleware relies on `LanguagePreferenceMiddleware`
+        so it must always be followed by `LanguagePreferenceMiddleware`. Otherwise, it will not work.
         """
         # If the user is logged in, check for their language preference and user's enterprise configuration.
         # Also check for real user, if current user is a masquerading user.
@@ -58,27 +58,16 @@ class EnterpriseLanguagePreferenceMiddleware(MiddlewareMixin):
         if current_user and current_user.is_authenticated:
             enterprise_customer = get_enterprise_customer_for_user(current_user)
 
-            if not (enterprise_customer and enterprise_customer.default_language):
-                # If user does not belong to an enterprise customer or the default language for the user's
-                # enterprise customer is not set, then no need to go any further.
-                return response
+            if enterprise_customer and enterprise_customer.default_language:
+                # Get the user's language preference
+                try:
+                    user_pref = get_user_preference(current_user, LANGUAGE_KEY)
+                except (UserAPIRequestError, UserAPIInternalError):
+                    # Ignore errors related to user preferences not found.
+                    pass
 
-            # Get the user's language preference
-            try:
-                user_pref = get_user_preference(current_user, LANGUAGE_KEY)
-            except (UserAPIRequestError, UserAPIInternalError):
-                # Ignore errors related to user preferences not found.
-                pass
-
-            # If user's language preference is not set and enterprise customer has a default language configured
-            # then set the default language as the learner's language
-            if not user_pref and not is_request_from_mobile_app(request):
-                response.set_cookie(
-                    settings.LANGUAGE_COOKIE,
-                    value=enterprise_customer.default_language,
-                    domain=settings.SESSION_COOKIE_DOMAIN,
-                    max_age=COOKIE_DURATION,
-                    secure=request.is_secure()
-                )
-
-        return response
+                # If user's language preference is not set and enterprise customer has a default language configured
+                # then set the default language as the learner's language
+                if not user_pref and not is_request_from_mobile_app(request):
+                    # pylint: disable=protected-access
+                    request._anonymous_user_cookie_lang = enterprise_customer.default_language

--- a/enterprise/signals.py
+++ b/enterprise/signals.py
@@ -32,6 +32,7 @@ from enterprise.utils import (
     delete_tableau_user_by_id,
     get_default_catalog_content_filter,
     track_enrollment,
+    unset_enterprise_learner_language,
 )
 
 try:
@@ -243,6 +244,18 @@ def delete_enterprise_learner_role_assignment(sender, instance, **kwargs):     #
         except SystemWideEnterpriseUserRoleAssignment.DoesNotExist:
             # Do nothing if no role assignment is present for the enterprise customer user.
             pass
+
+
+@receiver(post_save, sender=EnterpriseCustomerUser)
+def update_learner_language_preference(sender, instance, created, **kwargs):     # pylint: disable=unused-argument
+    """
+    Update the language preference of the learner.
+    Set the language preference to the value enterprise customer has used as the `default_language`.
+    """
+    # Unset the language preference when a new learner is linked with the enterprise customer.
+    # The middleware in the enterprise will handle the cases for setting a proper language for the learner.
+    if created and instance.enterprise_customer.default_language:
+        unset_enterprise_learner_language(instance)
 
 
 @receiver(pre_delete, sender=EnterpriseAnalyticsUser)

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -8,9 +8,7 @@ import ddt
 import mock
 from pytest import mark
 
-from django.conf import settings
 from django.contrib.sessions.middleware import SessionMiddleware
-from django.http import HttpResponse
 from django.test.client import Client, RequestFactory
 from django.utils.translation import LANGUAGE_SESSION_KEY
 
@@ -22,7 +20,6 @@ from test_utils.factories import (
     UserFactory,
 )
 
-COOKIE_DURATION = 14 * 24 * 60 * 60  # 14 days in seconds
 LANGUAGE_KEY = 'pref-lang'
 UserAPIInternalError = Exception
 UserAPIRequestError = Exception
@@ -39,6 +36,8 @@ class TestUserPreferenceMiddleware(unittest.TestCase):
         """
         Setup middleware, request, session, user and enterprise customer for tests. Also mock imports from edx-platform.
         """
+        self.mock_imports()
+
         super(TestUserPreferenceMiddleware, self).setUp()
         self.middleware = EnterpriseLanguagePreferenceMiddleware()
         self.session_middleware = SessionMiddleware()
@@ -54,35 +53,23 @@ class TestUserPreferenceMiddleware(unittest.TestCase):
             enterprise_customer=self.enterprise_customer,
             user_id=self.user.id,
         )
-        self.mock_imports()
 
     def mock_imports(self):
         """
         Mock all the imports from edx-platform
         """
         mocks = [
-            mock.patch('enterprise.middleware.COOKIE_DURATION', COOKIE_DURATION),
             mock.patch('enterprise.middleware.LANGUAGE_KEY', LANGUAGE_KEY),
             mock.patch('enterprise.middleware.UserAPIInternalError', UserAPIInternalError),
             mock.patch('enterprise.middleware.UserAPIRequestError', UserAPIRequestError),
             mock.patch('enterprise.middleware.get_user_preference', mock.MagicMock(return_value=None)),
             mock.patch('enterprise.middleware.is_request_from_mobile_app', mock.MagicMock(return_value=False)),
+            mock.patch('enterprise.utils.UserPreference', mock.MagicMock()),
 
         ]
         for mock_object in mocks:
             self.jwt_builder = mock_object.start()
             self.addCleanup(mock_object.stop)
-
-    def test_logout_should_not_remove_cookie(self):
-        """
-        Validate that the cookie is not removed if the learner logs out.
-        """
-        self.request.user = self.anonymous_user
-
-        response = mock.Mock(spec=HttpResponse)
-        self.middleware.process_response(self.request, response)
-
-        response.delete_cookie.assert_not_called()
 
     @ddt.data(None, 'es', 'en')
     def test_preference_setting_changes_cookie(self, lang_pref_out):
@@ -92,22 +79,10 @@ class TestUserPreferenceMiddleware(unittest.TestCase):
         """
         self.enterprise_customer.default_language = lang_pref_out
         self.enterprise_customer.save()
+        self.middleware.process_request(self.request)
 
-        response = mock.Mock(spec=HttpResponse)
-        self.middleware.process_response(self.request, response)
-
-        if lang_pref_out:
-            response.set_cookie.assert_called_with(
-                settings.LANGUAGE_COOKIE,
-                value=lang_pref_out,
-                domain=settings.SESSION_COOKIE_DOMAIN,
-                max_age=COOKIE_DURATION,
-                secure=self.request.is_secure(),
-            )
-        else:
-            response.set_cookie.assert_not_called()
-
-        self.assertNotIn(LANGUAGE_SESSION_KEY, self.request.session)
+        assert getattr(self.request, '_anonymous_user_cookie_lang', None) == lang_pref_out
+        assert LANGUAGE_SESSION_KEY not in self.request.session
 
     def test_real_user_extracted_from_request(self):
         """
@@ -117,19 +92,11 @@ class TestUserPreferenceMiddleware(unittest.TestCase):
         self.request.user = UserFactory()
         self.request.user.real_user = self.user
 
-        response = mock.Mock(spec=HttpResponse)
-        self.middleware.process_response(self.request, response)
+        self.middleware.process_request(self.request)
 
         # Make sure the real user is used for setting the language cookie
-        response.set_cookie.assert_called_with(
-            settings.LANGUAGE_COOKIE,
-            value=self.enterprise_customer.default_language,
-            domain=settings.SESSION_COOKIE_DOMAIN,
-            max_age=COOKIE_DURATION,
-            secure=self.request.is_secure(),
-        )
-
-        self.assertNotIn(LANGUAGE_SESSION_KEY, self.request.session)
+        assert getattr(self.request, '_anonymous_user_cookie_lang', None) == self.enterprise_customer.default_language
+        assert LANGUAGE_SESSION_KEY not in self.request.session
 
     def test_cookie_not_set_for_anonymous_user(self):
         """
@@ -137,13 +104,11 @@ class TestUserPreferenceMiddleware(unittest.TestCase):
         """
         # Hide the real user and masquerade as a fake user, fake user does not belong to any enterprise customer.
         self.request.user = self.anonymous_user
-
-        response = mock.Mock(spec=HttpResponse)
-        self.middleware.process_response(self.request, response)
+        self.middleware.process_request(self.request)
 
         # Make sure the set cookie is not called for anonymous users
-        response.set_cookie.assert_not_called()
-        self.assertNotIn(LANGUAGE_SESSION_KEY, self.request.session)
+        assert getattr(self.request, '_anonymous_user_cookie_lang', None) is None
+        assert LANGUAGE_SESSION_KEY not in self.request.session
 
     def test_cookie_not_set_for_non_enterprise_learners(self):
         """
@@ -151,13 +116,11 @@ class TestUserPreferenceMiddleware(unittest.TestCase):
         """
         # Hide the real user and masquerade as a fake user, fake user does not belong to any enterprise customer.
         self.request.user = UserFactory()
-
-        response = mock.Mock(spec=HttpResponse)
-        self.middleware.process_response(self.request, response)
+        self.middleware.process_request(self.request)
 
         # Make sure the set cookie is not called for anonymous users
-        response.set_cookie.assert_not_called()
-        self.assertNotIn(LANGUAGE_SESSION_KEY, self.request.session)
+        assert getattr(self.request, '_anonymous_user_cookie_lang', None) is None
+        assert LANGUAGE_SESSION_KEY not in self.request.session
 
     def test_cookie_when_there_is_no_request_user(self):
         """
@@ -168,12 +131,11 @@ class TestUserPreferenceMiddleware(unittest.TestCase):
         session_middleware = SessionMiddleware()
         session_middleware.process_request(request)
 
-        response = mock.Mock(spec=HttpResponse)
-        self.middleware.process_response(request, response)
+        self.middleware.process_request(request)
 
         # Make sure the set cookie is not called for anonymous users
-        response.set_cookie.assert_not_called()
-        self.assertNotIn(LANGUAGE_SESSION_KEY, request.session)
+        assert getattr(self.request, '_anonymous_user_cookie_lang', None) is None
+        assert LANGUAGE_SESSION_KEY not in self.request.session
 
     def test_errors_are_handled(self):
         """
@@ -182,18 +144,12 @@ class TestUserPreferenceMiddleware(unittest.TestCase):
         """
         with mock.patch('enterprise.middleware.get_user_preference') as mock_get_user_preference:
             mock_get_user_preference.side_effect = UserAPIInternalError
-            response = mock.Mock(spec=HttpResponse)
-            self.middleware.process_response(self.request, response)
+            self.middleware.process_request(self.request)
 
             # Make sure the set cookie is not called for anonymous users
-            response.set_cookie.assert_called_with(
-                settings.LANGUAGE_COOKIE,
-                value=self.enterprise_customer.default_language,
-                domain=settings.SESSION_COOKIE_DOMAIN,
-                max_age=COOKIE_DURATION,
-                secure=self.request.is_secure(),
-            )
-            self.assertNotIn(LANGUAGE_SESSION_KEY, self.request.session)
+            # pylint: disable=protected-access,no-member
+            assert self.request._anonymous_user_cookie_lang == self.enterprise_customer.default_language
+            assert LANGUAGE_SESSION_KEY not in self.request.session
 
     def test_cookie_not_set_for_mobile_requests(self):
         """
@@ -201,9 +157,8 @@ class TestUserPreferenceMiddleware(unittest.TestCase):
         """
         with mock.patch('enterprise.middleware.is_request_from_mobile_app') as mock_is_request_from_mobile_app:
             mock_is_request_from_mobile_app.return_value = True
-            response = mock.Mock(spec=HttpResponse)
-            self.middleware.process_response(self.request, response)
+            self.middleware.process_request(self.request)
 
             # Make sure the set cookie is not called for anonymous users
-            response.set_cookie.assert_not_called()
-            self.assertNotIn(LANGUAGE_SESSION_KEY, self.request.session)
+            assert getattr(self.request, '_anonymous_user_cookie_lang', None) is None
+            assert LANGUAGE_SESSION_KEY not in self.request.session


### PR DESCRIPTION


**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [x] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
