### PR TITLE
Refresh catalog metadata on create and update

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Change Log
 Unreleased
 -----------
 
+[3.12.2]
+--------
+
+* Refresh catalog metadata on create and update
+
 [3.12.1]
 --------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.12.1"
+__version__ = "3.12.2"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/signals.py
+++ b/enterprise/signals.py
@@ -334,6 +334,9 @@ def update_enterprise_catalog_query(sender, instance, **kwargs):     # pylint: d
 def update_enterprise_catalog_data(sender, instance, **kwargs):     # pylint: disable=unused-argument
     """
     Send data changes to Enterprise Catalogs to the Enterprise Catalog Service.
+
+    Additionally sends a request to update the catalog's metadata from discovery, and index any relevant content for
+    Algolia.
     """
     catalog_uuid = instance.uuid
     try:
@@ -376,6 +379,8 @@ def update_enterprise_catalog_data(sender, instance, **kwargs):     # pylint: di
                 'publish_audit_enrollment_urls': instance.publish_audit_enrollment_urls,
             }
             catalog_client.update_enterprise_catalog(catalog_uuid, **update_fields)
+        # Refresh catalog on all creates and updates
+        catalog_client.refresh_catalogs([instance])
 
 
 @receiver(post_delete, sender=EnterpriseCustomerCatalog)

--- a/tests/test_enterprise/test_signals.py
+++ b/tests/test_enterprise/test_signals.py
@@ -802,6 +802,7 @@ class TestEnterpriseCatalogSignals(unittest.TestCase):
             enterprise_catalog.enabled_course_modes,
             enterprise_catalog.publish_audit_enrollment_urls
         )
+        api_client_mock.return_value.refresh_catalogs.assert_called_with([enterprise_catalog])
 
     @mock.patch('enterprise.signals.EnterpriseCatalogApiClient')
     def test_update_catalog_without_existing_service_catalog(self, api_client_mock):
@@ -821,6 +822,7 @@ class TestEnterpriseCatalogSignals(unittest.TestCase):
             enterprise_catalog.enabled_course_modes,
             enterprise_catalog.publish_audit_enrollment_urls
         )
+        api_client_mock.return_value.refresh_catalogs.assert_called_with([enterprise_catalog])
 
     @mock.patch('enterprise.signals.EnterpriseCatalogApiClient')
     def test_update_catalog_with_existing_service_catalog(self, api_client_mock):
@@ -840,6 +842,7 @@ class TestEnterpriseCatalogSignals(unittest.TestCase):
             enabled_course_modes=enterprise_catalog.enabled_course_modes,
             publish_audit_enrollment_urls=enterprise_catalog.publish_audit_enrollment_urls
         )
+        api_client_mock.return_value.refresh_catalogs.assert_called_with([enterprise_catalog])
 
     @mock.patch('enterprise.signals.EnterpriseCatalogApiClient')
     def test_update_enterprise_catalog_query(self, api_client_mock):
@@ -893,6 +896,7 @@ class TestEnterpriseCatalogSignals(unittest.TestCase):
             enabled_course_modes=enterprise_catalog_2.enabled_course_modes,
             publish_audit_enrollment_urls=enterprise_catalog_2.publish_audit_enrollment_urls
         )
+        api_client_mock.return_value.refresh_catalogs.assert_called_with([enterprise_catalog_2])
 
 
 @mark.django_db


### PR DESCRIPTION
ENT-3531

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
