### PR TITLE
removing course mode from bulk enrollment required params 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Change Log
 Unreleased
 ----------
 
+[3.18.2]
+--------
+
+* Removes course mode as a required parameter to the bulk subscription enrollment endpoint.
+
 [3.18.1]
 --------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,5 +2,5 @@
 Your project description goes here.
 """
 
-__version__ = "3.18.1"
+__version__ = "3.18.2"
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -979,12 +979,12 @@ class EnterpriseCustomerBulkSubscriptionEnrollmentsSerializer(serializers.Serial
 
         # validate that each license info has the required keys
         for license_info in data.get('licenses_info'):
-            required_info = {'email', 'course_run_key', 'course_mode', 'license_uuid'}
+            required_info = {'email', 'course_run_key', 'license_uuid'}
             if not set(license_info.keys()) == required_info:
                 missing_fields = list(required_info - set(license_info.keys()))
                 missing_fields.sort()
                 raise serializers.ValidationError(
-                    'All license_info dicts must contain an email, course_run_key, course_mode and license_uuid. '
+                    'All license_info dicts must contain an email, course_run_key and license_uuid. '
                     'Missing fields: {}'.format(missing_fields)
                 )
         return data

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -40,6 +40,11 @@ from django.utils.translation import ungettext
 from enterprise.constants import ALLOWED_TAGS, DEFAULT_CATALOG_CONTENT_FILTER, PROGRAM_TYPE_DESCRIPTION
 
 try:
+    from common.djangoapps.course_modes.models import CourseMode
+except ImportError:
+    CourseMode = None
+
+try:
     from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 except ImportError:
     configuration_helpers = None
@@ -1787,3 +1792,17 @@ def batch(iterable, batch_size=1):
     iterable_len = len(iterable)
     for index in range(0, iterable_len, batch_size):
         yield iterable[index:min(index + batch_size, iterable_len)]
+
+
+def get_best_mode_from_course_key(course_key):
+    """
+    Helper method to retrieve a list of enrollments for a given course and select the one most applicable to enroll an
+    enterprise learner in.
+    """
+    course_modes = [mode.slug for mode in CourseMode.objects.filter(course_id=course_key)]
+    best_course_mode = 'verified' if 'verified' in course_modes \
+        else 'professional' if 'professional' in course_modes \
+        else 'no-id-professional' if 'no-id-professional' in course_modes \
+        else 'audit'
+
+    return best_course_mode

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -63,6 +63,7 @@ from enterprise.utils import (
     filter_audit_course_modes,
     format_price,
     get_active_course_runs,
+    get_best_mode_from_course_key,
     get_configuration_value,
     get_create_ent_enrollment,
     get_current_course_run,
@@ -581,17 +582,13 @@ class GrantDataSharingPermissions(View):
         if course_id and self.is_course_run_id(course_id):
             if license_uuid:
                 enrollment_api_client = EnrollmentApiClient()
-                course_modes = [mode['slug'] for mode in enrollment_api_client.get_course_modes(course_id)]
+                course_mode = get_best_mode_from_course_key(course_id)
                 LOGGER.info(
-                    'Retrieved Course Modes for Course {course_id}: {course_modes}'.format(
+                    'Retrieved Course Mode: {course_modes} for Course {course_id}'.format(
                         course_id=course_id,
-                        course_modes=course_modes
+                        course_modes=course_mode
                     )
                 )
-                course_mode = 'verified' if 'verified' in course_modes \
-                    else 'professional' if 'professional' in course_modes \
-                    else 'no-id-professional' if 'no-id-professional' in course_modes \
-                    else 'audit'
                 try:
                     enrollment_api_client.enroll_user_in_course(
                         request.user.username,

--- a/tests/test_enterprise/test_utils.py
+++ b/tests/test_enterprise/test_utils.py
@@ -217,7 +217,7 @@ class TestUtils(unittest.TestCase):
         )
         self.assertEqual(len(EnterpriseCourseEnrollment.objects.all()), 1)
 
-    def test_enroll_pending_licensed_users_in_courses_succeeds(self, ):
+    def test_enroll_pending_licensed_users_in_courses_succeeds(self):
         """
         Test that users that do not exist are pre-enrolled by enroll_licensed_users_in_courses and returned under the
         `pending` field.

--- a/tests/test_enterprise/views/test_grant_data_sharing_permissions.py
+++ b/tests/test_enterprise/views/test_grant_data_sharing_permissions.py
@@ -390,6 +390,7 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.get_best_mode_from_course_key')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     @ddt.data(
         str(uuid.uuid4()),
@@ -399,6 +400,7 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
             self,
             license_uuid,
             course_catalog_api_client_mock,
+            mock_get_course_mode,
             mock_enrollment_api_client,
             *args
     ):  # pylint: disable=unused-argument
@@ -426,7 +428,7 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
         course_catalog_api_client_mock.return_value.get_course_id.return_value = course_id
 
         course_mode = 'verified'
-        mock_enrollment_api_client.return_value.get_course_modes.return_value = [{'slug': course_mode}]
+        mock_get_course_mode.return_value = course_mode
         params = {
             'enterprise_customer_uuid': str(enterprise_customer.uuid),
             'course_id': course_id,
@@ -515,6 +517,7 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
 
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.get_best_mode_from_course_key')
     @mock.patch('enterprise.models.EnterpriseCatalogApiClient')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     @mock.patch('enterprise.views.reverse')
@@ -547,6 +550,7 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
             reverse_mock,
             course_catalog_api_client_mock,
             enterprise_catalog_api_client_mock,
+            mock_get_course_mode,
             mock_enrollment_api_client,
             *args
     ):  # pylint: disable=unused-argument,invalid-name
@@ -586,7 +590,7 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
 
         reverse_mock.return_value = '/dashboard'
         course_mode = 'verified'
-        mock_enrollment_api_client.return_value.get_course_modes.return_value = [{'slug': course_mode}]
+        mock_get_course_mode.return_value = course_mode
         post_data = {
             'enterprise_customer_uuid': enterprise_customer.uuid,
             'course_id': course_id,


### PR DESCRIPTION
fetch the course modes instead and select the best fitting.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
