### PR TITLE
omitting integrated assessment level canvas grades from final grade

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Change Log
 Unreleased
 ----------
 
+[3.17.38]
+
+* Omitting assessment level reporting from integrated Canvas learners final grade to not have redundant reported points
+  between final grades and subsection grades.
+
 [3.17.37]
 ---------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,5 +2,5 @@
 Your project description goes here.
 """
 
-__version__ = "3.17.37"
+__version__ = "3.17.38"
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/canvas/client.py
+++ b/integrated_channels/canvas/client.py
@@ -136,7 +136,8 @@ class CanvasAPIClient(IntegratedChannelApiClient):
             learner_data['subsectionID'],
             canvas_course_id,
             learner_data['subsection_name'],
-            learner_data['points_possible']
+            learner_data['points_possible'],
+            is_assessment_grade=True
         )
 
         # The percent grade from the grades api is represented as a decimal, but we can report the percent in the
@@ -355,7 +356,14 @@ class CanvasAPIClient(IntegratedChannelApiClient):
 
         return rsps.json()
 
-    def _handle_canvas_assignment_retrieval(self, integration_id, course_id, assignment_name, points_possible=100):
+    def _handle_canvas_assignment_retrieval(
+            self,
+            integration_id,
+            course_id,
+            assignment_name,
+            points_possible=100,
+            is_assessment_grade=False
+    ):
         """
         Helper method to handle course assignment creation or retrieval. Canvas requires an assignment
         in order for a user to get a grade, so first check the course for the "final grade"
@@ -408,7 +416,8 @@ class CanvasAPIClient(IntegratedChannelApiClient):
                     'submission_types': 'none',
                     'integration_id': integration_id,
                     'published': True,
-                    'points_possible': points_possible
+                    'points_possible': points_possible,
+                    'omit_from_final_grade': is_assessment_grade,
                 }
             }
             create_assignment_resp = self.session.post(canvas_assignments_url, json=assignment_creation_data)


### PR DESCRIPTION
Jira ticket: https://openedx.atlassian.net/browse/ENT-4148

Since assessment level and completion reporting are both implemented independently of each other and both use the same Canvas assignment object system to post their data, if one or both aren't omitted from the learner's final grade then the points the user earned will be inconsistent.

Example of current behavior:
![image](https://user-images.githubusercontent.com/67655836/108256123-1f718d80-712b-11eb-9cea-0cf1b0769228.png)

Because both assessment data and completion data are included in the user's final grade, we have the appropriate percentage, but the `Out of` points fraction has points from both.

There are two ways around this, we can either exclude the edx "final grade" or the assessment level grades from the user's final grade. As the assessments can be weighted inconsistently with the edX learner's total grade, and the "final grade" from edx is accurate to the student's score in the class, I have decided to omit the assessment level grades.

Expected behavior:
![image](https://user-images.githubusercontent.com/67655836/108252935-344c2200-7127-11eb-9b6a-bfe6098e0dac.png) 

Here, with the assessment level grades omitted, the learner is still able to view the amount of points they got on a particular subsection, but those points will not factor into the user's Canvas final grade.

It is important to note that with this change, the user won't be able to see in Canvas their overall grade in the course until they complete it on edX.

Unit testing is tricky to add as this is a field supplied to Canvas that has an effect on user experience **on Canvas**, not edX.
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
