### PR TITLE
finalization on integrated Blackboard course content structure

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Change Log
 Unreleased
 -----------
 
+[3.9.13]
+--------
+
+* Adding Blackboard customization to integrated channel content metadata creation.
+
 [3.9.12]
 --------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.9.12"
+__version__ = "3.9.13"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/blackboard/exporters/content_metadata.py
+++ b/integrated_channels/blackboard/exporters/content_metadata.py
@@ -22,7 +22,26 @@ class BlackboardContentMetadataExporter(ContentMetadataExporter):
         'course_child_content_metadata': 'course_child_content_metadata',
     }
 
-    DESCRIPTION_TEXT_TEMPLATE = "<a href={enrollment_url}>Go to edX course page</a><br />"
+    DESCRIPTION_TEXT_TEMPLATE = "<a href={enrollment_url}>Go to edX course page</a><br/>"
+    LARGE_DESCRIPTION_TEXT_TEMPLATE = "<a href={enrollment_url} style='font-size:150%'>Go to edX course page</a><br/>"
+
+    COURSE_TITLE_TEMPLATE = '<h1 style="font-size:xxx-large; margin-bottom:0; margin-top:0">{title}</h1>'
+
+    COURSE_DESCRIPTION_TEMPLATE = '<p style="width:60%;">{description}</p>'
+
+    COURSE_CONTENT_IMAGE_TEMPLATE = '<img src={image_url} width="30%" height="25%" border="40px"/>'
+
+    COURSE_CONTENT_BODY_TEMPLATE = '<div><div style="display: inline-block">' \
+                                   '{course_title}{large_description_text}<hr/></div>' \
+                                   '<br/>{course_content_image}' \
+                                   '<br/><br/><br/>{course_description}' \
+                                   '<br/>{description_text}</div>'.format(
+                                       course_title=COURSE_TITLE_TEMPLATE,
+                                       large_description_text=LARGE_DESCRIPTION_TEXT_TEMPLATE,
+                                       course_content_image=COURSE_CONTENT_IMAGE_TEMPLATE,
+                                       course_description=COURSE_DESCRIPTION_TEMPLATE,
+                                       description_text=DESCRIPTION_TEXT_TEMPLATE,
+                                   )
 
     def transform_course_metadata(self, content_metadata_item):
         """
@@ -52,15 +71,15 @@ class BlackboardContentMetadataExporter(ContentMetadataExporter):
         """
         title = content_metadata_item.get('title', None)
         return {
-            'title': title,
+            'title': 'edX Course Details',
             'availability': 'Yes',
             'contentHandler': {
-                'id': 'resource/x-bb-externallink',
-                'url': content_metadata_item.get('enrollment_url', None),
+                'id': 'resource/x-bb-document',
             },
-            'body': '<div>{title}</div><div>{description}</div><img src={image_url} />'.format(
+            'body': self.COURSE_CONTENT_BODY_TEMPLATE.format(
                 title=title,
                 description=content_metadata_item.get('full_description', None),
                 image_url=content_metadata_item.get('image_url', None),
+                enrollment_url=content_metadata_item.get('enrollment_url', None)
             )
         }

--- a/tests/test_integrated_channels/test_blackboard/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_blackboard/test_exporters/test_content_metadata.py
@@ -81,7 +81,7 @@ class TestBlackboardContentMetadataExporter(unittest.TestCase, EnterpriseMockMix
 
     def test_transform_course_child_content_metadata(self):
         content_metadata_item = {
-            'title': 'test title',
+            'title': 'edX Course Details',
             'enrollment_url': 'http://some/enrollment/url/',
             'full_description': 'short desc',
             'image_url': 'image_url',
@@ -92,13 +92,13 @@ class TestBlackboardContentMetadataExporter(unittest.TestCase, EnterpriseMockMix
             'title': content_metadata_item.get('title'),
             'availability': 'Yes',
             'contentHandler': {
-                'id': 'resource/x-bb-externallink',
-                'url': content_metadata_item.get('enrollment_url', None),
+                'id': 'resource/x-bb-document',
             },
-            'body': '<div>{title}</div><div>{description}</div><img src={image_url} />'.format(
+            'body': exporter.COURSE_CONTENT_BODY_TEMPLATE.format(
                 title=content_metadata_item.get('title'),
                 description=content_metadata_item.get('full_description', None),
                 image_url=content_metadata_item.get('image_url', None),
+                enrollment_url=content_metadata_item.get('enrollment_url', None),
             )
         }
         assert description == expected_description


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.


Finalizes the integrated course content to be:
![image](https://user-images.githubusercontent.com/67655836/97356759-194f5c80-186f-11eb-891e-fd6aed23061a.png)

Also fixed error handling in course content creation process.