### PR TITLE
ENT-3723: Rebranding update: more robust get_platform_logo_url and Learner Portal default colors update

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Change Log
 Unreleased
 -----------
 
+[3.13.7]
+--------
+
+* Rebranding update: removing use of urljoin in get_platform_logo_url
+
 [3.13.6]
 --------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,7 +19,7 @@ Unreleased
 [3.13.7]
 --------
 
-* Rebranding update: removing use of urljoin in get_platform_logo_url
+* Rebranding update: move to more robust ``get_platform_logo_url`` and update default branding colors.
 
 [3.13.6]
 --------

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.13.6"
+__version__ = "3.13.7"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/constants.py
+++ b/enterprise/constants.py
@@ -42,9 +42,9 @@ class DefaultColors:
     Class to group the default branding color codes.
     These color codes originated in the Enterprise Learner Portal.
     """
-    PRIMARY = '#1a337b'
-    SECONDARY = '#d7e3fc'
-    TERTIARY = '#007d88'
+    PRIMARY = '#00262B'
+    SECONDARY = '#EFF8FA'
+    TERTIARY = '#0A7DA3'
 
 
 class CourseModes:

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -7,7 +7,6 @@ import datetime
 import json
 import logging
 import re
-from urllib.parse import urljoin
 from uuid import UUID
 
 import bleach

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -7,6 +7,7 @@ import datetime
 import json
 import logging
 import re
+from urllib.parse import urljoin
 from uuid import UUID
 
 import bleach
@@ -1455,22 +1456,23 @@ def enroll_users_in_course(
 
 
 def is_valid_url(url):
-  try:
-    result = urlparse(url)
-    return all([result.scheme, result.netloc])
-  except ValueError:
-    return False
+    """
+    Return where the specified URL is a valid absolute url.
+    """
+    try:
+        result = urlparse(url)
+        return all([result.scheme, result.netloc])
+    except ValueError:
+        return False
 
 
 def get_platform_logo_url():
     """
     Return an absolute URL of the platform logo using the branding api.
     """
-    # Return fake URL for tests rather than mock get_logo_url for every test using EnterpriseCustomer
-    fake_url = 'http://fake.url'
-    logo_url = get_logo_url() 
+    logo_url = get_logo_url() if get_logo_url else None
     if not logo_url:
-        return fake_url
+        return None
 
     is_abs_url = is_valid_url(logo_url)
     if is_abs_url:

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -1455,15 +1455,29 @@ def enroll_users_in_course(
     return successes, pending, failures
 
 
+def is_valid_url(url):
+  try:
+    result = urlparse(url)
+    return all([result.scheme, result.netloc])
+  except ValueError:
+    return False
+
+
 def get_platform_logo_url():
     """
-    Return an absolute URL of the platform logo using the branding api
+    Return an absolute URL of the platform logo using the branding api.
     """
     # Return fake URL for tests rather than mock get_logo_url for every test using EnterpriseCustomer
-    return urljoin(
-        settings.LMS_ROOT_URL,
-        get_logo_url()
-    ) if get_logo_url else 'http://fake.url'
+    fake_url = 'http://fake.url'
+    logo_url = get_logo_url() 
+    if not logo_url:
+        return fake_url
+
+    is_abs_url = is_valid_url(logo_url)
+    if is_abs_url:
+        return logo_url
+
+    return urljoin(settings.LMS_ROOT_URL, logo_url)
 
 
 def create_tableau_user(user_id, enterprise_customer_user):

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -645,10 +645,12 @@ class TestEnterpriseAPIViews(APITest):
         ),
     )
     @ddt.unpack
-    def test_api_views(self, factory, url, sorting_key, model_items, expected_json):
+    @mock.patch('enterprise.utils.get_logo_url')
+    def test_api_views(self, factory, url, sorting_key, model_items, expected_json, mock_get_logo_url):
         """
         Make sure API end point returns all of the expected fields.
         """
+        mock_get_logo_url.return_value = 'http://fake.url'
         self.create_items(factory, model_items)
         response = self.client.get(settings.TEST_SERVER + url)
         response = self.load_json(response.content)
@@ -731,6 +733,7 @@ class TestEnterpriseAPIViews(APITest):
          {'count': 0, 'next': None, 'previous': None, 'results': []}),
     )
     @ddt.unpack
+    @mock.patch('enterprise.utils.get_logo_url')
     def test_enterprise_customer_with_access_to(
             self,
             is_staff,
@@ -738,12 +741,14 @@ class TestEnterpriseAPIViews(APITest):
             user_groups,
             query_params,
             has_access_to_enterprise,
-            expected_error
+            expected_error,
+            mock_get_logo_url,
     ):
         """
         ``enterprise_customer``'s detail list endpoint ``with_access_to`` should validate permissions
          and serialize the ``EnterpriseCustomer`` objects the user has access to.
         """
+        mock_get_logo_url.return_value = 'http://fake.url'
         enterprise_customer_data = {
             'uuid': FAKE_UUIDS[0], 'name': 'Test Enterprise Customer', 'slug': TEST_SLUG,
             'active': True, 'enable_data_sharing_consent': True,

--- a/tests/test_enterprise/test_utils.py
+++ b/tests/test_enterprise/test_utils.py
@@ -4,11 +4,12 @@ Tests for the `edx-enterprise` utils module.
 """
 
 import unittest
