### PR TITLE
Allow bulk enroll in several courses via CSV from Manage Learners screen

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Change Log
 Unreleased
 -----------
 
+[3.12.0]
+--------
+
+* Support a "course_id" column in the "Manage Learners" CSV bulk upload to allow manual enrollments in multiple courses at once.
+
 [3.11.1]
 --------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,7 +19,7 @@ Unreleased
 [3.12.0]
 --------
 
-* Support a "course_id" column in the "Manage Learners" CSV bulk upload to allow manual enrollments in multiple courses at once.
+* Support uploading a ``course_id`` column in the "Manage Learners" CSV bulk upload to allow manual enrollments in multiple courses at once.
 
 [3.11.1]
 --------

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.11.1"
+__version__ = "3.12.0"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/admin/forms.py
+++ b/enterprise/admin/forms.py
@@ -240,14 +240,33 @@ class ManageLearnersForm(forms.Form):
         cleaned_data[self.Fields.MODE] = mode
         cleaned_data[self.Fields.NOTIFY] = self.clean_notify()
 
+        self._validate_bulk_upload()
         self._validate_course()
         self._validate_reason()
 
         return cleaned_data
 
+    def _validate_bulk_upload(self):
+        """
+        Verify that when a csv file contains a "course_id" column, there is not a singular course ID
+        specified. Also verify that a course mode is specified, which is applied to all enrollments.
+        """
+        bulk_upload_csv = self.cleaned_data.get(self.Fields.BULK_UPLOAD)
+        if bulk_upload_csv:
+            bulk_csv_contents = bulk_upload_csv.read()
+            csv_column_names = bulk_csv_contents.decode('utf-8').split('\n', 1)[0].split(',')
+            if self.CsvColumns.COURSE_ID in csv_column_names:
+                # course id column exists in csv, so validate conditionally required fields
+                if self.cleaned_data.get(self.Fields.COURSE):
+                    raise ValidationError(ValidationMessages.BOTH_COURSE_FIELDS_SPECIFIED)
+                if not self.cleaned_data.get(self.Fields.COURSE_MODE):
+                    raise ValidationError(ValidationMessages.COURSE_WITHOUT_COURSE_MODE)
+                if not self.cleaned_data.get(self.Fields.REASON):
+                    raise ValidationError(ValidationMessages.MISSING_REASON)
+
     def _validate_course(self):
         """
-        Verify that the selected mode is valid for the given course .
+        Verify that the selected mode is valid for the given course.
         """
         # Verify that the selected mode is valid for the given course .
         course_details = self.cleaned_data.get(self.Fields.COURSE)

--- a/enterprise/admin/views.py
+++ b/enterprise/admin/views.py
@@ -542,7 +542,6 @@ class EnterpriseCustomerManageLearnersView(BaseEnterpriseCustomerView):
             emails=emails,
             already_linked_emails=already_linked_emails,
             duplicate_emails=duplicate_emails,
-            course_id_with_emails=course_id_with_emails,
         )
         return processable_emails, course_id_with_emails
 
@@ -668,7 +667,7 @@ class EnterpriseCustomerManageLearnersView(BaseEnterpriseCustomerView):
             enterprise_customer=enterprise_customer,
             course_id=course_id,
             course_mode=mode,
-            emails=emails,
+            emails=sorted(emails),
             enrollment_requester=request.user,
             enrollment_reason=enrollment_reason,
             discount=discount,
@@ -806,9 +805,6 @@ class EnterpriseCustomerManageLearnersView(BaseEnterpriseCustomerView):
                         discount=discount
                     )
             else:
-                if not manual_enrollment_reason:
-                    raise ValidationError(ValidationMessages.MISSING_REASON)
-
                 for course_id in course_id_with_emails:
                     emails_to_enroll = course_id_with_emails[course_id]
                     if emails_to_enroll:

--- a/enterprise/admin/views.py
+++ b/enterprise/admin/views.py
@@ -391,6 +391,78 @@ class EnterpriseCustomerManageLearnersView(BaseEnterpriseCustomerView):
             EnterpriseCustomerUser.objects.link_user(enterprise_customer, email)
             return [email]
 
