### PR TITLE
ENT-3509 Remove hyphens from ent-customer_uuid for tableau authentica…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Change Log
 Unreleased
 -----------
 
+[3.10.4]
+--------
+
+* Remove hyphens from  enterprise_customer_uuid for admin user creation and tableau authentication.
+
 [3.10.3]
 --------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.10.3"
+__version__ = "3.10.4"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -1024,7 +1024,9 @@ class TableauAuthViewSet(generics.GenericAPIView):
         """
         url = settings.TABLEAU_URL + '/trusted'
         enterprise_customer_uuid = get_enterprise_customer_from_user_id(request.user.id)
-        payload = {'username': enterprise_customer_uuid}
+        # Enterprise customer uuid is being store without hyphens in tableau
+        tableau_username = enterprise_customer_uuid.replace('-', '')
+        payload = {'username': tableau_username}
         files = []
         headers = {
             'Content-Type': 'application/x-www-form-urlencoded'

--- a/enterprise/signals.py
+++ b/enterprise/signals.py
@@ -183,7 +183,8 @@ def assign_or_delete_enterprise_admin_role(sender, instance, **kwargs):     # py
             )
             # Also create the Enterprise admin user in third party analytics application with the enterprise
             # customer uuid as username.
-            create_tableau_user(str(instance.enterprise_customer.uuid), instance)
+            tableau_username = str(instance.enterprise_customer.uuid).replace('-', '')
+            create_tableau_user(tableau_username, instance)
         elif not kwargs['created'] and not instance.linked:
             # EnterpriseCustomerUser record was updated but is not linked, so delete the enterprise_admin role.
             try:


### PR DESCRIPTION
…tion and admin user creation

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
