### PR TITLE
Add new endpoint for ent admins to link learners

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,10 @@ Unreleased
 
 * Nothing.
 
+[3.20.0]
+--------
+* feat: add support for enterprise admins to create pending enterprise users
+
 [3.19.0]
 --------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.19.0"
+__version__ = "3.20.0"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -468,14 +468,17 @@ class LinkLearnersSerializer(PendingEnterpriseCustomerUserSerializer):
     Extends the PendingEnterpriseCustomerSerializer to validate that the enterprise customer uuid
     matches the uuid the user has permissions to update
     """
+    NOT_AUTHORIZED_ERROR = 'Not authorized for this enterprise'
 
-    def validate_enterprise_customer(self, data):
+    def validate_enterprise_customer(self, value):
         """
         Check that the enterprise customer is the same as the one the user has permissions for
+        The value recieved is an EnterpriseCustomer object
         """
-        if data['enterprise_customer'] != self.context.get('enterprise__uuid'):
-            raise serializers.ValidationError('Not authorized for this enterprise')
-        return data
+
+        if str(value.uuid) != self.context.get('enterprise_customer__uuid'):
+            raise serializers.ValidationError(self.NOT_AUTHORIZED_ERROR)
+        return value
 
 
 class CourseDetailSerializer(ImmutableStateSerializer):

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -463,6 +463,21 @@ class PendingEnterpriseCustomerUserSerializer(serializers.ModelSerializer):
         return new_user, created
 
 
+class LinkLearnersSerializer(PendingEnterpriseCustomerUserSerializer):
+    """
+    Extends the PendingEnterpriseCustomerSerializer to validate that the enterprise customer uuid
+    matches the uuid the user has permissions to update
+    """
+
+    def validate_enterprise_customer(self, data):
+        """
+        Check that the enterprise customer is the same as the one the user has permissions for
+        """
+        if data['enterprise_customer'] != self.context.get('enterprise__uuid'):
+            raise serializers.ValidationError('Not authorized for this enterprise')
+        return data
+
+
 class CourseDetailSerializer(ImmutableStateSerializer):
     """
     Serializer for course data retrieved from the discovery service course detail API endpoint.