+    def _handle_bulk_upload_errors(self, manage_learners_form, errors):
+        """
+        TODO
+        """
+        manage_learners_form.add_error(
+            ManageLearnersForm.Fields.GENERAL_ERRORS, ValidationMessages.BULK_LINK_FAILED
+        )
+        for error in errors:
+            manage_learners_form.add_error(ManageLearnersForm.Fields.BULK_UPLOAD, error)
+        return [], {}
+
+    def _process_bulk_upload_data(
+            self,
+            request,
+            enterprise_customer,
+            emails,
+            already_linked_emails,
+            duplicate_emails,
+            course_id_with_emails
+    ):
+        """
+        TODO
+        """
+        count = len(emails)
+        messages.success(request, ungettext(
+            "{count} new learner was added to {enterprise_customer_name}.",
+            "{count} new learners were added to {enterprise_customer_name}.",
+            count
+        ).format(count=count, enterprise_customer_name=enterprise_customer.name))
+        this_customer_linked_emails = [
+            email for email, customer in already_linked_emails if customer == enterprise_customer
+        ]
+        other_customer_linked_emails = [
+            email for email, __ in already_linked_emails if email not in this_customer_linked_emails
+        ]
+        if this_customer_linked_emails:
+            messages.warning(
+                request,
+                _(
+                    "The following learners were already associated with this Enterprise "
+                    "Customer: {list_of_emails}"
+                ).format(
+                    list_of_emails=", ".join(this_customer_linked_emails)
+                )
+            )
+        if other_customer_linked_emails:
+            messages.warning(
+                request,
+                _(
+                    "The following learners are already associated with "
+                    "another Enterprise Customer. These learners were not "
+                    "added to {enterprise_customer_name}: {list_of_emails}"
+                ).format(
+                    enterprise_customer_name=enterprise_customer.name,
+                    list_of_emails=", ".join(other_customer_linked_emails),
+                )
+            )
+        if duplicate_emails:
+            messages.warning(
+                request,
+                _(
+                    "The following duplicate email addresses were not added: "
+                    "{list_of_emails}"
+                ).format(
+                    list_of_emails=", ".join(duplicate_emails)
+                )
+            )
+        # Build a list of all the emails that we can act on further; that is,
+        # emails that we either linked to this customer, or that were linked already.
+        all_processable_emails = list(emails) + this_customer_linked_emails
+        return all_processable_emails, course_id_with_emails
+
     @classmethod
     def _handle_bulk_upload(cls, enterprise_customer, manage_learners_form, request, email_list=None):
         """
@@ -443,66 +515,26 @@ class EnterpriseCustomerManageLearnersView(BaseEnterpriseCustomerView):
             errors.append(exc)
 
         if errors:
-            manage_learners_form.add_error(
-                ManageLearnersForm.Fields.GENERAL_ERRORS, ValidationMessages.BULK_LINK_FAILED
+            return cls._handle_bulk_upload_errors(
+                cls,
+                manage_learners_form=manage_learners_form,
+                errors=errors
             )
-            for error in errors:
-                manage_learners_form.add_error(ManageLearnersForm.Fields.BULK_UPLOAD, error)
-            return [], {}
 
         # There were no errors. Now do the actual linking:
         for email in emails:
             EnterpriseCustomerUser.objects.link_user(enterprise_customer, email)
 
-        # Report what happened:
-        count = len(emails)
-        messages.success(request, ungettext(
-            "{count} new learner was added to {enterprise_customer_name}.",
-            "{count} new learners were added to {enterprise_customer_name}.",
-            count
-        ).format(count=count, enterprise_customer_name=enterprise_customer.name))
-        this_customer_linked_emails = [
-            email for email, customer in already_linked_emails if customer == enterprise_customer
-        ]
-        other_customer_linked_emails = [
-            email for email, __ in already_linked_emails if email not in this_customer_linked_emails
-        ]
-        if this_customer_linked_emails:
-            messages.warning(
-                request,
-                _(
-                    "The following learners were already associated with this Enterprise "
-                    "Customer: {list_of_emails}"
-                ).format(
-                    list_of_emails=", ".join(this_customer_linked_emails)
-                )
-            )
-        if other_customer_linked_emails:
-            messages.warning(
-                request,
-                _(
-                    "The following learners are already associated with "
-                    "another Enterprise Customer. These learners were not "
-                    "added to {enterprise_customer_name}: {list_of_emails}"
-                ).format(
-                    enterprise_customer_name=enterprise_customer.name,
-                    list_of_emails=", ".join(other_customer_linked_emails),
-                )
-            )
-        if duplicate_emails:
-            messages.warning(
-                request,
-                _(
-                    "The following duplicate email addresses were not added: "
-                    "{list_of_emails}"
-                ).format(
-                    list_of_emails=", ".join(duplicate_emails)
-                )
-            )
-        # Build a list of all the emails that we can act on further; that is,
-        # emails that we either linked to this customer, or that were linked already.
-        all_processable_emails = list(emails) + this_customer_linked_emails
-        return all_processable_emails, course_id_with_emails
+        # Process the bulk uploaded data:
+        return cls._process_bulk_upload_data(
+            cls,
+            request=request,
+            enterprise_customer=enterprise_customer,
+            emails=emails,
+            already_linked_emails=already_linked_emails,
+            duplicate_emails=duplicate_emails,
+            course_id_with_emails=course_id_with_emails,
+        )
 
     @classmethod
     def send_messages(cls, http_request, message_requests):
@@ -722,7 +754,11 @@ class EnterpriseCustomerManageLearnersView(BaseEnterpriseCustomerView):
                     email_list=email_field_as_bulk_input
                 )
             else:
-                linked_learners, course_id_with_emails = self._handle_bulk_upload(enterprise_customer, manage_learners_form, request)
+                linked_learners, course_id_with_emails = self._handle_bulk_upload(
+                    enterprise_customer,
+                    manage_learners_form,
+                    request,
+                )
 
         # _handle_form might add form errors, so we check if it is still valid
         if manage_learners_form.is_valid():
@@ -741,12 +777,12 @@ class EnterpriseCustomerManageLearnersView(BaseEnterpriseCustomerView):
             notify = notification_type == ManageLearnersForm.NotificationTypes.BY_EMAIL
             discount = manage_learners_form.cleaned_data.get(ManageLearnersForm.Fields.DISCOUNT)
             sales_force_id = manage_learners_form.cleaned_data.get(ManageLearnersForm.Fields.SALES_FORCE_ID)
-            course_mode = manage_learners_form.cleaned_data[ManageLearnersForm.Fields.COURSE_MODE]
+            course_mode = manage_learners_form.cleaned_data.get(ManageLearnersForm.Fields.COURSE_MODE)
             course_id = None
 
             if not course_id_with_emails:
-                course_details = manage_learners_form.cleaned_data.get(ManageLearnersForm.Fields.COURSE)
-                course_id = course_details['course_id'] if course_details else None
+                course_details = manage_learners_form.cleaned_data.get(ManageLearnersForm.Fields.COURSE) or {}
+                course_id = course_details.get('course_id')
                 if course_id and linked_learners:
                     self._enroll_users(
                         request=request,

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -278,7 +278,6 @@ class EnterpriseCustomerViewSet(EnterpriseReadWriteModelViewSet):
                         enrollment_reason=enrollment_reason,
                         discount=discount,
                         sales_force_id=serializer.validated_data.get('salesforce_id'),
-                        enrollment_client=enrollment_client,
                     )
                     if serializer.validated_data.get('notify'):
                         enterprise_customer.notify_enrolled_learners(

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -266,7 +266,6 @@ class EnterpriseCustomerViewSet(EnterpriseReadWriteModelViewSet):
                 ]
                 linked_learners = list(emails) + this_customer_linked_emails
                 if linked_learners:
-                    enrollment_client = EnrollmentApiClient()
                     discount = serializer.validated_data.get('discount', 0.0)
                     enrollment_reason = serializer.validated_data.get('reason')
                     succeeded, pending, _ = enroll_users_in_course(

--- a/enterprise/api_client/lms.py
+++ b/enterprise/api_client/lms.py
@@ -33,7 +33,6 @@ except ImportError:
 LOGGER = logging.getLogger(__name__)
 LMS_API_DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 LMS_API_DATETIME_FORMAT_WITHOUT_TIMEZONE = '%Y-%m-%dT%H:%M:%S'
-MANUAL_ENROLLMENT_ROLE = "Learner"
 
 
 class NoAuthenticationLmsApiClient:

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -113,10 +113,14 @@ class ValidationMessages:
     COURSE_MODE_INVALID_FOR_COURSE = _(
         "Enrollment track {course_mode} is not available for course {course_id}.")
     COURSE_WITHOUT_COURSE_MODE = _(
-        "Select a course enrollment track for the given course.")
+        "Select a course enrollment track for the given course(s).")
     INVALID_COURSE_ID = _(
         "Could not retrieve details for the course ID {course_id}. Specify "
         "a valid ID.")
+    BOTH_COURSE_FIELDS_SPECIFIED = _(
+        "Either \"CSV bulk upload\" or a singular course ID may be used for manual enrollments, "
+        "but not both together."
+    )
     INVALID_EMAIL = _(
         "{argument} does not appear to be a valid email address.")
     INVALID_EMAIL_OR_USERNAME = _(
@@ -1597,6 +1601,7 @@ def unset_enterprise_learner_language(enterprise_customer_user):
             user_id=enterprise_customer_user.user_id,
             defaults={'value': ''}
         )
+
 
 def validate_course_exists_for_enterprise(enterprise_customer, course_id, **kwargs):
     """

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -67,6 +67,8 @@ try:
     )
 except ImportError:
     create_manual_enrollment_audit = None
