### PR TITLE
ENT-3279: Upgrade to pytest 6+ (and factoryboy 3+)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.py[cod]
 __pycache__
 .pytest_cache
+pyvenv.cfg
 
 # C extensions
 *.so

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Change Log
 Unreleased
 -----------
 
+[3.10.0]
+--------
+
+* Tests only: upgrade to pytest 6+ and factoryboy 3+ to bring up to date with edx-platform.
+
 [3.9.13]
 --------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.9.13"
+__version__ = "3.10.0"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/signals.py
+++ b/enterprise/signals.py
@@ -331,7 +331,9 @@ def update_enterprise_catalog_data(sender, instance, **kwargs):     # pylint: di
         else:
             response = catalog_client.get_enterprise_catalog(catalog_uuid=catalog_uuid)
     except NotConnectedToOpenEdX as exc:
-        logger.exception('Unable to update Enterprise Catalog {}'.format(str(catalog_uuid)))
+        logger.exception(
+            'Unable to update Enterprise Catalog {}'.format(str(catalog_uuid)), exc_info=exc
+        )
     else:
         if not response:
             # catalog with matching uuid does NOT exist in enterprise-catalog
@@ -369,7 +371,10 @@ def delete_enterprise_catalog_data(sender, instance, **kwargs):     # pylint: di
         catalog_client = EnterpriseCatalogApiClient()
         catalog_client.delete_enterprise_catalog(catalog_uuid)
     except NotConnectedToOpenEdX as exc:
-        logger.exception('Unable to delete Enterprise Catalog {}'.format(str(catalog_uuid)), exc)
+        logger.exception(
+            'Unable to delete Enterprise Catalog {}'.format(str(catalog_uuid)),
+            exc_info=exc
+        )
 
 
 def create_enterprise_enrollment_receiver(sender, instance, **kwargs):     # pylint: disable=unused-argument

--- a/enterprise/signals.py
+++ b/enterprise/signals.py
@@ -331,7 +331,7 @@ def update_enterprise_catalog_data(sender, instance, **kwargs):     # pylint: di
         else:
             response = catalog_client.get_enterprise_catalog(catalog_uuid=catalog_uuid)
     except NotConnectedToOpenEdX as exc:
-        logger.exception('Unable to update Enterprise Catalog {}'.format(str(catalog_uuid)), exc)
+        logger.exception('Unable to update Enterprise Catalog {}'.format(str(catalog_uuid)))
     else:
         if not response:
             # catalog with matching uuid does NOT exist in enterprise-catalog

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -32,8 +32,7 @@ freezegun==0.3.14
 # version 0.10.16 is having version conflict in make upgrade
 responses<0.10.16
 
-# version 3.0 is causing test failures
-factory-boy<3.0
+factory-boy<4.0
 
 # pytest version 6.0 causing test failures
 pytest<7.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -36,7 +36,7 @@ responses<0.10.16
 factory-boy<3.0
 
 # pytest version 6.0 causing test failures
-pytest<6.0
+pytest<7.0
 
 # Python 3.5 is dropped in version 5.0
 celery<5.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -103,7 +103,7 @@ pyparsing==2.4.7          # via -r requirements/doc.txt, -r requirements/test-ma
 pytest-catchlog==1.2.2    # via -r requirements/test.txt
 pytest-cov==2.10.1        # via -r requirements/test.txt
 pytest-django==4.1.0      # via -r requirements/test.txt
-pytest==6.1.1             # via -c requirements/constraints.txt, -r requirements/test.txt, pytest-catchlog, pytest-cov, pytest-django
+pytest==6.1.2             # via -c requirements/constraints.txt, -r requirements/test.txt, pytest-catchlog, pytest-cov, pytest-django
 python-dateutil==2.4.0    # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-drf-extensions, faker, freezegun
 python-slugify==4.0.1     # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, code-annotations
 pytz==2020.1              # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, babel, celery, django, edx-tincan-py35

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -65,6 +65,7 @@ idna==2.10                # via -r requirements/doc.txt, -r requirements/test-ma
 imagesize==1.2.0          # via -r requirements/doc.txt, sphinx
 importlib-metadata==2.0.0  # via -r requirements/test.txt, inflect
 inflect==3.0.2            # via -c requirements/constraints.txt, -r requirements/test.txt, jinja2-pluralize
+iniconfig==1.1.1          # via -r requirements/test.txt, pytest
 isort==4.3.21             # via -r requirements/dev.in, pylint
 jinja2-pluralize==0.3.0   # via -r requirements/test.txt, diff-cover
 jinja2==2.11.2            # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, code-annotations, diff-cover, jinja2-pluralize, sphinx
@@ -83,7 +84,7 @@ path==13.1.0              # via -r requirements/doc.txt, -r requirements/test-ma
 pbr==5.5.1                # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, stevedore
 pillow==7.2.0             # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
 pip-tools==5.3.1          # via -r requirements/dev.in
-pkginfo==1.6.0            # via twine
+pkginfo==1.6.1            # via twine
 pluggy==0.13.1            # via -r requirements/test.txt, diff-cover, pytest, tox
 pockets==0.9.1            # via -r requirements/doc.txt, sphinxcontrib-napoleon
 polib==1.1.0              # via edx-i18n-tools
@@ -93,7 +94,7 @@ pycodestyle==2.6.0        # via -r requirements/dev.in
 pycparser==2.20           # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, cffi
 pycryptodomex==3.9.8      # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, pyjwkest
 pydocstyle==5.1.1         # via -r requirements/dev.in
-pygments==2.7.1           # via -r requirements/doc.txt, -r requirements/test.txt, diff-cover, doc8, readme-renderer, sphinx
+pygments==2.7.2           # via -r requirements/doc.txt, -r requirements/test.txt, diff-cover, doc8, readme-renderer, sphinx
 pyjwkest==1.4.2           # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-drf-extensions
 pyjwt[crypto]==1.7.1      # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, drf-jwt, edx-rest-api-client
 pylint-celery==0.3        # via edx-lint
@@ -134,16 +135,15 @@ stevedore==1.32.0         # via -r requirements/doc.txt, -r requirements/test-ma
 tableauserverclient==0.13  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
 testfixtures==6.15.0      # via -r requirements/dev.in, -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
 text-unidecode==1.3       # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, faker, python-slugify
-toml==0.10.1              # via tox
+toml==0.10.1              # via -r requirements/test.txt, pytest, tox
 tox-battery==0.6.1        # via -r requirements/dev.in
 tox==3.20.1               # via -r requirements/dev.in, tox-battery
-tqdm==4.50.2              # via twine
+tqdm==4.51.0              # via twine
 twine==1.11.0             # via -r requirements/dev.in
 unicodecsv==0.14.1        # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
 urllib3==1.25.11          # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, requests
 vine==1.3.0               # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, amqp, celery
-virtualenv==20.0.35       # via tox
-wcwidth==0.2.5            # via -r requirements/test.txt, pytest
+virtualenv==20.1.0        # via tox
 webencodings==0.5.1       # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, bleach
 wheel==0.35.1             # via -r requirements/dev.in
 wrapt==1.11.2             # via astroid

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,6 +4,10 @@
 #
 #    make upgrade
 #
+--index-url http://edx.devstack.devpi:3141/root/pypi/+simple/
+--extra-index-url https://pypi.python.org/simple
+--trusted-host edx.devstack.devpi
+
 alabaster==0.7.12         # via -r requirements/doc.txt, sphinx
 amqp==2.6.1               # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, kombu
 aniso8601==8.0.0          # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-tincan-py35
@@ -43,7 +47,7 @@ djangorestframework==3.9.4  # via -r requirements/doc.txt, -r requirements/test-
 doc8==0.8.1               # via -r requirements/doc.txt
 docutils==0.16            # via -r requirements/doc.txt, doc8, readme-renderer, restructuredtext-lint, sphinx
 drf-jwt==1.17.2           # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-drf-extensions
-edx-django-utils==3.8.0   # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, django-config-models, edx-drf-extensions, edx-rest-api-client
+edx-django-utils==3.9.0   # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, django-config-models, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.2.0  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-rbac
 edx-i18n-tools==0.5.3     # via -r requirements/dev.in
 edx-lint==1.5.2           # via -r requirements/dev.in
@@ -59,7 +63,7 @@ freezegun==0.3.14         # via -c requirements/constraints.txt, -r requirements
 future==0.18.2            # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, pyjwkest
 idna==2.10                # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, requests
 imagesize==1.2.0          # via -r requirements/doc.txt, sphinx
-importlib-metadata==2.0.0  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, inflect, kombu, path, pluggy, pytest, tox, virtualenv
+importlib-metadata==2.0.0  # via -r requirements/test.txt, inflect
 inflect==3.0.2            # via -c requirements/constraints.txt, -r requirements/test.txt, jinja2-pluralize
 isort==4.3.21             # via -r requirements/dev.in, pylint
 jinja2-pluralize==0.3.0   # via -r requirements/test.txt, diff-cover
@@ -71,7 +75,7 @@ lazy-object-proxy==1.4.3  # via astroid
 markupsafe==1.1.1         # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, jinja2
 mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.txt
-more-itertools==8.5.0     # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, pytest, zipp
+more-itertools==8.5.0     # via -r requirements/test.txt, pytest, zipp
 newrelic==5.20.1.150      # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-django-utils
 packaging==20.4           # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, bleach, pytest, sphinx, tox
 path.py==12.5.0           # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-i18n-tools
@@ -79,7 +83,7 @@ path==13.1.0              # via -r requirements/doc.txt, -r requirements/test-ma
 pbr==5.5.1                # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, stevedore
 pillow==7.2.0             # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
 pip-tools==5.3.1          # via -r requirements/dev.in
-pkginfo==1.5.0.1          # via twine
+pkginfo==1.6.0            # via twine
 pluggy==0.13.1            # via -r requirements/test.txt, diff-cover, pytest, tox
 pockets==0.9.1            # via -r requirements/doc.txt, sphinxcontrib-napoleon
 polib==1.1.0              # via edx-i18n-tools
@@ -100,13 +104,13 @@ pymongo==3.10.1           # via -r requirements/doc.txt, -r requirements/test-ma
 pyparsing==2.4.7          # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, packaging
 pytest-catchlog==1.2.2    # via -r requirements/test.txt
 pytest-cov==2.10.1        # via -r requirements/test.txt
