### PR TITLE
Adding informative logs to the single learner transmission task

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Change Log
 Unreleased
 ----------
 
+[3.17.27]
+
+* Adding Logging to single learner assessment level reporting task.
+
 [3.17.26]
 ---------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.17.26"
+__version__ = "3.17.27"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/integrated_channel/exporters/learner_data.py
+++ b/integrated_channels/integrated_channel/exporters/learner_data.py
@@ -167,6 +167,12 @@ class LearnerExporter(Exporter):
         # We are transmitting for a single enrollment, so grab just the one.
         enterprise_enrollment = enrollment_queryset.first()
 
+        generate_formatted_log(
+            'Beginning single exportation of learner data for enrollment: {enrollment}'.format(
+                enrollment=enterprise_enrollment.id
+            )
+        )
+
         already_transmitted = is_already_transmitted(
             TransmissionAudit,
             enterprise_enrollment.id,

--- a/integrated_channels/integrated_channel/tasks.py
+++ b/integrated_channels/integrated_channel/tasks.py
@@ -167,6 +167,17 @@ def transmit_single_subsection_learner_data(username, course_run_id, subsection_
                 {'channel': None, 'enterprise_customer': enterprise_customer_uuid}
         ):
             integrated_channel = INTEGRATED_CHANNEL_CHOICES[channel.channel_code()].objects.get(pk=channel.pk)
+
+            LOGGER.info(
+                'Beginning single learner data transmission task. Channel: {channel}, Customer: {enterprise_uuid}, '
+                'Course: {course_run}, Username: {username}, Subsection_id: {subsection}'.format(
+                    channel=channel.channel_code(),
+                    username=username,
+                    course_run=course_run_id,
+                    enterprise_uuid=enterprise_customer_uuid,
+                    subsection=subsection_id
+                ))
+
             integrated_channel.transmit_single_subsection_learner_data(
                 learner_to_transmit=user,
                 course_run_id=course_run_id,


### PR DESCRIPTION
Jira: https://openedx.atlassian.net/browse/ENT-4101
It's difficult to tell if a particular learners transmission has begun as there are no logs except for the "completed transmission" one at the very end.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
