### PR TITLE
ENT-3884: refactor ``handle_user_post_save`` signal to account for admin permissions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,12 @@ Change Log
 
 Unreleased
 -----------
+
+[3.16.2]
+--------
+
+* Refactor ``handle_user_post_save`` to be responsible for linking PendingEnterpriseCustomerUser records and granting admin permissions.
+
 [3.16.1]
 --------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.16.1"
+__version__ = "3.16.2"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -1110,14 +1110,12 @@ class PendingEnterpriseCustomerUser(TimeStampedModel):
         app_label = 'enterprise'
         ordering = ['created']
 
-    @classmethod
-    def link_pending_enterprise_user(cls, pending_ecu, is_user_created, user):
+    def link_pending_enterprise_user(self, user, is_user_created):
         """
         Link a PendingEnterpriseCustomerUser to the appropriate EnterpriseCustomer by
         creating a EnterpriseCustomerUser record.
 
         Arguments:
-            pending_ecu: a PendingEnterpriseCustomerUser instance
             is_user_created: a boolean whether the User instance was created or updated
             user: a User instance
 
@@ -1141,22 +1139,20 @@ class PendingEnterpriseCustomerUser(TimeStampedModel):
                 pass  # nothing to do here
 
         enterprise_customer_user, __ = EnterpriseCustomerUser.objects.get_or_create(
-            enterprise_customer=pending_ecu.enterprise_customer,
+            enterprise_customer=self.enterprise_customer,
             user_id=user.id,
         )
         return enterprise_customer_user
 
-    @classmethod
-    def fulfill_pending_course_enrollments(cls, pending_ecu, enterprise_customer_user):
+    def fulfill_pending_course_enrollments(self, enterprise_customer_user):
         """
         Enrolls a newly created EnterpriseCustomerUser in any courses attached to their
         PendingEnterpriseCustomerUser record.
 
         Arguments:
-            pending_ecu: a PendingEnterpriseCustomerUser instance
             enterprise_customer_user: a EnterpriseCustomerUser instance
         """
-        pending_enrollments = list(pending_ecu.pendingenrollment_set.all())
+        pending_enrollments = list(self.pendingenrollment_set.all())
         if pending_enrollments:
             def _complete_user_enrollment():
                 """

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -29,7 +29,7 @@ from django.core import mail
 from django.core.exceptions import NON_FIELD_ERRORS, ObjectDoesNotExist, ValidationError
 from django.core.files.storage import default_storage
 from django.core.validators import MaxValueValidator, MinValueValidator
-from django.db import IntegrityError, models
+from django.db import IntegrityError, models, transaction
 from django.template import Context, Template
 from django.urls import reverse
 from django.utils.encoding import force_bytes, force_text, python_2_unicode_compatible
