### PR TITLE
fix: always return "completed" course run status if learner has a passing certificate

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,10 +14,16 @@ Change Log
 .. There should always be an "Unreleased" section for changes pending release.
 
 Unreleased
------------
+----------
+
+[3.17.4]
+--------
+
+* Ensure enterprise course enrollments return valid course run statuses such that when a learner earns a passing certificate, the ``enterprise_course_enrollments`` API endpoint deems that course complete even though the course itself may not have ended yet per the configured dates.
 
 [3.17.3]
------------
+--------
+
 * Fixed unnessary integrated channel signal transmission on course completion to inactive customers by adding guard condition.
 
 [3.17.2]

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,7 +19,7 @@ Unreleased
 [3.17.4]
 --------
 
-* Ensure enterprise course enrollments return valid course run statuses such that when a learner earns a passing certificate, the ``enterprise_course_enrollments`` API endpoint deems that course complete even though the course itself may not have ended yet per the configured dates.
+* Ensure enterprise course enrollments return valid course run statuses such that when a learner earns a passing certificate, the ``enterprise_course_enrollments`` API endpoint deems the course is complete even though the course itself may not have ended yet per the configured dates.
 
 [3.17.3]
 --------

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.17.3"
+__version__ = "3.17.4"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise_learner_portal/api/v1/serializers.py
+++ b/enterprise_learner_portal/api/v1/serializers.py
@@ -57,7 +57,7 @@ class EnterpriseCourseEnrollmentSerializer(serializers.Serializer):  # pylint: d
         representation['course_run_status'] = get_course_run_status(
             course_overview,
             certificate_info,
-            instance,
+            instance
         )
         representation['start_date'] = course_overview['start']
         representation['end_date'] = course_overview['end']

--- a/enterprise_learner_portal/api/v1/serializers.py
+++ b/enterprise_learner_portal/api/v1/serializers.py
@@ -57,7 +57,7 @@ class EnterpriseCourseEnrollmentSerializer(serializers.Serializer):  # pylint: d
         representation['course_run_status'] = get_course_run_status(
             course_overview,
             certificate_info,
-            instance
+            instance,
         )
         representation['start_date'] = course_overview['start']
         representation['end_date'] = course_overview['end']

--- a/enterprise_learner_portal/utils.py
+++ b/enterprise_learner_portal/utils.py
@@ -21,45 +21,32 @@ class CourseRunProgressStatuses:
 
 def get_course_run_status(course_overview, certificate_info, enterprise_enrollment):
     """
-    Get the progress status of a course run, given the state of a user's certificate in the course.
+    Get the status of a course run, given the state of a user's certificate in the course.
 
-    In the case of self-paced course runs, the run is considered completed when either the course run has ended
-    OR the user has earned a passing certificate 30 days ago or longer.
+    A run is considered "complete" when either the course run has ended OR the user has earned a
+    passing certificate.
 
     Arguments:
         course_overview (CourseOverview): the overview for the course run
-        certificate_info: A dict containing the following keys:
+        certificate_info: A dict containing the following key:
             ``is_passing``: whether the  user has a passing certificate in the course run
-            ``created``: the date the certificate was created
 
     Returns:
         status: one of (
+            CourseRunProgressStatuses.SAVED_FOR_LATER,
             CourseRunProgressStatuses.COMPLETE,
             CourseRunProgressStatuses.IN_PROGRESS,
             CourseRunProgressStatuses.UPCOMING,
         )
         None if pacing type is not matched
     """
-    is_certificate_passing = certificate_info.get('is_passing', False)
-    certificate_creation_date = certificate_info.get('created', datetime.max)
-
     if enterprise_enrollment and enterprise_enrollment.saved_for_later:
         return CourseRunProgressStatuses.SAVED_FOR_LATER
 
-    if course_overview['pacing'] == 'instructor':
-        if course_overview['has_ended']:
-            return CourseRunProgressStatuses.COMPLETED
-        if course_overview['has_started']:
-            return CourseRunProgressStatuses.IN_PROGRESS
-        return CourseRunProgressStatuses.UPCOMING
+    is_certificate_passing = certificate_info.get('is_passing', False)
 
-    if course_overview['pacing'] == 'self':
-        thirty_days_ago = datetime.now(UTC) - timedelta(30)
-        certificate_completed = is_certificate_passing and (certificate_creation_date <= thirty_days_ago)
-        if course_overview['has_ended'] or certificate_completed:
-            return CourseRunProgressStatuses.COMPLETED
-        if course_overview['has_started']:
-            return CourseRunProgressStatuses.IN_PROGRESS
-        return CourseRunProgressStatuses.UPCOMING
-
-    return None
+    if course_overview['has_ended'] or is_certificate_passing:
+        return CourseRunProgressStatuses.COMPLETED
+    if course_overview['has_started']:
+        return CourseRunProgressStatuses.IN_PROGRESS
+    return CourseRunProgressStatuses.UPCOMING

--- a/enterprise_learner_portal/utils.py
+++ b/enterprise_learner_portal/utils.py
@@ -34,7 +34,6 @@ def get_course_run_status(course_overview, certificate_info, enterprise_enrollme
             CourseRunProgressStatuses.IN_PROGRESS,
             CourseRunProgressStatuses.UPCOMING,
         )
-        None if pacing type is not matched
     """
     if enterprise_enrollment and enterprise_enrollment.saved_for_later:
         return CourseRunProgressStatuses.SAVED_FOR_LATER

--- a/enterprise_learner_portal/utils.py
+++ b/enterprise_learner_portal/utils.py
@@ -3,10 +3,6 @@
 enterprise_learner_portal utils.
 """
 
