### PR TITLE
Prevent NoneType with string concatination exception 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Change Log
 Unreleased
 ----------
 
+[3.17.29]
+---------
+
+* Prevent NoneType string concatenation when handling multiple enterprises logistration without redirects.
+
 [3.17.28]
 ---------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.17.28"
+__version__ = "3.17.29"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name


### PR DESCRIPTION
Jira ticket: https://openedx.atlassian.net/browse/ENT-3568
[Since roughly Dec 2020](https://splunk.edx.org/en-US/app/search/search?q=search%20reverse(%27enterprise_select_active%27)&display.page.search.mode=smart&dispatch.sample_ratio=1&earliest=0&latest=&sid=1612887358.17411684) we have been throwing exceptions In the enterprise logistration flow. 

When an enterprise user signs in with SSO and the social user's account is new or already binded with an edx account (and has multiple enterprise customers), we attempt to insert the `select active enterprise` page redirect in between where they are currently and the user's next redirect (presumably the dashboard?). However, we are failing to concatenate the redirects with either `strategy.session_get('next')` or `reverse('enterprise_select_active')` being None. It is my belief that `reverse('enterprise_select_active')` simply returns the view endpoint (and throws an exception when the view doesn't exist, not returns None) so that would leave the situation where the user's current session does not have a `next` redirect. In these cases, we could keep the user's session as is, or possibly redirect to the dashboard(?). I am slightly unsure of desired behaviors.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
