### PR TITLE
Both list_route and detail_route removed in drf = 3.10

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Change Log
 Unreleased
 -----------
 
+[3.13.5]
+--------
+
+* Fixed deprecation warnings related with drf methods (detail_route, list_route).
+
 [3.13.4]
 --------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.13.4"
+__version__ = "3.13.5"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -12,7 +12,7 @@ from edx_rbac.decorators import permission_required
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from rest_framework import filters, generics, permissions, status, viewsets
 from rest_framework.authentication import SessionAuthentication
-from rest_framework.decorators import action, detail_route, list_route
+from rest_framework.decorators import action
 from rest_framework.exceptions import NotFound, ValidationError
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.renderers import JSONRenderer
@@ -151,7 +151,7 @@ class EnterpriseCustomerViewSet(EnterpriseReadWriteModelViewSet):
             return serializers.EnterpriseCustomerBasicSerializer
         return self.serializer_class
 
-    @list_route()
+    @action(detail=False)
     # pylint: disable=invalid-name,unused-argument
     def basic_list(self, request, *arg, **kwargs):
         """
@@ -165,7 +165,7 @@ class EnterpriseCustomerViewSet(EnterpriseReadWriteModelViewSet):
         return Response(serializer.data)
 
     @method_decorator(require_at_least_one_query_parameter('course_run_ids', 'program_uuids'))
-    @detail_route()
+    @action(detail=True)
     @permission_required('enterprise.can_view_catalog', fn=lambda request, pk, course_run_ids, program_uuids: pk)
     # pylint: disable=invalid-name,unused-argument
     def contains_content_items(self, request, pk, course_run_ids, program_uuids):
@@ -191,7 +191,7 @@ class EnterpriseCustomerViewSet(EnterpriseReadWriteModelViewSet):
 
         return Response({'contains_content_items': contains_content_items})
 
-    @detail_route(methods=['post'], permission_classes=[permissions.IsAuthenticated])
+    @action(methods=['post'], permission_classes=[permissions.IsAuthenticated], detail=True)
     @permission_required('enterprise.can_enroll_learners', fn=lambda request, pk: pk)
     # pylint: disable=invalid-name,unused-argument
     def course_enrollments(self, request, pk):
@@ -213,7 +213,7 @@ class EnterpriseCustomerViewSet(EnterpriseReadWriteModelViewSet):
 
         return Response(serializer.errors, status=HTTP_400_BAD_REQUEST)
 
-    @detail_route(methods=['post'], permission_classes=[permissions.IsAuthenticated])
+    @action(detail=True, methods=['post'], permission_classes=[permissions.IsAuthenticated])
     @permission_required('enterprise.can_enroll_learners', fn=lambda request, pk: pk)
     # pylint: disable=invalid-name,unused-argument
     def enterprise_learners(self, request, pk):
@@ -303,7 +303,7 @@ class EnterpriseCustomerViewSet(EnterpriseReadWriteModelViewSet):
         return Response(status=HTTP_400_BAD_REQUEST)
 
     @method_decorator(require_at_least_one_query_parameter('permissions'))
-    @list_route(permission_classes=[permissions.IsAuthenticated, IsInEnterpriseGroup])
+    @action(permission_classes=[permissions.IsAuthenticated, IsInEnterpriseGroup], detail=False)
     def with_access_to(self, request, *args, **kwargs):  # pylint: disable=invalid-name,unused-argument
         """
         Returns the list of enterprise customers the user has a specified group permission access to.
@@ -321,7 +321,7 @@ class EnterpriseCustomerViewSet(EnterpriseReadWriteModelViewSet):
             self.queryset = self.queryset.filter(name__icontains=enterprise_name)
         return self.list(request, *args, **kwargs)
 
-    @list_route()
+    @action(detail=False)
     @permission_required('enterprise.can_access_admin_dashboard')
     def dashboard_list(self, request, *args, **kwargs):  # pylint: disable=invalid-name,unused-argument
         """
@@ -704,7 +704,7 @@ class EnterpriseCustomerCatalogViewSet(EnterpriseReadOnlyModelViewSet):
         return serializers.EnterpriseCustomerCatalogSerializer
 
     @method_decorator(require_at_least_one_query_parameter('course_run_ids', 'program_uuids'))
-    @detail_route()
+    @action(detail=True)
     # pylint: disable=invalid-name,unused-argument
     def contains_content_items(self, request, pk, course_run_ids, program_uuids):
         """