-from datetime import datetime, timedelta
-
-from pytz import UTC
-
 
 class CourseRunProgressStatuses:
     """

--- a/tests/test_enterprise_learner_portal/test_utils.py
+++ b/tests/test_enterprise_learner_portal/test_utils.py
@@ -21,100 +21,44 @@ class TestUtils(TestCase):
     """
     Tests for enterprise_learner_portal utils.
     """
-    NOW = datetime.now(UTC)
 
     @ddt.data(
-        (
-            {
-                'pacing': 'instructor',
-                'has_ended': True,
-                'has_started': False,
-            },
-            {
-                'is_passing': True,
-                'created': NOW,
-            },
-            False,
-            CourseRunProgressStatuses.COMPLETED,
-        ),
-        (
-            {
-                'pacing': 'instructor',
-                'has_ended': False,
-                'has_started': True,
-            },
-            {
-                'is_passing': True,
-                'created': NOW,
-            },
-            False,
-            CourseRunProgressStatuses.IN_PROGRESS,
-        ),
-        (
-            {
-                'pacing': 'instructor',
-                'has_ended': False,
-                'has_started': False,
-            },
-            {
-                'is_passing': True,
-                'created': NOW,
-            },
-            False,
-            CourseRunProgressStatuses.UPCOMING,
-        ),
-        (
-            {
-                'pacing': 'self',
-                'has_ended': True,
-                'has_started': False,
-            },
-            {
-                'is_passing': True,
-                'created': NOW,
-            },
-            False,
-            CourseRunProgressStatuses.COMPLETED,
-        ),
-        (
-            {
-                'pacing': 'self',
-                'has_ended': False,
-                'has_started': True,
-            },
-            {
-                'is_passing': False,
-                'created': NOW,
-            },
-            False,
-            CourseRunProgressStatuses.IN_PROGRESS,
-        ),
-        (
-            {
-                'pacing': 'self',
-                'has_ended': False,
-                'has_started': False,
-            },
-            {
-                'is_passing': False,
-                'created': NOW,
-            },
-            False,
-            CourseRunProgressStatuses.UPCOMING,
-        ),
-        (
-            {
-                'pacing': 'instructor',
-                'has_ended': False,
-                'has_started': True,
-            },
-            {
-                'is_passing': False,
-                'created': NOW,
-            },
-            True,
-            CourseRunProgressStatuses.SAVED_FOR_LATER,
-        ),
+        {
+            'course_overview': {'has_started': False, 'has_ended': False},
+            'certificate_info': {'is_passing': False},
+            'saved_for_later': False,
+            'expected_status': CourseRunProgressStatuses.UPCOMING,
+        },
+        {
+            'course_overview': {'has_started': True, 'has_ended': False},
+            'certificate_info': {'is_passing': False},
+            'saved_for_later': False,
+            'expected_status': CourseRunProgressStatuses.IN_PROGRESS,
+        },
+        {
+            'course_overview': {'has_started': True, 'has_ended': False},
+            'certificate_info': {'is_passing': True},
+            'saved_for_later': False,
+            'expected_status': CourseRunProgressStatuses.COMPLETED,
+        },
+        {
+            'course_overview': {'has_started': True, 'has_ended': True},
+            'certificate_info': {'is_passing': False},
+            'saved_for_later': False,
+            'expected_status': CourseRunProgressStatuses.COMPLETED,
+        },
+        {
+            'course_overview': {'has_started': True, 'has_ended': True},
+            'certificate_info': {'is_passing': True},
+            'saved_for_later': False,
+            'expected_status': CourseRunProgressStatuses.COMPLETED,
+        },
+        {
+            'course_overview': {'has_started': True, 'has_ended': False},
+            'certificate_info': {'is_passing': False},
+            'saved_for_later': True,
+            'expected_status': CourseRunProgressStatuses.SAVED_FOR_LATER,
+        },
     )
     @ddt.unpack
     def test_get_course_run_status(
@@ -122,7 +66,7 @@ class TestUtils(TestCase):
             course_overview,
             certificate_info,
             saved_for_later,
-            expected,
+            expected_status,
     ):
         """
         Assert get_course_run_status returns the proper results based on input parameters

--- a/tests/test_enterprise_learner_portal/test_utils.py
+++ b/tests/test_enterprise_learner_portal/test_utils.py
@@ -3,11 +3,8 @@
 Tests for the utils of the enterprise_learner_portal app.
 """
 
-from datetime import datetime
-
 import ddt
 from pytest import mark
-from pytz import UTC
 
 from django.test import TestCase
 
@@ -72,9 +69,9 @@ class TestUtils(TestCase):
         Assert get_course_run_status returns the proper results based on input parameters
         """
         enterprise_enrollment = factories.EnterpriseCourseEnrollmentFactory.create(saved_for_later=saved_for_later)
-        actual = get_course_run_status(
+        actual_status = get_course_run_status(
             course_overview,
             certificate_info,
             enterprise_enrollment
         )
-        assert actual == expected
+        assert actual_status == expected_status


### PR DESCRIPTION
This PR modifies the `get_course_run_status` util function such that if a learner has a passing certificate, it will always return the course as "completed". This results in the following cases:

1. Enrollment saved for later --> `CourseRunProgressStatuses.SAVED_FOR_LATER`
1. Course has started but not ended --> `CourseRunProgressStatuses.IN_PROGRESS`
1. Course has ended --> `CourseRunProgressStatuses.COMPLETED`
1. Learner has passing certificate --> `CourseRunProgressStatuses.COMPLETED`
1. Course has not started --> `CourseRunProgressStatuses.UPCOMING`

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
