### PR TITLE
ENT-3764 | Listen for student.CourseEnrollment unenrollment signal an…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,12 @@ Change Log
 Unreleased
 -----------
 
+[3.17.0]
+--------
+
+* Listen for ``student.CourseEnrollment`` unenrollment signal and delete associated
+  ``EnterpriseCourseEnrollment`` record if one exists (we will have a historical record of the deletion).
+
 [3.16.11]
 ---------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.16.11"
+__version__ = "3.17.0"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -1034,7 +1034,7 @@ class EnterpriseCustomerUser(TimeStampedModel):
         """
         enrollment_api_client = EnrollmentApiClient()
         if enrollment_api_client.unenroll_user_from_course(self.username, course_run_id):
-            EnterpriseCourseEnrollment.objects.filter(enterprise_customer_user=self, course_id=course_run_id).delete()
+            EnterpriseCourseEnrollment.unenroll_user_from_course(self, course_run_id)
             return True
         return False
 
@@ -1615,6 +1615,17 @@ class EnterpriseCourseEnrollment(TimeStampedModel):
                 )
             )
         return enterprise_course_enrollment_id
+
+    @classmethod
+    def unenroll_user_from_course(cls, enterprise_customer_user, course_id):
+        """
+        Unenroll the enterprise user from the given course
+        by deleting the associated ``EnterpriseCourseEnrollment`` record.
+        """
+        cls.objects.filter(
+            enterprise_customer_user=enterprise_customer_user,
+            course_id=course_id,
+        ).delete()
 
     def __str__(self):
         """

--- a/tests/test_enterprise/test_signals.py
+++ b/tests/test_enterprise/test_signals.py
@@ -25,10 +25,15 @@ from enterprise.models import (
     SystemWideEnterpriseRole,
     SystemWideEnterpriseUserRoleAssignment,
 )
-from enterprise.signals import create_enterprise_enrollment_receiver, handle_user_post_save
+from enterprise.signals import (
+    create_enterprise_enrollment_receiver,
+    delete_enterprise_enrollment_receiver,
+    handle_user_post_save,
+)
 from test_utils.factories import (
     EnterpriseAnalyticsUserFactory,
     EnterpriseCatalogQueryFactory,
+    EnterpriseCourseEnrollmentFactory,
     EnterpriseCustomerCatalogFactory,
     EnterpriseCustomerFactory,
     EnterpriseCustomerUserFactory,
@@ -692,6 +697,13 @@ class TestCourseEnrollmentSignals(unittest.TestCase):
             enterprise_customer=self.enterprise_customer,
         )
         self.non_enterprise_user = UserFactory(id=999, email='user999@example.com')
+        self.enterprise_course_enrollment = EnterpriseCourseEnrollmentFactory(
+            enterprise_customer_user=self.enterprise_customer_user,
+        )
+        self.course_enrollment = mock.Mock(
+            user=self.user,
+            course_id=self.enterprise_course_enrollment.course_id,
+        )
         super().setUp()
 
     @mock.patch('enterprise.tasks.create_enterprise_enrollment.delay')
@@ -739,6 +751,40 @@ class TestCourseEnrollmentSignals(unittest.TestCase):
 
         create_enterprise_enrollment_receiver(sender, instance, **kwargs)
         mock_task.assert_not_called()
+
+    def test_delete_enterprise_enrollment_receiver(self):
+        """
+        The receiver should cause an EnterpriseCourseEnrollment associated with
+        a CourseEnrollment instance to be deleted when it receives a signal
+        indicating that the CourseEnrollment has transitioned to an unenrolled state.
+        """
+        # setup an additional enrollment for the same user_id in the same course,
+        # and then make sure that both are deleted.
+        other_enterprise_customer = EnterpriseCustomerFactory(
+            name='Team Foo',
+        )
+        other_enterprise_customer_user = EnterpriseCustomerUserFactory(
+            user_id=self.user.id,
+            enterprise_customer=other_enterprise_customer,
+        )
+        _ = EnterpriseCourseEnrollmentFactory(
+            enterprise_customer_user=other_enterprise_customer_user,
+            course_id=self.enterprise_course_enrollment.course_id,
+        )
+
+        delete_enterprise_enrollment_receiver(
+            mock.Mock(),
+            course_enrollment=self.course_enrollment,
+        )
+
+        # The enterprise course enrollments still exists in memory,
+        # but should be deleted from the database.
+        self.assertFalse(
+            EnterpriseCourseEnrollment.objects.filter(
+                enterprise_customer_user__user_id=self.user.id,
+                course_id=self.enterprise_course_enrollment.course_id,
+            ).exists()
+        )
 
 
 @mark.django_db

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -141,6 +141,23 @@ class TestEnterpriseCourseEnrollment(unittest.TestCase):
         """
         self.assertIsNone(self.enrollment.course_enrollment)
 
+    def test_unenroll_user_from_course(self):
+        """
+        Calling ``unenroll_user_from_course()`` should cause the EnterpriseCourseEnrollment record
+        to be deleted.
+        """
+        self.enrollment.unenroll_user_from_course(
+            self.enterprise_customer_user,
+            self.course_id,
+        )
+
+        self.assertFalse(
+            EnterpriseCourseEnrollment.objects.filter(
+                enterprise_customer_user=self.enterprise_customer_user,
+                course_id=self.course_id,
+            ).exists()
+        )
+
 
 @mark.django_db
 class TestLicensedEnterpriseCourseEnrollment(unittest.TestCase):


### PR DESCRIPTION
…d delete associated EnterpriseCourseEnrollment record (we will have a historical record of the deletion).

https://openedx.atlassian.net/browse/ENT-3764

How to manually test:
* Be enrolled in a course as an enterprise learner.
* Make sure there's an `EnterpriseCourseEnrollment` associated with your course.  Find that enrollment in the Django admin e.g. http://localhost:18000/admin/enterprise/enterprisecourseenrollment/1/change/
* From the LMS dashboard, unenroll from the course (there's a little gear icon on the dashboard course card, under that is an unenroll option).
* Click the button that asks if you _really_ want to unenroll.
* Notice a message in the LMS logs saying the EnterpriseCourseEnrollment was deleted.
* Notice in the Django admin that the enterprise enrollment is gone.
* Confirm there's still a historical record of the enterprise enrollment in the database, e.g.`select * from enterprise_historicalenterprisecourseenrollment where id = 10\G`

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [x] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
