### PR TITLE
ENT-3627: Add end date to course level metadata

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,13 @@ Change Log
 Unreleased
 -----------
 
+[3.13.2]
+--------
+
+* Add course end date to course level metadata.
+
 [3.13.1]
+--------
 
 * Base implementation of assessment level reporting for Integrated Channels.
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.13.1"
+__version__ = "3.13.2"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -21,6 +21,7 @@ from enterprise.constants import ENTERPRISE_PERMISSION_GROUPS, DefaultColors
 from enterprise.utils import (
     CourseEnrollmentDowngradeError,
     CourseEnrollmentPermissionError,
+    get_last_course_run_end_date,
     has_course_run_available_for_enrollment,
     track_enrollment,
 )
@@ -310,6 +311,7 @@ class EnterpriseCustomerCatalogDetailSerializer(EnterpriseCustomerCatalogSeriali
             if content_type == 'course':
                 item['enrollment_url'] = instance.get_course_enrollment_url(item['key'])
                 item['active'] = has_course_run_available_for_enrollment(item['course_runs'])
+                item['end_date'] = get_last_course_run_end_date(item['course_runs'])
             if content_type == 'courserun':
                 item['enrollment_url'] = instance.get_course_run_enrollment_url(item['key'])
             if content_type == 'program':

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -924,6 +924,16 @@ def has_course_run_available_for_enrollment(course_runs):
     return False
 
 
+def get_last_course_run_end_date(course_runs):
+    """
+    Returns the end date of the course run that falls at the end.
+    """
+    latest_end_date = None
+    if course_runs:
+        latest_end_date = max(course_run['end'] for course_run in course_runs)
+    return latest_end_date
+
+
 def is_course_run_upgradeable(course_run):
     """
     Return true if the course run has a verified seat with an unexpired upgrade deadline, false otherwise.

--- a/test_utils/__init__.py
+++ b/test_utils/__init__.py
@@ -121,7 +121,8 @@ def update_course_with_enterprise_context(
         course,
         add_utm_info=True,
         enterprise_catalog_uuid=None,
-        add_active_info=True
+        add_active_info=True,
+        add_end_date_info=True
 ):
     """
     Populate a fake course response with any necessary Enterprise context for testing purposes.
@@ -144,6 +145,8 @@ def update_course_with_enterprise_context(
 
     if add_active_info:
         course['active'] = utils.has_course_run_available_for_enrollment(course_runs)
+    if add_end_date_info:
+        course['end_date'] = utils.get_last_course_run_end_date(course_runs)
     for course_run in course_runs:
         update_course_run_with_enterprise_context(
             course_run,
@@ -178,6 +181,7 @@ def update_program_with_enterprise_context(program, add_utm_info=True, enterpris
             add_utm_info=add_utm_info,
             enterprise_catalog_uuid=enterprise_catalog_uuid,
             add_active_info=False,
+            add_end_date_info=False
         )
 
     return program

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1317,6 +1317,44 @@ class TestEnterpriseUtils(unittest.TestCase):
         assert utils.has_course_run_available_for_enrollment(course_runs) == expected_enrollment_eligibility
 
     @ddt.data(
+        (
+            [],
+            None,
+        ),
+        (
+            [
+                {
+                    "end": "2020-09-13T13:11:01Z",
+                },
+                {
+                    "end": "2020-10-13T01:11:01Z",
+                },
+                {
+                    "end": "2019-07-13T01:11:01Z",
+                },
+            ],
+            "2020-10-13T01:11:01Z",
+        ),
+        (
+            [
+                {
+                    "end": "3000-05-29T12:11:01Z",
+                },
+                {
+                    "end": "3000-10-13T13:11:01Z",
+                },
+            ],
+            "3000-10-13T13:11:01Z",  # future dates
+        ),
+    )
+    @ddt.unpack
+    def test_course_end_date(self, course_runs, expected_end_date):
+        """
+        Tests that course end_date is always equal to latest course run's end date.
+        """
+        assert utils.get_last_course_run_end_date(course_runs) == expected_end_date
+
+    @ddt.data(
         ({"seats": [{"type": "verified", "upgrade_deadline": "3000-10-13T13:11:04Z"}]}, True),
         ({"seats": [{"type": "verified", "upgrade_deadline": None}]}, True),
         ({"seats": [{"type": "verified"}]}, True),


### PR DESCRIPTION
**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [x] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