-pytest-django==4.0.0      # via -r requirements/test.txt
-pytest==5.4.3             # via -c requirements/constraints.txt, -r requirements/test.txt, pytest-catchlog, pytest-cov, pytest-django
+pytest-django==4.1.0      # via -r requirements/test.txt
+pytest==6.1.1             # via -c requirements/constraints.txt, -r requirements/test.txt, pytest-catchlog, pytest-cov, pytest-django
 python-dateutil==2.4.0    # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-drf-extensions, faker, freezegun
 python-slugify==4.0.1     # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, code-annotations
 pytz==2020.1              # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, babel, celery, django, edx-tincan-py35
 pyyaml==5.3.1             # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, code-annotations, edx-i18n-tools
-readme-renderer==27.0     # via -r requirements/doc.txt
+readme-renderer==28.0     # via -r requirements/doc.txt
 requests-toolbelt==0.9.1  # via twine
 requests==2.24.0          # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-toolbelt, responses, slumber, sphinx, tableauserverclient, twine
 responses==0.10.15        # via -c requirements/constraints.txt, -r requirements/test.txt
@@ -135,7 +139,6 @@ tox-battery==0.6.1        # via -r requirements/dev.in
 tox==3.20.1               # via -r requirements/dev.in, tox-battery
 tqdm==4.50.2              # via twine
 twine==1.11.0             # via -r requirements/dev.in
-typed-ast==1.4.1          # via astroid
 unicodecsv==0.14.1        # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
 urllib3==1.25.11          # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, requests
 vine==1.3.0               # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, amqp, celery
@@ -144,7 +147,7 @@ wcwidth==0.2.5            # via -r requirements/test.txt, pytest
 webencodings==0.5.1       # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, bleach
 wheel==0.35.1             # via -r requirements/dev.in
 wrapt==1.11.2             # via astroid
-zipp==1.0.0               # via -c requirements/constraints.txt, -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, importlib-metadata
+zipp==1.0.0               # via -c requirements/constraints.txt, -r requirements/test.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,9 +4,6 @@
 #
 #    make upgrade
 #
---index-url http://edx.devstack.devpi:3141/root/pypi/+simple/
---extra-index-url https://pypi.python.org/simple
---trusted-host edx.devstack.devpi
 
 alabaster==0.7.12         # via -r requirements/doc.txt, sphinx
 amqp==2.6.1               # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, kombu

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -53,7 +53,7 @@ edx-rbac==1.3.3           # via -r requirements/doc.txt, -r requirements/test-ma
 edx-rest-api-client==5.2.1  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
 edx-sphinx-theme==1.5.0   # via -r requirements/doc.txt
 edx-tincan-py35==0.0.9    # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
-factory-boy==2.12.0       # via -c requirements/constraints.txt, -r requirements/test.txt
+factory-boy==3.1.0        # via -c requirements/constraints.txt, -r requirements/test.txt
 faker==4.14.0             # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via tox, virtualenv
 freezegun==0.3.14         # via -c requirements/constraints.txt, -r requirements/test.txt
@@ -73,7 +73,7 @@ lazy-object-proxy==1.4.3  # via astroid
 markupsafe==1.1.1         # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, jinja2
 mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.txt
-more-itertools==8.5.0     # via -r requirements/test.txt, pytest, zipp
+more-itertools==8.5.0     # via -r requirements/test.txt, zipp
 newrelic==5.20.1.150      # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-django-utils
 packaging==20.4           # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, bleach, pytest, sphinx, tox
 path.py==12.5.0           # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-i18n-tools

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -64,7 +64,7 @@ pockets==0.9.1            # via sphinxcontrib-napoleon
 psutil==5.7.2             # via -r requirements/test-master.txt, edx-django-utils
 pycparser==2.20           # via -r requirements/test-master.txt, cffi
 pycryptodomex==3.9.8      # via -r requirements/test-master.txt, pyjwkest
-pygments==2.7.1           # via doc8, readme-renderer, sphinx
+pygments==2.7.2           # via doc8, readme-renderer, sphinx
 pyjwkest==1.4.2           # via -r requirements/test-master.txt, edx-drf-extensions
 pyjwt[crypto]==1.7.1      # via -r requirements/test-master.txt, drf-jwt, edx-rest-api-client
 pymongo==3.10.1           # via -r requirements/test-master.txt, edx-opaque-keys

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -4,9 +4,6 @@
 #
 #    make upgrade
 #
---index-url http://edx.devstack.devpi:3141/root/pypi/+simple/
---extra-index-url https://pypi.python.org/simple
---trusted-host edx.devstack.devpi
 
 alabaster==0.7.12         # via sphinx
 amqp==2.6.1               # via -r requirements/test-master.txt, kombu

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -4,6 +4,10 @@
 #
 #    make upgrade
 #
+--index-url http://edx.devstack.devpi:3141/root/pypi/+simple/
+--extra-index-url https://pypi.python.org/simple
+--trusted-host edx.devstack.devpi
+
 alabaster==0.7.12         # via sphinx
 amqp==2.6.1               # via -r requirements/test-master.txt, kombu
 aniso8601==8.0.0          # via -r requirements/test-master.txt, edx-tincan-py35
@@ -35,7 +39,7 @@ djangorestframework==3.9.4  # via -r requirements/test-master.txt, django-config
 doc8==0.8.1               # via -r requirements/doc.in
 docutils==0.16            # via -r requirements/doc.in, doc8, readme-renderer, restructuredtext-lint, sphinx
 drf-jwt==1.17.2           # via -r requirements/test-master.txt, edx-drf-extensions
-edx-django-utils==3.8.0   # via -r requirements/test-master.txt, django-config-models, edx-drf-extensions, edx-rest-api-client
+edx-django-utils==3.9.0   # via -r requirements/test-master.txt, django-config-models, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.2.0  # via -r requirements/test-master.txt, edx-rbac
 edx-opaque-keys[django]==2.1.1  # via -r requirements/test-master.txt, edx-drf-extensions
 edx-rbac==1.3.3           # via -r requirements/test-master.txt
@@ -45,13 +49,11 @@ edx-tincan-py35==0.0.9    # via -r requirements/test-master.txt
 future==0.18.2            # via -r requirements/test-master.txt, pyjwkest
 idna==2.10                # via -r requirements/test-master.txt, requests
 imagesize==1.2.0          # via sphinx
-importlib-metadata==2.0.0  # via -r requirements/test-master.txt, kombu, path
 jinja2==2.11.2            # via -r requirements/test-master.txt, code-annotations, sphinx
 jsondiff==1.2.0           # via -r requirements/test-master.txt
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/test-master.txt
 kombu==4.6.11             # via -r requirements/test-master.txt, celery
 markupsafe==1.1.1         # via -r requirements/test-master.txt, jinja2
-more-itertools==8.5.0     # via -r requirements/test-master.txt, zipp
 newrelic==5.20.1.150      # via -r requirements/test-master.txt, edx-django-utils
 packaging==20.4           # via -r requirements/test-master.txt, bleach, sphinx
 path.py==12.5.0           # via -r requirements/test-master.txt
@@ -71,7 +73,7 @@ python-dateutil==2.4.0    # via -r requirements/test-master.txt, edx-drf-extensi
 python-slugify==4.0.1     # via -r requirements/test-master.txt, code-annotations
 pytz==2020.1              # via -r requirements/test-master.txt, babel, celery, django, edx-tincan-py35
 pyyaml==5.3.1             # via -r requirements/test-master.txt, code-annotations
-readme-renderer==27.0     # via -r requirements/doc.in
+readme-renderer==28.0     # via -r requirements/doc.in
 requests==2.24.0          # via -r requirements/test-master.txt, edx-drf-extensions, edx-rest-api-client, pyjwkest, slumber, sphinx, tableauserverclient
 rest-condition==1.0.3     # via -r requirements/test-master.txt, edx-drf-extensions
 restructuredtext-lint==1.3.1  # via doc8
@@ -97,7 +99,6 @@ unicodecsv==0.14.1        # via -r requirements/test-master.txt
 urllib3==1.25.11          # via -r requirements/test-master.txt, requests
 vine==1.3.0               # via -r requirements/test-master.txt, amqp, celery
 webencodings==0.5.1       # via -r requirements/test-master.txt, bleach
-zipp==1.0.0               # via -c requirements/constraints.txt, -r requirements/test-master.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/edx-platform-constraints.txt
+++ b/requirements/edx-platform-constraints.txt
@@ -79,7 +79,7 @@ edx-django-release-util==0.4.4  # via -r requirements/edx/base.in
 edx-django-sites-extensions==2.5.1  # via -r requirements/edx/base.in
 edx-django-utils==3.9.0   # via -r requirements/edx/base.in, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-toggles, edx-when
 edx-drf-extensions==6.2.0  # via -r requirements/edx/base.in, edx-completion, edx-enterprise, edx-organizations, edx-proctoring, edx-rbac, edx-when, edxval
-edx-enterprise==3.9.6     # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
+edx-enterprise==3.9.10     # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
 edx-i18n-tools==0.5.3     # via ora2
 edx-milestones==0.3.0     # via -r requirements/edx/base.in
 edx-opaque-keys[django]==2.1.1  # via -r requirements/edx/paver.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, lti-consumer-xblock, xmodule
@@ -88,7 +88,7 @@ edx-proctoring-proctortrack==1.0.5  # via -r requirements/edx/base.in
 edx-proctoring==2.4.8     # via -r requirements/edx/base.in, edx-proctoring-proctortrack
 edx-rest-api-client==5.2.1  # via -r requirements/edx/base.in, edx-enterprise, edx-proctoring
 edx-search==1.4.1         # via -r requirements/edx/base.in
-edx-sga==0.11.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
+edx-sga==0.13.0           # via -r requirements/edx/base.in
 edx-submissions==3.2.2    # via -r requirements/edx/base.in, ora2
 edx-toggles==1.0.0        # via -r requirements/edx/base.in
 edx-user-state-client==1.2.0  # via -r requirements/edx/base.in
@@ -212,7 +212,7 @@ user-util==0.3.1          # via -r requirements/edx/base.in
 vine==1.3.0               # via amqp, celery
 voluptuous==0.12.0        # via ora2
 watchdog==0.10.3          # via -r requirements/edx/paver.txt
