### PR TITLE
ENT-4091: handle email_csv case and also multi line when pasting emails on multiple lines in textfield

### DIFF
--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -233,7 +233,6 @@ class EnterpriseCustomerViewSet(EnterpriseReadWriteModelViewSet):
         )
         if serializer.is_valid(raise_exception=True):
             already_linked_emails = []
-            duplicate_emails = []
             errors = []
             enrolled_count = 0
 
@@ -252,8 +251,6 @@ class EnterpriseCustomerViewSet(EnterpriseReadWriteModelViewSet):
                     else:
                         if already_linked:
                             already_linked_emails.append((email, already_linked.enterprise_customer))
-                        elif email in emails:
-                            duplicate_emails.append(email)
             except ValidationError as exc:
                 errors.append(exc)
 

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -235,6 +235,7 @@ class EnterpriseCustomerViewSet(EnterpriseReadWriteModelViewSet):
             already_linked_emails = []
             duplicate_emails = []
             errors = []
+            enrolled_count = 0
 
             singular_email = serializer.validated_data.get('email')
             if singular_email:
@@ -284,6 +285,7 @@ class EnterpriseCustomerViewSet(EnterpriseReadWriteModelViewSet):
                         discount=discount,
                         sales_force_id=serializer.validated_data.get('salesforce_id'),
                     )
+                    enrolled_count = len(succeeded + pending)
                     if serializer.validated_data.get('notify'):
                         enterprise_customer.notify_enrolled_learners(
                             catalog_api_user=request.user,
@@ -305,7 +307,7 @@ class EnterpriseCustomerViewSet(EnterpriseReadWriteModelViewSet):
                             "sales_force_id": serializer.validated_data.get('salesforce_id'),
                         } for success in succeeded]
                         EcommerceApiClient(get_ecommerce_worker_user()).create_manual_enrollment_orders(enrollments)
-            return Response(status=HTTP_202_ACCEPTED)
+            return Response('{} learners enrolled'.format(enrolled_count), status=HTTP_202_ACCEPTED)
         return Response(status=HTTP_400_BAD_REQUEST)
 
     @method_decorator(require_at_least_one_query_parameter('permissions'))

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -237,9 +237,9 @@ class EnterpriseCustomerViewSet(EnterpriseReadWriteModelViewSet):
             errors = []
             enrolled_count = 0
 
-            singular_email = serializer.validated_data.get('email')
-            if singular_email:
-                emails = set(singular_email.splitlines())
+            email_list = serializer.validated_data.get('email')
+            if email_list:
+                emails = set(email_list.splitlines())
             else:
                 emails = set(serializer.validated_data.get('email_csv', []))
 

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -287,7 +287,7 @@ class EnterpriseCustomerViewSet(EnterpriseReadWriteModelViewSet):
                             course_id=course_run_key,
                             users=succeeded + pending,
                         )
-                    self._create_ecommerce_orders_for_successful_enrollments(
+                    self._create_ecom_orders_for_enrollments(
                         course_run_key,
                         mode,
                         discount,
@@ -297,7 +297,15 @@ class EnterpriseCustomerViewSet(EnterpriseReadWriteModelViewSet):
             return Response('{} learners enrolled'.format(enrolled_count), status=HTTP_202_ACCEPTED)
         return Response(status=HTTP_400_BAD_REQUEST)
 
-    def _create_ecommerce_orders_for_successful_enrollments(self, course_run_key, mode, discount, salesforce_id, succeeded_enrollments):
+    def _create_ecom_orders_for_enrollments(self,
+                                            course_run_key,
+                                            mode,
+                                            discount,
+                                            salesforce_id,
+                                            succeeded_enrollments):
+        """
+        Create ecommerce enrollment order for provided enrollments
+        """
         paid_modes = ['verified', 'professional']
         enterprise_customer = self.get_object()
         if mode in paid_modes:

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -2661,6 +2661,17 @@ class TestEnterpriseAPIViews(APITest):
             'expected_code': 202,
             'expected_body': None,
         },
+        {
+            'body': {
+                'email': 'abc@test.com\ndef@test.com'
+                'email_csv': base64.b64encode(b'email\ntest@example.com').decode(),
+                'course_run_key': 'course-v1:edX+DemoX+Demo_Course',
+                'course_mode': 'audit',
+                'discount': 100,
+            },
+            'expected_code': 202,
+            'expected_body': None,
+        },
     )
     @ddt.unpack
     def test_bulk_enrollment(self, body, expected_code, expected_body):

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -2649,7 +2649,7 @@ class TestEnterpriseAPIViews(APITest):
                 'discount': 100,
             },
             'expected_code': 202,
-            'expected_body': None,
+            'expected_body': '1 learners enrolled',
         },
         {
             'body': {
@@ -2659,18 +2659,18 @@ class TestEnterpriseAPIViews(APITest):
                 'discount': 100,
             },
             'expected_code': 202,
-            'expected_body': None,
+            'expected_body': '1 learners enrolled',
         },
         {
             'body': {
-                'email': 'abc@test.com\ndef@test.com'
+                'email': 'abc@test.com\ndef@test.com',
                 'email_csv': base64.b64encode(b'email\ntest@example.com').decode(),
                 'course_run_key': 'course-v1:edX+DemoX+Demo_Course',
                 'course_mode': 'audit',
                 'discount': 100,
             },
             'expected_code': 202,
-            'expected_body': None,
+            'expected_body': '2 learners enrolled',
         },
     )
     @ddt.unpack
@@ -2809,6 +2809,7 @@ class TestEnterpriseReportingConfigAPIViews(APITest):
     """
     Test Reporting Configuration Views
     """
+
     def _create_user_and_enterprise_customer(self, username, password):
         """
         Helper method to create the User and Enterprise Customer used in tests.


### PR DESCRIPTION
JIRA: ENT-4091

Fixes:

- [x] Issue with email_csv not being properly processed even after parsing
- [x] Issue with multi line email list in text area not being processed correctly, added `splitlines()` to handle that,  it now works with one or more emails
- [x] priority is still given to 'email' when both 'email' and 'email_csv' are present
- [x] adds a message to the response that says `N learners enrolled` for debugging/reporting/testing etc
- [x] test updates

Testing notes:

Tested by

[1] typing in multiline emails in textarea and hitting enroll learners and checking enrollments were created
[2] uploading csv file that looked like attached and repeating
```
email
learner1@example.com
learner2@example.com
```

as per required format (email first one is used as a header and also dict key)

at http://localhost:1991/test-enterprise/admin/catalog_management?features=BULK_ENROLLMENT

checked frontend response too like '2 learners enrolled'


**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
