### PR TITLE
fix: Adds the catalog admin role to roles_api.roles_by_name().

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,13 @@ Change Log
 Unreleased
 ----------
 
+* Nothing.
+
+[3.18.3]
+--------
+
+* Adds the catalog admin role to ``roles_api.roles_by_name()``.
+
 [3.18.2]
 --------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,5 +2,5 @@
 Your project description goes here.
 """
 
-__version__ = "3.18.2"
+__version__ = "3.18.3"
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/roles_api.py
+++ b/enterprise/roles_api.py
@@ -3,7 +3,12 @@ Python API for doing CRUD operations on roles and user role assignments.
 """
 from cache_memoize import cache_memoize
 
-from enterprise.constants import ENTERPRISE_ADMIN_ROLE, ENTERPRISE_LEARNER_ROLE, ENTERPRISE_OPERATOR_ROLE
+from enterprise.constants import (
+    ENTERPRISE_ADMIN_ROLE,
+    ENTERPRISE_LEARNER_ROLE,
+    ENTERPRISE_OPERATOR_ROLE,
+    SYSTEM_ENTERPRISE_CATALOG_ADMIN_ROLE,
+)
 from enterprise.models import SystemWideEnterpriseRole, SystemWideEnterpriseUserRoleAssignment
 
 
@@ -36,6 +41,11 @@ def openedx_operator_role():
     return get_or_create_system_wide_role(ENTERPRISE_OPERATOR_ROLE)
 
 
+def catalog_admin_role():
+    """ Returns the enterprise catalog admin role. """
+    return get_or_create_system_wide_role(SYSTEM_ENTERPRISE_CATALOG_ADMIN_ROLE)
+
+
 def roles_by_name():
     """
     Returns a mapping of system wide roles by name.
@@ -44,6 +54,7 @@ def roles_by_name():
         ENTERPRISE_ADMIN_ROLE: admin_role(),
         ENTERPRISE_LEARNER_ROLE: learner_role(),
         ENTERPRISE_OPERATOR_ROLE: openedx_operator_role(),
+        SYSTEM_ENTERPRISE_CATALOG_ADMIN_ROLE: catalog_admin_role(),
     }
 
 

--- a/tests/test_roles_api.py
+++ b/tests/test_roles_api.py
@@ -1,0 +1,41 @@
+"""
+Tests for the `roles_api` module.
+"""
+from django.test import TestCase
+
+from enterprise import roles_api
+from enterprise.constants import (
+    ENTERPRISE_ADMIN_ROLE,
+    ENTERPRISE_LEARNER_ROLE,
+    ENTERPRISE_OPERATOR_ROLE,
+    SYSTEM_ENTERPRISE_CATALOG_ADMIN_ROLE,
+)
+from enterprise.models import SystemWideEnterpriseRole
+
+
+class TestUpdateRoleAssignmentsCommand(TestCase):
+    """
+    Tests the roles_api functions.
+    """
+    ALL_ROLE_NAMES = (
+        ENTERPRISE_ADMIN_ROLE,
+        ENTERPRISE_LEARNER_ROLE,
+        ENTERPRISE_OPERATOR_ROLE,
+        SYSTEM_ENTERPRISE_CATALOG_ADMIN_ROLE,
+    )
+
+    def setUp(self):
+        """ Creates role objects for each system role specified in constants."""
+        super().setUp()
+        for role_name in self.ALL_ROLE_NAMES:
+            SystemWideEnterpriseRole.objects.get_or_create(name=role_name)
+
+    def tearDown(self):
+        """ Delete any existing role objects."""
+        super().tearDown()
+        SystemWideEnterpriseRole.objects.all().delete()
+
+    def test_roles_by_name(self):
+        for role_name in self.ALL_ROLE_NAMES:
+            role_object = roles_api.roles_by_name().get(role_name)
+            self.assertEqual(role_name, role_object.name)


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
