### PR TITLE
version 3.17.15 | Update get_context()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,14 @@ Change Log
 Unreleased
 ----------
 
+[3.17.15]
+---------
+
+* In ``SystemWideEnterpriseUserRoleAssignment``, Use either ``applies_to_all_contexts`` or ``enterprise_customer``
+  if they are True or non-null, respectively, in determining the result of ``get_context()``,
+  but continue to return list of all linked enterprise customer UUIDs if not, (which is the current behavior).
+  This is a small step on our journey to explicitly defining user-role assignments.
+
 [3.17.14]
 ---------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.17.14"
+__version__ = "3.17.15"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -2597,13 +2597,22 @@ class SystemWideEnterpriseUserRoleAssignment(EnterpriseRoleAssignmentContextMixi
         ),
     )
 
+    def has_access_to_all_contexts(self):
+        """
+        Returns true if the role for this assignment is ``ENTERPRISE_OPERATOR_ROLE``,
+        or if ``applies_to_all_contexts`` is true; returns false otherwise.
+        """
+        return (self.role.name == ENTERPRISE_OPERATOR_ROLE) or self.applies_to_all_contexts  # pylint: disable=no-member
+
     def get_context(self):
         """
         Return the context for this role assignment class.
         """
-        # do not add enterprise id for `enterprise_openedx_operator` role
-        if self.role.name == ENTERPRISE_OPERATOR_ROLE:  # pylint: disable=no-member
+        if self.has_access_to_all_contexts():
             return [ALL_ACCESS_CONTEXT]
+
+        if self.enterprise_customer:
+            return [str(self.enterprise_customer.uuid)]
 
         return super().get_context()
 


### PR DESCRIPTION
In ``SystemWideEnterpriseUserRoleAssignment``, Use either ``applies_to_all_contexts`` or ``enterprise_customer``
  if they are True or non-null, respectively, in determining the result of ``get_context()``,
  but continue to return list of all linked enterprise customer UUIDs if not, (which is the current behavior).
  This is a small step on our journey to explicitly defining user-role assignments

*Manual Testing*
1. Give a user 2 explicit assignments for `enterprise_learner`, to two different enterprise customers, make sure there's a JWT role entry for both:
![Screen Shot 2021-01-29 at 10 52 02 AM](https://user-images.githubusercontent.com/2307986/106306717-6d7e2a00-622c-11eb-8898-45af6fb505a3.png)
<img width="397" alt="Screen Shot 2021-01-29 at 10 52 21 AM" src="https://user-images.githubusercontent.com/2307986/106306732-7242de00-622c-11eb-92b1-a9fa6a46cbdb.png">

2. Give a user the `enterprise_admin` role with `applies_to_all_contexts` set to true, see that their JWT role has an `enterprise_admin:*` entry:
![Screen Shot 2021-01-29 at 10 53 09 AM](https://user-images.githubusercontent.com/2307986/106306827-90a8d980-622c-11eb-93aa-75a3d044a290.png)
![Screen Shot 2021-01-29 at 10 59 51 AM](https://user-images.githubusercontent.com/2307986/106306843-97cfe780-622c-11eb-934f-1e18e4ad1148.png)

3. Give a user the `enterprise_openedx_operator` role, set `applies_to_all_contexts` to false, see that they still have `enterprise_openedx_operator:*` in their JWT roles:
![Screen Shot 2021-01-29 at 10 55 40 AM](https://user-images.githubusercontent.com/2307986/106306928-b59d4c80-622c-11eb-9112-b501a8e8cdc4.png)
<img width="319" alt="Screen Shot 2021-01-29 at 10 57 16 AM" src="https://user-images.githubusercontent.com/2307986/106306932-b7671000-622c-11eb-9f6a-1575c3c6ad60.png">


**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
