### PR TITLE
allowing for channel retrieval to filter for assessment reporting support.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Change Log
 Unreleased
 ----------
 
+[3.17.36]
+---------
+
+* Properly filtering integrated channels that support assessment level reporting.
+
 [3.17.35]
 ---------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.17.35"
+__version__ = "3.17.36"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/integrated_channel/management/commands/transmit_subsection_learner_data.py
+++ b/integrated_channels/integrated_channel/management/commands/transmit_subsection_learner_data.py
@@ -45,6 +45,7 @@ class Command(IntegratedChannelCommandMixin, BaseCommand):
         """
         # Ensure that we were given an api_user name, and that User exists.
         api_username = options['api_user']
+        options['assessment_level_support'] = True
         try:
             User.objects.get(username=api_username)
         except User.DoesNotExist as no_user_error:

--- a/integrated_channels/integrated_channel/tasks.py
+++ b/integrated_channels/integrated_channel/tasks.py
@@ -164,7 +164,7 @@ def transmit_single_subsection_learner_data(username, course_run_id, subsection_
     # Starting Export. N customer is usually 1 but multiple are supported in codebase.
     for enterprise_customer_uuid in enterprise_customer_uuids:
         for channel in channel_utils.get_integrated_channels(
-                {'channel': None, 'enterprise_customer': enterprise_customer_uuid}
+                {'channel': None, 'enterprise_customer': enterprise_customer_uuid, 'assessment_level_support': True}
         ):
             integrated_channel = INTEGRATED_CHANNEL_CHOICES[channel.channel_code()].objects.get(pk=channel.pk)
 

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -47,6 +47,7 @@ from enterprise.models import (
 from integrated_channels.degreed.models import DegreedEnterpriseCustomerConfiguration
 from integrated_channels.integrated_channel.exporters.learner_data import LearnerExporter
 from integrated_channels.integrated_channel.management.commands import (
+    ASSESSMENT_LEVEL_REPORTING_INTEGRATED_CHANNEL_CHOICES,
     INTEGRATED_CHANNEL_CHOICES,
     IntegratedChannelCommandMixin,
 )
@@ -87,6 +88,29 @@ class TestIntegratedChannelCommandMixin(unittest.TestCase):
         """
         channel_class = INTEGRATED_CHANNEL_CHOICES[channel_code]
         assert IntegratedChannelCommandMixin.get_channel_classes(channel_code) == [channel_class]
+
+    def test_does_not_return_unsupported_channels(self):
+        """
+        If an unsupported channel is requested while retrieving supported channels, should expect an exception.
+        """
+        channel = (set(INTEGRATED_CHANNEL_CHOICES) - set(ASSESSMENT_LEVEL_REPORTING_INTEGRATED_CHANNEL_CHOICES)).pop()
+        with raises(CommandError) as excinfo:
+            IntegratedChannelCommandMixin.get_channel_classes(
+                channel,
+                assessment_level_support=True,
+            )
+        assert excinfo.value.args == ('Invalid integrated channel: {channel}'.format(channel=channel),)
+
+    def test_get_assessment_level_reporting_supported_channels(self):
+        """
+        Only retrieve channels that support assessment level reporting.
+        """
+        channel = set(ASSESSMENT_LEVEL_REPORTING_INTEGRATED_CHANNEL_CHOICES).pop()
+        channel_class = ASSESSMENT_LEVEL_REPORTING_INTEGRATED_CHANNEL_CHOICES[channel]
+        assert IntegratedChannelCommandMixin.get_channel_classes(
+            channel,
+            assessment_level_support=True,
+        ) == [channel_class]
 
 
 @mark.django_db


### PR DESCRIPTION
Bulk assessment level data transmissions were being sent out to all channels, including those that don't support it.

Similarly single learner transmissions would be sent to unsupported channels.

Added a fix to support filtering on channel retrieval and unit testing to make sure newly supported channels are filtered.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
