### PR TITLE
Add support for creating multiple pending users

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,11 @@ Unreleased
 
 * Nothing.
 
+[3.19.0]
+--------
+
+* feat: add support for creating multiple pending enterprise users
+
 [3.18.7]
 --------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.18.7"
+__version__ = "3.19.0"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -400,7 +400,7 @@ class EnterpriseCustomerUserWriteSerializer(serializers.ModelSerializer):
             error_message = ('[Enterprise API] Saving to EnterpriseCustomerUser failed'
                              ' due to non-existing user. User: {}').format(value)
             LOGGER.error(error_message)
-            raise serializers.ValidationError(self.USER_DOES_NOT_EXIST)
+            raise serializers.ValidationError(self.USER_DOES_NOT_EXIST) from None
 
         return value
 

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -433,46 +433,34 @@ class PendingEnterpriseCustomerUserSerializer(serializers.ModelSerializer):
             'enterprise_customer', 'user_email'
         )
 
-    def validate(self, attrs):
-        """
-        Validate if the EnterpriseCustomerUser record already exists.
-        """
-        enterprise_customer = attrs.get('enterprise_customer')
-        user_email = attrs.get('user_email')
-        try:
-            user = User.objects.get(email=user_email)
-            models.EnterpriseCustomerUser.objects.get(
-                user_id=user.pk,
-                enterprise_customer=enterprise_customer
-            )
-        except (User.DoesNotExist, models.EnterpriseCustomerUser.DoesNotExist):
-            pass
-        else:
-            raise serializers.ValidationError('EnterpriseCustomerUser record already exists')
+    def to_representation(self, instance):
+        '''
+        Because we are returning whether or not the instance was created from the create method, we must use the
+        instance for to_representation and ignore the "created" half of the tuple
+        '''
+        return super().to_representation(instance[0])
 
-        return attrs
-
-    def save(self):  # pylint: disable=arguments-differ
+    def create(self, attrs):  # pylint: disable=arguments-differ
         """
-        Save the PendingEnterpriseCustomerUser, or EnterpriseCustomerUser
+        Create the PendingEnterpriseCustomerUser, or EnterpriseCustomerUser
         if a user with the validated_email already exists.
         """
-        enterprise_customer = self.validated_data['enterprise_customer']
-        user_email = self.validated_data['user_email']
+        enterprise_customer = attrs['enterprise_customer']
+        user_email = attrs['user_email']
         try:
             user = User.objects.get(email=user_email)
             defaults = {'active': user.is_active}