-web-fragments==0.3.2      # via -r requirements/edx/base.in, crowdsourcehinter-xblock, staff-graded-xblock, xblock, xblock-utils
+web-fragments==0.3.2      # via -r requirements/edx/base.in, crowdsourcehinter-xblock, edx-sga, staff-graded-xblock, xblock, xblock-utils
 webencodings==0.5.1       # via bleach, html5lib
 webob==1.8.6              # via xblock, xmodule
 wrapt==1.11.2             # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.txt

--- a/requirements/edx-platform-constraints.txt
+++ b/requirements/edx-platform-constraints.txt
@@ -21,6 +21,7 @@ cffi==1.14.3              # via -r requirements/edx/../edx-sandbox/shared.txt, c
 chardet==3.0.4            # via -r requirements/edx/paver.txt, pysrt, requests
 chem==1.2.0               # via -r requirements/edx/base.in
 click==7.1.2              # via -r requirements/edx/../edx-sandbox/shared.txt, code-annotations, nltk, user-util
+code-annotations==0.9.0   # via edx-enterprise, edx-toggles
 contextlib2==0.6.0.post1  # via -r requirements/edx/base.in
 coreapi==2.3.3            # via drf-yasg
 coreschema==0.0.4         # via coreapi, drf-yasg
@@ -37,7 +38,7 @@ django-config-models==2.0.3  # via -r requirements/edx/base.in, edx-enterprise
 django-cookies-samesite==0.8.0  # via -r requirements/edx/base.in
 django-cors-headers==2.5.3  # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
 django-countries==5.5     # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, edx-enterprise
-django-crum==0.7.7        # via -r requirements/edx/base.in, edx-enterprise, edx-proctoring, edx-rbac, super-csv
+django-crum==0.7.7        # via -r requirements/edx/base.in, edx-enterprise, edx-proctoring, edx-rbac, edx-toggles, super-csv
 django-fernet-fields==0.6  # via -r requirements/edx/base.in, edx-enterprise, edxval
 django-filter==2.4.0      # via -r requirements/edx/base.in, edx-enterprise
 django-ipware==2.1.0      # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, edx-enterprise, edx-proctoring
@@ -46,7 +47,7 @@ django-method-override==1.0.4  # via -r requirements/edx/base.in
 django-model-utils==4.0.0  # via -r requirements/edx/base.in, django-user-tasks, edx-bulk-grades, edx-celeryutils, edx-completion, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-rbac, edx-submissions, edx-when, edxval, ora2, super-csv
 django-mptt==0.11.0       # via -r requirements/edx/base.in, django-wiki
 django-mysql==3.9.0       # via -r requirements/edx/base.in
-django-oauth-toolkit==1.3.2  # via -r requirements/edx/base.in
+django-oauth-toolkit==1.3.2  # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
 django-pipeline==1.7.0    # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
 django-pyfs==2.2          # via -r requirements/edx/base.in
 git+https://github.com/edx/django-ratelimit-backend.git@v2.0.1a5#egg=django-ratelimit-backend==2.0.1a5  # via -r requirements/edx/github.in
@@ -59,9 +60,9 @@ django-splash==0.2.9      # via -r requirements/edx/base.in
 django-statici18n==2.0.1  # via -r requirements/edx/base.in
 django-storages==1.8      # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, edxval
 django-user-tasks==1.3.0  # via -r requirements/edx/base.in
-django-waffle==2.0.0      # via -r requirements/edx/base.in, edx-django-utils, edx-drf-extensions, edx-enterprise, edx-proctoring
+django-waffle==2.0.0      # via -r requirements/edx/base.in, edx-django-utils, edx-drf-extensions, edx-enterprise, edx-proctoring, edx-toggles
 django-webpack-loader==0.7.0  # via -r requirements/edx/base.in, edx-proctoring
-django==2.2.16            # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, code-annotations, django-appconf, django-classy-tags, django-config-models, django-cors-headers, django-crum, django-fernet-fields, django-filter, django-method-override, django-model-utils, django-mptt, django-multi-email-field, django-mysql, django-oauth-toolkit, django-pyfs, django-ratelimit-backend, django-sekizai, django-ses, django-splash, django-statici18n, django-storages, django-user-tasks, django-wiki, drf-jwt, drf-yasg, edx-ace, edx-api-doc-tools, edx-bulk-grades, edx-celeryutils, edx-completion, edx-django-release-util, edx-django-sites-extensions, edx-django-utils, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-milestones, edx-opaque-keys, edx-organizations, edx-proctoring, edx-rbac, edx-search, edx-submissions, edx-when, edxval, enmerkar, enmerkar-underscore, event-tracking, help-tokens, jsonfield2, lti-consumer-xblock, ora2, rest-condition, super-csv, xss-utils
+django==2.2.16            # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, code-annotations, django-appconf, django-classy-tags, django-config-models, django-cors-headers, django-crum, django-fernet-fields, django-filter, django-method-override, django-model-utils, django-mptt, django-multi-email-field, django-mysql, django-oauth-toolkit, django-pyfs, django-ratelimit-backend, django-sekizai, django-ses, django-splash, django-statici18n, django-storages, django-user-tasks, django-wiki, drf-jwt, drf-yasg, edx-ace, edx-api-doc-tools, edx-bulk-grades, edx-celeryutils, edx-completion, edx-django-release-util, edx-django-sites-extensions, edx-django-utils, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-milestones, edx-opaque-keys, edx-organizations, edx-proctoring, edx-rbac, edx-search, edx-submissions, edx-toggles, edx-when, edxval, enmerkar, enmerkar-underscore, event-tracking, help-tokens, jsonfield2, lti-consumer-xblock, ora2, rest-condition, super-csv, xss-utils
 djangorestframework==3.9.4  # via -r requirements/edx/base.in, django-config-models, django-user-tasks, drf-jwt, drf-yasg, edx-api-doc-tools, edx-completion, edx-drf-extensions, edx-enterprise, edx-organizations, edx-proctoring, edx-submissions, ora2, rest-condition, super-csv
 docopt==0.6.2             # via xmodule
 docutils==0.16            # via botocore
@@ -76,19 +77,20 @@ edx-celeryutils==0.5.2    # via -r requirements/edx/base.in, super-csv
 edx-completion==3.2.4     # via -r requirements/edx/base.in
 edx-django-release-util==0.4.4  # via -r requirements/edx/base.in
 edx-django-sites-extensions==2.5.1  # via -r requirements/edx/base.in
-edx-django-utils==3.8.0   # via -r requirements/edx/base.in, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-when
+edx-django-utils==3.9.0   # via -r requirements/edx/base.in, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-toggles, edx-when
 edx-drf-extensions==6.2.0  # via -r requirements/edx/base.in, edx-completion, edx-enterprise, edx-organizations, edx-proctoring, edx-rbac, edx-when, edxval
-edx-enterprise==3.8.42    # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
+edx-enterprise==3.9.5     # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
 edx-i18n-tools==0.5.3     # via ora2
 edx-milestones==0.3.0     # via -r requirements/edx/base.in
 edx-opaque-keys[django]==2.1.1  # via -r requirements/edx/paver.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, lti-consumer-xblock, xmodule
-edx-organizations==5.2.0  # via -r requirements/edx/base.in
+edx-organizations==5.3.0  # via -r requirements/edx/base.in
 edx-proctoring-proctortrack==1.0.5  # via -r requirements/edx/base.in
-edx-proctoring==2.4.7     # via -r requirements/edx/base.in, edx-proctoring-proctortrack
+edx-proctoring==2.4.8     # via -r requirements/edx/base.in, edx-proctoring-proctortrack
 edx-rest-api-client==5.2.1  # via -r requirements/edx/base.in, edx-enterprise, edx-proctoring
 edx-search==1.4.1         # via -r requirements/edx/base.in
 edx-sga==0.11.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
 edx-submissions==3.2.2    # via -r requirements/edx/base.in, ora2
+edx-toggles==1.0.0        # via -r requirements/edx/base.in
 edx-user-state-client==1.2.0  # via -r requirements/edx/base.in
 edx-when==1.3.0           # via -r requirements/edx/base.in, edx-proctoring
 edxval==1.4.2             # via -r requirements/edx/base.in
@@ -106,6 +108,7 @@ help-tokens==1.1.2        # via -r requirements/edx/base.in
 html5lib==1.1             # via -r requirements/edx/base.in, ora2
 icalendar==4.0.7          # via -r requirements/edx/base.in
 idna==2.10                # via -r requirements/edx/paver.txt, requests
+importlib-metadata==1.7.0  # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.txt, kombu, path
 inflection==0.5.1         # via drf-yasg
 ipaddress==1.0.23         # via -r requirements/edx/base.in
 isodate==0.6.0            # via python3-saml
@@ -129,6 +132,7 @@ maxminddb==1.5.4          # via -c requirements/edx/../constraints.txt, geoip2
 mock==3.0.5               # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.txt, xblock-drag-and-drop-v2, xblock-poll
 git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a#egg=MongoDBProxy==0.1.0+edx.2  # via -r requirements/edx/github.in
 mongoengine==0.20.0       # via -r requirements/edx/base.in
+more-itertools==8.5.0     # via -r requirements/edx/paver.txt, zipp
 mpmath==1.1.0             # via sympy
 mysqlclient==2.0.1        # via -r requirements/edx/base.in
 newrelic==5.20.1.150      # via -r requirements/edx/base.in, edx-django-utils
@@ -137,7 +141,7 @@ nodeenv==1.5.0            # via -r requirements/edx/base.in
 numpy==1.18.5             # via -c requirements/edx/../constraints.txt, chem, openedx-calc, scipy
 oauthlib==3.0.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, django-oauth-toolkit, lti-consumer-xblock, requests-oauthlib, social-auth-core
 openedx-calc==1.0.9       # via -r requirements/edx/base.in
-ora2==2.10.2              # via -r requirements/edx/base.in
+ora2==2.10.3              # via -r requirements/edx/base.in
 packaging==20.4           # via bleach, drf-yasg
 path.py==12.5.0           # via edx-enterprise, edx-i18n-tools, ora2, staff-graded-xblock, xmodule
 path==13.1.0              # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.txt, path.py
