### PR TITLE
allow upgrading from audit into verified for enrollments made in B2C

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing.
 
+[3.20.2]
+--------
+* Allow licensed audit enrollment to have a path to upgrade into verified
+
 [3.20.1]
 --------
 * update edx-rbac to 1.4.2, plus a bunch of other version bumps.

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.20.1"
+__version__ = "3.20.2"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -37,7 +37,7 @@ from django.utils.text import slugify
 from django.utils.translation import ugettext as _
 from django.utils.translation import ungettext
 
-from enterprise.constants import ALLOWED_TAGS, DEFAULT_CATALOG_CONTENT_FILTER, PROGRAM_TYPE_DESCRIPTION
+from enterprise.constants import ALLOWED_TAGS, DEFAULT_CATALOG_CONTENT_FILTER, PROGRAM_TYPE_DESCRIPTION, CourseModes
 
 try:
     from common.djangoapps.course_modes.models import CourseMode
@@ -1801,9 +1801,9 @@ def get_best_mode_from_course_key(course_key):
     enterprise learner in.
     """
     course_modes = [mode.slug for mode in CourseMode.objects.filter(course_id=course_key)]
-    best_course_mode = 'verified' if 'verified' in course_modes \
-        else 'professional' if 'professional' in course_modes \
-        else 'no-id-professional' if 'no-id-professional' in course_modes \
-        else 'audit'
+    best_course_mode = CourseModes.VERIFIED if CourseModes.VERIFIED in course_modes \
+        else CourseModes.PROFESSIONAL if CourseModes.PROFESSIONAL in course_modes \
+        else CourseModes.NO_ID_PROFESSIONAL if CourseModes.NO_ID_PROFESSIONAL in course_modes \
+        else CourseModes.AUDIT
 
     return best_course_mode


### PR DESCRIPTION
### **Test Plan:**
**For enterprises with DSC disabled:**
- [ ] Verify a licensed learner can enroll from learner portal normally
- [ ] Verify a licensed learner can enroll into Audit in B2C and upon clicking on View Course in the Learner Portal get upgraded into Verified

**For enterprises with DSC enabled:**
- [ ] Verify a licensed learner can enroll after consenting from the learner portal normally
- [ ] Verify a licensed learner can enroll after consenting into Audit in B2C and upon clicking on View Course in the Learner Portal gets upgraded into Verified
- [ ] Verify a learner who clicks on Enroll in the Learner Portal and see the DSC page and does not give consent is asked for consent again the next time they try to view/enroll in the course
    - [ ] Verify that upon being asked for consent a second time and then giving it they successfully get into the verified track
- [ ] Verify a learner who click on Enroll in B2C and does not give consent is asked for consent again the next time they try to view/enroll in the course.
    - [ ] Verify that upon being asked for consent a second time and then giving it they successfully get into the verified track


**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [x] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