@@ -730,7 +730,7 @@ class EnterpriseCustomerCatalogViewSet(EnterpriseReadOnlyModelViewSet):
 
         return Response({'contains_content_items': contains_content_items})
 
-    @detail_route(url_path='courses/{}'.format(COURSE_KEY_URL_PATTERN))
+    @action(detail=True, url_path='courses/{}'.format(COURSE_KEY_URL_PATTERN))
     @permission_required(
         'enterprise.can_view_catalog',
         fn=lambda request, pk, course_key: get_enterprise_customer_from_catalog_id(pk))
@@ -758,7 +758,7 @@ class EnterpriseCustomerCatalogViewSet(EnterpriseReadOnlyModelViewSet):
         serializer = serializers.CourseDetailSerializer(course, context=context)
         return Response(serializer.data)
 
-    @detail_route(url_path='course_runs/{}'.format(settings.COURSE_ID_PATTERN))
+    @action(detail=True, url_path='course_runs/{}'.format(settings.COURSE_ID_PATTERN))
     @permission_required(
         'enterprise.can_view_catalog',
         fn=lambda request, pk, course_id: get_enterprise_customer_from_catalog_id(pk))
@@ -786,7 +786,7 @@ class EnterpriseCustomerCatalogViewSet(EnterpriseReadOnlyModelViewSet):
         serializer = serializers.CourseRunDetailSerializer(course_run, context=context)
         return Response(serializer.data)
 
-    @detail_route(url_path='programs/(?P<program_uuid>[^/]+)')
+    @action(detail=True, url_path='programs/(?P<program_uuid>[^/]+)')
     @permission_required(
         'enterprise.can_view_catalog',
         fn=lambda request, pk, program_uuid: get_enterprise_customer_from_catalog_id(pk))

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -77,18 +77,15 @@ ENTERPRISE_CATALOGS_CONTAINS_CONTENT_ENDPOINT = reverse(
     kwargs={'pk': FAKE_UUIDS[1]}
 )
 ENTERPRISE_CATALOGS_COURSE_ENDPOINT = reverse(
-    # pylint: disable=anomalous-backslash-in-string
-    r'enterprise-catalogs-courses/(?P<course-key>[^/+]+(/|\+)[^/+]+)',
+    'enterprise-catalogs-course-detail',
     kwargs={'pk': FAKE_UUIDS[1], 'course_key': TEST_COURSE_KEY}
 )
 ENTERPRISE_CATALOGS_COURSE_RUN_ENDPOINT = reverse(
-    # pylint: disable=anomalous-backslash-in-string
-    r'enterprise-catalogs-course-runs/(?P<course-id>[^/+]+(/|\+)[^/+]+(/|\+)[^/?]+)',
+    'enterprise-catalogs-course-run-detail',
     kwargs={'pk': FAKE_UUIDS[1], 'course_id': TEST_COURSE}
 )
 ENTERPRISE_CATALOGS_PROGRAM_ENDPOINT = reverse(
-    r'enterprise-catalogs-programs/(?P<program-uuid>[^/]+)',
-    kwargs={'pk': FAKE_UUIDS[1], 'program_uuid': FAKE_UUIDS[3]}
+    'enterprise-catalogs-program-detail', kwargs={'pk': FAKE_UUIDS[1], 'program_uuid': FAKE_UUIDS[3]}
 )
 ENTERPRISE_COURSE_ENROLLMENT_LIST_ENDPOINT = reverse('enterprise-course-enrollment-list')
 ENTERPRISE_CUSTOMER_BRANDING_LIST_ENDPOINT = reverse('enterprise-customer-branding-list')


### PR DESCRIPTION
edx-platform gives error while upgrading drf version to 3.10 due to enterprise.

https://openedx.atlassian.net/browse/BOM-2130

This issue is caught by `make docs` inside edx-platform. Tests failed to capture this issue.




https://www.django-rest-framework.org/community/3.8-announcement/#action-decorator-replaces-list_route-and-detail_route

Both list_route and detail_route are now pending deprecation. They will be deprecated in 3.9 and removed entirely in 3.10.

The new action decorator takes a boolean detail argument.

Replace detail_route uses with @action(detail=True).
Replace list_route uses with @action(detail=False).
