### PR TITLE
Fix deprecated third_party_auth import

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Change Log
 Unreleased
 ----------
 
+[3.17.9]
+--------
+
+* Fix deprecation warning: ``third_party_auth`` should be imported as ``common.djangoapps.third_party_auth``.
+
 [3.17.8]
 --------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -3,6 +3,6 @@ Your project description goes here.
 """
 
 
-__version__ = "3.17.8"
+__version__ = "3.17.9"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/tpa_pipeline.py
+++ b/enterprise/tpa_pipeline.py
@@ -20,7 +20,7 @@ except ImportError:
     UserSocialAuth = None
 
 try:
-    from third_party_auth.provider import Registry
+    from common.djangoapps.third_party_auth.provider import Registry
 except ImportError:
     Registry = None
 


### PR DESCRIPTION
```
The correct import path is
`common.djangoapps.third_party_auth`.

Support for the unqualified import path will soon
be dropped.

Bump version to 3.17.9
```

This is related to the [the impending removal of support for deprecated edx-platform import paths](https://github.com/edx/edx-platform/pull/25932).
