### PR TITLE
fix: query EnterpriseCustomerUsers with both user_id and enterprise_customer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Change Log
 Unreleased
 -----------
 
+[3.16.11]
+---------
+
+* Retrieve ``EnterpriseCustomerUser`` by both user_id and enterprise_customer to handle users who are pending for more than 1 enterprise.
+
 [3.16.10]
 ---------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.16.10"
+__version__ = "3.16.11"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -1136,9 +1136,13 @@ class PendingEnterpriseCustomerUser(TimeStampedModel):
         """
         if not is_user_created:
             # user already existed and may simply be logging in or existing user may have changed
-            # their email to match one of pending link records - try linking them to EnterpriseCustomer.
+            # their email to match one of pending link records. if an ``EnterpriseCustomerUser``
+            # record exists, return it since user is already linked.
             try:
-                enterprise_customer_user = EnterpriseCustomerUser.objects.get(user_id=user.id)
+                enterprise_customer_user = EnterpriseCustomerUser.objects.get(
+                    user_id=user.id,
+                    enterprise_customer=self.enterprise_customer,
+                )
                 message_template = "User {user} has logged in or changed email to match pending " \
                     "Enterprise Customer link, but was already " \
                     "linked to Enterprise Customer {enterprise_customer} - " \

--- a/enterprise/signals.py
+++ b/enterprise/signals.py
@@ -68,7 +68,7 @@ def handle_user_post_save(sender, **kwargs):  # pylint: disable=unused-argument
 
     # link PendingEnterpriseCustomerUser to the EnterpriseCustomer and fulfill pending enrollments
     for pending_ecu in pending_ecus:
-        enterprise_customer_user = pending_ecu.link_pending_enterprise_user(
+        enterprise_customer_user = pending_ecu.link_pending_enterprise_users(
             user=user_instance,
             is_user_created=created,
         )

--- a/enterprise/signals.py
+++ b/enterprise/signals.py
@@ -68,7 +68,7 @@ def handle_user_post_save(sender, **kwargs):  # pylint: disable=unused-argument
 
     # link PendingEnterpriseCustomerUser to the EnterpriseCustomer and fulfill pending enrollments
     for pending_ecu in pending_ecus:
-        enterprise_customer_user = pending_ecu.link_pending_enterprise_users(
+        enterprise_customer_user = pending_ecu.link_pending_enterprise_user(
             user=user_instance,
             is_user_created=created,
         )

--- a/tests/test_enterprise/test_signals.py
+++ b/tests/test_enterprise/test_signals.py
@@ -224,8 +224,14 @@ class TestUserPostSaveSignalHandler(unittest.TestCase):
 
         assert EnterpriseCustomerUser.objects.filter(user_id=user.id).count() == 2, "Should return 2 existing links"
 
-        link_1 = EnterpriseCustomerUser.objects.get(user_id=user.id, enterprise_customer1)
-        link_2 = EnterpriseCustomerUser.objects.get(user_id=user.id, enterprise_customer2)
+        link_1 = EnterpriseCustomerUser.objects.get(
+            user_id=user.id,
+            enterprise_customer=enterprise_customer1,
+        )
+        link_2 = EnterpriseCustomerUser.objects.get(
+            user_id=user.id,
+            enterprise_customer=enterprise_customer2,
+        )
         assert link_1.enterprise_customer == enterprise_customer1
         assert link_2.enterprise_customer == enterprise_customer2
 

--- a/tests/test_enterprise/test_signals.py
+++ b/tests/test_enterprise/test_signals.py
@@ -212,7 +212,7 @@ class TestUserPostSaveSignalHandler(unittest.TestCase):
         email = "jackie.chan@hollywood.com"
         user = UserFactory(id=1, email=email)
         enterprise_customer1, enterprise_customer2 = EnterpriseCustomerFactory(), EnterpriseCustomerFactory()
-        existing_link = EnterpriseCustomerUserFactory(enterprise_customer=enterprise_customer1, user_id=user.id)
+        EnterpriseCustomerUserFactory(enterprise_customer=enterprise_customer1, user_id=user.id)
         PendingEnterpriseCustomerUserFactory(enterprise_customer=enterprise_customer2, user_email=email)
 
         assert EnterpriseCustomerUser.objects.filter(user_id=user.id).count() == 1, "Precondition check: links exists"

--- a/tests/test_enterprise/test_signals.py
+++ b/tests/test_enterprise/test_signals.py
@@ -222,9 +222,12 @@ class TestUserPostSaveSignalHandler(unittest.TestCase):
         parameters = {"instance": user, "created": False}
         handle_user_post_save(mock.Mock(), **parameters)
 
-        link = EnterpriseCustomerUser.objects.get(user_id=user.id)
-        assert link.id == existing_link.id, "Should keep existing link intact"
-        assert link.enterprise_customer == enterprise_customer1, "Should keep existing link intact"
+        assert EnterpriseCustomerUser.objects.filter(user_id=user.id).count() == 2, "Should return 2 existing links"
+
+        link_1 = EnterpriseCustomerUser.objects.get(user_id=user.id, enterprise_customer1)
+        link_2 = EnterpriseCustomerUser.objects.get(user_id=user.id, enterprise_customer2)
+        assert link_1.enterprise_customer == enterprise_customer1
+        assert link_2.enterprise_customer == enterprise_customer2
 
         assert PendingEnterpriseCustomerUser.objects.count() == 0, "Should delete pending link"
 


### PR DESCRIPTION


**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
