### PR TITLE
Prefix edx-platform/common/djangoapps imports with 'common.djangoapps'

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,12 @@ Change Log
 Unreleased
 -----------
 
+[3.13.0]
+--------
+
+* Use full paths for edx-platform/common/djangoapps imports, as described in
+  `edx-platform ADR #7 <https://github.com/edx/edx-platform/blob/master/docs/decisions/0007-sys-path-modification-removal.rst>`_.
+
 [3.12.4]
 --------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.12.4"
+__version__ = "3.13.0"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/admin/views.py
+++ b/enterprise/admin/views.py
@@ -51,7 +51,7 @@ from enterprise.utils import (
 
 # Only create manual enrollments if running in edx-platform
 try:
-    from student.api import create_manual_enrollment_audit
+    from common.djangoapps.student.api import create_manual_enrollment_audit
 except ImportError:
     create_manual_enrollment_audit = None
 

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -66,7 +66,7 @@ from enterprise.utils import (
 from enterprise_learner_portal.utils import CourseRunProgressStatuses, get_course_run_status
 
 try:
-    from course_modes.models import CourseMode
+    from common.djangoapps.course_modes.models import CourseMode
     from lms.djangoapps.certificates.api import get_certificate_for_user
     from openedx.core.djangoapps.content.course_overviews.api import get_course_overviews
 except ImportError:

--- a/enterprise/management/commands/seed_enterprise_devstack_data.py
+++ b/enterprise/management/commands/seed_enterprise_devstack_data.py
@@ -34,7 +34,7 @@ from enterprise.models import (
 )
 
 try:
-    from student.models import UserProfile
+    from common.djangoapps.student.models import UserProfile
 except ImportError:
     UserProfile = None
 

--- a/enterprise/tpa_pipeline.py
+++ b/enterprise/tpa_pipeline.py
@@ -20,7 +20,7 @@ except ImportError:
     UserSocialAuth = None
 
 try:
-    from third_party_auth.provider import Registry
+    from common.djangoapps.third_party_auth.provider import Registry
 except ImportError:
     Registry = None
 

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -75,7 +75,7 @@ LOGGER = logging.getLogger(__name__)
 try:
     from common.djangoapps.third_party_auth.provider import Registry  # pylint: disable=unused-import
 except ImportError as exception:
-    LOGGER.warning("Could not import Registry from third_party_auth.provider")
+    LOGGER.warning("Could not import Registry from common.djangoapps.third_party_auth.provider")
     LOGGER.warning(exception)
     Registry = None
 
@@ -200,9 +200,9 @@ def get_identity_provider(provider_id):
     """
     try:
         # pylint: disable=redefined-outer-name,import-outside-toplevel
-        from third_party_auth.provider import Registry
+        from common.djangoapps.third_party_auth.provider import Registry
     except ImportError as exception:
-        LOGGER.warning("Could not import Registry from third_party_auth.provider")
+        LOGGER.warning("Could not import Registry from common.djangoapps.third_party_auth.provider")
         LOGGER.warning(exception)
         Registry = None  # pylint: disable=redefined-outer-name
 
@@ -221,9 +221,9 @@ def get_idp_choices():
     """
     try:
         # pylint: disable=redefined-outer-name,import-outside-toplevel
-        from third_party_auth.provider import Registry
+        from common.djangoapps.third_party_auth.provider import Registry
     except ImportError as exception:
-        LOGGER.warning("Could not import Registry from third_party_auth.provider")
+        LOGGER.warning("Could not import Registry from common.djangoapps.third_party_auth.provider")
         LOGGER.warning(exception)
         Registry = None  # pylint: disable=redefined-outer-name
 

--- a/integrated_channels/xapi/management/commands/send_course_enrollments.py
+++ b/integrated_channels/xapi/management/commands/send_course_enrollments.py
@@ -17,7 +17,7 @@ from integrated_channels.xapi.models import XAPILearnerDataTransmissionAudit, XA
 from integrated_channels.xapi.utils import is_success_response, send_course_enrollment_statement
 
 try:
-    from student.models import CourseEnrollment
+    from common.djangoapps.student.models import CourseEnrollment
 except ImportError:
     CourseEnrollment = None
 


### PR DESCRIPTION
Previously, code from these djangoapps could be imported without
the 'common.djangoapps' prefix. For example, one could write
'from student import models' intead of
'from common.djangoapps.student import models'.

This import pattern unidiomatic and is now deprecated. See
[edx-platform/docs/decisions/0007-sys-path-modification-removal.rst](https://github.com/edx/edx-platform/blob/master/docs/decisions/0007-sys-path-modification-removal.rst)
for details and justification.

Related to https://github.com/edx/edx-platform/pull/25477

_____________________________
Update -- People are seeing this error on Devstack:
```
RuntimeError: Conflicting 'oauth2providerconfig' models in application 'third_party_auth': <class 'third_party_auth.models.OAuth2ProviderConfig'> and <class 'common.djangoapps.third_party_auth.models.OAuth2ProviderConfig'>.
```
I believe this PR would resolve that error.