### PR TITLE
ENT-3509 change username with enterprise_customer_uuid for tableau authentic…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Change Log
 Unreleased
 -----------
 
+[3.10.1]
+--------
+
+* change username with enterprise_customer_uuid for tableau trusted authentication and tableau user creation.
+
 [3.10.0]
 --------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.10.0"
+__version__ = "3.10.1"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -1023,7 +1023,8 @@ class TableauAuthViewSet(generics.GenericAPIView):
         Get the auth token against logged in user from tableau
         """
         url = settings.TABLEAU_URL + '/trusted'
-        payload = {'username': request.user.id}
+        enterprise_customer_uuid = get_enterprise_customer_from_user_id(request.user.id)
+        payload = {'username': enterprise_customer_uuid}
         files = []
         headers = {
             'Content-Type': 'application/x-www-form-urlencoded'

--- a/enterprise/signals.py
+++ b/enterprise/signals.py
@@ -28,7 +28,6 @@ from enterprise.tasks import create_enterprise_enrollment
 from enterprise.utils import (
     NotConnectedToOpenEdX,
     create_tableau_user,
-    delete_tableau_user,
     delete_tableau_user_by_id,
     get_default_catalog_content_filter,
     track_enrollment,
@@ -174,8 +173,6 @@ def assign_or_delete_enterprise_admin_role(sender, instance, **kwargs):     # py
                     user=instance.user,
                     role=enterprise_admin_role
                 ).delete()
-                # Also delete the Enterprise admin user in the third party analytics application
-                delete_tableau_user(instance)
             except SystemWideEnterpriseUserRoleAssignment.DoesNotExist:
                 # Do nothing if no role assignment is present for the enterprise customer user.
                 pass

--- a/enterprise/signals.py
+++ b/enterprise/signals.py
@@ -164,8 +164,9 @@ def assign_or_delete_enterprise_admin_role(sender, instance, **kwargs):     # py
                 user=instance.user,
                 enterprise_customer=instance.enterprise_customer,
             )
-            # Also create the Enterprise admin user in third party analytics application
-            create_tableau_user(instance.user.id, instance)
+            # Also create the Enterprise admin user in third party analytics application with the enterprise
+            # customer uuid as username.
+            create_tableau_user(str(instance.enterprise_customer.uuid), instance)
         elif not kwargs['created'] and not instance.linked:
             # EnterpriseCustomerUser record was updated but is not linked, so delete the enterprise_admin role.
             try:

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -1467,10 +1467,11 @@ def create_tableau_user(user_id, enterprise_customer_user):
                 )
                 add_user_to_tableau_group(user.id, str(enterprise_uuid))
         except ServerResponseError as exc:
-            LOGGER.error(
-                '[TABLEAU USER SYNC] Could not sync enterprise admin user %s in tableau.'
-                'Server returned: %s', user_id, str(exc),
-            )
+            if not exc.code == '409017':
+                LOGGER.error(
+                    '[TABLEAU USER SYNC] Could not sync enterprise admin user %s in tableau.'
+                    'Server returned: %s', user_id, str(exc),
+                )
     else:
         LOGGER.warning(
             '[TABLEAU USER SYNC] Could not create user %s in tableau.',

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -1171,13 +1171,11 @@ class TestUnlinkSAPLearnersManagementCommand(unittest.TestCase, EnterpriseMockMi
     @mock.patch('integrated_channels.sap_success_factors.client.SAPSuccessFactorsAPIClient.update_content_metadata')
     @mock.patch('integrated_channels.sap_success_factors.exporters.learner_data.get_user_from_social_auth')
     @mock.patch('integrated_channels.sap_success_factors.exporters.learner_data.get_identity_provider')
-    @mock.patch('enterprise.signals.delete_tableau_user')
     def test_unlink_inactive_sap_learners_task_success(
             self,
             lms_learners,
             inactive_sap_learners,
             unlinked_sap_learners,
-            mock_delete_tableau_user,
             get_identity_provider_mock,
             get_user_from_social_auth_mock,
             sapsf_update_content_metadata_mock,


### PR DESCRIPTION
…ation

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
