### PR TITLE
Update course title to include '- via edX.org'

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Change Log
 Unreleased
 ----------
 
+[3.17.31]
+---------
+
+* Change moodle course title in exporter, to include edX text.
+
 [3.17.30]
 ---------
 
@@ -1607,6 +1612,7 @@ Unreleased
 * Sorted results of enterprise-learner API by active flag in descending order so active enterprises are on the top
 
 [2.0.18] - 2019-11-13
+
 ---------------------
 
 * Better handling when Integrated Channels return unexpected results

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.17.30"
+__version__ = "3.17.31"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/moodle/exporters/content_metadata.py
+++ b/integrated_channels/moodle/exporters/content_metadata.py
@@ -42,6 +42,7 @@ class MoodleContentMetadataExporter(ContentMetadataExporter):
     def transform_title(self, content_metadata_item):
         """
         Returns the course title with all organizations (partners) appended in parantheses
+        Returned format is: courseTitle - via edX.org (Partner)
         """
         formatted_orgs = []
         for org in content_metadata_item.get('organizations', []):
@@ -55,8 +56,9 @@ class MoodleContentMetadataExporter(ContentMetadataExporter):
         else:
             final_orgs = ' ({})'.format(', '.join(formatted_orgs))
 
+        edx_formatted_title = '{} - via edX.org'.format(content_metadata_item.get('title'))
         return '{}{}'.format(
-            content_metadata_item.get('title'),
+            edx_formatted_title,
             final_orgs
         )
 

--- a/tests/test_integrated_channels/test_moodle/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_moodle/test_exporters/test_content_metadata.py
@@ -161,7 +161,7 @@ class TestMoodleContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):
             ]
         }
         expected_title = '{} ({})'.format(
-            content_metadata_item['title'],
+            '{} - via edX.org'.format(content_metadata_item['title']),
             ', '.join(content_metadata_item['organizations'])
         )
         exporter = MoodleContentMetadataExporter('fake-user', self.config)


### PR DESCRIPTION
JIRA: https://openedx.atlassian.net/browse/ENT-3994

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
