### PR TITLE
Conditionally allows the deletion of individual EnterpriseCourseEnrollment records

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,14 @@ Change Log
 Unreleased
 ----------
 
+[3.17.12]
+---------
+
+* Conditionally allows the deletion of individual ``EnterpriseCourseEnrollment`` and related
+  ``LicensedEnterpriseCourseEnrollment`` records via the Django Admin site, so that site admins can manually
+  delete enterprise enrollments that were created in error.
+  This is only allowed if a Django settings feature flag is set to ``True``.
+
 [3.17.11]
 ---------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -3,6 +3,6 @@ Your project description goes here.
 """
 
 
-__version__ = "3.17.11"
+__version__ = "3.17.12"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/constants.py
+++ b/enterprise/constants.py
@@ -154,6 +154,10 @@ CONTENT_FILTER_FIELD_TYPES = {
     'first_enrollable_paid_seat_price__lte': {'type': str}
 }
 
+# FEATURE flag that indicates if deletion of EnterpriseCourseEnrollment records via
+# the Django Admin site is allowed.
+ALLOW_ADMIN_ENTERPRISE_COURSE_ENROLLMENT_DELETION = 'ALLOW_ADMIN_ENTERPRISE_COURSE_ENROLLMENT_DELETION'
+
 
 def json_serialized_course_modes():
     """


### PR DESCRIPTION
Conditionally allows the deletion of individual EnterpriseCourseEnrollment records and related
LicensedEnterpriseCourseEnrollment records via the Django Admin site, so that site admins can manually
delete enterprise enrollments that were created in error.
This is only allowed if a Django settings feature flag is set to True.

How I manually tested - 
1. Create a licensed enterprise enrollment for the `verified@example.com` user in the pied-piper customer: 
<img width="1527" alt="1-licensed-enrollment-learner-portal" src="https://user-images.githubusercontent.com/2307986/106020683-09bff980-6092-11eb-8f72-e0b80be39744.png">

2. As a site admin, visit the Django Admin for enterprise enrollments, see that I'm allowed to delete this one (I toggled the feature on in my local settings):
![2-admin-now-allows-deletion](https://user-images.githubusercontent.com/2307986/106020808-22c8aa80-6092-11eb-9401-ee5e74967158.png)

3. Click delete, get the confirmation screen that shows me I'll delete both the Enterprise Course Enrollment and the LicensedEnterpriseCourseEnrollment record: 
![3-confirm-deletion-of-licensed-enrollment](https://user-images.githubusercontent.com/2307986/106020892-3bd15b80-6092-11eb-954b-2bf850074c1f.png)

4. After confirming deletion, noticed that my enrollment is gone from the list: 
![4-enrollment-is-gone-from-admin](https://user-images.githubusercontent.com/2307986/106021199-8c48b900-6092-11eb-859c-cc596166f7ce.png)


5. As `verified@example.com`, notice that the course is no longer on my learner portal dashboard: 
<img width="1530" alt="5-course-is-gone-from-learner-portal" src="https://user-images.githubusercontent.com/2307986/106021016-599ec080-6092-11eb-9d49-789ef2ddebcb.png">

6. As the same learner, see that the course remains on my "personal" dashboard, indicating that the underlying `student.CourseEnrollment` record still exists: 
<img width="1126" alt="6-course-is-still-in-personal-dashboard" src="https://user-images.githubusercontent.com/2307986/106021083-6f13ea80-6092-11eb-9337-a781782294ed.png">

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [x] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
