### PR TITLE
Revert "ENT-3764 | Listen for student.CourseEnrollment unenrollment s…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Change Log
 Unreleased
 -----------
 
+[3.17.2]
+--------
+
+* Stop listening for ``student.CourseEnrollment`` unenrollment signal, as introduced in 3.17.0
+
 [3.17.1]
 --------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.17.1"
+__version__ = "3.17.2"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -1034,7 +1034,7 @@ class EnterpriseCustomerUser(TimeStampedModel):
         """
         enrollment_api_client = EnrollmentApiClient()
         if enrollment_api_client.unenroll_user_from_course(self.username, course_run_id):
-            EnterpriseCourseEnrollment.unenroll_user_from_course(self, course_run_id)
+            EnterpriseCourseEnrollment.objects.filter(enterprise_customer_user=self, course_id=course_run_id).delete()
             return True
         return False
 
@@ -1615,17 +1615,6 @@ class EnterpriseCourseEnrollment(TimeStampedModel):
                 )
             )
         return enterprise_course_enrollment_id
-
-    @classmethod
-    def unenroll_user_from_course(cls, enterprise_customer_user, course_id):
-        """
-        Unenroll the enterprise user from the given course
-        by deleting the associated ``EnterpriseCourseEnrollment`` record.
-        """
-        cls.objects.filter(
-            enterprise_customer_user=enterprise_customer_user,
-            course_id=course_id,
-        ).delete()
 
     def __str__(self):
         """

--- a/enterprise/signals.py
+++ b/enterprise/signals.py
@@ -15,7 +15,6 @@ from enterprise.decorators import disable_for_loaddata
 from enterprise.models import (
     EnterpriseAnalyticsUser,
     EnterpriseCatalogQuery,
-    EnterpriseCourseEnrollment,
     EnterpriseCustomer,
     EnterpriseCustomerBrandingConfiguration,
     EnterpriseCustomerCatalog,
@@ -36,10 +35,8 @@ from enterprise.utils import (
 
 try:
     from common.djangoapps.student.models import CourseEnrollment
-    from common.djangoapps.student.signals import UNENROLL_DONE
 except ImportError:
     CourseEnrollment = None
-    UNENROLL_DONE = None
 
 logger = getLogger(__name__)  # pylint: disable=invalid-name
 _UNSAVED_FILEFIELD = 'unsaved_filefield'
@@ -350,31 +347,6 @@ def create_enterprise_enrollment_receiver(sender, instance, **kwargs):     # pyl
         )
 
 
-def delete_enterprise_enrollment_receiver(sender, **kwargs):  # pylint: disable=unused-argument
-    """
-    Receives the ``UNENROLL_DONE`` signal, defined in
-    https://github.com/edx/edx-platform/blob/master/common/djangoapps/student/signals/signals.py
-
-    and deletes any ``EnterpriseCourseEnrollment`` associated with the modified
-    ``student.CourseEnrollment``.
-    """
-    course_enrollment = kwargs['course_enrollment']
-
-    user_id = course_enrollment.user.id
-    course_id = course_enrollment.course_id
-
-    EnterpriseCourseEnrollment.objects.filter(
-        enterprise_customer_user__user_id=user_id,
-        course_id=course_id,
-    ).delete()
-
-    logger.info('Deleted EnterpriseCourseEnrollment(s) for user {} in course {}'.format(user_id, course_id))
-
-
-# Don't connect the enrollment create/delete receivers
-# if we dont have access to objects defined in edx-platform
+# Don't connect this receiver if we dont have access to CourseEnrollment model
 if CourseEnrollment is not None:
     post_save.connect(create_enterprise_enrollment_receiver, sender=CourseEnrollment)
-
-if UNENROLL_DONE is not None:
-    UNENROLL_DONE.connect(delete_enterprise_enrollment_receiver)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -141,23 +141,6 @@ class TestEnterpriseCourseEnrollment(unittest.TestCase):
         """
         self.assertIsNone(self.enrollment.course_enrollment)
 
-    def test_unenroll_user_from_course(self):
-        """
-        Calling ``unenroll_user_from_course()`` should cause the EnterpriseCourseEnrollment record
-        to be deleted.
-        """
-        self.enrollment.unenroll_user_from_course(
-            self.enterprise_customer_user,
-            self.course_id,
-        )
-
-        self.assertFalse(
-            EnterpriseCourseEnrollment.objects.filter(
-                enterprise_customer_user=self.enterprise_customer_user,
-                course_id=self.course_id,
-            ).exists()
-        )
-
 
 @mark.django_db
 class TestLicensedEnterpriseCourseEnrollment(unittest.TestCase):


### PR DESCRIPTION
…ignal and delete associated EnterpriseCourseEnrollment record (we will have a historical record of the deletion)."

This reverts commit 675f46a52f8bb287e02af482f69000bbd0e0f522.

See discussion in comments of https://openedx.atlassian.net/browse/ENT-3936

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