--- a/enterprise/api/v1/urls.py
+++ b/enterprise/api/v1/urls.py
@@ -35,7 +35,7 @@ urlpatterns = [
     url(
         r'link_pending_enterprise_users/(?P<enterprise_uuid>[A-Za-z0-9-]+)/?$',
         views.PendingEnterpriseCustomerUserEnterpriseAdminViewSet.as_view({'post': 'link_learners'}),
-        name='link-pending-enteprise-learner'
+        name='link-pending-enterprise-learner'
     ),
     url(
         r'^enterprise_catalog_query/(?P<catalog_query_id>[\d]+)/$',

--- a/enterprise/api/v1/urls.py
+++ b/enterprise/api/v1/urls.py
@@ -33,6 +33,11 @@ router.register(
 
 urlpatterns = [
     url(
+        r'link_pending_enterprise_users/(?P<enterprise_uuid>[A-Za-z0-9-]+)/?$',
+        views.PendingEnterpriseCustomerUserEnterpriseAdminViewSet.as_view({'post': 'link_learners'}),
+        name='link-pending-enteprise-learner'
+    ),
+    url(
         r'^enterprise_catalog_query/(?P<catalog_query_id>[\d]+)/$',
         views.CatalogQueryView.as_view(),
         name='enterprise-catalog-query'
@@ -44,7 +49,7 @@ urlpatterns = [
     ),
     url(
         r'^tableau_token$',
-        views.TableauAuthViewSet.as_view(),
+        views.TableauAuthView.as_view(),
         name='tableau-token'
     ),
 ]

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -845,8 +845,8 @@ class PendingEnterpriseCustomerUserViewSet(EnterpriseReadWriteModelViewSet):
 
     def create(self, request, *args, **kwargs):
         """
-        If a Django user exists, but the correspinding EnterpriseUser does not, creates a PendingEnterpriseUser for
-        the email in question.
+        Creates a PendingEnterpriseCustomerUser if no EnterpriseCustomerUser for the given (customer, email)
+        combination(s) exists.
         Can accept one user or a list of users.
 
         Returns 201 if any users were created, 204 if no users were created.
@@ -864,19 +864,19 @@ class PendingEnterpriseCustomerUserEnterpriseAdminViewSet(PendingEnterpriseCusto
     Admin must be an administrator for the enterprise in question
     """
     permission_classes = (permissions.IsAuthenticated,)
-    serializer = serializers.LinkLearnersSerializer
+    serializer_class = serializers.LinkLearnersSerializer
 
     @action(methods=['post'], detail=False)
     @permission_required('enterprise.can_access_admin_dashboard', fn=lambda request, enterprise_uuid: enterprise_uuid)
     def link_learners(self, request, enterprise_uuid):
         """
-        If a Django user exists, but the correspinding EnterpriseUser does not, creates a PendingEnterpriseUser for
-        the email in question.
+        Creates a PendingEnterpriseCustomerUser if no EnterpriseCustomerUser for the given (customer, email)
+        combination(s) exists.
         Can accept one user or a list of users.
 
         Returns 201 if any users were created, 204 if no users were created.
         """
-        context = {'enterprise_uuid': enterprise_uuid}
+        context = {'enterprise_customer__uuid': enterprise_uuid}
         serializer = self.get_serializer(
             data=request.data,
             many=isinstance(request.data, list),

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -876,7 +876,7 @@ class PendingEnterpriseCustomerUserEnterpriseAdminViewSet(PendingEnterpriseCusto
 
         Returns 201 if any users were created, 204 if no users were created.
         """
-        context = { 'enterprise_uuid': enterprise_uuid }
+        context = {'enterprise_uuid': enterprise_uuid}
         serializer = self.get_serializer(
             data=request.data,
             many=isinstance(request.data, list),

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -810,6 +810,7 @@ class EnterpriseCustomerUserViewSet(EnterpriseReadWriteModelViewSet):
 class PendingEnterpriseCustomerUserViewSet(EnterpriseReadWriteModelViewSet):
     """
     API views for the ``pending-enterprise-learner`` API endpoint.
+    Requires staff permissions
     """
     queryset = models.PendingEnterpriseCustomerUser.objects.all()
     filter_backends = (filters.OrderingFilter, DjangoFilterBackend)
@@ -843,7 +844,44 @@ class PendingEnterpriseCustomerUserViewSet(EnterpriseReadWriteModelViewSet):
         return status.HTTP_204_NO_CONTENT
 
     def create(self, request, *args, **kwargs):
+        """
+        If a Django user exists, but the correspinding EnterpriseUser does not, creates a PendingEnterpriseUser for
+        the email in question.
+        Can accept one user or a list of users.
+
+        Returns 201 if any users were created, 204 if no users were created.
+        """
         serializer = self.get_serializer(data=request.data, many=isinstance(request.data, list))
+        return_status = self._get_return_status(serializer, many=isinstance(request.data, list))
+        headers = self.get_success_headers(serializer.data)
+        return Response(serializer.data, status=return_status, headers=headers)
+
+
+class PendingEnterpriseCustomerUserEnterpriseAdminViewSet(PendingEnterpriseCustomerUserViewSet):
+    """
+    Viewset for allowing enterpise admins to create linked learners
+    Endpoint url: link_pending_enterprise_users/(?P<enterprise_uuid>[A-Za-z0-9-]+)/?$
+    Admin must be an administrator for the enterprise in question
+    """
+    permission_classes = (permissions.IsAuthenticated,)
+    serializer = serializers.LinkLearnersSerializer
+
+    @action(methods=['post'], detail=False)
+    @permission_required('enterprise.can_access_admin_dashboard', fn=lambda request, enterprise_uuid: enterprise_uuid)
+    def link_learners(self, request, enterprise_uuid):
+        """
+        If a Django user exists, but the correspinding EnterpriseUser does not, creates a PendingEnterpriseUser for
+        the email in question.
+        Can accept one user or a list of users.
+
+        Returns 201 if any users were created, 204 if no users were created.
+        """
+        context = { 'enterprise_uuid': enterprise_uuid }
+        serializer = self.get_serializer(
+            data=request.data,
+            many=isinstance(request.data, list),
+            context=context,
+        )
         return_status = self._get_return_status(serializer, many=isinstance(request.data, list))
         headers = self.get_success_headers(serializer.data)
         return Response(serializer.data, status=return_status, headers=headers)
@@ -1203,7 +1241,7 @@ class CouponCodesView(APIView):
             )
 
 
-class TableauAuthViewSet(generics.GenericAPIView):
+class TableauAuthView(generics.GenericAPIView):
     """
     API to authenticate user with Tableau.
     """

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -1059,7 +1059,6 @@ class TestPendingEnterpriseCustomerUserEnterpriseAdminViewSet(BaseTestEnterprise
             user_email=new_user_email, enterprise_customer=enterprise_customer
         ).count() == 0
 
-
     def test_post_pending_enterprise_customer_user_logged_out(self):
         """
         Make sure users can't post PendingEnterpriseCustomerUsers when logged out.

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -8,6 +8,7 @@ import json
 import uuid
 from operator import itemgetter
 from smtplib import SMTPException
+from faker import Faker
 
 import ddt
 import mock
@@ -66,6 +67,7 @@ from test_utils import (
 )
 from test_utils.factories import FAKER
 from test_utils.fake_enterprise_api import get_default_branding_object
+fake = Faker()
 
 ENTERPRISE_CATALOGS_LIST_ENDPOINT = reverse('enterprise-catalogs-list')
 ENTERPRISE_CATALOGS_DETAIL_ENDPOINT = reverse(
@@ -586,12 +588,13 @@ class TestPendingEnterpriseCustomerUser(BaseTestEnterpriseAPIViews):
         self.setup_admin_user(is_staff)
 
         # Create fake enterprise
-        enterprise_customer = factories.EnterpriseCustomerFactory(uuid=FAKE_UUIDS[0])
+        ent_uuid = fake.uuid4()
+        enterprise_customer = factories.EnterpriseCustomerFactory(uuid=ent_uuid)
 
         new_user_email = 'newuser@example.com'
         # data to be passed to the request
         data = {
-            'enterprise_customer': FAKE_UUIDS[0],
+            'enterprise_customer': ent_uuid,
             'user_email': new_user_email,
         }
 
@@ -638,12 +641,13 @@ class TestPendingEnterpriseCustomerUser(BaseTestEnterpriseAPIViews):
         self.setup_admin_user(is_staff)
 
         # Create fake enterprise
-        enterprise_customer = factories.EnterpriseCustomerFactory(uuid=FAKE_UUIDS[0])
+        ent_uuid = fake.uuid4()
+        enterprise_customer = factories.EnterpriseCustomerFactory(uuid=ent_uuid)
 
         new_user_email = 'newuser@example.com'
         # data to be passed to the request
         data = {
-            'enterprise_customer': FAKE_UUIDS[0],
+            'enterprise_customer': ent_uuid,
             'user_email': new_user_email,
         }
 
@@ -676,12 +680,13 @@ class TestPendingEnterpriseCustomerUser(BaseTestEnterpriseAPIViews):
         self.setup_admin_user(is_staff)
 
         # create fake enterprise
-        enterprise_customer = factories.EnterpriseCustomerFactory(uuid=FAKE_UUIDS[0])
+        ent_uuid = fake.uuid4()
+        enterprise_customer = factories.EnterpriseCustomerFactory(uuid=ent_uuid)
 
         new_user_email = 'newuser@example.com'
         # data to be passed to the request
         data = {
-            'enterprise_customer': FAKE_UUIDS[0],
+            'enterprise_customer': ent_uuid,
             'user_email': new_user_email,
         }
 
@@ -712,13 +717,15 @@ class TestPendingEnterpriseCustomerUser(BaseTestEnterpriseAPIViews):
     @ddt.unpack
     def test_post_pending_enterprise_customer_multiple_customers(self, userlist, status_code):
         self.setup_admin_user()
-        enterprise_customer = factories.EnterpriseCustomerFactory(uuid=FAKE_UUIDS[0])
+        ent_uuid = fake.uuid4()
+
+        enterprise_customer = factories.EnterpriseCustomerFactory(uuid=ent_uuid)
         data = []
         users = []
         for idx, user in enumerate(userlist):
             user_email = 'new_user{}@example.com'.format(idx)
             data.append({
-                'enterprise_customer': FAKE_UUIDS[0],
+                'enterprise_customer': ent_uuid,
                 'user_email': user_email
             })
 
@@ -764,6 +771,309 @@ class TestPendingEnterpriseCustomerUser(BaseTestEnterpriseAPIViews):
             'username': self.user.username
         }
         response = self.client.post(settings.TEST_SERVER + PENDING_ENTERPRISE_LEARNER_LIST_ENDPOINT, data=data)
+        assert response.status_code == 401
+
+
+@ddt.ddt
+@mark.django_db
+class TestPendingEnterpriseCustomerUserEnterpriseAdminViewSet(BaseTestEnterpriseAPIViews):
+    """
+    Test PendingEnterpriseCustomerUserViewSet and LinkLearnersSerializer
+    """
+
+    def create_ent_user(self, user_exists, ecu_exists, pending_ecu_exists, user_email, enterprise_customer):
+        """
+        Creates enterprise users or pending users
+        """
+        user = None
+        if user_exists:
+            user = factories.UserFactory(email=user_email)
+            if ecu_exists:
+                factories.EnterpriseCustomerUserFactory(user_id=user.id, enterprise_customer=enterprise_customer)
+
+        if pending_ecu_exists:
+            factories.PendingEnterpriseCustomerUserFactory(
+                user_email=user_email, enterprise_customer=enterprise_customer
+            )
+        return user
+
+    def setup_admin_user(self):
+        """
+        Creates an admin user and logs them in
+        """
+        client_username = 'client_username'
+        self.client.logout()
+        self.create_user(username=client_username, password=TEST_PASSWORD)
+        self.client.login(username=client_username, password=TEST_PASSWORD)
+
+    @ddt.data(
+        {'user_exists': True, 'ecu_exists': False, 'pending_ecu_exists': True, 'status_code': 201},
+        {'user_exists': False, 'ecu_exists': False, 'pending_ecu_exists': False, 'status_code': 201},
+        {'user_exists': True, 'ecu_exists': False, 'pending_ecu_exists': False, 'status_code': 201},
+    )
+    @ddt.unpack
+    def test_post_pending_enterprise_customer_user_creation(
+            self,
+            user_exists,
+            ecu_exists,
+            pending_ecu_exists,
+            status_code):
+        """
+        Make sure service users can post new PendingEnterpriseCustomerUsers.
+        """
+
+        # create user making the request
+        self.setup_admin_user()
+
+        # Create fake enterprise
+        ent_uuid = fake.uuid4()
+        enterprise_customer = factories.EnterpriseCustomerFactory(uuid=ent_uuid)
+        # Fake enterprise admin permissions
+        self.set_jwt_cookie(ENTERPRISE_ADMIN_ROLE, ent_uuid)
+
+        new_user_email = 'newuser@example.com'
+        # data to be passed to the request
+        data = {
+            'enterprise_customer': ent_uuid,
+            'user_email': new_user_email,
+        }
+
+        # create preexisting user(s) as necessary
+        user = self.create_ent_user(
+            user_exists=user_exists,
+            ecu_exists=ecu_exists,
+            pending_ecu_exists=pending_ecu_exists,
+            user_email=new_user_email,
+            enterprise_customer=enterprise_customer,
+        )
+
+        response = self.client.post(
+            settings.TEST_SERVER + reverse('link-pending-enteprise-learner', kwargs={'enterprise_uuid': ent_uuid}),
+            data=data
+        )
+        assert response.status_code == status_code
+        response = self.load_json(response.content)
+        self.assertDictEqual(data, response)
+        if not user_exists:
+            assert PendingEnterpriseCustomerUser.objects.get(
+                user_email=new_user_email, enterprise_customer=enterprise_customer
+            )
+        else:
+            assert EnterpriseCustomerUser.objects.get(
+                user_id=user.id, enterprise_customer=enterprise_customer, active=user.is_active
+            )
+
+    @ddt.data(
+        {'user_exists': True, 'ecu_exists': True, 'pending_ecu_exists': False, 'status_code': 204},
+        {'user_exists': False, 'ecu_exists': False, 'pending_ecu_exists': True, 'status_code': 204},
+    )
+    @ddt.unpack
+    def test_post_pending_enterprise_customer_user_creation_no_user_created(
+        self,
+        user_exists,
+        ecu_exists,
+        pending_ecu_exists,
+        status_code
+    ):
+        """
+        Make sure service users can post new PendingEnterpriseCustomerUsers.
+        """
+
+        # create user making the request
+        self.setup_admin_user()
+
+        # Create fake enterprise
+        ent_uuid = fake.uuid4()
+        enterprise_customer = factories.EnterpriseCustomerFactory(uuid=ent_uuid)
+        # Fake enterprise admin permissions
+        self.set_jwt_cookie(ENTERPRISE_ADMIN_ROLE, ent_uuid)
+
+        new_user_email = 'newuser@example.com'
+        # data to be passed to the request
+        data = {
+            'enterprise_customer': ent_uuid,
+            'user_email': new_user_email,
+        }
+
+        # create preexisting user(s) as necessary
+        self.create_ent_user(
+            user_exists=user_exists,
+            ecu_exists=ecu_exists,
+            pending_ecu_exists=pending_ecu_exists,
+            user_email=new_user_email,
+            enterprise_customer=enterprise_customer,
+        )
+
+        response = self.client.post(
+            settings.TEST_SERVER + reverse('link-pending-enteprise-learner', kwargs={'enterprise_uuid': ent_uuid}),
+            data=data
+        )
+        assert response.status_code == status_code
+        assert not response.content
+
+    def test_post_pending_enterprise_customer_unauthorized_user(self):
+        # create user making the request
+        self.setup_admin_user()
+
+        # create fake enterprise
+        ent_uuid = fake.uuid4()
+        enterprise_customer = factories.EnterpriseCustomerFactory(uuid=ent_uuid)
+
+        new_user_email = 'newuser@example.com'
+        # data to be passed to the request
+        data = {
+            'enterprise_customer': ent_uuid,
+            'user_email': new_user_email,
+        }
+
+        # create preexisting user(s) as necessary
+        self.create_ent_user(
+            user_exists=False,
+            ecu_exists=False,
+            pending_ecu_exists=False,
+            user_email=new_user_email,
+            enterprise_customer=enterprise_customer,
+        )
+
+        response = self.client.post(
+            settings.TEST_SERVER + reverse('link-pending-enteprise-learner', kwargs={'enterprise_uuid': ent_uuid}),
+            data=data
+        )
+        assert response.status_code == 403
+
+    def test_post_pending_enterprise_customer_user_authorized_for_different_enterprise(self):
+        # create user making the request
+        self.setup_admin_user()
+
+        # create fake enterprise
+        ent_uuid = fake.uuid4()
+        enterprise_customer = factories.EnterpriseCustomerFactory(uuid=ent_uuid)
+        # Fake enterprise admin permissions for different enterprise
+        self.set_jwt_cookie(ENTERPRISE_ADMIN_ROLE, fake.uuid4())
+
+        new_user_email = 'newuser@example.com'
+        # data to be passed to the request
+        data = {
+            'enterprise_customer': ent_uuid,
+            'user_email': new_user_email,
+        }
+
+        # create preexisting user(s) as necessary
+        self.create_ent_user(
+            user_exists=False,
+            ecu_exists=False,
+            pending_ecu_exists=False,
+            user_email=new_user_email,
+            enterprise_customer=enterprise_customer,
+        )
+
+        response = self.client.post(
+            settings.TEST_SERVER + reverse('link-pending-enteprise-learner', kwargs={'enterprise_uuid': ent_uuid}),
+            data=data
+        )
+        assert response.status_code == 403
+
+    @ddt.data(
+        ([{'user_exists': True, 'ecu_exists': False, 'pending_ecu_exists': True},
+          {'user_exists': False, 'ecu_exists': False, 'pending_ecu_exists': False},
+          {'user_exists': True, 'ecu_exists': False, 'pending_ecu_exists': False},
+          {'user_exists': True, 'ecu_exists': True, 'pending_ecu_exists': False},
+          {'user_exists': False, 'ecu_exists': False, 'pending_ecu_exists': True}], 201),
+        ([{'user_exists': True, 'ecu_exists': False, 'pending_ecu_exists': True},
+          {'user_exists': False, 'ecu_exists': False, 'pending_ecu_exists': False},
+          {'user_exists': True, 'ecu_exists': False, 'pending_ecu_exists': False}], 201),
+        ([{'user_exists': True, 'ecu_exists': True, 'pending_ecu_exists': False},
+          {'user_exists': False, 'ecu_exists': False, 'pending_ecu_exists': True}], 204)
+    )
+    @ddt.unpack
+    def test_post_pending_enterprise_customer_multiple_customers(self, userlist, status_code):
+        self.setup_admin_user()
+        ent_uuid = fake.uuid4()
+        self.set_jwt_cookie(ENTERPRISE_ADMIN_ROLE, ent_uuid)
+        enterprise_customer = factories.EnterpriseCustomerFactory(uuid=ent_uuid)
+        data = []
+        users = []
+        for idx, user in enumerate(userlist):
+            user_email = 'new_user{}@example.com'.format(idx)
+            data.append({
+                'enterprise_customer': ent_uuid,
+                'user_email': user_email
+            })
+
+            existing_user = self.create_ent_user(
+                user_exists=user['user_exists'],
+                ecu_exists=user['ecu_exists'],
+                pending_ecu_exists=user['pending_ecu_exists'],
+                user_email=user_email,
+                enterprise_customer=enterprise_customer,
+            )
+            users.append({
+                'user_exists': user['user_exists'],
+                'user_email': user_email,
+                'existing_user': existing_user
+            })
+
+        response = self.client.post(
+            settings.TEST_SERVER + reverse('link-pending-enteprise-learner', kwargs={'enterprise_uuid': ent_uuid}),
+            data=data,
+            format='json',
+        )
+        assert response.status_code == status_code
+        for user in users:
+            # assert that the correct users were created
+            if not user['user_exists']:
+                assert PendingEnterpriseCustomerUser.objects.get(
+                    user_email=user['user_email'], enterprise_customer=enterprise_customer
+                )
+            else:
+                assert EnterpriseCustomerUser.objects.get(
+                    user_id=user['existing_user'].id,
+                    enterprise_customer=enterprise_customer,
+                    active=user['existing_user'].is_active
+                )
+
+    def test_post_pending_enterprise_customer_user_cannot_create_users_for_different_enterprise(self):
+        # create user making the request
+        self.setup_admin_user()
+
+        # Create fake enterprise
+        ent_uuid = fake.uuid4()
+        enterprise_customer = factories.EnterpriseCustomerFactory(uuid=ent_uuid)
+        # Fake enterprise admin permissions
+        self.set_jwt_cookie(ENTERPRISE_ADMIN_ROLE, ent_uuid)
+
+        new_user_email = 'newuser@example.com'
+        # data to be passed to the request
+        data = {
+            'enterprise_customer': fake.uuid4(),
+            'user_email': new_user_email,
+        }
+
+        response = self.client.post(
+            settings.TEST_SERVER + reverse('link-pending-enteprise-learner', kwargs={'enterprise_uuid': ent_uuid}),
+            data=data
+        )
+        # This should cause a validation error
+        assert response.status_code == 400
+        assert PendingEnterpriseCustomerUser.objects.filter(
+            user_email=new_user_email, enterprise_customer=enterprise_customer
+        ).count() == 0
+
+
+    def test_post_pending_enterprise_customer_user_logged_out(self):
+        """
+        Make sure users can't post PendingEnterpriseCustomerUsers when logged out.
+        """
+        self.client.logout()
+        ent_uuid = fake.uuid4()
+        data = {
+            'enterprise_customer': ent_uuid,
+            'username': self.user.username
+        }
+        response = self.client.post(
+            settings.TEST_SERVER + reverse('link-pending-enteprise-learner', kwargs={'enterprise_uuid': ent_uuid}),
+            data=data
+        )
         assert response.status_code == 401
 
 


### PR DESCRIPTION
Allows admins to link learners (ie, create EnterpriseCustomerUsers or PendingEnterpriseCustomerUsers) for their enterprise

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [x] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
