### PR TITLE
fix: add mode to enterprise_course_enrollments endpoint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Change Log
 Unreleased
 ----------
 
+[3.17.16]
+---------
+
+* Include course mode for the user's ``student.CourseEnrollment`` in the ``EnterpriseCourseEnrollmentSerializer``.
+
 [3.17.15]
 ---------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.17.15"
+__version__ = "3.17.16"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -1643,6 +1643,13 @@ class EnterpriseCourseEnrollment(TimeStampedModel):
         """
         return self.course_enrollment.is_active
 
+    @property
+    def mode(self):
+        """
+        Returns the mode of the ``student.CourseEnrollment`` associated with this enterprise course enrollment record.
+        """
+        return self.course_enrollment.mode
+
     @classmethod
     def get_enterprise_course_enrollment_id(cls, user, course_id, enterprise_customer):
         """

--- a/enterprise_learner_portal/api/v1/serializers.py
+++ b/enterprise_learner_portal/api/v1/serializers.py
@@ -68,6 +68,7 @@ class EnterpriseCourseEnrollmentSerializer(serializers.Serializer):  # pylint: d
         representation['org_name'] = course_overview['display_org_with_default']
         representation['is_revoked'] = instance.license.is_revoked if instance.license else False
         representation['is_enrollment_active'] = instance.is_active
+        representation['mode'] = instance.mode
 
         return representation
 

--- a/tests/test_enterprise_learner_portal/api/test_serializers.py
+++ b/tests/test_enterprise_learner_portal/api/test_serializers.py
@@ -69,6 +69,7 @@ class TestEnterpriseCourseEnrollmentSerializer(TestCase):
             course_id=course_run_id
         )
         mock_course_enrollment_class.objects.get.return_value.is_active = True
+        mock_course_enrollment_class.objects.get.return_value.mode = 'verified'
 
         request = self.factory.get('/')
         request.user = self.user
@@ -93,6 +94,7 @@ class TestEnterpriseCourseEnrollmentSerializer(TestCase):
             ('org_name', 'my university'),
             ('is_revoked', False),
             ('is_enrollment_active', True),
+            ('mode', 'verified')
         ])
         actual = serializer.data[0]
         self.assertDictEqual(actual, expected)


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