+from unittest import mock
 
 import ddt
 from pytest import mark
 
-from enterprise.utils import get_idiff_list
+from enterprise.utils import get_idiff_list, get_platform_logo_url
 
 
 @mark.django_db
@@ -39,3 +40,19 @@ class TestGetDifferenceList(unittest.TestCase):
     def test_get_idiff_list_method(self, all_emails, registered_emails, unregistered_emails):
         emails = get_idiff_list(all_emails, registered_emails)
         self.assertEqual(sorted(emails), sorted(unregistered_emails))
+
+
+class TestUtils(unittest.TestCase):
+    """
+    Tests for utility functions in enterprise.utils
+    """
+
+    @mock.patch('enterprise.utils.get_logo_url')
+    def test_get_platform_logo_url(self, mock_get_logo_url):
+        """
+        Verify that the URL returned from get_logo_url is
+        returned from get_platform_logo_url.
+        """
+        fake_url = 'http://logo.url'
+        mock_get_logo_url.return_value = fake_url
+        self.assertEqual(get_platform_logo_url(), fake_url)

--- a/tests/test_enterprise/test_utils.py
+++ b/tests/test_enterprise/test_utils.py
@@ -9,6 +9,8 @@ from unittest import mock
 import ddt
 from pytest import mark
 
+from django.conf import settings
+
 from enterprise.utils import get_idiff_list, get_platform_logo_url
 
 
@@ -42,17 +44,24 @@ class TestGetDifferenceList(unittest.TestCase):
         self.assertEqual(sorted(emails), sorted(unregistered_emails))
 
 
+@mark.django_db
+@ddt.ddt
 class TestUtils(unittest.TestCase):
     """
     Tests for utility functions in enterprise.utils
     """
 
+    @ddt.unpack
+    @ddt.data(
+        (None, None),
+        ('http://fake.url/logo.png', 'http://fake.url/logo.png'),
+        ('./images/logo.png', '{}/images/logo.png'.format(settings.LMS_ROOT_URL)),
+    )
     @mock.patch('enterprise.utils.get_logo_url')
-    def test_get_platform_logo_url(self, mock_get_logo_url):
+    def test_get_platform_logo_url(self, logo_url, expected_logo_url, mock_get_logo_url):
         """
         Verify that the URL returned from get_logo_url is
         returned from get_platform_logo_url.
         """
-        fake_url = 'http://logo.url'
-        mock_get_logo_url.return_value = fake_url
-        self.assertEqual(get_platform_logo_url(), fake_url)
+        mock_get_logo_url.return_value = logo_url
+        self.assertEqual(get_platform_logo_url(), expected_logo_url)


### PR DESCRIPTION
**ENT-3723:**

As part of the rebranding effort, `get_logo_url` is being updated. Since `get_logo_url` will always return an absolute URL, we can remove the use of `urljoin` in `get_platform_logo_url`

[Associated edx-platform PR](https://github.com/edx/edx-platform/pull/25654)

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
