### PR TITLE
fix: The update_role_assignments_with_customers command no longer updates records

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,12 @@ Unreleased
 
 * Nothing.
 
+[3.18.6]
+--------
+
+* fix: The update_role_assignments_with_customers command no longer updates records.  It only creates
+  new records, which helps de-risk the operation.
+
 [3.18.5]
 --------
 * fix: do not include unpublished courses when enrollment link resolves course_runs

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.18.5"
+__version__ = "3.18.6"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -1659,12 +1659,13 @@ class TestUpdateRoleAssignmentsCommand(unittest.TestCase):
             ).count() == 1
 
         queryset = SystemWideEnterpriseUserRoleAssignment.objects.filter(
-            role=roles_api.learner_role()
+            role=roles_api.learner_role(),
+        ).exclude(
+            enterprise_customer__isnull=True
         )
         if expected_customer:
             queryset = queryset.filter(enterprise_customer=expected_customer)
-        # There might be extra open assignments, which is ok.
-        assert len(expected_user_customer_assignments) <= queryset.count()
+        assert len(expected_user_customer_assignments) == queryset.count()
 
     def _admin_assertions(self, expected_customer=None):
         """ Helper to assert that expected enterprise admins are assigned to expected customers. """
@@ -1694,10 +1695,11 @@ class TestUpdateRoleAssignmentsCommand(unittest.TestCase):
 
         queryset = SystemWideEnterpriseUserRoleAssignment.objects.filter(
             role=roles_api.admin_role()
+        ).exclude(
+            enterprise_customer__isnull=True
         )
         if expected_customer:
             queryset = queryset.filter(enterprise_customer=expected_customer)
-        # there might be extra open assignments, which is ok
         assert len(expected_user_customer_assignments) <= queryset.count()
 
     def _operator_assertions(self):


### PR DESCRIPTION
It only creates new records, which helps de-risk the operation.

See updates AC in https://openedx.atlassian.net/browse/ENT-4099 for explanation of future steps.
