### PR TITLE
ENT-3781: Course run end date bug fix in catalog api

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Change Log
 Unreleased
 -----------
 
+[3.13.3]
+--------
+
+* Course end date bugfix.
+
 [3.13.2]
 --------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.13.2"
+__version__ = "3.13.3"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -930,7 +930,7 @@ def get_last_course_run_end_date(course_runs):
     """
     latest_end_date = None
     if course_runs:
-        latest_end_date = max(course_run['end'] for course_run in course_runs)
+        latest_end_date = max(course_run['end'] for course_run in course_runs if course_run['end'] is not None)
     return latest_end_date
 
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1346,6 +1346,20 @@ class TestEnterpriseUtils(unittest.TestCase):
             ],
             "3000-10-13T13:11:01Z",  # future dates
         ),
+        (
+            [
+                {
+                    "end": "3000-05-29T12:11:01Z",
+                },
+                {
+                    "end": "2020-05-29T12:11:01Z",
+                },
+                {
+                    "end": None,
+                },
+            ],
+            "3000-05-29T12:11:01Z",  # future dates
+        ),
     )
     @ddt.unpack
     def test_course_end_date(self, course_runs, expected_end_date):


### PR DESCRIPTION

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/edx-enterprise), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