+    UNENROLLED_TO_ENROLLED = None
+    UNENROLLED_TO_ALLOWEDTOENROLL = None
 
 LOGGER = logging.getLogger(__name__)
 
@@ -139,7 +141,7 @@ class ValidationMessages:
         "Customer {ec_name}")
     USER_NOT_LINKED = _("User is not linked with Enterprise Customer")
     USER_NOT_EXIST = _("User with email address {email} doesn't exist.")
-    COURSE_NOT_EXIST_IN_CATALOG = _("Course doesn't exist in Enterprise Customer's Catalog")
+    COURSE_NOT_EXIST_IN_CATALOG = _("Course ID {course_id} doesn't exist in Enterprise Customer's Catalog")
     INVALID_CHANNEL_WORKER = _(
         'Enterprise channel worker user with the username "{channel_worker_username}" was not found.'
     )
@@ -1317,7 +1319,7 @@ def enroll_user(enterprise_customer, user, course_mode, *course_ids, **kwargs):
     Returns:
         Boolean: Whether or not enrollment succeeded for all courses specified
     """
-    enrollment_client = kwargs.pop('enrollment_client')
+    enrollment_client = kwargs.pop('enrollment_client', None)
     if not enrollment_client:
         from enterprise.api_client.lms import EnrollmentApiClient  # pylint: disable=import-outside-toplevel
         enrollment_client = EnrollmentApiClient()
@@ -1331,7 +1333,7 @@ def enroll_user(enterprise_customer, user, course_mode, *course_ids, **kwargs):
             enrollment_client.enroll_user_in_course(user.username, course_id, course_mode)
         except HttpClientError as exc:
             # Check if user is already enrolled then we should ignore exception
-            if is_user_enrolled(user, course_id, course_mode, enrollment_client=enrollment_client):
+            if is_user_enrolled(user, course_id, course_mode):
                 succeeded = True
             else:
                 succeeded = False
@@ -1368,7 +1370,6 @@ def enroll_users_in_course(
         enrollment_reason=None,
         discount=0.0,
         sales_force_id=None,
-        enrollment_client=None,
 ):
     """
     Enroll existing users in a course, and create a pending enrollment for nonexisting users.
