### PR TITLE
ENT-3586 Change identity_provider property to support multiple identity_providers

### DIFF
--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -34,7 +34,7 @@ from django.template import Context, Template
 from django.urls import reverse
 from django.utils.encoding import force_bytes, force_text, python_2_unicode_compatible
 from django.utils.functional import cached_property, lazy
-from django.utils.http import urlquote
+from django.utils.http import urlquote, urlencode
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext
 from django.utils.translation import ugettext_lazy as _
@@ -347,9 +347,7 @@ class EnterpriseCustomer(TimeStampedModel):
     @property
     def has_identity_providers(self):
         """
-        Return the unique slug for the identity provider associated with this enterprise customer.
-
-        Returns `None` if enterprise customer does not have any identity provider.
+        Return True if there are any identity providers associated with this enterprise customer.
         """
         # pylint: disable=no-member
         return self.enterprise_customer_identity_providers.exists()
@@ -580,12 +578,14 @@ class EnterpriseCustomer(TimeStampedModel):
             )
             return
 
-        course_path = urlquote(
-            '/courses/{course_id}/course/?tpa_hint={tpa_hint}'.format(
-                course_id=course_id,
-                tpa_hint=self.identity_provider,
-            )
-        )
+        course_path = '/courses/{course_id}/course'.format(course_id=course_id)
+        params = {}
+
+        # add tap_hint if there is only one IdP attached with enterprise_customer
+        if self.identity_providers.count() == 1:
+            params = {'tpa_hint': self.identity_providers.first().provider_id}
+        course_path = urlquote("{}?{}".format(course_path, urlencode(params)))
+
         lms_root_url = utils.get_configuration_value_for_site(
             self.site,
             'LMS_ROOT_URL',

--- a/enterprise/tpa_pipeline.py
+++ b/enterprise/tpa_pipeline.py
@@ -126,12 +126,12 @@ def get_user_social_auth(user, enterprise_customer):
         enterprise_customer (EnterpriseCustomer): User id of user in third party LMS
 
     """
-    provider_id = enterprise_customer.identity_provider
-    tpa_provider = get_identity_provider(provider_id)
-    user_social_auth = UserSocialAuth.objects.filter(
-        user=user,
-        provider=tpa_provider.backend_name
-    ).first()
+    enterprise_customer_identity_providers = enterprise_customer.identity_providers
+    provider_backend_names = []
+    for idp in enterprise_customer_identity_providers:
+        tpa_provider = get_identity_provider(idp.provider_id)
+        provider_backend_names.append(tpa_provider.backend_name)
+    user_social_auth = UserSocialAuth.objects.filter(provider__in=provider_backend_names, user=user).first()
 
     return user_social_auth
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -205,8 +205,10 @@ class TestEnterpriseCustomer(unittest.TestCase):
         Test identity_provider property returns correct value without errors.
         """
         customer = factories.EnterpriseCustomerFactory()
-        ent_idp = factories.EnterpriseCustomerIdentityProviderFactory(enterprise_customer=customer)
-        assert customer.identity_provider == ent_idp.provider_id
+        ent_idp_one = factories.EnterpriseCustomerIdentityProviderFactory(enterprise_customer=customer)
+        ent_idp_two = factories.EnterpriseCustomerIdentityProviderFactory(enterprise_customer=customer)
+        assert customer.identity_provider == ent_idp_one[0].provider_id
+        assert customer.identity_provider == ent_idp_two[1].provider_id
 
     def test_no_identity_provider(self):
         """
@@ -215,7 +217,7 @@ class TestEnterpriseCustomer(unittest.TestCase):
         Test that identity_provider property does not raise ObjectDoesNotExist and returns None
         if enterprise customer does not have an associated identity provider.
         """
-        assert factories.EnterpriseCustomerFactory().identity_provider is None
+        assert factories.EnterpriseCustomerFactory().identity_providers is None
 
     @mock.patch('enterprise.models.EnterpriseCatalogApiClient', return_value=mock.MagicMock())
     def test_catalog_contains_course_with_enterprise_customer_catalog(self, api_client_mock):


### PR DESCRIPTION


**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