@@ -175,7 +179,7 @@ recommender-xblock==1.4.9  # via -r requirements/edx/base.in
 redis==3.5.3              # via -r requirements/edx/base.in
 regex==2020.10.15         # via -r requirements/edx/../edx-sandbox/shared.txt, nltk
 requests-oauthlib==1.3.0  # via -r requirements/edx/base.in, social-auth-core
-requests==2.24.0          # via -r requirements/edx/paver.txt, analytics-python, coreapi, django-oauth-toolkit, edx-analytics-data-api-client, edx-bulk-grades, edx-drf-extensions, edx-enterprise, edx-rest-api-client, geoip2, mailsnake, pyjwkest, python-swiftclient, requests-oauthlib, sailthru-client, slumber, social-auth-core
+requests==2.24.0          # via -r requirements/edx/paver.txt, analytics-python, coreapi, django-oauth-toolkit, edx-analytics-data-api-client, edx-bulk-grades, edx-drf-extensions, edx-enterprise, edx-rest-api-client, geoip2, mailsnake, pyjwkest, python-swiftclient, requests-oauthlib, sailthru-client, slumber, social-auth-core, tableauserverclient
 rest-condition==1.0.3     # via -r requirements/edx/base.in, edx-drf-extensions
 ruamel.yaml.clib==0.2.2   # via ruamel.yaml
 ruamel.yaml==0.16.12      # via drf-yasg
@@ -218,6 +222,7 @@ xblock-utils==2.1.1       # via -r requirements/edx/base.in, edx-sga, lti-consum
 xblock==1.4.0             # via -r requirements/edx/base.in, acid-xblock, crowdsourcehinter-xblock, done-xblock, edx-completion, edx-sga, edx-user-state-client, edx-when, lti-consumer-xblock, ora2, rate-xblock, staff-graded-xblock, xblock-discussion, xblock-drag-and-drop-v2, xblock-google-drive, xblock-poll, xblock-utils
 xmlsec==1.3.8             # via python3-saml
 xss-utils==0.1.3          # via -r requirements/edx/base.in
+zipp==1.0.0               # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/edx-platform-constraints.txt
+++ b/requirements/edx-platform-constraints.txt
@@ -79,7 +79,7 @@ edx-django-release-util==0.4.4  # via -r requirements/edx/base.in
 edx-django-sites-extensions==2.5.1  # via -r requirements/edx/base.in
 edx-django-utils==3.9.0   # via -r requirements/edx/base.in, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-toggles, edx-when
 edx-drf-extensions==6.2.0  # via -r requirements/edx/base.in, edx-completion, edx-enterprise, edx-organizations, edx-proctoring, edx-rbac, edx-when, edxval
-edx-enterprise==3.9.5     # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
+edx-enterprise==3.9.6     # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
 edx-i18n-tools==0.5.3     # via ora2
 edx-milestones==0.3.0     # via -r requirements/edx/base.in
 edx-opaque-keys[django]==2.1.1  # via -r requirements/edx/paver.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, lti-consumer-xblock, xmodule

--- a/requirements/js_test.txt
+++ b/requirements/js_test.txt
@@ -4,9 +4,6 @@
 #
 #    make upgrade
 #
---index-url http://edx.devstack.devpi:3141/root/pypi/+simple/
---extra-index-url https://pypi.python.org/simple
---trusted-host edx.devstack.devpi
 
 cheroot==8.4.5            # via cherrypy
 cherrypy==18.6.0          # via jasmine

--- a/requirements/js_test.txt
+++ b/requirements/js_test.txt
@@ -4,6 +4,10 @@
 #
 #    make upgrade
 #
+--index-url http://edx.devstack.devpi:3141/root/pypi/+simple/
+--extra-index-url https://pypi.python.org/simple
+--trusted-host edx.devstack.devpi
+
 cheroot==8.4.5            # via cherrypy
 cherrypy==18.6.0          # via jasmine
 glob2==0.7                # via jasmine-core

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -4,9 +4,6 @@
 #
 #    make upgrade
 #
---index-url http://edx.devstack.devpi:3141/root/pypi/+simple/
---extra-index-url https://pypi.python.org/simple
---trusted-host edx.devstack.devpi
 
 amqp==2.6.1               # via kombu
 aniso8601==8.0.0          # via -c requirements/edx-platform-constraints.txt, edx-tincan-py35

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -4,6 +4,10 @@
 #
 #    make upgrade
 #
+--index-url http://edx.devstack.devpi:3141/root/pypi/+simple/
+--extra-index-url https://pypi.python.org/simple
+--trusted-host edx.devstack.devpi
+
 amqp==2.6.1               # via kombu
 aniso8601==8.0.0          # via -c requirements/edx-platform-constraints.txt, edx-tincan-py35
 billiard==3.6.3.0         # via celery
@@ -13,7 +17,7 @@ certifi==2020.6.20        # via -c requirements/edx-platform-constraints.txt, re
 cffi==1.14.3              # via -c requirements/edx-platform-constraints.txt, cryptography
 chardet==3.0.4            # via -c requirements/edx-platform-constraints.txt, requests
 click==7.1.2              # via -c requirements/edx-platform-constraints.txt, code-annotations
-code-annotations==0.9.0   # via -r requirements/base.in
+code-annotations==0.9.0   # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
 cryptography==3.1.1       # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, django-fernet-fields, pyjwt
 defusedxml==0.6.0         # via -c requirements/edx-platform-constraints.txt, djangorestframework-xml
 django-config-models==2.0.3  # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
@@ -31,7 +35,7 @@ django==2.2.16            # via -c requirements/edx-platform-constraints.txt, -r
 djangorestframework-xml==2.0.0  # via -r requirements/base.in
 djangorestframework==3.9.4  # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, django-config-models, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.17.2           # via -c requirements/edx-platform-constraints.txt, edx-drf-extensions
-edx-django-utils==3.8.0   # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, django-config-models, edx-drf-extensions, edx-rest-api-client
+edx-django-utils==3.9.0   # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, django-config-models, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.2.0  # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, edx-rbac
 edx-opaque-keys[django]==2.1.1  # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, edx-drf-extensions
 edx-rbac==1.3.3           # via -r requirements/base.in
@@ -39,13 +43,11 @@ edx-rest-api-client==5.2.1  # via -c requirements/edx-platform-constraints.txt, 
 edx-tincan-py35==0.0.9    # via -r requirements/base.in
 future==0.18.2            # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, pyjwkest
 idna==2.10                # via -c requirements/edx-platform-constraints.txt, requests
-importlib-metadata==2.0.0  # via kombu, path
 jinja2==2.11.2            # via -c requirements/edx-platform-constraints.txt, code-annotations
 jsondiff==1.2.0           # via -r requirements/base.in
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -c requirements/edx-platform-constraints.txt, -r requirements/base.in
 kombu==4.6.11             # via celery
 markupsafe==1.1.1         # via -c requirements/edx-platform-constraints.txt, jinja2
-more-itertools==8.5.0     # via zipp
 newrelic==5.20.1.150      # via -c requirements/edx-platform-constraints.txt, edx-django-utils
 packaging==20.4           # via -c requirements/edx-platform-constraints.txt, bleach
 path.py==12.5.0           # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
@@ -78,4 +80,3 @@ unicodecsv==0.14.1        # via -c requirements/edx-platform-constraints.txt, -r
 urllib3==1.25.11          # via -c requirements/edx-platform-constraints.txt, requests
 vine==1.3.0               # via -c requirements/edx-platform-constraints.txt, amqp, celery
 webencodings==0.5.1       # via -c requirements/edx-platform-constraints.txt, bleach
-zipp==1.0.0               # via -c requirements/constraints.txt, importlib-metadata

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,6 +4,10 @@
 #
 #    make upgrade
 #
+--index-url http://edx.devstack.devpi:3141/root/pypi/+simple/
+--extra-index-url https://pypi.python.org/simple
+--trusted-host edx.devstack.devpi
+
 amqp==2.6.1               # via -r requirements/test-master.txt, kombu
 aniso8601==8.0.0          # via -r requirements/test-master.txt, edx-tincan-py35
 attrs==20.2.0             # via pytest
@@ -34,7 +38,7 @@ django-waffle==2.0.0      # via -r requirements/test-master.txt, edx-django-util
 djangorestframework-xml==2.0.0  # via -r requirements/test-master.txt
 djangorestframework==3.9.4  # via -r requirements/test-master.txt, django-config-models, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.17.2           # via -r requirements/test-master.txt, edx-drf-extensions
-edx-django-utils==3.8.0   # via -r requirements/test-master.txt, django-config-models, edx-drf-extensions, edx-rest-api-client
+edx-django-utils==3.9.0   # via -r requirements/test-master.txt, django-config-models, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.2.0  # via -r requirements/test-master.txt, edx-rbac
 edx-opaque-keys[django]==2.1.1  # via -r requirements/test-master.txt, edx-drf-extensions
 edx-rbac==1.3.3           # via -r requirements/test-master.txt
@@ -45,7 +49,7 @@ faker==4.14.0             # via factory-boy
 freezegun==0.3.14         # via -c requirements/constraints.txt, -r requirements/test.in
 future==0.18.2            # via -r requirements/test-master.txt, pyjwkest
 idna==2.10                # via -r requirements/test-master.txt, requests
-importlib-metadata==2.0.0  # via -r requirements/test-master.txt, kombu, path, pluggy, pytest
+importlib-metadata==2.0.0  # via inflect
 inflect==3.0.2            # via -c requirements/constraints.txt, jinja2-pluralize
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.11.2            # via -r requirements/test-master.txt, code-annotations, diff-cover, jinja2-pluralize
@@ -54,7 +58,7 @@ jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements
 kombu==4.6.11             # via -r requirements/test-master.txt, celery
 markupsafe==1.1.1         # via -r requirements/test-master.txt, jinja2
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.in
-more-itertools==8.5.0     # via -r requirements/test-master.txt, pytest, zipp
+more-itertools==8.5.0     # via pytest
 newrelic==5.20.1.150      # via -r requirements/test-master.txt, edx-django-utils
 packaging==20.4           # via -r requirements/test-master.txt, bleach, pytest
 path.py==12.5.0           # via -r requirements/test-master.txt