@@ -1382,7 +1383,6 @@ def enroll_users_in_course(
         enrollment_reason (str): A reason for enrollment.
         discount (Decimal): Percentage discount for enrollment.
         sales_force_id (str): Salesforce opportunity id.
-        enrollment_client: An optional EnrollmentAPIClient if it's already been instantiated and should be passed in.
 
     Returns:
         successes: A list of users who were successfully enrolled in the course
@@ -1397,7 +1397,7 @@ def enroll_users_in_course(
     failures = []
 
     for user in existing_users:
-        succeeded = enroll_user(enterprise_customer, user, course_mode, course_id, enrollment_client=enrollment_client)
+        succeeded = enroll_user(enterprise_customer, user, course_mode, course_id)
         if succeeded:
             successes.append(user)
             if enrollment_requester and enrollment_reason:
@@ -1597,3 +1597,23 @@ def unset_enterprise_learner_language(enterprise_customer_user):
             user_id=enterprise_customer_user.user_id,
             defaults={'value': ''}
         )
+
+def validate_course_exists_for_enterprise(enterprise_customer, course_id, **kwargs):
+    """
+    Validates that a specified course id exists within the LMS and within the enterprise_customer's catalog(s).
+
+    Arguments:
+        enterprise_customer (EnterpriseCustomer): Instance of the enterprise customer.
+        course_id (string): The unique identifier of a course.
+        kwargs: Should contain enrollment_client if it's already been instantiated and is passed in.
+    """
+    enrollment_client = kwargs.pop('enrollment_client', None)
+    if not enrollment_client:
+        from enterprise.api_client.lms import EnrollmentApiClient  # pylint: disable=import-outside-toplevel
+        enrollment_client = EnrollmentApiClient()
+    course_details = enrollment_client.get_course_details(course_id)
+    if not course_details:
+        raise ValidationError(ValidationMessages.INVALID_COURSE_ID.format(course_id=course_id))
+    if not enterprise_customer.catalog_contains_course(course_id):
+        raise ValidationError(ValidationMessages.COURSE_NOT_EXIST_IN_CATALOG.format(course_id=course_id))
+    return course_details or False

--- a/tests/test_admin/test_forms.py
+++ b/tests/test_admin/test_forms.py
@@ -194,10 +194,13 @@ class TestManageLearnersForm(unittest.TestCase):
         assert form.is_valid()
         assert form.cleaned_data[form.Fields.COURSE] is None
 
-    @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
-    def test_clean_course_valid(self, enrollment_client):
-        instance = enrollment_client.return_value
-        instance.get_course_details.side_effect = fake_enrollment_api.get_course_details
+    @mock.patch("enterprise.models.EnterpriseCatalogApiClient")
+    @mock.patch("enterprise.api_client.lms.EnrollmentApiClient")
+    def test_clean_course_valid(self, enrollment_client, enterprise_catalog_client):
+        enrollment_instance = enrollment_client.return_value
+        enrollment_instance.get_course_details.side_effect = fake_enrollment_api.get_course_details
+        enterprise_catalog_instance = enterprise_catalog_client.return_value
+        enterprise_catalog_instance.enterprise_contains_content_items.return_value = True
         course_id = "course-v1:edX+DemoX+Demo_Course"
         course_details = fake_enrollment_api.COURSE_DETAILS[course_id]
         course_mode = "audit"
@@ -206,7 +209,7 @@ class TestManageLearnersForm(unittest.TestCase):
         assert form.cleaned_data[form.Fields.COURSE] == course_details
 
     @ddt.data("course-v1:does+not+exist", "invalid_course_id")
-    @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
+    @mock.patch("enterprise.api_client.lms.EnrollmentApiClient")
     def test_clean_course_invalid(self, course_id, enrollment_client):
         instance = enrollment_client.return_value
         instance.get_course_details.side_effect = fake_enrollment_api.get_course_details
@@ -216,19 +219,25 @@ class TestManageLearnersForm(unittest.TestCase):
             form.Fields.COURSE: [ValidationMessages.INVALID_COURSE_ID.format(course_id=course_id)],
         }
 
