### PR TITLE
Assessment level transmissions deal should have assessment level audits

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Change Log
 Unreleased
 ----------
 
+[3.17.23]
+---------
+
+* Fixing assessment level reporting audit retrieval.
+
 [3.17.22]
 ---------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.17.22"
+__version__ = "3.17.23"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/blackboard/transmitters/learner_data.py
+++ b/integrated_channels/blackboard/transmitters/learner_data.py
@@ -42,7 +42,7 @@ class BlackboardLearnerTransmitter(LearnerTransmitter):
             exporter: The learner completion data payload to send to blackboard
         """
         kwargs['app_label'] = 'blackboard'
-        kwargs['model_name'] = 'BlackboardLearnerDataTransmissionAudit'
+        kwargs['model_name'] = 'BlackboardLearnerAssessmentDataTransmissionAudit'
         kwargs['remote_user_id'] = 'blackboard_user_email'
         super().single_learner_assessment_grade_transmit(exporter, **kwargs)
 
@@ -53,6 +53,6 @@ class BlackboardLearnerTransmitter(LearnerTransmitter):
             exporter: The learner completion data payload to send to blackboard
         """
         kwargs['app_label'] = 'blackboard'
-        kwargs['model_name'] = 'BlackboardLearnerDataTransmissionAudit'
+        kwargs['model_name'] = 'BlackboardLearnerAssessmentDataTransmissionAudit'
         kwargs['remote_user_id'] = 'blackboard_user_email'
         super().assessment_level_transmit(exporter, **kwargs)

--- a/integrated_channels/canvas/exporters/learner_data.py
+++ b/integrated_channels/canvas/exporters/learner_data.py
@@ -69,7 +69,7 @@ class CanvasLearnerExporter(LearnerExporter):
             assessment_grade_data,
     ):
         """
-        Return a CanvasLearnerDataTransmissionAudit with the given enrollment and assessment level data.
+        Return a CanvasLearnerAssessmentDataTransmissionAudit with the given enrollment and assessment level data.
 
         If there is no subsection grade then something has gone horribly wrong and it is recommended to look at the
         return value of platform's gradebook view.

--- a/integrated_channels/canvas/transmitters/learner_data.py
+++ b/integrated_channels/canvas/transmitters/learner_data.py
@@ -42,7 +42,7 @@ class CanvasLearnerTransmitter(LearnerTransmitter):
             payload: The learner completion data payload to send to Canvas
         """
         kwargs['app_label'] = 'canvas'
-        kwargs['model_name'] = 'CanvasLearnerDataTransmissionAudit'
+        kwargs['model_name'] = 'CanvasLearnerAssessmentDataTransmissionAudit'
         kwargs['remote_user_id'] = 'canvas_user_email'
         super().single_learner_assessment_grade_transmit(exporter, **kwargs)
 
@@ -54,6 +54,6 @@ class CanvasLearnerTransmitter(LearnerTransmitter):
             payload: The learner completion data payload to send to Canvas
         """
         kwargs['app_label'] = 'canvas'
-        kwargs['model_name'] = 'CanvasLearnerDataTransmissionAudit'
+        kwargs['model_name'] = 'CanvasLearnerAssessmentDataTransmissionAudit'
         kwargs['remote_user_id'] = 'canvas_user_email'
         super().assessment_level_transmit(exporter, **kwargs)

--- a/integrated_channels/integrated_channel/transmitters/learner_data.py
+++ b/integrated_channels/integrated_channel/transmitters/learner_data.py
@@ -55,7 +55,7 @@ class LearnerTransmitter(Transmitter):
         for learner_data in exporter.single_assessment_level_export(**kwargs):
             serialized_payload = learner_data.serialize(enterprise_configuration=self.enterprise_configuration)
             try:
-                code, body = self.client.create_course_completion(
+                code, body = self.client.create_assessment_reporting(
                     getattr(learner_data, kwargs.get('remote_user_id')),
                     serialized_payload
                 )

--- a/tests/test_integrated_channels/test_cornerstone/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_cornerstone/test_exporters/test_content_metadata.py
@@ -327,7 +327,7 @@ class TestCornerstoneContentMetadataExporter(unittest.TestCase, EnterpriseMockMi
                         "enrollment_start": None,
                         "pacing_type": "instructor_paced",
                         "end": "2013-02-05T05:00:00Z",
-                        "start": "2023-02-05T05:00:00Z",
+                        "start": "2013-02-05T05:00:00Z",
                         "modified": "2019-02-05T05:00:00Z",
                         "go_live_date": None,
                         "availability": "Archived"


### PR DESCRIPTION
Our assessment level transmissions were using the completion level audits as the model name. 

For testing, the bugs found addressed in this PR came from testing on staging, so testing will be done on stage after this is merged.

No migrations needed.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