@@ -73,8 +77,8 @@ pymongo==3.10.1           # via -r requirements/test-master.txt, edx-opaque-keys
 pyparsing==2.4.7          # via -r requirements/test-master.txt, packaging
 pytest-catchlog==1.2.2    # via -r requirements/test.in
 pytest-cov==2.10.1        # via -r requirements/test.in
-pytest-django==4.0.0      # via -r requirements/test.in
-pytest==5.4.3             # via -c requirements/constraints.txt, pytest-catchlog, pytest-cov, pytest-django
+pytest-django==4.1.0      # via -r requirements/test.in
+pytest==6.1.1             # via -c requirements/constraints.txt, pytest-catchlog, pytest-cov, pytest-django
 python-dateutil==2.4.0    # via -r requirements/test-master.txt, edx-drf-extensions, faker, freezegun
 python-slugify==4.0.1     # via -r requirements/test-master.txt, code-annotations
 pytz==2020.1              # via -r requirements/test-master.txt, celery, django, edx-tincan-py35
@@ -96,4 +100,4 @@ urllib3==1.25.11          # via -r requirements/test-master.txt, requests
 vine==1.3.0               # via -r requirements/test-master.txt, amqp, celery
 wcwidth==0.2.5            # via pytest
 webencodings==0.5.1       # via -r requirements/test-master.txt, bleach
-zipp==1.0.0               # via -c requirements/constraints.txt, -r requirements/test-master.txt, importlib-metadata
+zipp==1.0.0               # via -c requirements/constraints.txt, importlib-metadata

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -76,7 +76,7 @@ pyparsing==2.4.7          # via -r requirements/test-master.txt, packaging
 pytest-catchlog==1.2.2    # via -r requirements/test.in
 pytest-cov==2.10.1        # via -r requirements/test.in
 pytest-django==4.1.0      # via -r requirements/test.in
-pytest==6.1.1             # via -c requirements/constraints.txt, pytest-catchlog, pytest-cov, pytest-django
+pytest==6.1.2             # via -c requirements/constraints.txt, pytest-catchlog, pytest-cov, pytest-django
 python-dateutil==2.4.0    # via -r requirements/test-master.txt, edx-drf-extensions, faker, freezegun
 python-slugify==4.0.1     # via -r requirements/test-master.txt, code-annotations
 pytz==2020.1              # via -r requirements/test-master.txt, celery, django, edx-tincan-py35

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,9 +4,6 @@
 #
 #    make upgrade
 #
---index-url http://edx.devstack.devpi:3141/root/pypi/+simple/
---extra-index-url https://pypi.python.org/simple
---trusted-host edx.devstack.devpi
 
 amqp==2.6.1               # via -r requirements/test-master.txt, kombu
 aniso8601==8.0.0          # via -r requirements/test-master.txt, edx-tincan-py35

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -41,7 +41,7 @@ edx-opaque-keys[django]==2.1.1  # via -r requirements/test-master.txt, edx-drf-e
 edx-rbac==1.3.3           # via -r requirements/test-master.txt
 edx-rest-api-client==5.2.1  # via -r requirements/test-master.txt
 edx-tincan-py35==0.0.9    # via -r requirements/test-master.txt
-factory-boy==2.12.0       # via -c requirements/constraints.txt, -r requirements/test.in
+factory-boy==3.1.0        # via -c requirements/constraints.txt, -r requirements/test.in
 faker==4.14.0             # via factory-boy
 freezegun==0.3.14         # via -c requirements/constraints.txt, -r requirements/test.in
 future==0.18.2            # via -r requirements/test-master.txt, pyjwkest

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -51,6 +51,7 @@ future==0.18.2            # via -r requirements/test-master.txt, pyjwkest
 idna==2.10                # via -r requirements/test-master.txt, requests
 importlib-metadata==2.0.0  # via inflect
 inflect==3.0.2            # via -c requirements/constraints.txt, jinja2-pluralize
+iniconfig==1.1.1          # via pytest
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.11.2            # via -r requirements/test-master.txt, code-annotations, diff-cover, jinja2-pluralize
 jsondiff==1.2.0           # via -r requirements/test-master.txt
@@ -58,7 +59,7 @@ jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements
 kombu==4.6.11             # via -r requirements/test-master.txt, celery
 markupsafe==1.1.1         # via -r requirements/test-master.txt, jinja2
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.in
-more-itertools==8.5.0     # via pytest
+more-itertools==8.5.0     # via zipp
 newrelic==5.20.1.150      # via -r requirements/test-master.txt, edx-django-utils
 packaging==20.4           # via -r requirements/test-master.txt, bleach, pytest
 path.py==12.5.0           # via -r requirements/test-master.txt
@@ -70,7 +71,7 @@ psutil==5.7.2             # via -r requirements/test-master.txt, edx-django-util
 py==1.9.0                 # via pytest, pytest-catchlog
 pycparser==2.20           # via -r requirements/test-master.txt, cffi
 pycryptodomex==3.9.8      # via -r requirements/test-master.txt, pyjwkest
-pygments==2.7.1           # via diff-cover
+pygments==2.7.2           # via diff-cover
 pyjwkest==1.4.2           # via -r requirements/test-master.txt, edx-drf-extensions
 pyjwt[crypto]==1.7.1      # via -r requirements/test-master.txt, drf-jwt, edx-rest-api-client
 pymongo==3.10.1           # via -r requirements/test-master.txt, edx-opaque-keys
@@ -95,9 +96,9 @@ stevedore==1.32.0         # via -r requirements/test-master.txt, code-annotation
 tableauserverclient==0.13  # via -r requirements/test-master.txt
 testfixtures==6.15.0      # via -r requirements/test-master.txt, -r requirements/test.in
 text-unidecode==1.3       # via -r requirements/test-master.txt, faker, python-slugify
+toml==0.10.1              # via pytest
 unicodecsv==0.14.1        # via -r requirements/test-master.txt
 urllib3==1.25.11          # via -r requirements/test-master.txt, requests
 vine==1.3.0               # via -r requirements/test-master.txt, amqp, celery
-wcwidth==0.2.5            # via pytest
 webencodings==0.5.1       # via -r requirements/test-master.txt, bleach
 zipp==1.0.0               # via -c requirements/constraints.txt, importlib-metadata

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -4,9 +4,6 @@
 #
 #    make upgrade
 #
---index-url http://edx.devstack.devpi:3141/root/pypi/+simple/
---extra-index-url https://pypi.python.org/simple
---trusted-host edx.devstack.devpi
 
 appdirs==1.4.4            # via virtualenv
 certifi==2020.6.20        # via requests

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -26,4 +26,4 @@ toml==0.10.1              # via tox
 tox-battery==0.6.1        # via -r requirements/travis.in
 tox==3.20.1               # via -r requirements/travis.in, tox-battery
 urllib3==1.25.11          # via requests
-virtualenv==20.0.35       # via tox
+virtualenv==20.1.0        # via tox

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -4,6 +4,10 @@
 #
 #    make upgrade
 #
+--index-url http://edx.devstack.devpi:3141/root/pypi/+simple/
+--extra-index-url https://pypi.python.org/simple
+--trusted-host edx.devstack.devpi
+
 appdirs==1.4.4            # via virtualenv
 certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
@@ -12,8 +16,6 @@ coverage==5.3             # via codecov
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
 idna==2.10                # via requests
-importlib-metadata==2.0.0  # via pluggy, tox, virtualenv
-more-itertools==8.5.0     # via zipp
 packaging==20.4           # via tox
 pluggy==0.13.1            # via tox
 py==1.9.0                 # via tox
@@ -25,4 +27,3 @@ tox-battery==0.6.1        # via -r requirements/travis.in
 tox==3.20.1               # via -r requirements/travis.in, tox-battery
 urllib3==1.25.11          # via requests
 virtualenv==20.0.35       # via tox
-zipp==1.0.0               # via -c requirements/constraints.txt, importlib-metadata

--- a/test_utils/factories.py
+++ b/test_utils/factories.py
@@ -10,8 +10,8 @@ from faker import Factory as FakerFactory
 
 from django.contrib.auth.models import AnonymousUser, Group, User
 from django.contrib.sites.models import Site
-from django.utils import timezone
 from django.db.models.signals import post_delete, post_save, pre_delete, pre_save
