### PR TITLE
ENT-3522: Updated the logic to clear enterprise learner language in a way that db lock does not happen.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Change Log
 Unreleased
 -----------
 
+[3.10.2]
+--------
+
+* Updated the logic to clear enterprise learner language in a way that db lock does not happen.
+
 [3.10.1]
 --------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.10.1"
+__version__ = "3.10.2"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/admin/__init__.py
+++ b/enterprise/admin/__init__.py
@@ -55,12 +55,7 @@ from enterprise.models import (
     PendingEnterpriseCustomerUser,
     SystemWideEnterpriseUserRoleAssignment,
 )
-from enterprise.utils import (
-    discovery_query_url,
-    get_all_field_names,
-    get_default_catalog_content_filter,
-    unset_language_of_all_enterprise_learners,
-)
+from enterprise.utils import discovery_query_url, get_all_field_names, get_default_catalog_content_filter
 
 try:
     from enterprise.api_client.enterprise_catalog import EnterpriseCatalogApiClient
@@ -197,18 +192,6 @@ class EnterpriseCustomerAdmin(DjangoObjectActions, SimpleHistoryAdmin):
 
     class Meta:
         model = EnterpriseCustomer
-
-    def save_model(self, request, obj, form, change):
-        """
-        Check if `default_language` has changed or not, if it is changed then update language preference of all the
-        learners belonging to this enterprise customer.
-        """
-        super(EnterpriseCustomerAdmin, self).save_model(request, obj, form, change)
-
-        if 'default_language' in form.changed_data and obj.default_language:
-            # Unset the language preference when all the learners linked with the enterprise customer.
-            # The middleware in the enterprise will handle the cases for setting a proper language for the learner.
-            unset_language_of_all_enterprise_learners(obj)
 
     def change_view(self, request, object_id, form_url='', extra_context=None):
         catalog_uuid = EnterpriseCustomerCatalogAdminForm.get_catalog_preview_uuid(request.POST)

--- a/tests/test_admin/test_view.py
+++ b/tests/test_admin/test_view.py
@@ -13,17 +13,15 @@ from edx_rest_api_client.exceptions import HttpClientError
 from pytest import mark
 
 from django.conf import settings
-from django.contrib.admin.sites import AdminSite
 from django.contrib.auth.models import User
 from django.contrib.messages import constants as messages
 from django.core import mail
-from django.test import Client, RequestFactory, TestCase, override_settings
+from django.test import Client, TestCase, override_settings
 from django.urls import reverse
 
 from consent.models import DataSharingConsent
 from enterprise import admin as enterprise_admin
 from enterprise.admin import (
-    EnterpriseCustomerAdmin,
     EnterpriseCustomerManageLearnerDataSharingConsentView,
     EnterpriseCustomerManageLearnersView,
     EnterpriseCustomerTransmitCoursesView,
@@ -1814,33 +1812,3 @@ class TestEnterpriseCustomerTransmitCoursesViewPost(BaseTestEnterpriseCustomerTr
                 )
             ]
         }
-
-
-class TestEnterpriseCustomerAdmin(TestCase):
-    """
-    Validate the behavior of Enterprise Customer Admin.
-    """
-
-    def setUp(self):
-        """
-        Setup admin site and model admin.
-        """
-        super(TestEnterpriseCustomerAdmin, self).setUp()
-
-        self.site = AdminSite()
-        self.enterprise_customer = EnterpriseCustomerFactory()
-        self.admin = EnterpriseCustomerAdmin(EnterpriseCustomerAdmin.Meta.model, self.site)
-
-    def test_save_model(self):
-        """
-        Validate that the enhancements to save_model functionality work as expected.
-        """
-        request = RequestFactory().get('/admin/enterprise/enterprise-customer')
-        request.user = UserFactory()
-
-        self.admin.save_model(
-            request=request,
-            obj=self.enterprise_customer,
-            form=mock.MagicMock(changed_data={'default_language': 'es-417'}),
-            change=True
-        )


### PR DESCRIPTION


**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [x] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