-    @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
-    def test_clean_valid_course_empty_mode(self, enrollment_client):
-        instance = enrollment_client.return_value
-        instance.get_course_details.side_effect = fake_enrollment_api.get_course_details
+    @mock.patch("enterprise.models.EnterpriseCatalogApiClient")
+    @mock.patch("enterprise.api_client.lms.EnrollmentApiClient")
+    def test_clean_valid_course_empty_mode(self, enrollment_client, enterprise_catalog_client):
+        enrollment_instance = enrollment_client.return_value
+        enrollment_instance.get_course_details.side_effect = fake_enrollment_api.get_course_details
+        enterprise_catalog_instance = enterprise_catalog_client.return_value
+        enterprise_catalog_instance.enterprise_contains_content_items.return_value = True
         course_id = "course-v1:edX+DemoX+Demo_Course"
         form = self._make_bound_form("irrelevant@example.com", course=course_id, course_mode="")
         assert not form.is_valid()
         assert form.errors == {"__all__": [ValidationMessages.COURSE_WITHOUT_COURSE_MODE]}
 
-    @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
-    def test_clean_valid_course_invalid_mode(self, enrollment_client):
-        instance = enrollment_client.return_value
-        instance.get_course_details.side_effect = fake_enrollment_api.get_course_details
+    @mock.patch("enterprise.models.EnterpriseCatalogApiClient")
+    @mock.patch("enterprise.api_client.lms.EnrollmentApiClient")
+    def test_clean_valid_course_invalid_mode(self, enrollment_client, enterprise_catalog_client):
+        enrollment_instance = enrollment_client.return_value
+        enrollment_instance.get_course_details.side_effect = fake_enrollment_api.get_course_details
+        enterprise_catalog_instance = enterprise_catalog_client.return_value
+        enterprise_catalog_instance.enterprise_contains_content_items.return_value = True
         course_id = "course-v1:edX+DemoX+Demo_Course"
         course_mode = "verified"
         form = self._make_bound_form("irrelevant@example.com", course=course_id, course_mode=course_mode)
@@ -279,10 +288,13 @@ class TestManageLearnersForm(unittest.TestCase):
         cleaned_data = form.clean()
         assert cleaned_data[ManageLearnersForm.Fields.REASON] == expected_reason
 
-    @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
-    def test_validate_reason(self, enrollment_client):
-        instance = enrollment_client.return_value
-        instance.get_course_details.side_effect = fake_enrollment_api.get_course_details
+    @mock.patch("enterprise.models.EnterpriseCatalogApiClient")
+    @mock.patch("enterprise.api_client.lms.EnrollmentApiClient")
+    def test_validate_reason(self, enrollment_client, enterprise_catalog_client):
+        enrollment_instance = enrollment_client.return_value
+        enrollment_instance.get_course_details.side_effect = fake_enrollment_api.get_course_details
+        enterprise_catalog_instance = enterprise_catalog_client.return_value
+        enterprise_catalog_instance.enterprise_contains_content_items.return_value = True
         course_id = "course-v1:edX+DemoX+Demo_Course"
         reason = ""
         form = self._make_bound_form("irrelevant@example.com", course=course_id, reason=reason, course_mode="audit")
@@ -326,7 +338,7 @@ class TestManageLearnersDataSharingConsentForm(unittest.TestCase):
         cleaned_data = form.clean()
         assert cleaned_data[field_name] == expected_field_value
 