+from django.utils import timezone
 
 from consent.models import DataSharingConsent, DataSharingConsentTextOverrides
 from enterprise.models import (
@@ -338,17 +338,27 @@ class LicensedEnterpriseCourseEnrollmentFactory(factory.django.DjangoModelFactor
     is_revoked = False
 
 
-def enterprise_customer_catalog_factory_no_signals(*args, **kwargs):
-    """
-    Returns a context wrapped version of EnterpriseCustomerCatalogFactory with signals turned off
-    """
-    with factory.django.mute_signals(pre_save, post_save):
-        return EnterpriseCustomerCatalogFactory(*args, **kwargs)
-
-
-class EnterpriseCustomerCatalogFactory(factory.django.DjangoModelFactory):
+class EnterpriseCustomerCatalogFactoryWithSignals(factory.django.DjangoModelFactory):
     """
     EnterpriseCustomerCatalog factory.
+
+    Creates an instance of EnterpriseCustomerCatalog with minimal boilerplate.
+    """
+
+    class Meta:
+        """
+        Meta for EnterpriseCustomerCatalog.
+        """
+
+        model = EnterpriseCustomerCatalog
+
+    uuid = factory.LazyAttribute(lambda x: UUID(FAKER.uuid4()))
+    enterprise_customer = factory.SubFactory(EnterpriseCustomerFactory)
+
+
+class EnterpriseCustomerCatalogFactory(BaseModelFactoryNoSignals):
+    """
+    EnterpriseCustomerCatalog factory with signals muted.
 
     Creates an instance of EnterpriseCustomerCatalog with minimal boilerplate.
     """

--- a/test_utils/factories.py
+++ b/test_utils/factories.py
@@ -10,7 +10,6 @@ from faker import Factory as FakerFactory
 
 from django.contrib.auth.models import AnonymousUser, Group, User
 from django.contrib.sites.models import Site
-from django.db.models.signals import post_save, pre_save
 from django.utils import timezone
 
 from consent.models import DataSharingConsent, DataSharingConsentTextOverrides
@@ -51,14 +50,6 @@ from integrated_channels.sap_success_factors.models import (
 from integrated_channels.xapi.models import XAPILearnerDataTransmissionAudit, XAPILRSConfiguration
 
 FAKER = FakerFactory.create()
-
-
-@factory.django.mute_signals(pre_save, post_save)
-class BaseModelFactoryNoSignals(factory.django.DjangoModelFactory):
-    """
-    Base DjangoModelFactory with signals turned off for use in unit tests.
-    As of pytest 6, factoryboy mocks seems to not turn off signals automatically?
-    """
 
 
 # pylint: disable=no-member
@@ -338,27 +329,9 @@ class LicensedEnterpriseCourseEnrollmentFactory(factory.django.DjangoModelFactor
     is_revoked = False
 
 
-class EnterpriseCustomerCatalogFactoryWithSignals(factory.django.DjangoModelFactory):
+class EnterpriseCustomerCatalogFactory(factory.django.DjangoModelFactory):
     """
     EnterpriseCustomerCatalog factory.
-
-    Creates an instance of EnterpriseCustomerCatalog with minimal boilerplate.
-    """
-
-    class Meta:
-        """
-        Meta for EnterpriseCustomerCatalog.
-        """
-
-        model = EnterpriseCustomerCatalog
-
-    uuid = factory.LazyAttribute(lambda x: UUID(FAKER.uuid4()))
-    enterprise_customer = factory.SubFactory(EnterpriseCustomerFactory)
-
-
-class EnterpriseCustomerCatalogFactory(BaseModelFactoryNoSignals):
-    """
-    EnterpriseCustomerCatalog factory with signals muted.
 
     Creates an instance of EnterpriseCustomerCatalog with minimal boilerplate.
     """

--- a/test_utils/factories.py
+++ b/test_utils/factories.py
@@ -80,7 +80,7 @@ class SiteFactory(factory.django.DjangoModelFactory):
     name = factory.LazyAttribute(lambda x: FAKER.company())
 
 
-class EnterpriseCustomerFactory(BaseModelFactoryNoSignals):
+class EnterpriseCustomerFactory(factory.django.DjangoModelFactory):
     """
     EnterpriseCustomer factory.
 
@@ -338,7 +338,15 @@ class LicensedEnterpriseCourseEnrollmentFactory(factory.django.DjangoModelFactor
     is_revoked = False
 
 
-class EnterpriseCustomerCatalogFactory(BaseModelFactoryNoSignals):
+def enterprise_customer_catalog_factory_no_signals(*args, **kwargs):
+    """
+    Returns a context wrapped version of EnterpriseCustomerCatalogFactory with signals turned off
+    """
+    with factory.django.mute_signals(pre_save, post_save):
+        return EnterpriseCustomerCatalogFactory(*args, **kwargs)
+
+
+class EnterpriseCustomerCatalogFactory(factory.django.DjangoModelFactory):
     """
     EnterpriseCustomerCatalog factory.
 

--- a/test_utils/factories.py
+++ b/test_utils/factories.py
@@ -10,7 +10,7 @@ from faker import Factory as FakerFactory
 
 from django.contrib.auth.models import AnonymousUser, Group, User
 from django.contrib.sites.models import Site
-from django.db.models.signals import post_delete, post_save, pre_delete, pre_save
+from django.db.models.signals import post_save, pre_save
 from django.utils import timezone
 
 from consent.models import DataSharingConsent, DataSharingConsentTextOverrides

--- a/test_utils/factories.py
+++ b/test_utils/factories.py
@@ -11,6 +11,7 @@ from faker import Factory as FakerFactory
 from django.contrib.auth.models import AnonymousUser, Group, User
 from django.contrib.sites.models import Site
 from django.utils import timezone
+from django.db.models.signals import post_delete, post_save, pre_delete, pre_save
 
 from consent.models import DataSharingConsent, DataSharingConsentTextOverrides
 from enterprise.models import (
@@ -52,6 +53,14 @@ from integrated_channels.xapi.models import XAPILearnerDataTransmissionAudit, XA
 FAKER = FakerFactory.create()
 
 
+@factory.django.mute_signals(pre_save, post_save)
+class BaseModelFactoryNoSignals(factory.django.DjangoModelFactory):
+    """
+    Base DjangoModelFactory with signals turned off for use in unit tests.
+    As of pytest 6, factoryboy mocks seems to not turn off signals automatically?
+    """
+
+
 # pylint: disable=no-member
 # pylint: disable=invalid-name
 class SiteFactory(factory.django.DjangoModelFactory):
@@ -71,7 +80,7 @@ class SiteFactory(factory.django.DjangoModelFactory):
     name = factory.LazyAttribute(lambda x: FAKER.company())
 
 
-class EnterpriseCustomerFactory(factory.django.DjangoModelFactory):
+class EnterpriseCustomerFactory(BaseModelFactoryNoSignals):
     """
     EnterpriseCustomer factory.
 
@@ -329,7 +338,7 @@ class LicensedEnterpriseCourseEnrollmentFactory(factory.django.DjangoModelFactor
     is_revoked = False
 
 
-class EnterpriseCustomerCatalogFactory(factory.django.DjangoModelFactory):
+class EnterpriseCustomerCatalogFactory(BaseModelFactoryNoSignals):
     """
     EnterpriseCustomerCatalog factory.
 

--- a/test_utils/factories.py
+++ b/test_utils/factories.py
@@ -180,7 +180,7 @@ class PendingEnterpriseCustomerAdminUserFactory(factory.django.DjangoModelFactor
     user_email = factory.LazyAttribute(lambda x: FAKER.email())
 
 
-class GroupFactory(factory.DjangoModelFactory):
+class GroupFactory(factory.django.DjangoModelFactory):
     """
     Group factory.
 
@@ -194,7 +194,7 @@ class GroupFactory(factory.DjangoModelFactory):
     name = factory.Sequence(u'group{0}'.format)
 
 
-class UserFactory(factory.DjangoModelFactory):
+class UserFactory(factory.django.DjangoModelFactory):
     """
     User factory.
 

--- a/tests/test_enterprise/test_signals.py
+++ b/tests/test_enterprise/test_signals.py
@@ -28,7 +28,6 @@ from enterprise.signals import create_enterprise_enrollment_receiver, handle_use
 from test_utils.factories import (
     EnterpriseCatalogQueryFactory,
     EnterpriseCustomerCatalogFactory,
-    EnterpriseCustomerCatalogFactoryWithSignals,
     EnterpriseCustomerFactory,
     EnterpriseCustomerUserFactory,
     PendingEnrollmentFactory,
@@ -245,7 +244,7 @@ class TestDefaultContentFilter(unittest.TestCase):
         Test that `EnterpriseCustomerCatalog`.content_filter is saved with correct default content filter.
         """
         with override_settings(ENTERPRISE_CUSTOMER_CATALOG_DEFAULT_CONTENT_FILTER=default_content_filter):
-            enterprise_catalog = EnterpriseCustomerCatalogFactoryWithSignals()
+            enterprise_catalog = EnterpriseCustomerCatalogFactory()
             assert enterprise_catalog.content_filter == expected_content_filter
 
 
@@ -784,7 +783,7 @@ class TestEnterpriseCatalogSignals(unittest.TestCase):
 
     @mock.patch('enterprise.signals.EnterpriseCatalogApiClient')
     def test_delete_catalog(self, api_client_mock):
-        enterprise_catalog = EnterpriseCustomerCatalogFactoryWithSignals()
+        enterprise_catalog = EnterpriseCustomerCatalogFactory()
         enterprise_catalog_uuid = enterprise_catalog.uuid
         api_client_mock.return_value.get_enterprise_catalog.return_value = True
         enterprise_catalog.delete()
@@ -796,7 +795,7 @@ class TestEnterpriseCatalogSignals(unittest.TestCase):
     @mock.patch('enterprise.signals.EnterpriseCatalogApiClient')
     def test_create_catalog(self, api_client_mock):
         api_client_mock.return_value.get_enterprise_catalog.return_value = {}
-        enterprise_catalog = EnterpriseCustomerCatalogFactoryWithSignals()
+        enterprise_catalog = EnterpriseCustomerCatalogFactory()
 
         # Verify the API was called and the catalog "was created" (even though it already was)
         # This method is a little weird in that the object is sort of created / not-created at the same time
@@ -812,7 +811,7 @@ class TestEnterpriseCatalogSignals(unittest.TestCase):
 
     @mock.patch('enterprise.signals.EnterpriseCatalogApiClient')
     def test_update_catalog_without_existing_service_catalog(self, api_client_mock):
-        enterprise_catalog = EnterpriseCustomerCatalogFactoryWithSignals()
+        enterprise_catalog = EnterpriseCustomerCatalogFactory()
         api_client_mock.return_value.get_enterprise_catalog.return_value = {}
 
         enterprise_catalog.title = 'New title'
@@ -831,7 +830,7 @@ class TestEnterpriseCatalogSignals(unittest.TestCase):
 
     @mock.patch('enterprise.signals.EnterpriseCatalogApiClient')
     def test_update_catalog_with_existing_service_catalog(self, api_client_mock):
-        enterprise_catalog = EnterpriseCustomerCatalogFactoryWithSignals()
+        enterprise_catalog = EnterpriseCustomerCatalogFactory()
         api_client_mock.return_value.get_enterprise_catalog.return_value = True
 
         enterprise_catalog.title = 'New title'

--- a/tests/test_enterprise/test_signals.py
+++ b/tests/test_enterprise/test_signals.py
@@ -28,6 +28,7 @@ from enterprise.signals import create_enterprise_enrollment_receiver, handle_use
 from test_utils.factories import (
     EnterpriseCatalogQueryFactory,
     EnterpriseCustomerCatalogFactory,
+    EnterpriseCustomerCatalogFactoryWithSignals,
     EnterpriseCustomerFactory,
     EnterpriseCustomerUserFactory,
     PendingEnrollmentFactory,
@@ -244,7 +245,7 @@ class TestDefaultContentFilter(unittest.TestCase):
         Test that `EnterpriseCustomerCatalog`.content_filter is saved with correct default content filter.
         """
         with override_settings(ENTERPRISE_CUSTOMER_CATALOG_DEFAULT_CONTENT_FILTER=default_content_filter):
-            enterprise_catalog = EnterpriseCustomerCatalogFactory()
+            enterprise_catalog = EnterpriseCustomerCatalogFactoryWithSignals()
             assert enterprise_catalog.content_filter == expected_content_filter
 
 
@@ -783,7 +784,7 @@ class TestEnterpriseCatalogSignals(unittest.TestCase):
 
     @mock.patch('enterprise.signals.EnterpriseCatalogApiClient')
     def test_delete_catalog(self, api_client_mock):
-        enterprise_catalog = EnterpriseCustomerCatalogFactory()
+        enterprise_catalog = EnterpriseCustomerCatalogFactoryWithSignals()
         enterprise_catalog_uuid = enterprise_catalog.uuid
         api_client_mock.return_value.get_enterprise_catalog.return_value = True
         enterprise_catalog.delete()
@@ -795,7 +796,7 @@ class TestEnterpriseCatalogSignals(unittest.TestCase):
     @mock.patch('enterprise.signals.EnterpriseCatalogApiClient')
     def test_create_catalog(self, api_client_mock):
         api_client_mock.return_value.get_enterprise_catalog.return_value = {}
-        enterprise_catalog = EnterpriseCustomerCatalogFactory()
+        enterprise_catalog = EnterpriseCustomerCatalogFactoryWithSignals()
 
         # Verify the API was called and the catalog "was created" (even though it already was)
         # This method is a little weird in that the object is sort of created / not-created at the same time
@@ -811,7 +812,7 @@ class TestEnterpriseCatalogSignals(unittest.TestCase):
 
     @mock.patch('enterprise.signals.EnterpriseCatalogApiClient')
     def test_update_catalog_without_existing_service_catalog(self, api_client_mock):
-        enterprise_catalog = EnterpriseCustomerCatalogFactory()
+        enterprise_catalog = EnterpriseCustomerCatalogFactoryWithSignals()
         api_client_mock.return_value.get_enterprise_catalog.return_value = {}
 
         enterprise_catalog.title = 'New title'
@@ -830,7 +831,7 @@ class TestEnterpriseCatalogSignals(unittest.TestCase):
 
     @mock.patch('enterprise.signals.EnterpriseCatalogApiClient')
     def test_update_catalog_with_existing_service_catalog(self, api_client_mock):
-        enterprise_catalog = EnterpriseCustomerCatalogFactory()
+        enterprise_catalog = EnterpriseCustomerCatalogFactoryWithSignals()
         api_client_mock.return_value.get_enterprise_catalog.return_value = True
 
         enterprise_catalog.title = 'New title'

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -10,6 +10,7 @@ import shutil
 import unittest
 
 import ddt
+import factory
 import mock
 from edx_rest_api_client.exceptions import HttpClientError
 from faker import Factory as FakerFactory
@@ -21,6 +22,7 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.files import File
 from django.core.files.storage import Storage
+from django.db.models.signals import post_delete, post_save, pre_delete, pre_save
 from django.db.utils import IntegrityError
 from django.http import QueryDict
 from django.test.testcases import TransactionTestCase
@@ -1203,6 +1205,7 @@ class TestEnterpriseCustomerCatalog(unittest.TestCase):
         enterprise_customer_catalog = factories.EnterpriseCustomerCatalogFactory()
         assert enterprise_customer_catalog.get_program('fake-uuid') is None
 
+    @factory.django.mute_signals(pre_save, post_save)  # needed as of pytest 6 to turn of signals that fail the test
     def test_title_length(self):
         """
         Test `EnterpriseCustomerCatalog.title` field can take 255 characters.
@@ -1210,6 +1213,7 @@ class TestEnterpriseCustomerCatalog(unittest.TestCase):
         faker = FakerFactory.create()
         uuid = faker.uuid4()  # pylint: disable=no-member
         title = faker.text(max_nb_chars=255)  # pylint: disable=no-member
+
         enterprise_catalog = EnterpriseCustomerCatalog(
             uuid=uuid,
             enterprise_customer=factories.EnterpriseCustomerFactory(),
@@ -1218,6 +1222,7 @@ class TestEnterpriseCustomerCatalog(unittest.TestCase):
         enterprise_catalog.save()
         assert EnterpriseCustomerCatalog.objects.get(uuid=uuid).title == title
 
+    @factory.django.mute_signals(pre_save, post_save)  # needed as of pytest 6 to turn of signals that fail the test
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     def test_get_paginated_content_uses_total_count_from_response(self, mock_catalog_api_class):
         """
@@ -1237,6 +1242,7 @@ class TestEnterpriseCustomerCatalog(unittest.TestCase):
         faker = FakerFactory.create()
         uuid = faker.uuid4()  # pylint: disable=no-member
         title = faker.text(max_nb_chars=255)  # pylint: disable=no-member
+
         enterprise_catalog = EnterpriseCustomerCatalog(
             uuid=uuid,
             enterprise_customer=factories.EnterpriseCustomerFactory(),
@@ -1274,6 +1280,7 @@ class TestEnterpriseCustomerCatalog(unittest.TestCase):
         mock_catalog_api.get_catalog_results.return_value = {}
         assert catalog.contains_programs([fake_catalog_api.FAKE_PROGRAM_RESPONSE1['uuid']]) is False
 
+    @factory.django.mute_signals(pre_save, post_save)  # needed as of pytest 6 to turn of signals that fail the test
     def test_get_content_filter(self):
         """
         Test `get_content_filter` method of `EnterpriseCustomerCatalog` model should return content filter

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -225,7 +225,7 @@ class TestEnterpriseCustomer(unittest.TestCase):
         Test EnterpriseCustomer.catalog_contains_course with a related EnterpriseCustomerCatalog.
         """
         enterprise_customer = factories.EnterpriseCustomerFactory()
-        factories.EnterpriseCustomerCatalogFactory(enterprise_customer=enterprise_customer)
+        factories.enterprise_customer_catalog_factory_no_signals(enterprise_customer=enterprise_customer)
 
         # Test when content is in the enterprise customer's catalog(s)
         api_client_mock.return_value.enterprise_contains_content_items.return_value = True
@@ -1172,7 +1172,7 @@ class TestEnterpriseCustomerCatalog(unittest.TestCase):
         """
         api_client_mock.return_value.contains_content_items.return_value = False
 
-        enterprise_customer_catalog = factories.EnterpriseCustomerCatalogFactory()
+        enterprise_customer_catalog = factories.enterprise_customer_catalog_factory_no_signals()
         assert enterprise_customer_catalog.get_course_and_course_run('fake-course-run-id') == (None, None)
 
     @mock.patch('enterprise.models.EnterpriseCatalogApiClient', return_value=mock.MagicMock())
@@ -1182,7 +1182,7 @@ class TestEnterpriseCustomerCatalog(unittest.TestCase):
         """
         api_client_mock.return_value.contains_content_items.return_value = False
 
-        enterprise_customer_catalog = factories.EnterpriseCustomerCatalogFactory()
+        enterprise_customer_catalog = factories.enterprise_customer_catalog_factory_no_signals()
         assert enterprise_customer_catalog.get_course_run('fake-course-run-id') is None
 
     @mock.patch('enterprise.models.EnterpriseCatalogApiClient', return_value=mock.MagicMock())
@@ -1192,7 +1192,7 @@ class TestEnterpriseCustomerCatalog(unittest.TestCase):
         """
         api_client_mock.return_value.contains_content_items.return_value = False
 
-        enterprise_customer_catalog = factories.EnterpriseCustomerCatalogFactory()
+        enterprise_customer_catalog = factories.enterprise_customer_catalog_factory_no_signals()
         assert enterprise_customer_catalog.get_course('fake-course-id') is None
 
     @mock.patch('enterprise.models.EnterpriseCatalogApiClient', return_value=mock.MagicMock())
@@ -1202,7 +1202,7 @@ class TestEnterpriseCustomerCatalog(unittest.TestCase):
         """
         api_client_mock.return_value.contains_content_items.return_value = False
 
-        enterprise_customer_catalog = factories.EnterpriseCustomerCatalogFactory()
+        enterprise_customer_catalog = factories.enterprise_customer_catalog_factory_no_signals()
         assert enterprise_customer_catalog.get_program('fake-uuid') is None
 
     @factory.django.mute_signals(pre_save, post_save)  # needed as of pytest 6 to turn off signals that fail the test
@@ -1260,7 +1260,7 @@ class TestEnterpriseCustomerCatalog(unittest.TestCase):
         the discovery service API
         """
         mock_catalog_api = mock_catalog_api_class.return_value
-        enterprise_catalog = factories.EnterpriseCustomerCatalogFactory()
+        enterprise_catalog = factories.enterprise_customer_catalog_factory_no_signals()
         enterprise_catalog.get_paginated_content(QueryDict())
         default_catalog_content_filter = get_default_catalog_content_filter()
         query_param = {"exclude_expired_course_run": True}

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1266,6 +1266,7 @@ class TestEnterpriseCustomerCatalog(unittest.TestCase):
         query_param = {"exclude_expired_course_run": True}
         mock_catalog_api.get_catalog_results.assert_called_with(default_catalog_content_filter, query_param)
 
+    @factory.django.mute_signals(pre_save, post_save)  # needed as of pytest 6 to turn of signals that fail the test
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     def test_contains_programs(self, mock_catalog_api_class):
         """
@@ -1315,6 +1316,7 @@ class TestEnterpriseCustomerCatalog(unittest.TestCase):
             'error': ["Content filter 'key' must contain values of type <class 'str'>"]
         }
     )
+    @factory.django.mute_signals(pre_save, post_save)  # needed as of pytest 6 to turn of signals that fail the test
     @ddt.unpack
     def test_save_content_filter_fail(self, content_filter, error):
         fail_catalog = factories.EnterpriseCustomerCatalogFactory(content_filter=content_filter)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -22,7 +22,7 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.files import File
 from django.core.files.storage import Storage
-from django.db.models.signals import post_delete, post_save, pre_delete, pre_save
+from django.db.models.signals import post_save, pre_save
 from django.db.utils import IntegrityError
 from django.http import QueryDict
 from django.test.testcases import TransactionTestCase
@@ -225,7 +225,7 @@ class TestEnterpriseCustomer(unittest.TestCase):
         Test EnterpriseCustomer.catalog_contains_course with a related EnterpriseCustomerCatalog.
         """
         enterprise_customer = factories.EnterpriseCustomerFactory()
-        factories.enterprise_customer_catalog_factory_no_signals(enterprise_customer=enterprise_customer)
+        factories.EnterpriseCustomerCatalogFactory(enterprise_customer=enterprise_customer)
 
         # Test when content is in the enterprise customer's catalog(s)
         api_client_mock.return_value.enterprise_contains_content_items.return_value = True
@@ -1172,7 +1172,7 @@ class TestEnterpriseCustomerCatalog(unittest.TestCase):
         """
         api_client_mock.return_value.contains_content_items.return_value = False
 
-        enterprise_customer_catalog = factories.enterprise_customer_catalog_factory_no_signals()
+        enterprise_customer_catalog = factories.EnterpriseCustomerCatalogFactory()
         assert enterprise_customer_catalog.get_course_and_course_run('fake-course-run-id') == (None, None)
 
     @mock.patch('enterprise.models.EnterpriseCatalogApiClient', return_value=mock.MagicMock())
@@ -1182,7 +1182,7 @@ class TestEnterpriseCustomerCatalog(unittest.TestCase):
         """
         api_client_mock.return_value.contains_content_items.return_value = False
 
-        enterprise_customer_catalog = factories.enterprise_customer_catalog_factory_no_signals()
+        enterprise_customer_catalog = factories.EnterpriseCustomerCatalogFactory()
         assert enterprise_customer_catalog.get_course_run('fake-course-run-id') is None
 
     @mock.patch('enterprise.models.EnterpriseCatalogApiClient', return_value=mock.MagicMock())
@@ -1192,7 +1192,7 @@ class TestEnterpriseCustomerCatalog(unittest.TestCase):
         """
         api_client_mock.return_value.contains_content_items.return_value = False
 
-        enterprise_customer_catalog = factories.enterprise_customer_catalog_factory_no_signals()
+        enterprise_customer_catalog = factories.EnterpriseCustomerCatalogFactory()
         assert enterprise_customer_catalog.get_course('fake-course-id') is None
 
     @mock.patch('enterprise.models.EnterpriseCatalogApiClient', return_value=mock.MagicMock())
@@ -1202,7 +1202,7 @@ class TestEnterpriseCustomerCatalog(unittest.TestCase):
         """
         api_client_mock.return_value.contains_content_items.return_value = False
 
-        enterprise_customer_catalog = factories.enterprise_customer_catalog_factory_no_signals()
+        enterprise_customer_catalog = factories.EnterpriseCustomerCatalogFactory()
         assert enterprise_customer_catalog.get_program('fake-uuid') is None
 
     @factory.django.mute_signals(pre_save, post_save)  # needed as of pytest 6 to turn off signals that fail the test
@@ -1260,7 +1260,7 @@ class TestEnterpriseCustomerCatalog(unittest.TestCase):
         the discovery service API
         """
         mock_catalog_api = mock_catalog_api_class.return_value
-        enterprise_catalog = factories.enterprise_customer_catalog_factory_no_signals()
+        enterprise_catalog = factories.EnterpriseCustomerCatalogFactory()
         enterprise_catalog.get_paginated_content(QueryDict())
         default_catalog_content_filter = get_default_catalog_content_filter()
         query_param = {"exclude_expired_course_run": True}

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1205,7 +1205,7 @@ class TestEnterpriseCustomerCatalog(unittest.TestCase):
         enterprise_customer_catalog = factories.EnterpriseCustomerCatalogFactory()
         assert enterprise_customer_catalog.get_program('fake-uuid') is None
 
-    @factory.django.mute_signals(pre_save, post_save)  # needed as of pytest 6 to turn of signals that fail the test
+    @factory.django.mute_signals(pre_save, post_save)  # needed as of pytest 6 to turn off signals that fail the test
     def test_title_length(self):
         """
         Test `EnterpriseCustomerCatalog.title` field can take 255 characters.
@@ -1222,7 +1222,7 @@ class TestEnterpriseCustomerCatalog(unittest.TestCase):
         enterprise_catalog.save()
         assert EnterpriseCustomerCatalog.objects.get(uuid=uuid).title == title
 
-    @factory.django.mute_signals(pre_save, post_save)  # needed as of pytest 6 to turn of signals that fail the test
+    @factory.django.mute_signals(pre_save, post_save)  # needed as of pytest 6 to turn off signals that fail the test
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     def test_get_paginated_content_uses_total_count_from_response(self, mock_catalog_api_class):
         """
@@ -1266,7 +1266,7 @@ class TestEnterpriseCustomerCatalog(unittest.TestCase):
         query_param = {"exclude_expired_course_run": True}
         mock_catalog_api.get_catalog_results.assert_called_with(default_catalog_content_filter, query_param)
 
-    @factory.django.mute_signals(pre_save, post_save)  # needed as of pytest 6 to turn of signals that fail the test
+    @factory.django.mute_signals(pre_save, post_save)  # needed as of pytest 6 to turn off signals that fail the test
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     def test_contains_programs(self, mock_catalog_api_class):
         """
@@ -1281,7 +1281,7 @@ class TestEnterpriseCustomerCatalog(unittest.TestCase):
         mock_catalog_api.get_catalog_results.return_value = {}
         assert catalog.contains_programs([fake_catalog_api.FAKE_PROGRAM_RESPONSE1['uuid']]) is False
 
-    @factory.django.mute_signals(pre_save, post_save)  # needed as of pytest 6 to turn of signals that fail the test
+    @factory.django.mute_signals(pre_save, post_save)  # needed as of pytest 6 to turn off signals that fail the test
     def test_get_content_filter(self):
         """
         Test `get_content_filter` method of `EnterpriseCustomerCatalog` model should return content filter
@@ -1316,7 +1316,7 @@ class TestEnterpriseCustomerCatalog(unittest.TestCase):
             'error': ["Content filter 'key' must contain values of type <class 'str'>"]
         }
     )
-    @factory.django.mute_signals(pre_save, post_save)  # needed as of pytest 6 to turn of signals that fail the test
+    @factory.django.mute_signals(pre_save, post_save)  # needed as of pytest 6 to turn off signals that fail the test
     @ddt.unpack
     def test_save_content_filter_fail(self, content_filter, error):
         fail_catalog = factories.EnterpriseCustomerCatalogFactory(content_filter=content_filter)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -22,7 +22,6 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.files import File
 from django.core.files.storage import Storage
-from django.db.models.signals import post_save, pre_save
 from django.db.utils import IntegrityError
 from django.http import QueryDict
 from django.test.testcases import TransactionTestCase
@@ -1205,7 +1204,6 @@ class TestEnterpriseCustomerCatalog(unittest.TestCase):
         enterprise_customer_catalog = factories.EnterpriseCustomerCatalogFactory()
         assert enterprise_customer_catalog.get_program('fake-uuid') is None
 
-    @factory.django.mute_signals(pre_save, post_save)  # needed as of pytest 6 to turn off signals that fail the test
     def test_title_length(self):
         """
         Test `EnterpriseCustomerCatalog.title` field can take 255 characters.
@@ -1222,7 +1220,6 @@ class TestEnterpriseCustomerCatalog(unittest.TestCase):
         enterprise_catalog.save()
         assert EnterpriseCustomerCatalog.objects.get(uuid=uuid).title == title
 
-    @factory.django.mute_signals(pre_save, post_save)  # needed as of pytest 6 to turn off signals that fail the test
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     def test_get_paginated_content_uses_total_count_from_response(self, mock_catalog_api_class):
         """
@@ -1266,7 +1263,6 @@ class TestEnterpriseCustomerCatalog(unittest.TestCase):
         query_param = {"exclude_expired_course_run": True}
         mock_catalog_api.get_catalog_results.assert_called_with(default_catalog_content_filter, query_param)
 
-    @factory.django.mute_signals(pre_save, post_save)  # needed as of pytest 6 to turn off signals that fail the test
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     def test_contains_programs(self, mock_catalog_api_class):
         """
@@ -1281,7 +1277,6 @@ class TestEnterpriseCustomerCatalog(unittest.TestCase):
         mock_catalog_api.get_catalog_results.return_value = {}
         assert catalog.contains_programs([fake_catalog_api.FAKE_PROGRAM_RESPONSE1['uuid']]) is False
 
-    @factory.django.mute_signals(pre_save, post_save)  # needed as of pytest 6 to turn off signals that fail the test
     def test_get_content_filter(self):
         """
         Test `get_content_filter` method of `EnterpriseCustomerCatalog` model should return content filter
@@ -1316,7 +1311,6 @@ class TestEnterpriseCustomerCatalog(unittest.TestCase):
             'error': ["Content filter 'key' must contain values of type <class 'str'>"]
         }
     )
-    @factory.django.mute_signals(pre_save, post_save)  # needed as of pytest 6 to turn off signals that fail the test
     @ddt.unpack
     def test_save_content_filter_fail(self, content_filter, error):
         fail_catalog = factories.EnterpriseCustomerCatalogFactory(content_filter=content_filter)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -10,7 +10,6 @@ import shutil
 import unittest
 
 import ddt
-import factory
 import mock
 from edx_rest_api_client.exceptions import HttpClientError
 from faker import Factory as FakerFactory


### PR DESCRIPTION
Why? To bring enterprise in line with platform wrt pytest

Notes:

1: pytest 6 now fails on logging errors (instead of prior where used to go to stderr), courtesy Alex:
[#6433:](https://github.com/pytest-dev/pytest/pull/7231/files) If an error is encountered while formatting the message in a logging call, for example logging.warning("oh no!: %s: %s", "first") (a second argument is missing), pytest now propagates the error, likely causing the test to fail.
Previously, such a mistake would cause an error to be printed to stderr, which is not displayed by default for passing tests. This change makes the mistake visible during testing.
You may supress this behavior temporarily or permanently by setting logging.raiseExceptions = False.
2: here is a logging exception in the signal handler that most every test using the EnterpriseCustomerCatalogFactory() appears to hit!!! (which I do not like). I figure it's because one of the imports fails as we are not running inside the edx-platform environment with the needed libs.
3: This was behind almost all of the test failures with pytest6! The least obvious (still haven't fully grasped it) is a mock realted failure. My guess is we never hit the mock code correctly due to this error, but have not stepped through it.
4: The only real needed fix was to fix the logging.exception line


Q for reviewers: Is this the best way to apply the upgrade?

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
