### PR TITLE
Setting courses to the Canvas public index by default

### DIFF
--- a/integrated_channels/canvas/client.py
+++ b/integrated_channels/canvas/client.py
@@ -221,8 +221,9 @@ class CanvasAPIClient(IntegratedChannelApiClient):
                     self.enterprise_configuration.canvas_base_url,
                     course_id,
                 )
+                # Providing the param `event` and setting it to `offer` is equivalent to publishing the course.
                 self._put(url, json.dumps({
-                    'course': {'image_url': content_metadata_item['image_url']}
+                    'course': {'image_url': content_metadata_item['image_url'], 'event': 'offer'}
                 }).encode('utf-8'))
         except Exception:  # pylint: disable=broad-except
             # we do not want course image update to cause failures

--- a/integrated_channels/canvas/exporters/content_metadata.py
+++ b/integrated_channels/canvas/exporters/content_metadata.py
@@ -24,6 +24,7 @@ class CanvasContentMetadataExporter(ContentMetadataExporter):
         'is_public': 'is_public',
         'self_enrollment': 'self_enrollment',
         'course_code': 'key',
+        'indexed': 'indexed'
     }
 
     LONG_STRING_LIMIT = 2000
@@ -60,7 +61,9 @@ class CanvasContentMetadataExporter(ContentMetadataExporter):
 
     def transform_is_public(self, content_metadata_item):  # pylint: disable=unused-argument
         """
-        Whether to make the course visible in the public Canvas index by default.
+        Whether to make the course content visible to students by default. Note that setting this feature to false
+        will not remove the course from discovery, but will rather remove all visible content from the course if
+        any student attempts to access it.
         """
         return True
 
@@ -69,3 +72,9 @@ class CanvasContentMetadataExporter(ContentMetadataExporter):
         Whether to allow students to self enroll. Helps students enroll via link or enroll button.
         """
         return True
+
+    def transform_indexed(self, content_metadata_item):  # pylint: disable=unused-argument
+        """
+        Whether to make the course default to the public index or not.
+        """
+        return 1

--- a/tests/test_integrated_channels/test_canvas/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_canvas/test_exporters/test_content_metadata.py
@@ -139,3 +139,12 @@ class TestCanvasContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):
         content_metadata_item = GENERIC_CONTENT_METADATA_ITEM
         exporter = CanvasContentMetadataExporter('fake-user', self.config)
         assert exporter.transform_self_enrollment(content_metadata_item) is True
+
+    @responses.activate
+    def test_transform_indexed(self):
+        """
+        `CanvasContentMetadataExporter``'s ''transform_indexed` returns 1 as a value
+        """
+        content_metadata_item = GENERIC_CONTENT_METADATA_ITEM
+        exporter = CanvasContentMetadataExporter('fake-user', self.config)
+        assert exporter.transform_indexed(content_metadata_item) == 1


### PR DESCRIPTION
In order to make the integrated course discoverable on Canvas, we need to set it to be a part of the public index. 

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
