### PR TITLE
Committing ability of request to override text that appears on page.

### DIFF
--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -577,7 +577,9 @@ class GrantDataSharingPermissions(View):
 
         if request.GET.get('left_sidebar_text_override') is not None:
             # Allows sidebar text to be overridden by calling API
-            context_data.update({'text_override_available': True, 'left_sidebar_text': request.GET.get('left_sidebar_text_override')})
+            context_data.update({'text_override_available': True,
+                                 'left_sidebar_text': request.GET.get('left_sidebar_text_override')
+                                 })
 
         return context_data
 

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -575,6 +575,10 @@ class GrantDataSharingPermissions(View):
         else:
             context_data.update(self.get_default_context(enterprise_customer, platform_name))
 
+        if request.GET.get('left_sidebar_text_override') is not None:
+            # Allows sidebar text to be overridden by calling API
+            context_data.update({'text_override_available': True, 'left_sidebar_text': request.GET.get('left_sidebar_text_override')})
+
         return context_data
 
     @staticmethod


### PR DESCRIPTION
Supports: https://github.com/edx/frontend-app-learner-portal-enterprise/pull/206 and ENT-4024




**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
