### PR TITLE
Removing uneeded API call in favor of direct model import.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,12 @@ Change Log
 
 Unreleased
 ----------
+
+[3.17.44]
+---------
+
+* Replaced an LMS Enrollment API call with direct call the DB to avoid LMS rate limiting during integrated channels bulk jobs.
+
 [3.17.43]
 ---------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,5 +2,5 @@
 Your project description goes here.
 """
 
-__version__ = "3.17.43"
+__version__ = "3.17.44"
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -1622,13 +1622,11 @@ class EnterpriseCourseEnrollment(TimeStampedModel):
 
         :return: Whether the course enrollment mode is of an audit type.
         """
-        course_enrollment_api = EnrollmentApiClient()
-        course_enrollment = course_enrollment_api.get_course_enrollment(
-            self.enterprise_customer_user.username,
-            self.course_id
-        )
+
+        course_enrollment = self.course_enrollment
+
         audit_modes = getattr(settings, 'ENTERPRISE_COURSE_ENROLLMENT_AUDIT_MODES', ['audit', 'honor'])
-        return course_enrollment and course_enrollment.get('mode') in audit_modes
+        return course_enrollment and (course_enrollment.mode in audit_modes)
 
     @property
     def license(self):

--- a/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_learner_data.py
+++ b/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_learner_data.py
@@ -362,7 +362,7 @@ class TestLearnerExporter(unittest.TestCase):
         (False, TOMORROW, None, LearnerExporter.GRADE_INCOMPLETE, 'verified'),
     )
     @ddt.unpack
-    @mock.patch('enterprise.models.EnrollmentApiClient')
+    @mock.patch('enterprise.models.CourseEnrollment')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.GradesApiClient')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CourseApiClient')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
@@ -376,7 +376,7 @@ class TestLearnerExporter(unittest.TestCase):
             mock_course_catalog_api,
             mock_course_api,
             mock_grades_api,
-            mock_enrollment_api
+            mock_course_enrollment_class
     ):
         enrollment = factories.EnterpriseCourseEnrollmentFactory(
             enterprise_customer_user=self.enterprise_customer_user,
@@ -397,10 +397,7 @@ class TestLearnerExporter(unittest.TestCase):
         )
 
         # Mock enrollment data
-        mock_enrollment_api.return_value.get_course_enrollment.return_value = dict(
-            mode=course_enrollment_mode,
-        )
-
+        mock_course_enrollment_class.objects.get.return_value.mode = course_enrollment_mode
         # Collect the learner data, with time set to NOW
         with freeze_time(self.NOW):
             learner_data = list(self.exporter.export())
@@ -581,7 +578,7 @@ class TestLearnerExporter(unittest.TestCase):
 
     @ddt.data(
         (True, True, 'audit', 2),
-        (True, False, 'audit', 0),
+        (True, False, 'audit', 0), #THIS ONE
         (False, True, 'audit', 0),
         (False, False, 'audit', 0),
         (True, True, 'verified', 2),
@@ -590,7 +587,7 @@ class TestLearnerExporter(unittest.TestCase):
         (False, False, 'verified', 2),
     )
     @ddt.unpack
-    @mock.patch('enterprise.models.EnrollmentApiClient')
+    @mock.patch('enterprise.models.CourseEnrollment')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.GradesApiClient')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.CourseApiClient')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
@@ -603,7 +600,7 @@ class TestLearnerExporter(unittest.TestCase):
             mock_course_catalog_api,
             mock_course_api,
             mock_grades_api,
-            mock_enrollment_api
+            mock_course_enrollment_class
     ):
         mock_course_catalog_api.return_value.get_course_id.return_value = self.course_key
 
@@ -629,9 +626,7 @@ class TestLearnerExporter(unittest.TestCase):
         )
 
         # Mock enrollment data, in particular the enrollment mode
-        mock_enrollment_api.return_value.get_course_enrollment.return_value = dict(
-            mode=mode
-        )
+        mock_course_enrollment_class.objects.get.return_value.mode = mode
 
         # Collect the learner data
         with freeze_time(self.NOW):


### PR DESCRIPTION
Property call here was causing rate limiting when used in bulk jobs for integrated channels.

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
