### PR TITLE
ENT-2010: Improve efficiency of the data sharing consent flow

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing.
 
+[3.20.4]
+--------
+* Refactored code in `proxied_get()` to clean up duplicate logic.
+
 [3.20.3]
 --------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.20.3"
+__version__ = "3.20.4"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/tests/test_consent/test_helpers.py
+++ b/tests/test_consent/test_helpers.py
@@ -4,6 +4,7 @@ Tests for helper functions in the Consent application.
 """
 
 import ddt
+import mock
 from pytest import mark
 
 from django.test import testcases
@@ -18,9 +19,15 @@ class ConsentHelpersTest(testcases.TestCase):
     """
     Test cases for helper functions for the Consent application.
     """
+    def setUp(self):
+        self.fake_course_id = 'fake-course'
+        super().setUp()
 
-    def test_get_data_sharing_consent_no_enterprise(self):
+    @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
+    def test_get_data_sharing_consent_no_enterprise(self, mock_catalog_api_class):
         """
         Test that the returned consent record is None when no EnterpriseCustomer exists.
         """
-        assert helpers.get_data_sharing_consent('bob', TEST_UUID, course_id='fake-course') is None
+        mock_catalog_api_class = mock_catalog_api_class.return_value
+        mock_catalog_api_class.get_course_id.return_value = self.fake_course_id
+        assert helpers.get_data_sharing_consent('bob', TEST_UUID, course_id=self.fake_course_id) is None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1594,14 +1594,17 @@ class TestProxyDataSharingConsent(EmptyCacheMixin, TransactionTestCase):
         for attr, val in expected_attrs.items():
             assert getattr(proxy_dsc, attr) == val
 
+    @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     @ddt.data(True, False)
-    def test_consent_exists_proxy_enrollment(self, user_exists):
+    def test_consent_exists_proxy_enrollment(self, user_exists, mock_catalog_api_class):
         """
         If we did proxy enrollment, we return ``True`` for the consent existence question.
         """
+        mock_catalog_api_class = mock_catalog_api_class.return_value
         if user_exists:
             factories.UserFactory(id=1)
         ece = factories.EnterpriseCourseEnrollmentFactory(enterprise_customer_user__user_id=1)
+        mock_catalog_api_class.get_course_id.return_value = ece.course_id
         consent_exists = get_data_sharing_consent(
             ece.enterprise_customer_user.username,
             ece.enterprise_customer_user.enterprise_customer.uuid,


### PR DESCRIPTION
JIRA: https://openedx.atlassian.net/browse/ENT-2010

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [x] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
