### PR TITLE
ENT-3588: Updated EnterpriseCustomerCourseEnrollmentsSerializer.validate_tpa_user_id to account for multiple IdPs

### DIFF
--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -839,14 +839,14 @@ class EnterpriseCustomerCourseEnrollmentsSerializer(serializers.Serializer):
 
         try:
             tpa_client = ThirdPartyAuthApiClient(self.context['request_user'])
-            username = tpa_client.get_username_from_remote_id(
-                enterprise_customer.identity_provider, value
-            )
-            user = User.objects.get(username=username)
-            return models.EnterpriseCustomerUser.objects.get(
-                user_id=user.id,
-                enterprise_customer=enterprise_customer
-            )
+            for identity_provider in enterprise_customer.identity_providers:
+                username = tpa_client.get_username_from_remote_id(identity_provider, value)
+                if username:
+                    user = User.objects.get(username=username)
+                    return models.EnterpriseCustomerUser.objects.get(
+                        user_id=user.id,
+                        enterprise_customer=enterprise_customer
+                    )
         except (models.EnterpriseCustomerUser.DoesNotExist, User.DoesNotExist):
             pass
 

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -1548,6 +1548,9 @@ class TestEnterpriseAPIViews(APITest):
             name="test_enterprise",
             enable_autocohorting=enable_autocohorting
         )
+        factories.EnterpriseCustomerIdentityProviderFactory(
+            enterprise_customer=enterprise_customer
+        )
 
         permission = Permission.objects.get(name='Can add Enterprise Customer')
         self.user.user_permissions.add(permission)


### PR DESCRIPTION

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [x] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
