### PR TITLE
fix: Don't try to delete "open" assignments just yet

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,14 @@ Unreleased
 
 * Nothing.
 
+[3.18.4]
+--------
+
+* fix: The update_role_assignments_with_customers command no longer deletes open assignments.  Allowing it to do so
+  left us prone to error when an explicit enterprise_customer_uuid arg is provided.  We should modify this command
+  in the future to perform deletions of open assignments as its only action, and it should only be invoked this way
+  after we have verified that all backfilled enterprise_customer fields on the assignments have been set correctly.
+
 [3.18.3]
 --------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,5 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.18.3"
+__version__ = "3.18.4"
+
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -1608,7 +1608,7 @@ class TestUpdateRoleAssignmentsCommand(unittest.TestCase):
                 role=role,
             ).save()
             # create a potentially extra open role assignment, so we
-            # can test that extras are deleted after running the command.
+            # can test that extras are not deleted after running the command.
             factories.SystemWideEnterpriseUserRoleAssignment(
                 user=linked_user,
                 role=role,
@@ -1658,13 +1658,13 @@ class TestUpdateRoleAssignmentsCommand(unittest.TestCase):
                 **assignment_kwargs,
             ).count() == 1
 
-        # assert that there are no other learner assignments
         queryset = SystemWideEnterpriseUserRoleAssignment.objects.filter(
             role=roles_api.learner_role()
         )
         if expected_customer:
             queryset = queryset.filter(enterprise_customer=expected_customer)
-        assert len(expected_user_customer_assignments) == queryset.count()
+        # There might be extra open assignments, which is ok.
+        assert len(expected_user_customer_assignments) <= queryset.count()
 
     def _admin_assertions(self, expected_customer=None):
         """ Helper to assert that expected enterprise admins are assigned to expected customers. """
@@ -1692,13 +1692,13 @@ class TestUpdateRoleAssignmentsCommand(unittest.TestCase):
                 **assignment_kwargs,
             ).count() == 1
 
-        # assert that there are no other admin assignments
         queryset = SystemWideEnterpriseUserRoleAssignment.objects.filter(
             role=roles_api.admin_role()
         )
         if expected_customer:
             queryset = queryset.filter(enterprise_customer=expected_customer)
-        assert len(expected_user_customer_assignments) == queryset.count()
+        # there might be extra open assignments, which is ok
+        assert len(expected_user_customer_assignments) <= queryset.count()
 
     def _operator_assertions(self):
         """ Helper to assert that expected enterprise operators have `applies_to_all_contexts=True`. """


### PR DESCRIPTION
The update_role_assignments_with_customers command no longer deletes open assignments.  Allowing it to do so
left us prone to error when an explicit enterprise_customer_uuid arg is provided.  We should modify this command
in the future to perform deletions of open assignments as its only action, and it should only be invoked this way
after we have verified that all backfilled enterprise_customer fields on the assignments have been set correctly.
ENT-4099.

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [x] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
