### PR TITLE
ENT-3764 | Modify the learner portal enterprise_course_enrollments en…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,14 @@ Change Log
 Unreleased
 -----------
 
+[3.16.7]
+--------
+
+* Modify the learner portal enterprise_course_enrollments endpoint to include an ``is_enrollment_active``
+  key that indicates the status of the enterprise enrollment's related ``student.CourseEnrollment`.
+  Allow the endpoint to optionally accept an ``?is_active`` query param, so that clients may request
+  only active enrollments from it.
+
 [3.16.6]
 --------
 
@@ -28,6 +36,7 @@ Unreleased
 
 [3.16.4]
 --------
+
 * Add SuccessFactors Customer Configuration API endpoint.
 
 [3.16.3]

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.16.6"
+__version__ = "3.16.7"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise_learner_portal/api/v1/serializers.py
+++ b/enterprise_learner_portal/api/v1/serializers.py
@@ -67,6 +67,7 @@ class EnterpriseCourseEnrollmentSerializer(serializers.Serializer):  # pylint: d
         representation['pacing'] = course_overview['pacing']
         representation['org_name'] = course_overview['display_org_with_default']
         representation['is_revoked'] = instance.license.is_revoked if instance.license else False
+        representation['is_enrollment_active'] = instance.course_enrollment.is_active
 
         return representation
 

--- a/enterprise_learner_portal/api/v1/views.py
+++ b/enterprise_learner_portal/api/v1/views.py
@@ -32,7 +32,33 @@ class EnterpriseCourseEnrollmentView(APIView):
 
     def get(self, request):
         """
-        Get method for the view.
+        Returns a list of EnterpriseCourseEnrollment data related to the requesting user.
+
+        Example response:
+
+        [
+            {
+                "certificate_download_url": null,
+                "course_run_id": "course-v1:edX+DemoX+Demo_Course",
+                "course_run_status": "in_progress",
+                "start_date": "2013-02-05T06:00:00Z",
+                "end_date": null,
+                "display_name": "edX Demonstration Course",
+                "course_run_url": "http://localhost:18000/courses/course-v1:edX+DemoX+Demo_Course/course/",
+                "due_dates": [],
+                "pacing": "instructor",
+                "org_name": "edX",
+                "is_revoked": false,
+                "is_enrollment_active": true
+            }
+        ]
+
+        Query params:
+          'enterprise_id' (UUID string, required): The enterprise customer UUID with which to filter
+            EnterpriseCustomerRecords by.
+          'is_active' (boolean string, optional): If provided, will filter the resulting list of enterprise
+            enrollment records to only those for which the corresponding ``student.CourseEnrollment``
+            record has an ``is_active`` equal to the provided boolean value ('true' or 'false').
         """
         if get_course_overviews is None:
             raise NotConnectedToOpenEdX(
@@ -64,6 +90,18 @@ class EnterpriseCourseEnrollmentView(APIView):
             many=True,
             context={'request': request, 'course_overviews': course_overviews},
         ).data
+
+        if request.query_params.get('is_active'):
+            is_active_filter_value = None
+            if request.query_params['is_active'].lower() == 'true':
+                is_active_filter_value = True
+            if request.query_params['is_active'].lower() == 'false':
+                is_active_filter_value = False
+            if is_active_filter_value is not None:
+                data = [
+                    record for record in data
+                    if record['is_enrollment_active'] == is_active_filter_value
+                ]
 
         return Response(data)
 

--- a/tests/test_enterprise_learner_portal/api/test_serializers.py
+++ b/tests/test_enterprise_learner_portal/api/test_serializers.py
@@ -28,6 +28,7 @@ class TestEnterpriseCourseEnrollmentSerializer(TestCase):
         self.factory = RequestFactory()
         self.enterprise_customer_user = factories.EnterpriseCustomerUserFactory.create(user_id=self.user.id)
 