@@ -58,10 +58,13 @@ from enterprise.utils import (
     CourseEnrollmentDowngradeError,
     CourseEnrollmentPermissionError,
     NotConnectedToOpenEdX,
+    create_tableau_user,
+    delete_tableau_user,
     get_configuration_value,
     get_ecommerce_worker_user,
     get_enterprise_worker_user,
     get_platform_logo_url,
+    track_enrollment,
 )
 from enterprise.validators import (
     validate_content_filter_fields,
@@ -1106,6 +1109,74 @@ class PendingEnterpriseCustomerUser(TimeStampedModel):
     class Meta:
         app_label = 'enterprise'
         ordering = ['created']
+
+    @classmethod
+    def link_pending_enterprise_user(cls, pending_ecu, is_user_created, user):
+        """
+        Link a PendingEnterpriseCustomerUser to the appropriate EnterpriseCustomer by
+        creating a EnterpriseCustomerUser record.
+
+        Arguments:
+            pending_ecu: a PendingEnterpriseCustomerUser instance
+            is_user_created: a boolean whether the User instance was created or updated
+            user: a User instance
+
+        Returns: an EnterpriseCustomerUser instance
+        """
+        if not is_user_created:
+            # user already existed and may simply be logging in or existing user may have changed
+            # their email to match one of pending link records - try linking them to EnterpriseCustomer.
+            try:
+                enterprise_customer_user = EnterpriseCustomerUser.objects.get(user_id=user.id)
+                message_template = "User {user} has logged in or changed email to match pending " \
+                    "Enterprise Customer link, but was already " \
+                    "linked to Enterprise Customer {enterprise_customer} - " \
+                    "deleting pending link record"
+                LOGGER.info(message_template.format(
+                    user=user,
+                    enterprise_customer=enterprise_customer_user.enterprise_customer,
+                ))
+                return enterprise_customer_user
+            except EnterpriseCustomerUser.DoesNotExist:
+                pass  # nothing to do here
+
+        enterprise_customer_user, __ = EnterpriseCustomerUser.objects.get_or_create(
+            enterprise_customer=pending_ecu.enterprise_customer,
+            user_id=user.id,
+        )
+        return enterprise_customer_user
+
+    @classmethod
+    def fulfill_pending_course_enrollments(cls, pending_ecu, enterprise_customer_user):
+        """
+        Enrolls a newly created EnterpriseCustomerUser in any courses attached to their
+        PendingEnterpriseCustomerUser record.
+
+        Arguments:
+            pending_ecu: a PendingEnterpriseCustomerUser instance
+            enterprise_customer_user: a EnterpriseCustomerUser instance
+        """
+        pending_enrollments = list(pending_ecu.pendingenrollment_set.all())
+        if pending_enrollments:
+            def _complete_user_enrollment():
+                """
+                Complete an Enterprise User's enrollment.
+
+                EnterpriseCustomers may enroll users in courses before the users themselves
+                actually exist in the system; in such a case, the enrollment for each such
+                course is finalized when the user registers with the OpenEdX platform.
+                """
+                for enrollment in pending_enrollments:
+                    enterprise_customer_user.enroll(
+                        enrollment.course_id,
+                        enrollment.course_mode,
+                        cohort=enrollment.cohort_name,
+                        source_slug=getattr(enrollment.source, 'slug', None),
+                        discount_percentage=enrollment.discount_percentage,
+                        sales_force_id=enrollment.sales_force_id,
+                    )
+                    track_enrollment('pending-admin-enrollment', enterprise_customer_user.user.id, enrollment.course_id)
+            transaction.on_commit(_complete_user_enrollment)
 
     def __str__(self):
         """
@@ -2510,32 +2581,56 @@ class PendingEnterpriseCustomerAdminUser(TimeStampedModel):
         return registration_url
 
     @classmethod
-    def activate_admin_permissions(cls, user, enterprise_customer):
+    def activate_admin_permissions(cls, enterprise_customer_user):
         """
         Activates admin permissions for an existing PendingEnterpriseCustomerAdminUser.
 
         Specifically, the "enterprise_admin" system-wide role is assigned to the user and
         the PendingEnterpriseCustomerAdminUser record is removed.
 
+        Requires an EnterpriseCustomerUser record to exist which ensures the user already
+        has the "enterprise_learner" role as a prerequisite.
+
         Arguments:
-            user: a User instance
-            enterprise_customer: An EnterpriseCustomer instance
+            enterprise_customer_user: an EnterpriseCustomerUser instance
         """
         try:
             pending_admin_user = PendingEnterpriseCustomerAdminUser.objects.get(
-                user_email=user.email,
-                enterprise_customer=enterprise_customer,
+                user_email=enterprise_customer_user.user.email,
+                enterprise_customer=enterprise_customer_user.enterprise_customer,
             )
         except PendingEnterpriseCustomerAdminUser.DoesNotExist:
-            LOGGER.error(
-                'Unable to activate admin permissions as no PendingEnterpriseCustomerAdminUser'
-                ' records exist for user %s', user.id,
-            )
-            return
+            return  # this is ok, nothing to do
 
-        # create enterprise_admin role and delete pending admin user record
+        # get_or_create "enterprise_admin" role
         enterprise_admin_role, __ = SystemWideEnterpriseRole.objects.get_or_create(name=ENTERPRISE_ADMIN_ROLE)
-        SystemWideEnterpriseUserRoleAssignment.objects.get_or_create(user=user, role=enterprise_admin_role)
+
+        if not enterprise_customer_user.linked:
+            # EnterpriseCustomerUser is no longer linked, so delete the "enterprise_admin" role and
+            # their Tableau user.
+            try:
+                SystemWideEnterpriseUserRoleAssignment.objects.get(
+                    user=enterprise_customer_user.user,
+                    role=enterprise_admin_role,
+                ).delete()
+            except SystemWideEnterpriseUserRoleAssignment.DoesNotExist:
+                pass
+
+            delete_tableau_user(enterprise_customer_user)
+            return  # nothing left to do
+
+        # grant the "enterprise_admin" role
+        SystemWideEnterpriseUserRoleAssignment.objects.get_or_create(
+            user=enterprise_customer_user.user,
+            role=enterprise_admin_role,
+        )
+
+        # Also create the Enterprise admin user in third-party analytics application with the enterprise
+        # customer uuid as username.
+        tableau_username = str(enterprise_customer_user.enterprise_customer.uuid).replace('-', '')
+        create_tableau_user(tableau_username, enterprise_customer_user)
+
+        # delete the PendingEnterpriseCustomerAdminUser record
         pending_admin_user.delete()
 
     def __str__(self):

--- a/enterprise/signals.py
+++ b/enterprise/signals.py
@@ -70,15 +70,11 @@ def handle_user_post_save(sender, **kwargs):  # pylint: disable=unused-argument
 
     # link PendingEnterpriseCustomerUser to the EnterpriseCustomer and fulfill pending enrollments
     if pending_ecu:
-        enterprise_customer_user = PendingEnterpriseCustomerUser.link_pending_enterprise_user(
-            pending_ecu=pending_ecu,
-            is_user_created=created,
+        enterprise_customer_user = pending_ecu.link_pending_enterprise_user(
             user=user_instance,
+            is_user_created=created,
         )
-        PendingEnterpriseCustomerUser.fulfill_pending_course_enrollments(
-            pending_ecu=pending_ecu,
-            enterprise_customer_user=enterprise_customer_user,
-        )
+        pending_ecu.fulfill_pending_course_enrollments(enterprise_customer_user)
         pending_ecu.delete()
 
     try:
@@ -87,9 +83,7 @@ def handle_user_post_save(sender, **kwargs):  # pylint: disable=unused-argument
         return  # nothing to do here
 
     # activate admin permissions for an existing EnterpriseCustomerUser, if applicable
-    PendingEnterpriseCustomerAdminUser.activate_admin_permissions(
-        enterprise_customer_user=enterprise_customer_user,
-    )
+    PendingEnterpriseCustomerAdminUser.activate_admin_permissions(enterprise_customer_user)
 
 
 @receiver(pre_save, sender=EnterpriseCustomer)

--- a/enterprise/signals.py
+++ b/enterprise/signals.py
@@ -6,7 +6,6 @@ Django signal handlers.
 from logging import getLogger
 
 from django.core.exceptions import ObjectDoesNotExist
-from django.db import transaction
 from django.db.models.signals import post_delete, post_save, pre_delete, pre_save
 from django.dispatch import receiver
 
@@ -28,10 +27,8 @@ from enterprise.models import (
 from enterprise.tasks import create_enterprise_enrollment
 from enterprise.utils import (
     NotConnectedToOpenEdX,
-    create_tableau_user,
     delete_tableau_user_by_id,
     get_default_catalog_content_filter,
-    track_enrollment,
     unset_enterprise_learner_language,
     unset_language_of_all_enterprise_learners,
 )
@@ -48,10 +45,17 @@ _UNSAVED_FILEFIELD = 'unsaved_filefield'
 @disable_for_loaddata
 def handle_user_post_save(sender, **kwargs):  # pylint: disable=unused-argument
     """
-    Handle User model changes - checks if pending enterprise customer user record exists and upgrades it to actual link.
+    Handle User model changes. Context: This signal runs any time a user logs in, including b2c users.
 
-    If there are pending enrollments attached to the PendingEnterpriseCustomerUser, then this signal also takes the
-    newly-created users and enrolls them in the relevant courses.
+    Steps:
+    1. Check for existing PendingEnterpriseCustomerUser for user's email. If one exists,
+        create an EnterpriseCustomerUser record which will ensure the user has the "enterprise_learner" role.
+    2. When we get a new EnterpriseCustomerUser record (or an existing record if one existed), check if the
+        PendingEnterpriseCustomerUser has any pending course enrollments. If so, enroll the user in these courses.
+    3. Delete the PendingEnterpriseCustomerUser record as its no longer needed.
+    4. Using the newly created EnterpriseCustomerUser (or an existing record if one existed), check if there
+        is a PendingEnterpriseCustomerAdminUser. If so, ensure the user has the "enterprise_admin" role and
+        a Tableau user is created for the user.
     """
     created = kwargs.get("created", False)
     user_instance = kwargs.get("instance", None)
@@ -62,51 +66,30 @@ def handle_user_post_save(sender, **kwargs):  # pylint: disable=unused-argument
     try:
         pending_ecu = PendingEnterpriseCustomerUser.objects.get(user_email=user_instance.email)
     except PendingEnterpriseCustomerUser.DoesNotExist:
-        return  # nothing to do in this case
+        pending_ecu = None
 
-    if not created:
-        # existing user changed his email to match one of pending link records - try linking him to EC
-        try:
-            existing_record = EnterpriseCustomerUser.objects.get(user_id=user_instance.id)
-            message_template = "User {user} have changed email to match pending Enterprise Customer link, " \
-                               "but was already linked to Enterprise Customer {enterprise_customer} - " \
-                               "deleting pending link record"
-            logger.info(message_template.format(
-                user=user_instance, enterprise_customer=existing_record.enterprise_customer
-            ))
-            pending_ecu.delete()
-            return
-        except EnterpriseCustomerUser.DoesNotExist:
-            pass  # everything ok - current user is not linked to other ECs
-
-    enterprise_customer_user = EnterpriseCustomerUser.objects.create(
-        enterprise_customer=pending_ecu.enterprise_customer,
-        user_id=user_instance.id
-    )
-    pending_enrollments = list(pending_ecu.pendingenrollment_set.all())
-    if pending_enrollments:
-        def _complete_user_enrollment():
-            """
-            Complete an Enterprise User's enrollment.
-
-            EnterpriseCustomers may enroll users in courses before the users themselves
-            actually exist in the system; in such a case, the enrollment for each such
-            course is finalized when the user registers with the OpenEdX platform.
-            """
-            for enrollment in pending_enrollments:
-                enterprise_customer_user.enroll(
-                    enrollment.course_id,
-                    enrollment.course_mode,
-                    cohort=enrollment.cohort_name,
-                    source_slug=getattr(enrollment.source, 'slug', None),
-                    discount_percentage=enrollment.discount_percentage,
-                    sales_force_id=enrollment.sales_force_id,
-                )
-                track_enrollment('pending-admin-enrollment', user_instance.id, enrollment.course_id)
-            pending_ecu.delete()
-        transaction.on_commit(_complete_user_enrollment)
-    else:
+    # link PendingEnterpriseCustomerUser to the EnterpriseCustomer and fulfill pending enrollments
+    if pending_ecu:
+        enterprise_customer_user = PendingEnterpriseCustomerUser.link_pending_enterprise_user(
+            pending_ecu=pending_ecu,
+            is_user_created=created,
+            user=user_instance,
+        )
+        PendingEnterpriseCustomerUser.fulfill_pending_course_enrollments(
+            pending_ecu=pending_ecu,
+            enterprise_customer_user=enterprise_customer_user,
+        )
         pending_ecu.delete()
+
+    try:
+        enterprise_customer_user = EnterpriseCustomerUser.objects.get(user_id=user_instance.id)
+    except EnterpriseCustomerUser.DoesNotExist:
+        return  # nothing to do here
+
+    # activate admin permissions for an existing EnterpriseCustomerUser, if applicable
+    PendingEnterpriseCustomerAdminUser.activate_admin_permissions(
+        enterprise_customer_user=enterprise_customer_user,
+    )
 
 
 @receiver(pre_save, sender=EnterpriseCustomer)
@@ -154,54 +137,6 @@ def default_content_filter(sender, instance, **kwargs):     # pylint: disable=un
     if kwargs['created'] and not instance.content_filter:
         instance.content_filter = get_default_catalog_content_filter()
         instance.save()
-
-
-@receiver(post_save, sender=EnterpriseCustomerUser)
-def assign_or_delete_enterprise_admin_role(sender, instance, **kwargs):     # pylint: disable=unused-argument
-    """
-    Assign or delete enterprise_admin role for EnterpriseCustomerUser when updated.
-    Create third party analytics user.
-
-    This only occurs if a PendingEnterpriseCustomerAdminUser record exists.
-    """
-    if instance.user:
-        enterprise_admin_role, __ = SystemWideEnterpriseRole.objects.get_or_create(name=ENTERPRISE_ADMIN_ROLE)
-        try:
-            pending_enterprise_admin_user = PendingEnterpriseCustomerAdminUser.objects.get(
-                user_email=instance.user.email,
-                enterprise_customer=instance.enterprise_customer,
-            )
-        except PendingEnterpriseCustomerAdminUser.DoesNotExist:
-            pending_enterprise_admin_user = None
-
-        if kwargs['created'] and pending_enterprise_admin_user:
-            # EnterpriseCustomerUser record was created and a pending admin user
-            # exists, so assign the enterprise_admin role.
-            pending_enterprise_admin_user.activate_admin_permissions(
-                user=instance.user,
-                enterprise_customer=instance.enterprise_customer,
-            )
-            # Also create the Enterprise admin user in third party analytics application with the enterprise
-            # customer uuid as username.
-            tableau_username = str(instance.enterprise_customer.uuid).replace('-', '')
-            create_tableau_user(tableau_username, instance)
-        elif not kwargs['created'] and not instance.linked:
-            # EnterpriseCustomerUser record was updated but is not linked, so delete the enterprise_admin role.
-            try:
-                SystemWideEnterpriseUserRoleAssignment.objects.get(
-                    user=instance.user,
-                    role=enterprise_admin_role
-                ).delete()
-            except SystemWideEnterpriseUserRoleAssignment.DoesNotExist:
-                # Do nothing if no role assignment is present for the enterprise customer user.
-                pass
-        else:
-            logger.info(
-                'Could not assign or delete enterprise_admin role for user %s'
-                ' due to a PendingEnterpriseCustomerAdminUser record not existing'
-                ' or the user not being linked.',
-                instance.user.id,
-            )
 
 
 @receiver(post_delete, sender=EnterpriseCustomerUser)
@@ -278,7 +213,7 @@ def update_learner_language_preference(sender, instance, created, **kwargs):    
 @receiver(pre_delete, sender=EnterpriseAnalyticsUser)
 def delete_enterprise_analytics_user(sender, instance, **kwargs):     # pylint: disable=unused-argument
     """
-    Delete the associated enterprise analytics user in tableau.
+    Delete the associated enterprise analytics user in Tableau.
     """
     if instance.analytics_user_id:
         delete_tableau_user_by_id(instance.analytics_user_id)

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -1546,7 +1546,7 @@ def add_user_to_tableau_group(tableau_user_id, tableau_group):
 
 def delete_tableau_user(enterprise_customer_user):
     """
-    Delete the user in tableau.
+    Delete the user in Tableau.
     """
     from enterprise.models import EnterpriseAnalyticsUser  # pylint: disable=import-outside-toplevel
     enterprise_analytics_user = EnterpriseAnalyticsUser.objects.filter(
@@ -1563,7 +1563,7 @@ def delete_tableau_user(enterprise_customer_user):
 
 def delete_tableau_user_by_id(tableau_user_id):
     """
-    Delete the user in tableau.
+    Delete the user in Tableau.
     """
     tableau_auth, server = get_tableau_server()
     if tableau_user_id and tableau_auth and server:
@@ -1572,12 +1572,12 @@ def delete_tableau_user_by_id(tableau_user_id):
                 server.users.remove(tableau_user_id)
         except ServerResponseError as exc:
             LOGGER.info(
-                '[TABLEAU USER SYNC] Could not delete enterprise admin user in tableau.'
+                '[TABLEAU USER SYNC] Could not delete enterprise admin user in Tableau.'
                 'Server returned: %s', str(exc),
             )
     else:
         LOGGER.warning(
-            '[TABLEAU USER SYNC] Could not delete the tableau user %s.',
+            '[TABLEAU USER SYNC] Could not delete the Tableau user %s.',
             tableau_user_id,
         )
 

--- a/test_utils/factories.py
+++ b/test_utils/factories.py
@@ -27,6 +27,7 @@ from enterprise.models import (
     PendingEnrollment,
     PendingEnterpriseCustomerAdminUser,
     PendingEnterpriseCustomerUser,
+    SystemWideEnterpriseUserRoleAssignment,
 )
 from integrated_channels.blackboard.models import BlackboardEnterpriseCustomerConfiguration
 from integrated_channels.canvas.models import CanvasEnterpriseCustomerConfiguration
@@ -178,6 +179,21 @@ class PendingEnterpriseCustomerAdminUserFactory(factory.django.DjangoModelFactor
 
     enterprise_customer = factory.SubFactory(EnterpriseCustomerFactory)
     user_email = factory.LazyAttribute(lambda x: FAKER.email())
+
+
+class SystemWideEnterpriseUserRoleAssignmentFactory(factory.django.DjangoModelFactory):
+    """
+    SystemWideEnterpriseUserRoleAssignment factory.
+
+    Creates an instance of SystemWideEnterpriseUserRoleAssignment.
+    """
+
+    class Meta:
+        """
+        Meta for SystemWideEnterpriseUserRoleAssignmentFactory.
+        """
+
+        model = SystemWideEnterpriseUserRoleAssignment
 
 
 class GroupFactory(factory.django.DjangoModelFactory):


### PR DESCRIPTION
https://openedx.atlassian.net/browse/ENT-3884

Related PR: https://github.com/edx/frontend-app-admin-portal/pull/421

Previously, admin permissions were granted to the user based on the creation/update of an `EnterpriseCustomerUser` record through a Django signal. However, if a user is already linked to an `EnterpriseCustomer`, there is no creation/update of an `EnterpriseCustomerUser` record so the admin permissions were never granted on their next login.

Instead, the granting of admin permissions was moved to coincide whenever a user logs in instead so that we will always grant the correct access roles on each login.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