-    @mock.patch("enterprise.admin.forms.EnrollmentApiClient")
+    @mock.patch("enterprise.api_client.lms.EnrollmentApiClient")
     def test_clean(self, enrollment_client):
         """
         Test clean_email_or_username and clean_course methods.

--- a/tests/test_admin/test_view.py
+++ b/tests/test_admin/test_view.py
@@ -886,7 +886,7 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
         enrollment_instance.enroll_user_in_course.side_effect = fake_enrollment_api.enroll_user_in_course
         enrollment_instance.get_course_details.side_effect = fake_enrollment_api.get_course_details
         enterprise_catalog_instance = enterprise_catalog_client.return_value
-        enterprise_catalog_instance.enterprise_contains_content_items.return_value = {'contains_content_items': True}
+        enterprise_catalog_instance.enterprise_contains_content_items.return_value = True
 
         user = UserFactory()
         course_id = "course-v1:HarvardX+CoolScience+2016"
@@ -959,7 +959,7 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
         enrollment_instance.enroll_user_in_course.side_effect = fake_enrollment_api.enroll_user_in_course
         enrollment_instance.get_course_details.side_effect = fake_enrollment_api.get_course_details
         enterprise_catalog_instance = enterprise_catalog_client.return_value
-        enterprise_catalog_instance.enterprise_contains_content_items.return_value = {'contains_content_items': True}
+        enterprise_catalog_instance.enterprise_contains_content_items.return_value = True
 
         enrollment_count = 0
         user = None
@@ -1066,7 +1066,7 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
         enrollment_instance.enroll_user_in_course.side_effect = fake_enrollment_api.enroll_user_in_course
         enrollment_instance.get_course_details.side_effect = fake_enrollment_api.get_course_details
         enterprise_catalog_instance = enterprise_catalog_client.return_value
-        enterprise_catalog_instance.enterprise_contains_content_items.return_value = {'contains_content_items': True}
+        enterprise_catalog_instance.enterprise_contains_content_items.return_value = True
 
         user = UserFactory()
         course_id = "course-v1:HarvardX+CoolScience+2016"
@@ -1114,7 +1114,7 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
         enrollment_instance.get_course_enrollment.side_effect = fake_enrollment_api.get_course_enrollment
         enrollment_instance.get_course_details.side_effect = fake_enrollment_api.get_course_details
         enterprise_catalog_instance = enterprise_catalog_client.return_value
-        enterprise_catalog_instance.enterprise_contains_content_items.return_value = {'contains_content_items': True}
+        enterprise_catalog_instance.enterprise_contains_content_items.return_value = True
 
         user = UserFactory()
         course_id = "course-v1:HarvardX+CoolScience+2016"
@@ -1159,7 +1159,7 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
         enrollment_instance.get_course_enrollment.side_effect = fake_enrollment_api.get_course_enrollment
         enrollment_instance.get_course_details.side_effect = fake_enrollment_api.get_course_details
         enterprise_catalog_instance = enterprise_catalog_client.return_value
-        enterprise_catalog_instance.enterprise_contains_content_items.return_value = {'contains_content_items': True}
+        enterprise_catalog_instance.enterprise_contains_content_items.return_value = True
 
         user = UserFactory()
         course_id = "course-v1:HarvardX+CoolScience+2016"
@@ -1199,7 +1199,7 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
         enrollment_instance.get_course_enrollment.return_value = None
         enrollment_instance.get_course_details.side_effect = fake_enrollment_api.get_course_details
         enterprise_catalog_instance = enterprise_catalog_client.return_value
-        enterprise_catalog_instance.enterprise_contains_content_items.return_value = {'contains_content_items': True}
+        enterprise_catalog_instance.enterprise_contains_content_items.return_value = True
 
         user = UserFactory()
         course_id = "course-v1:HarvardX+CoolScience+2016"
@@ -1243,7 +1243,7 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
         enrollment_instance.enroll_user_in_course.side_effect = fake_enrollment_api.enroll_user_in_course
         enrollment_instance.get_course_details.side_effect = fake_enrollment_api.get_course_details
         enterprise_catalog_instance = enterprise_catalog_client.return_value
-        enterprise_catalog_instance.enterprise_contains_content_items.return_value = {'contains_content_items': True}
+        enterprise_catalog_instance.enterprise_contains_content_items.return_value = True
 
         user = UserFactory()
         course_id = "course-v1:HarvardX+CoolScience+2016"
@@ -1290,7 +1290,7 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
         )
         enrollment_instance.get_course_details.side_effect = fake_enrollment_api.get_course_details
         enterprise_catalog_instance = enterprise_catalog_client.return_value
-        enterprise_catalog_instance.enterprise_contains_content_items.return_value = {'contains_content_items': True}
+        enterprise_catalog_instance.enterprise_contains_content_items.return_value = True
 
         user = UserFactory()
         course_id = "course-v1:HarvardX+CoolScience+2016"
@@ -1325,7 +1325,7 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
         )
         enrollment_instance.get_course_details.side_effect = fake_enrollment_api.get_course_details
         enterprise_catalog_instance = enterprise_catalog_client.return_value
-        enterprise_catalog_instance.enterprise_contains_content_items.return_value = {'contains_content_items': True}
+        enterprise_catalog_instance.enterprise_contains_content_items.return_value = True
 
         user = UserFactory()
         course_id = "course-v1:HarvardX+CoolScience+2016"
@@ -1490,38 +1490,56 @@ class TestEnterpriseCustomerManageLearnersViewPostBulkUpload(BaseTestEnterpriseC
         second_email = FAKER.email()  # pylint: disable=no-member
         third_email = FAKER.email()  # pylint: disable=no-member
         course_id = "course-v1:edX+DemoX+Demo_Course"
-        second_course_id = "course-v1:edX+DemoX+Demo_Course_2"
+        second_course_id = "course-v1:HarvardX+CoolScience+2016"
         should_create_enrollments = False
 
         enrollment_instance = enrollment_client.return_value
         course_catalog_instance = course_catalog_client.return_value
         enterprise_catalog_instance = enterprise_catalog_client.return_value
         enterprise_catalog_instance.enterprise_contains_content_items.return_value = course_in_catalog
-        create_manual_enrollment_audit_mock.return_value = True
+        create_enrollment_audit_mock.return_value = True
         enroll_users_in_course_mock.return_value = [user], [], []
 
+        csv_columns = [ManageLearnersForm.CsvColumns.EMAIL, ManageLearnersForm.CsvColumns.COURSE_ID]
+        csv_data = [
+            (user.email, course_id),
+            (second_email, course_id),
+            (third_email, second_course_id),
+        ]
+
         if valid_course_id:
-            enrollment_instance.get_course_details.side_effect = fake_enrollment_api.get_course_details
-            course_catalog_instance.get_course_run.return_value = {
-                'key': course_id,
-                'title': 'Fake Course',
-                'start': '2020-11-01T00:00:00Z',
-            }
+            enrollment_instance.get_course_details.side_effect = [
+                fake_enrollment_api.get_course_details(course_id),
+                fake_enrollment_api.get_course_details(course_id),
+                fake_enrollment_api.get_course_details(second_course_id),
+            ]
+            course_catalog_instance.get_course_run.side_effect = [
+                {
+                    'key': course_id,
+                    'title': 'Fake Course',
+                    'start': '2020-11-01T00:00:00Z',
+                },
+                {
+                    'key': course_id,
+                    'title': 'Fake Course',
+                    'start': '2020-11-01T00:00:00Z',
+                },
+                {
+                    'key': second_course_id,
+                    'title': 'Fake Course 2',
+                    'start': '2019-10-01T00:00:00Z',
+                },
+            ]
         else:
             enrollment_instance.get_course_details.return_value = {}
 
-        columns = [ManageLearnersForm.CsvColumns.EMAIL, ManageLearnersForm.CsvColumns.COURSE_ID]
-        data = [
-            (user.email, course_id),
-            (second_email, course_id),
-            (third_email, another_course_id),
-        ]
-        response = self._perform_request(columns, data, notify=False)
+        response = self._perform_request(csv_columns, csv_data, notify=False)
 
         manage_learners_form = self._get_form(response, expected_status_code=expected_status_code)
         bulk_upload_errors = []
         if manage_learners_form:
             bulk_upload_errors = manage_learners_form.errors[ManageLearnersForm.Fields.BULK_UPLOAD]
+            print('bulk_upload_errors', bulk_upload_errors)
 
         if valid_course_id and course_in_catalog:
             # valid input, no errors
@@ -1537,7 +1555,7 @@ class TestEnterpriseCustomerManageLearnersViewPostBulkUpload(BaseTestEnterpriseC
 
         if should_create_enrollments:
             # assert correct users are enrolled in the proper courses based on the csv data
-            enroll_users_in_course_mock.assert_called_once_with(
+            enroll_users_in_course_mock.assert_any_call(
                 course_id=course_id,
                 emails=[user.email, second_email],
                 course_mode=ANY,
@@ -1547,8 +1565,8 @@ class TestEnterpriseCustomerManageLearnersViewPostBulkUpload(BaseTestEnterpriseC
                 enterprise_customer=ANY,
                 sales_force_id=ANY,
             )
-            enroll_users_in_course_mock.assert_called_once_with(
-                course_id=another_course_id,
+            enroll_users_in_course_mock.assert_any_call(
+                course_id=second_course_id,
                 emails=[third_email],
                 course_mode=ANY,
                 discount=ANY,
@@ -1673,7 +1691,7 @@ class TestEnterpriseCustomerManageLearnersViewPostBulkUpload(BaseTestEnterpriseC
         enrollment_instance.enroll_user_in_course.side_effect = fake_enrollment_api.enroll_user_in_course
         enrollment_instance.get_course_details.side_effect = fake_enrollment_api.get_course_details
         enterprise_catalog_instance = enterprise_catalog_client.return_value
-        enterprise_catalog_instance.enterprise_contains_content_items.return_value = {'contains_content_items': True}
+        enterprise_catalog_instance.enterprise_contains_content_items.return_value = True
 
         self._login()
         user = UserFactory.create()
@@ -1728,7 +1746,7 @@ class TestEnterpriseCustomerManageLearnersViewPostBulkUpload(BaseTestEnterpriseC
         enrollment_instance.enroll_user_in_course.side_effect = fake_enrollment_api.enroll_user_in_course
         enrollment_instance.get_course_details.side_effect = fake_enrollment_api.get_course_details
         enterprise_catalog_instance = enterprise_catalog_client.return_value
-        enterprise_catalog_instance.enterprise_contains_content_items.return_value = {'contains_content_items': True}
+        enterprise_catalog_instance.enterprise_contains_content_items.return_value = True
 
         self._login()
         user = UserFactory.create()
@@ -1776,7 +1794,7 @@ class TestEnterpriseCustomerManageLearnersViewPostBulkUpload(BaseTestEnterpriseC
         enrollment_instance.enroll_user_in_course.side_effect = fake_enrollment_api.enroll_user_in_course
         enrollment_instance.get_course_details.side_effect = fake_enrollment_api.get_course_details
         enterprise_catalog_instance = enterprise_catalog_client.return_value
-        enterprise_catalog_instance.enterprise_contains_content_items.return_value = {'contains_content_items': True}
+        enterprise_catalog_instance.enterprise_contains_content_items.return_value = True
 
         self._login()
         user = UserFactory.create()

--- a/tests/test_admin/test_view.py
+++ b/tests/test_admin/test_view.py
@@ -1462,28 +1462,28 @@ class TestEnterpriseCustomerManageLearnersViewPostBulkUpload(BaseTestEnterpriseC
         line_error_message = ValidationMessages.INVALID_EMAIL.format(argument=invalid_email)
         self._assert_line_message(bulk_upload_errors[0], 3, line_error_message)
 
+    @ddt.data(
+        {'valid_course_id': False, 'course_in_catalog': False, 'expected_status_code': 200},
+        {'valid_course_id': False, 'course_in_catalog': True, 'expected_status_code': 200},
+        {'valid_course_id': True, 'course_in_catalog': False, 'expected_status_code': 200},
+        {'valid_course_id': True, 'course_in_catalog': True, 'expected_status_code': 302},
+    )
+    @ddt.unpack
     @mock.patch("enterprise.admin.views.create_manual_enrollment_audit")
     @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.api_client.lms.EnrollmentApiClient")
     @mock.patch("enterprise.models.EnterpriseCatalogApiClient")
     @mock.patch("enterprise.admin.views.enroll_users_in_course")
-    @ddt.data(
-        (False, False, 200),
-        (False, True, 200),
-        (True, False, 200),
-        (True, True, 302),  # input is valid, expect a redirect
-    )
-    @ddt.unpack
     def test_post_create_course_enrollments(
             self,
-            valid_course_id,
-            course_in_catalog,
-            expected_status_code,
             enroll_users_in_course_mock,
             enterprise_catalog_client,
             enrollment_client,
             course_catalog_client,
             create_enrollment_audit_mock,
+            valid_course_id,
+            course_in_catalog,
+            expected_status_code,
     ):
         self._login()
         user = UserFactory()
@@ -1557,7 +1557,7 @@ class TestEnterpriseCustomerManageLearnersViewPostBulkUpload(BaseTestEnterpriseC
             # assert correct users are enrolled in the proper courses based on the csv data
             enroll_users_in_course_mock.assert_any_call(
                 course_id=course_id,
-                emails=[user.email, second_email],
+                emails=sorted([user.email, second_email]),
                 course_mode=ANY,
                 discount=ANY,
                 enrollment_reason=ANY,


### PR DESCRIPTION
ENT-3597

Modifies the bulk csv upload tool in the "Manage Learners" screen to accept an optional "course_id" column to support enrolling users in multiple courses at once. Currently, the form only allows a single course for all uploaded users.

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [x] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
