### PR TITLE
fix: ENT-3954 filter out unpublished courses from enrollment

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,10 @@ Unreleased
 
 * Nothing.
 
+[3.18.5]
+--------
+* fix: do not include unpublished courses when enrollment link resolves course_runs
+
 [3.18.4]
 --------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.18.4"
+__version__ = "3.18.5"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -1047,8 +1047,9 @@ def get_current_course_run(course, users_active_course_runs):
                 filtered_course_runs.append(course_run)
 
         if not filtered_course_runs:
-            # Consider all runs if there were not any enrollable/upgradeable ones.
-            filtered_course_runs = all_course_runs
+            # Consider all published runs if there were not any enrollable/upgradeable ones.
+            filtered_course_runs = [course_run for course_run in all_course_runs
+                                    if course_run['status'] == 'published']
 
         if filtered_course_runs:
             current_course_runs = [

--- a/test_utils/fake_catalog_api.py
+++ b/test_utils/fake_catalog_api.py
@@ -1283,7 +1283,8 @@ def create_course_run_dict(start="2014-10-14T13:11:03Z", end="3000-10-13T13:11:0
                            enrollment_start="2014-10-13T13:11:03Z",
                            enrollment_end="2999-10-13T13:11:04Z",
                            upgrade_deadline="3000-10-13T13:11:04Z",
-                           availability='Starting Soon',
+                           availability="Starting Soon",
+                           status="published",
                            weeks_to_complete=1):
     """
     Return enrollable and upgradeable course run dict.
@@ -1291,6 +1292,7 @@ def create_course_run_dict(start="2014-10-14T13:11:03Z", end="3000-10-13T13:11:0
     return {
         "start": start,
         "end": end,
+        "status": status,
         "enrollment_start": enrollment_start,
         "enrollment_end": enrollment_end,
         "seats": [{"type": "verified", "upgrade_deadline": upgrade_deadline}],

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1541,6 +1541,36 @@ class TestEnterpriseUtils(unittest.TestCase):
 
     @ddt.data(
         (
+            # Test with two Current runs, but one not published. Should choose published one.
+            {
+                "course_runs": [
+                    fake_catalog_api.create_course_run_dict(
+                        availability="Current",
+                        start="2015-10-15T13:11:03Z",
+                        status="unpublished",
+                        end="2014-10-15T13:11:03Z",
+                        enrollment_start=None,
+                        enrollment_end=None,
+                    ),
+                    fake_catalog_api.create_course_run_dict(
+                        availability="Current",
+                        start="2015-10-15T13:11:03Z",
+                        end="2015-10-15T13:11:03Z",
+                        enrollment_start=None,
+                        enrollment_end=None,
+                    ),
+                ],
+            },
+            [],
+            fake_catalog_api.create_course_run_dict(
+                availability="Current",
+                start="2015-10-15T13:11:03Z",
+                end="2015-10-15T13:11:03Z",
+                enrollment_start=None,
+                enrollment_end=None,
+            ),
+        ),
+        (
             # Test with two enrollable/upgradeable course runs.
             {
                 "course_runs": [


### PR DESCRIPTION
With current logic, even unpublished courses are considered when deciding which course run a course should resolve to, when a user hits the enrollment landing page. This change takes out the unpublished (or more accurately course_runs with status != 'published' ) from consideration

There are no known use cases when unpublished courses should be considered for this page. See: https://edx-internal.slack.com/archives/CDXAQ8G02/p1615818761060100

This is expected to fix course `course-v1:NYIF+CR.3x+2T2020`

There are two other courses mentioned in the ticket, which may or may not be handled by this fix. But I would love to verify from stage/prod before making any more changes.

Also this causes older course runs like the one reported in the ticket to be picked up which may not even have content metadata and can lead to bad user experience.

With this change, if a user with no enrollments visits the page they should now be led to the more recent published course.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