-            __, created = models.EnterpriseCustomerUser.objects.update_or_create(
+            new_user, created = models.EnterpriseCustomerUser.objects.update_or_create(
                 user_id=user.pk,
                 enterprise_customer=enterprise_customer,
                 defaults=defaults,
             )
         except User.DoesNotExist:
-            __, created = models.PendingEnterpriseCustomerUser.objects.update_or_create(
+            new_user, created = models.PendingEnterpriseCustomerUser.objects.update_or_create(
                 user_email=user_email,
                 enterprise_customer=enterprise_customer,
             )
-        return created
+        return new_user, created
 
 
 class CourseDetailSerializer(ImmutableStateSerializer):

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -378,6 +378,7 @@ class EnterpriseCustomerUserWriteSerializer(serializers.ModelSerializer):
     """
     Serializer for writing to the EnterpriseCustomerUser model.
     """
+    USER_DOES_NOT_EXIST = "User does not exist"
 
     class Meta:
         model = models.EnterpriseCustomerUser
@@ -395,11 +396,11 @@ class EnterpriseCustomerUserWriteSerializer(serializers.ModelSerializer):
         """
         try:
             self.user = User.objects.get(username=value)
-        except User.DoesNotExist as no_user_error:
+        except User.DoesNotExist:
             error_message = ('[Enterprise API] Saving to EnterpriseCustomerUser failed'
                              ' due to non-existing user. User: {}').format(value)
             LOGGER.error(error_message)
-            raise serializers.ValidationError("User does not exist") from no_user_error
+            raise serializers.ValidationError(self.USER_DOES_NOT_EXIST)
 
         return value
 

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -853,7 +853,7 @@ class PendingEnterpriseCustomerUserViewSet(BasePendingEnterpriseCustomerViewSet)
         return return_status
 
     def create(self, request, *args, **kwargs):
-        serializer = self.get_serializer(data=request.data)
+        serializer = self.get_serializer(data=request.data, many=isinstance(request.data,list))
         return_status = self._get_return_status(serializer)
         headers = self.get_success_headers(serializer.data)
         return Response(serializer.data, status=return_status, headers=headers)

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -817,8 +817,8 @@ class PendingEnterpriseCustomerUserViewSet(EnterpriseReadWriteModelViewSet):
     permission_classes = (permissions.IsAuthenticated, permissions.IsAdminUser)
 
     FIELDS = (
-          'enterprise_customer', 'user_email',
-      )
+        'enterprise_customer', 'user_email',
+    )
     filterset_fields = FIELDS
     ordering_fields = FIELDS
 
@@ -843,8 +843,8 @@ class PendingEnterpriseCustomerUserViewSet(EnterpriseReadWriteModelViewSet):
         return status.HTTP_204_NO_CONTENT
 
     def create(self, request, *args, **kwargs):
-        serializer = self.get_serializer(data=request.data, many=isinstance(request.data,list))
-        return_status = self._get_return_status(serializer, many=isinstance(request.data,list))
+        serializer = self.get_serializer(data=request.data, many=isinstance(request.data, list))
+        return_status = self._get_return_status(serializer, many=isinstance(request.data, list))
         headers = self.get_success_headers(serializer.data)
         return Response(serializer.data, status=return_status, headers=headers)
 

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -807,7 +807,10 @@ class EnterpriseCustomerUserViewSet(EnterpriseReadWriteModelViewSet):
         return serializers.EnterpriseCustomerUserWriteSerializer
 
 
-class BasePendingEnterpriseCustomerViewSet(EnterpriseReadWriteModelViewSet):
+class PendingEnterpriseCustomerUserViewSet(EnterpriseReadWriteModelViewSet):
+    """
+    API views for the ``pending-enterprise-learner`` API endpoint.
+    """
     queryset = models.PendingEnterpriseCustomerUser.objects.all()
     filter_backends = (filters.OrderingFilter, DjangoFilterBackend)
     serializer_class = serializers.PendingEnterpriseCustomerUserSerializer
@@ -822,12 +825,6 @@ class BasePendingEnterpriseCustomerViewSet(EnterpriseReadWriteModelViewSet):
     UNIQUE = 'unique'
     USER_EXISTS_ERROR = 'EnterpriseCustomerUser record already exists'
 
-
-class PendingEnterpriseCustomerUserViewSet(BasePendingEnterpriseCustomerViewSet):
-    """
-    API views for the ``pending-enterprise-learner`` API endpoint.
-    """
-
     def _get_return_status(self, serializer, many):
         """
         Run serializer validation and get return status
@@ -841,8 +838,8 @@ class PendingEnterpriseCustomerUserViewSet(BasePendingEnterpriseCustomerViewSet)
 
         data_list = serializer.save()
         for _, created in data_list:
-          if created:
-            return status.HTTP_201_CREATED
+            if created:
+                return status.HTTP_201_CREATED
         return status.HTTP_204_NO_CONTENT
 
     def create(self, request, *args, **kwargs):

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -243,6 +243,7 @@ class BaseTestEnterpriseAPIViews(APITest):
 
         return enterprise_customer_user, enterprise_course_enrollment, licensed_course_enrollment
 
+
 @ddt.ddt
 @mark.django_db
 class TestCourseEnrollmentView(BaseTestEnterpriseAPIViews):
@@ -419,6 +420,7 @@ class TestCourseEnrollmentView(BaseTestEnterpriseAPIViews):
         else:
             mock_track_enrollment.assert_not_called()
 
+
 @ddt.ddt
 @mark.django_db
 class TestEnterpriseCustomerUser(BaseTestEnterpriseAPIViews):
@@ -530,6 +532,7 @@ class TestEnterpriseCustomerUser(BaseTestEnterpriseAPIViews):
         response = self.client.post(settings.TEST_SERVER + ENTERPRISE_LEARNER_LIST_ENDPOINT, data=data)
         assert response.status_code == 401
 
+
 @ddt.ddt
 @mark.django_db
 class TestPendingEnterpriseCustomerUser(BaseTestEnterpriseAPIViews):
@@ -585,7 +588,6 @@ class TestPendingEnterpriseCustomerUser(BaseTestEnterpriseAPIViews):
         # Create fake enterprise
         enterprise_customer = factories.EnterpriseCustomerFactory(uuid=FAKE_UUIDS[0])
 
-
         new_user_email = 'newuser@example.com'
         # data to be passed to the request
         data = {
@@ -638,7 +640,6 @@ class TestPendingEnterpriseCustomerUser(BaseTestEnterpriseAPIViews):
         # Create fake enterprise
         enterprise_customer = factories.EnterpriseCustomerFactory(uuid=FAKE_UUIDS[0])
 
-
         new_user_email = 'newuser@example.com'
         # data to be passed to the request
         data = {
@@ -663,7 +664,8 @@ class TestPendingEnterpriseCustomerUser(BaseTestEnterpriseAPIViews):
         {'is_staff': False, 'user_exists': False, 'ecu_exists': False, 'pending_ecu_exists': False, 'status_code': 403},
     )
     @ddt.unpack
-    def test_post_pending_enterprise_customer_unauthorized_user(self,
+    def test_post_pending_enterprise_customer_unauthorized_user(
+        self,
         is_staff,
         user_exists,
         ecu_exists,
@@ -695,18 +697,17 @@ class TestPendingEnterpriseCustomerUser(BaseTestEnterpriseAPIViews):
         response = self.client.post(settings.TEST_SERVER + PENDING_ENTERPRISE_LEARNER_LIST_ENDPOINT, data=data)
         assert response.status_code == status_code
 
-
     @ddt.data(
-      ([{ 'user_exists': True, 'ecu_exists': False, 'pending_ecu_exists': True },
-        { 'user_exists': False, 'ecu_exists': False, 'pending_ecu_exists': False },
-        { 'user_exists': True, 'ecu_exists': False, 'pending_ecu_exists': False },
-        { 'user_exists': True, 'ecu_exists': True, 'pending_ecu_exists': False },
-        { 'user_exists': False, 'ecu_exists': False, 'pending_ecu_exists': True }], 201),
-      ([{ 'user_exists': True, 'ecu_exists': False, 'pending_ecu_exists': True },
-        { 'user_exists': False, 'ecu_exists': False, 'pending_ecu_exists': False },
-        { 'user_exists': True, 'ecu_exists': False, 'pending_ecu_exists': False }], 201 ),
-      ([{ 'user_exists': True, 'ecu_exists': True, 'pending_ecu_exists': False },
-        { 'user_exists': False, 'ecu_exists': False, 'pending_ecu_exists': True }], 204)
+        ([{'user_exists': True, 'ecu_exists': False, 'pending_ecu_exists': True},
+          {'user_exists': False, 'ecu_exists': False, 'pending_ecu_exists': False},
+          {'user_exists': True, 'ecu_exists': False, 'pending_ecu_exists': False},
+          {'user_exists': True, 'ecu_exists': True, 'pending_ecu_exists': False},
+          {'user_exists': False, 'ecu_exists': False, 'pending_ecu_exists': True}], 201),
+        ([{'user_exists': True, 'ecu_exists': False, 'pending_ecu_exists': True},
+          {'user_exists': False, 'ecu_exists': False, 'pending_ecu_exists': False},
+          {'user_exists': True, 'ecu_exists': False, 'pending_ecu_exists': False}], 201),
+        ([{'user_exists': True, 'ecu_exists': True, 'pending_ecu_exists': False},
+          {'user_exists': False, 'ecu_exists': False, 'pending_ecu_exists': True}], 204)
     )
     @ddt.unpack
     def test_post_pending_enterprise_customer_multiple_customers(self, userlist, status_code):
@@ -717,8 +718,8 @@ class TestPendingEnterpriseCustomerUser(BaseTestEnterpriseAPIViews):
         for idx, user in enumerate(userlist):
             user_email = 'new_user{}@example.com'.format(idx)
             data.append({
-              'enterprise_customer': FAKE_UUIDS[0],
-              'user_email': user_email
+                'enterprise_customer': FAKE_UUIDS[0],
+                'user_email': user_email
             })
 
             existing_user = self.create_ent_user(
@@ -729,9 +730,9 @@ class TestPendingEnterpriseCustomerUser(BaseTestEnterpriseAPIViews):
                 enterprise_customer=enterprise_customer,
             )
             users.append({
-              'user_exists': user['user_exists'],
-              'user_email': user_email,
-              'existing_user': existing_user
+                'user_exists': user['user_exists'],
+                'user_email': user_email,
+                'existing_user': existing_user
             })
 
         response = self.client.post(
@@ -764,6 +765,7 @@ class TestPendingEnterpriseCustomerUser(BaseTestEnterpriseAPIViews):
         }
         response = self.client.post(settings.TEST_SERVER + PENDING_ENTERPRISE_LEARNER_LIST_ENDPOINT, data=data)
         assert response.status_code == 401
+
 
 @ddt.ddt
 @mark.django_db
@@ -1130,6 +1132,7 @@ class TestEnterpriseCustomerListViews(BaseTestEnterpriseAPIViews):
         response = self.client.get(settings.TEST_SERVER + ENTERPRISE_CUSTOMER_BRANDING_DETAIL_ENDPOINT)
         response = self.load_json(response.content)
         assert expected_item == response
+
 
 @ddt.ddt
 @mark.django_db
@@ -1797,6 +1800,7 @@ class TestEntepriseCustomerCatalogs(BaseTestEnterpriseAPIViews):
         assert 'course_run_ids' in message
         assert response.status_code == 400
 
+
 @ddt.ddt
 @mark.django_db
 class TestEnterpriesCustomerCourseEnrollments(BaseTestEnterpriseAPIViews):
@@ -2345,6 +2349,7 @@ class TestEnterpriesCustomerCourseEnrollments(BaseTestEnterpriseAPIViews):
         response_xml = self.client.get('/enterprise/api/v1/enterprise_catalogs.xml')
         self.assertEqual(response_xml['content-type'], 'application/xml; charset=utf-8')
 
+
 @ddt.ddt
 @mark.django_db
 class TestCatalogQueryView(BaseTestEnterpriseAPIViews):
@@ -2425,6 +2430,7 @@ class TestCatalogQueryView(BaseTestEnterpriseAPIViews):
         assert response.status_code == 403
         response = response.json()
         assert response['detail'] == 'Authentication credentials were not provided.'
+
 
 @ddt.ddt
 @mark.django_db
@@ -2588,6 +2594,7 @@ class TestRequestCodesEndpoint(BaseTestEnterpriseAPIViews):
         )
 
         assert response.status_code == expected_status
+
 
 @ddt.ddt
 @mark.django_db
@@ -2871,6 +2878,7 @@ class TestLicensedEnterpriseCourseEnrollemntViewset(BaseTestEnterpriseAPIViews):
                 username=enterprise_customer_user.username,
                 course_id=enterprise_course_enrollment.course_id,
             )
+
 
 @ddt.ddt
 @mark.django_db
@@ -3167,6 +3175,7 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
         self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
         self.assertEqual(response.json(), enrollment_response)
 
+
 @ddt.ddt
 @mark.django_db
 class TestExpiredLicenseCourseEnrollment(BaseTestEnterpriseAPIViews):
@@ -3257,6 +3266,7 @@ class TestExpiredLicenseCourseEnrollment(BaseTestEnterpriseAPIViews):
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
+
 
 @ddt.ddt
 @mark.django_db


### PR DESCRIPTION
This PR also re-organizes tests; it may be best to review it commit by commit.
Much of the "new" code in the test file may just be code that is has been moved; please focus on the PendingEnterpriseCustomerUser stuff.

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [x] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