+    @mock.patch('enterprise.models.CourseEnrollment')
     @mock.patch('enterprise_learner_portal.api.v1.serializers.get_course_run_status')
     @mock.patch('enterprise_learner_portal.api.v1.serializers.get_emails_enabled')
     @mock.patch('enterprise_learner_portal.api.v1.serializers.get_course_run_url')
@@ -38,6 +39,7 @@ class TestEnterpriseCourseEnrollmentSerializer(TestCase):
             mock_get_course_run_url,
             mock_get_emails_enabled,
             mock_get_course_run_status,
+            mock_course_enrollment_class,
     ):
         """
         EnterpriseCourseEnrollmentSerializer should create proper representation
@@ -66,6 +68,7 @@ class TestEnterpriseCourseEnrollmentSerializer(TestCase):
             enterprise_customer_user=self.enterprise_customer_user,
             course_id=course_run_id
         )
+        mock_course_enrollment_class.objects.get.return_value.is_active = True
 
         request = self.factory.get('/')
         request.user = self.user
@@ -89,6 +92,7 @@ class TestEnterpriseCourseEnrollmentSerializer(TestCase):
             ('pacing', 'instructor'),
             ('org_name', 'my university'),
             ('is_revoked', False),
+            ('is_enrollment_active', True),
         ])
         actual = serializer.data[0]
         self.assertDictEqual(actual, expected)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -118,6 +118,29 @@ class TestEnterpriseCourseEnrollment(unittest.TestCase):
         """
         assert self.enrollment.license is None
 
+    @mock.patch('enterprise.models.CourseEnrollment')
+    def test_course_enrollment_does_not_exist(self, mock_course_enrollment_class):
+        """
+        Test that the ``course_enrollment`` property returns None when no CourseEnrollment exists.
+        """
+        mock_course_enrollment_class.DoesNotExist = Exception
+        mock_course_enrollment_class.objects.get.side_effect = mock_course_enrollment_class.DoesNotExist
+        self.assertIsNone(self.enrollment.course_enrollment)
+
+    @mock.patch('enterprise.models.CourseEnrollment')
+    def test_course_enrollment_exists(self, mock_course_enrollment_class):
+        """
+        Test that the ``course_enrollment`` property a CourseEnrollment
+        """
+        expected_result = mock_course_enrollment_class.objects.get.return_value
+        self.assertEqual(expected_result, self.enrollment.course_enrollment)
+
+    def test_course_enrollment_class_is_none(self):
+        """
+        Test that the ``course_enrollment`` property returns None when we're not in an edx-platform runtime.
+        """
+        self.assertIsNone(self.enrollment.course_enrollment)
+
 
 @mark.django_db
 class TestLicensedEnterpriseCourseEnrollment(unittest.TestCase):


### PR DESCRIPTION
…dpoint to include an `is_enrollment_active` key that indicates the status of the enterprise enrollment's related student.CourseEnrollment.  Allow the endpoint to optionally accept an `?is_active` query param, so that clients may request only active (or only inactive) enrollments from it.

Partially addresses https://openedx.atlassian.net/browse/ENT-3764

So now, when requesting http://localhost:18000/enterprise_learner_portal/api/v1/enterprise_course_enrollments/?enterprise_id=378d5bf0-f67d-4bf7-8b2a-cbbc53d0f772 you'll get something like
```
[
    {
        "certificate_download_url": null,
        "course_run_id": "course-v1:edX+DemoX+Demo_Course",
        "course_run_status": "in_progress",
        "start_date": "2013-02-05T06:00:00Z",
        "end_date": null,
        "display_name": "edX Demonstration Course",
        "course_run_url": "http://localhost:18000/courses/course-v1:edX+DemoX+Demo_Course/course/",
        "due_dates": [],
        "pacing": "instructor",
        "org_name": "edX",
        "is_revoked": false,
        "is_enrollment_active": true
    }
]
```

...and adding `&is_active=false` to the above url will get you an empty list in response.

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [x] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
