### PR TITLE
ENT-3591: update EnterpriseProxyLoginView

### DIFF
--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -1066,15 +1066,14 @@ class EnterpriseProxyLoginView(View):
             )
             query_dict['next'] = learner_portal_base_url + '/' + enterprise_slug
 
-        tpa_hint = query_params.get('tpa_hint')
+        # Check if tpa_hint was passed as query param then redirect to that IDP login
+        # Otherwise check if enterprise is linked to one IDP, then page will be redirected there
+        tpa_hint = query_params.get('tpa_hint') or enterprise_customer.identity_providers.first().provider_id if \
+            enterprise_customer.identity_providers.count() == 1 else None
+
         if tpa_hint:
-            # If there is tpa_hint already in the query_string then no need to update it in query_dict
-            pass
-        elif enterprise_customer.identity_providers and enterprise_customer.identity_providers.count() == 1:
-            # If there's only one linked IDP and no tpa_hint provided in query_params, then redirect to that IDP login
             # Add the tpa_hint to the redirect's 'next' query parameter
             # Redirect will be to the Enterprise Customer's TPA provider
-            tpa_hint = enterprise_customer.identity_providers.first().provider_id
             tpa_next_param = {
                 'tpa_hint': tpa_hint,
             }

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -1066,15 +1066,21 @@ class EnterpriseProxyLoginView(View):
             )
             query_dict['next'] = learner_portal_base_url + '/' + enterprise_slug
 
-        if enterprise_customer.identity_provider:
+        tpa_hint = query_params.get('tpa_hint')
+        if tpa_hint:
+            # If there is tpa_hint already in the query_string then no need to update it in query_dict
+            pass
+        elif enterprise_customer.identity_providers and enterprise_customer.identity_providers.count() == 1:
+            # If there's only one linked IDP and no tpa_hint provided in query_params, then redirect to that IDP login
             # Add the tpa_hint to the redirect's 'next' query parameter
             # Redirect will be to the Enterprise Customer's TPA provider
-            tpa_hint = enterprise_customer.identity_provider
+            tpa_hint = enterprise_customer.identity_providers.first().provider_id
             tpa_next_param = {
                 'tpa_hint': tpa_hint,
             }
             query_dict['next'] = update_query_parameters(str(query_dict['next']), tpa_next_param)
         else:
+            # If there's no linked IDP or multiple IDPs are linked and no tpa_hint provided in query_param
             # Add Enterprise Customer UUID and proxy_login to the redirect's query parameters
             # Redirect will be to the edX Logistration with Enterprise Proxy Login sidebar
             query_dict['enterprise_customer'] = [str(enterprise_customer.uuid)]

--- a/tests/test_enterprise/views/test_enterprise_proxy_login_view.py
+++ b/tests/test_enterprise/views/test_enterprise_proxy_login_view.py
@@ -26,7 +26,7 @@ class TestEnterpriseProxyLoginView(TestCase):
         super().setUpTestData()
         cls.client = Client()
         cls.enterprise_customer = EnterpriseCustomerFactory()
-        cls.identity_provider = EnterpriseCustomerIdentityProviderFactory(enterprise_customer=cls.enterprise_customer)
+        cls.identity_providers = EnterpriseCustomerIdentityProviderFactory(enterprise_customer=cls.enterprise_customer)
 
     def _get_url_with_params(self, use_enterprise_slug=True, use_next=True, enterprise_slug_override=None,
                              next_override=None):
@@ -97,6 +97,7 @@ class TestEnterpriseProxyLoginView(TestCase):
         else:
             learner_portal_url = settings.ENTERPRISE_LEARNER_PORTAL_BASE_URL
             next_url = learner_portal_url + '/' + self.enterprise_customer.slug
-        query_params['next'] = next_url + '?tpa_hint=' + self.enterprise_customer.identity_provider
+        query_params['next'] = next_url + '?tpa_hint=' + str(self.enterprise_customer.identity_providers.first().
+                                                             provider_id)
         expected_url = LMS_LOGIN_URL + '?' + query_params.urlencode()
         self.assertRedirects(response, expected_url, fetch_redirect_response=False)


### PR DESCRIPTION
JIRA: https://openedx.atlassian.net/browse/ENT-3591

**A.C:**

- enterprise/proxy-login should redirect to the IDP if there is only one IDP linked to the enterprise customer.
- if user has provided IDP in requested URL, user redirected to that IDP login Page.
- if there are multiple IDPs linked to the customer and tpa_hint is also not provided in query_string params then redirect to the normal login page.
- if there is not an IDP, then the user should be redirected to the normal login page.



**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
