### PR TITLE
ENT-4222 : replace REST api calls to LMS for certificate and grade data fetch

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing.
 
+[3.20.5]
+--------
+* Integrated channels learner_data module refactored to avoid making some LMS REST API calls
+
 [3.20.4]
 --------
 * Refactored code in `proxied_get()` to clean up duplicate logic.

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.20.4"
+__version__ = "3.20.5"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/blackboard/exporters/learner_data.py
+++ b/integrated_channels/blackboard/exporters/learner_data.py
@@ -7,9 +7,9 @@ from logging import getLogger
 
 from django.apps import apps
 
+from integrated_channels.catalog_service_utils import get_course_id_for_enrollment
 from integrated_channels.integrated_channel.exporters.learner_data import LearnerExporter
 from integrated_channels.utils import parse_datetime_to_epoch_millis
-from integrated_channels.catalog_service_utils import get_course_id_for_enrollment
 
 LOGGER = getLogger(__name__)
 

--- a/integrated_channels/catalog_service_utils.py
+++ b/integrated_channels/catalog_service_utils.py
@@ -1,0 +1,14 @@
+"""
+A utility collection for calls from integrated_channels to Catalog service
+"""
+from enterprise.api_client.discovery import get_course_catalog_api_service_client
+
+
+def get_course_id_for_enrollment(enterprise_enrollment):
+    """
+    Fetch course_id for a given enterprise enrollment
+    """
+    course_catalog_client = get_course_catalog_api_service_client(
+        site=enterprise_enrollment.enterprise_customer_user.enterprise_customer.site
+    )
+    return course_catalog_client.get_course_id(enterprise_enrollment.course_id)

--- a/integrated_channels/catalog_service_utils.py
+++ b/integrated_channels/catalog_service_utils.py
@@ -7,6 +7,7 @@ from enterprise.api_client.discovery import get_course_catalog_api_service_clien
 def get_course_id_for_enrollment(enterprise_enrollment):
     """
     Fetch course_id for a given enterprise enrollment
+    Returns None if no course id found for course_id associated with input enterprise_enrollment
     """
     course_catalog_client = get_course_catalog_api_service_client(
         site=enterprise_enrollment.enterprise_customer_user.enterprise_customer.site
@@ -16,7 +17,8 @@ def get_course_id_for_enrollment(enterprise_enrollment):
 
 def get_course_run_for_enrollment(enterprise_enrollment):
     """
-    course_run associated with the enrollment
+    Fetch course_run associated with the enrollment
+    Returns empty dict {} if no course_run found for enterprise_enrollment.course_id
     """
     course_catalog_client = get_course_catalog_api_service_client(
         site=enterprise_enrollment.enterprise_customer_user.enterprise_customer.site

--- a/integrated_channels/catalog_service_utils.py
+++ b/integrated_channels/catalog_service_utils.py
@@ -12,3 +12,14 @@ def get_course_id_for_enrollment(enterprise_enrollment):
         site=enterprise_enrollment.enterprise_customer_user.enterprise_customer.site
     )
     return course_catalog_client.get_course_id(enterprise_enrollment.course_id)
+
+
+def get_course_run_for_enrollment(enterprise_enrollment):
+    """
+    course_run associated with the enrollment
+    """
+    course_catalog_client = get_course_catalog_api_service_client(
+        site=enterprise_enrollment.enterprise_customer_user.enterprise_customer.site
+    )
+    course_run = course_catalog_client.get_course_run(enterprise_enrollment.course_id)
+    return course_run

--- a/integrated_channels/cornerstone/exporters/learner_data.py
+++ b/integrated_channels/cornerstone/exporters/learner_data.py
@@ -7,7 +7,7 @@ from logging import getLogger
 
 from django.apps import apps
 
-from enterprise.api_client.discovery import get_course_catalog_api_service_client
+from integrated_channels.catalog_service_utils import get_course_id_for_enrollment
 from integrated_channels.integrated_channel.exporters.learner_data import LearnerExporter
 
 LOGGER = getLogger(__name__)
@@ -42,13 +42,10 @@ class CornerstoneLearnerExporter(LearnerExporter):
             'CornerstoneLearnerDataTransmissionAudit'
         )
 
-        course_catalog_client = get_course_catalog_api_service_client(
-            site=enterprise_enrollment.enterprise_customer_user.enterprise_customer.site
-        )
         try:
             csod_learner_data_transmission = CornerstoneLearnerDataTransmissionAudit.objects.get(
                 user_id=enterprise_enrollment.enterprise_customer_user.user.id,
-                course_id=course_catalog_client.get_course_id(enterprise_enrollment.course_id),
+                course_id=get_course_id_for_enrollment(enterprise_enrollment),
             )
             csod_learner_data_transmission.enterprise_course_enrollment_id = enterprise_enrollment.id
             csod_learner_data_transmission.grade = grade

--- a/integrated_channels/degreed/exporters/learner_data.py
+++ b/integrated_channels/degreed/exporters/learner_data.py
@@ -8,7 +8,7 @@ from logging import getLogger
 
 from django.apps import apps
 
-from enterprise.api_client.discovery import get_course_catalog_api_service_client
+from integrated_channels.catalog_service_utils import get_course_id_for_enrollment
 from integrated_channels.integrated_channel.exporters.learner_data import LearnerExporter
 
 LOGGER = getLogger(__name__)
@@ -42,14 +42,11 @@ class DegreedLearnerExporter(LearnerExporter):
             )
             # We return two records here, one with the course key and one with the course run id, to account for
             # uncertainty about the type of content (course vs. course run) that was sent to the integrated channel.
-            course_catalog_client = get_course_catalog_api_service_client(
-                site=enterprise_enrollment.enterprise_customer_user.enterprise_customer.site
-            )
             return [
                 DegreedLearnerDataTransmissionAudit(
                     enterprise_course_enrollment_id=enterprise_enrollment.id,
                     degreed_user_email=enterprise_enrollment.enterprise_customer_user.user_email,
-                    course_id=course_catalog_client.get_course_id(enterprise_enrollment.course_id),
+                    course_id=get_course_id_for_enrollment(enterprise_enrollment),
                     course_completed=completed_date is not None and is_passing,
                     completed_timestamp=completed_timestamp,
                 ),

--- a/integrated_channels/integrated_channel/exporters/content_metadata.py
+++ b/integrated_channels/integrated_channel/exporters/content_metadata.py
@@ -11,7 +11,6 @@ import json
 from collections import OrderedDict
 from logging import getLogger
 
-from enterprise.api_client.enterprise import EnterpriseApiClient
 from enterprise.api_client.enterprise_catalog import EnterpriseCatalogApiClient
 from enterprise.utils import get_content_metadata_item_id
 from integrated_channels.integrated_channel.exporters import Exporter
@@ -68,7 +67,6 @@ class ContentMetadataExporter(Exporter):
         Initialize the exporter.
         """
         super().__init__(user, enterprise_configuration)
-        self.enterprise_api = EnterpriseApiClient(self.user)
         self.enterprise_catalog_api = EnterpriseCatalogApiClient(self.user)
 
     def export(self, **kwargs):

--- a/integrated_channels/integrated_channel/exporters/learner_data.py
+++ b/integrated_channels/integrated_channel/exporters/learner_data.py
@@ -8,6 +8,7 @@ enterprise customer.
 """
 
 from logging import getLogger
+
 from opaque_keys import InvalidKeyError
 from slumber.exceptions import HttpNotFoundError
 
@@ -19,12 +20,8 @@ from consent.models import DataSharingConsent
 from enterprise.api_client.lms import CourseApiClient, GradesApiClient
 from enterprise.models import EnterpriseCourseEnrollment
 from integrated_channels.integrated_channel.exporters import Exporter
-from integrated_channels.utils import (
-    generate_formatted_log,
-    is_already_transmitted,
-    parse_datetime_to_epoch_millis,
-)
 from integrated_channels.lms_utils import get_course_certificate
+from integrated_channels.utils import generate_formatted_log, is_already_transmitted, parse_datetime_to_epoch_millis
 
 LOGGER = getLogger(__name__)
 

--- a/integrated_channels/integrated_channel/exporters/learner_data.py
+++ b/integrated_channels/integrated_channel/exporters/learner_data.py
@@ -567,28 +567,32 @@ class LearnerExporter(Exporter):
         percent_grade = None
 
         try:
+            breakpoint()
             certificate = get_course_certificate(course_id, username)
-            if not certificate:
-                self._log_cert_not_found(course_id, enterprise_enrollment, user_id)
-                return completed_date, grade, is_passing, percent_grade
-            completed_date = certificate.get('created_date')
-            if completed_date:
-                completed_date = parse_datetime(completed_date)
-            else:
-                completed_date = timezone.now()
-
-            # For consistency with _collect_grades_data, we only care about Pass/Fail grades. This could change.
-            is_passing = certificate.get('is_passing')
-            percent_grade = certificate.get('grade')
-            grade = self.grade_passing if is_passing else self.grade_failing
         except InvalidKeyError:
             self._log_courseid_not_found(course_id, enterprise_enrollment, user_id)
+            return completed_date, grade, is_passing, percent_grade
+
+        if not certificate:
+            self._log_cert_not_found(course_id, enterprise_enrollment, user_id)
+            return completed_date, grade, is_passing, percent_grade
+
+        completed_date = certificate.get('created_date')
+        if completed_date:
+            completed_date = parse_datetime(completed_date)
+        else:
+            completed_date = timezone.now()
+
+        # For consistency with _collect_grades_data, we only care about Pass/Fail grades. This could change.
+        is_passing = certificate.get('is_passing')
+        percent_grade = certificate.get('grade')
+        grade = self.grade_passing if is_passing else self.grade_failing
 
         return completed_date, grade, is_passing, percent_grade
 
     def _log_cert_not_found(self, course_id, enterprise_enrollment, user_id):
         """
-        Standardized logging for no certificate found
+        Standardized logging for no certificate found (refactor candidate)
         """
         LOGGER.error('[Integrated Channel] Certificate not found for user'
                      ' Course: {course_id}, EnterpriseEnrollment: {enterprise_enrollment}, '
@@ -601,7 +605,7 @@ class LearnerExporter(Exporter):
 
     def _log_courseid_not_found(self, course_id, enterprise_enrollment, user_id):
         """
-        Standardized logging for no certificate found
+        Standardized logging for no certificate found  (refactor candidate)
         """
         LOGGER.error('[Integrated Channel] Certificate fetch failed due to invalid course_id'
                      ' Course: {course_id}, EnterpriseEnrollment: {enterprise_enrollment}, '

--- a/integrated_channels/integrated_channel/exporters/learner_data.py
+++ b/integrated_channels/integrated_channel/exporters/learner_data.py
@@ -12,8 +12,8 @@ from logging import getLogger
 from opaque_keys import InvalidKeyError
 from slumber.exceptions import HttpNotFoundError
 
-from django.contrib import auth
 from django.apps import apps
+from django.contrib import auth
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 

--- a/integrated_channels/integrated_channel/exporters/learner_data.py
+++ b/integrated_channels/integrated_channel/exporters/learner_data.py
@@ -567,7 +567,6 @@ class LearnerExporter(Exporter):
         percent_grade = None
 
         try:
-            breakpoint()
             certificate = get_course_certificate(course_id, username)
         except InvalidKeyError:
             self._log_courseid_not_found(course_id, enterprise_enrollment, user_id)

--- a/integrated_channels/lms_utils.py
+++ b/integrated_channels/lms_utils.py
@@ -1,0 +1,33 @@
+"""
+A utility collection for calls from integrated_channels to LMS APIs
+If integrated_channels calls LMS APIs, put them here for better tracking.
+"""
+from opaque_keys.edx.keys import CourseKey
+try:
+    from lms.djangoapps.certificates.api import get_certificate_for_user
+except ImportError:
+    get_certificate_for_user = None
+
+
+def get_course_certificate(course_id, username):
+    """
+    A course certificate for a user.
+    If there is a problem finding the course, throws a opaque_keys.InvalidKeyError
+
+    Returns dict, for example:
+        {
+            "username": "bob",
+            "course_id": "edX/DemoX/Demo_Course",
+            "certificate_type": "verified",
+            "created_date": "2015-12-03T13:14:28+0000",
+            "status": "downloadable",
+            "is_passing": true,
+            "download_url": "http://www.example.com/cert.pdf",
+            "grade": "0.98"
+        }
+    """
+    if not get_certificate_for_user:
+        return None
+    course_key = CourseKey.from_string(course_id)
+    user_cert = get_certificate_for_user(username=username, course_key=course_key)
+    return user_cert

--- a/integrated_channels/lms_utils.py
+++ b/integrated_channels/lms_utils.py
@@ -15,9 +15,9 @@ except ImportError:
     CourseGradeFactory = None
 
 
-def get_course_certificate(course_id, username):
+def get_course_certificate(course_id, user):
     """
-    A course certificate for a user.
+    A course certificate for a user (must be a django.contrib.auth.User instance).
     If there is a problem finding the course, throws a opaque_keys.InvalidKeyError
 
     Returns dict, for example:
@@ -35,13 +35,13 @@ def get_course_certificate(course_id, username):
     if not get_certificate_for_user:
         return None
     course_key = CourseKey.from_string(course_id)
-    user_cert = get_certificate_for_user(username=username, course_key=course_key)
+    user_cert = get_certificate_for_user(username=user.username, course_key=course_key)
     return user_cert
 
 
-def get_single_user_grade(course_id, grade_user):
+def get_single_user_grade(course_id, user):
     """
-    Returns a grade for the user object corresponding to the provided user
+    Returns a grade for the user (must be a django.contrib.auth.User instance).
     Args:
         course_key (CourseLocator): The course to retrieve user grades for.
 
@@ -51,5 +51,5 @@ def get_single_user_grade(course_id, grade_user):
     if not CourseGradeFactory:
         return None
     course_key = CourseKey.from_string(course_id)
-    course_grade = CourseGradeFactory().read(grade_user, course_key=course_key)
+    course_grade = CourseGradeFactory().read(user.username, course_key=course_key)
     return course_grade

--- a/integrated_channels/lms_utils.py
+++ b/integrated_channels/lms_utils.py
@@ -3,6 +3,7 @@ A utility collection for calls from integrated_channels to LMS APIs
 If integrated_channels calls LMS APIs, put them here for better tracking.
 """
 from opaque_keys.edx.keys import CourseKey
+
 try:
     from lms.djangoapps.certificates.api import get_certificate_for_user
 except ImportError:

--- a/integrated_channels/lms_utils.py
+++ b/integrated_channels/lms_utils.py
@@ -9,6 +9,11 @@ try:
 except ImportError:
     get_certificate_for_user = None
 
+try:
+    from lms.djangoapps.grades.course_grade_factory import CourseGradeFactory
+except ImportError:
+    CourseGradeFactory = None
+
 
 def get_course_certificate(course_id, username):
     """
@@ -32,3 +37,19 @@ def get_course_certificate(course_id, username):
     course_key = CourseKey.from_string(course_id)
     user_cert = get_certificate_for_user(username=username, course_key=course_key)
     return user_cert
+
+
+def get_single_user_grade(course_id, grade_user):
+    """
+    Returns a grade for the user object corresponding to the provided user
+    Args:
+        course_key (CourseLocator): The course to retrieve user grades for.
+
+    Returns:
+        A serializable list of grade responses
+    """
+    if not CourseGradeFactory:
+        return None
+    course_key = CourseKey.from_string(course_id)
+    course_grade = CourseGradeFactory().read(grade_user, course_key=course_key)
+    return course_grade

--- a/integrated_channels/moodle/exporters/learner_data.py
+++ b/integrated_channels/moodle/exporters/learner_data.py
@@ -7,7 +7,7 @@ from logging import getLogger
 
 from django.apps import apps
 
-from enterprise.api_client.discovery import get_course_catalog_api_service_client
+from integrated_channels.catalog_service_utils import get_course_id_for_enrollment
 from integrated_channels.integrated_channel.exporters.learner_data import LearnerExporter
 from integrated_channels.utils import parse_datetime_to_epoch_millis
 
@@ -48,17 +48,13 @@ class MoodleLearnerExporter(LearnerExporter):
             'MoodleLearnerDataTransmissionAudit'
         )
 
-        course_catalog_client = get_course_catalog_api_service_client(
-            site=enterprise_customer.enterprise_customer.site
-        )
-
         percent_grade = kwargs.get('grade_percent', None)
 
         return [
             MoodleLearnerDataTransmissionAudit(
                 enterprise_course_enrollment_id=enterprise_enrollment.id,
                 moodle_user_email=enterprise_customer.user_email,
-                course_id=course_catalog_client.get_course_id(enterprise_enrollment.course_id),
+                course_id=get_course_id_for_enrollment(enterprise_enrollment),
                 course_completed=completed_date is not None and is_passing,
                 grade=percent_grade,
                 completed_timestamp=completed_timestamp,

--- a/integrated_channels/sap_success_factors/exporters/learner_data.py
+++ b/integrated_channels/sap_success_factors/exporters/learner_data.py
@@ -9,9 +9,9 @@ from requests import RequestException
 
 from django.apps import apps
 
-from integrated_channels.catalog_service_utils import get_course_id_for_enrollment, get_course_run_for_enrollment
 from enterprise.models import EnterpriseCustomerUser, PendingEnterpriseCustomerUser
 from enterprise.tpa_pipeline import get_user_from_social_auth
+from integrated_channels.catalog_service_utils import get_course_id_for_enrollment, get_course_run_for_enrollment
 from integrated_channels.exceptions import ClientError
 from integrated_channels.integrated_channel.exporters.learner_data import LearnerExporter
 from integrated_channels.sap_success_factors.client import SAPSuccessFactorsAPIClient

--- a/integrated_channels/sap_success_factors/exporters/learner_data.py
+++ b/integrated_channels/sap_success_factors/exporters/learner_data.py
@@ -9,7 +9,7 @@ from requests import RequestException
 
 from django.apps import apps
 
-from enterprise.api_client.discovery import get_course_catalog_api_service_client
+from integrated_channels.catalog_service_utils import get_course_id_for_enrollment, get_course_run_for_enrollment
 from enterprise.models import EnterpriseCustomerUser, PendingEnterpriseCustomerUser
 from enterprise.tpa_pipeline import get_user_from_social_auth
 from integrated_channels.exceptions import ClientError
@@ -55,10 +55,7 @@ class SapSuccessFactorsLearnerExporter(LearnerExporter):
             )
             # We return two records here, one with the course key and one with the course run id, to account for
             # uncertainty about the type of content (course vs. course run) that was sent to the integrated channel.
-            course_catalog_client = get_course_catalog_api_service_client(
-                site=enterprise_enrollment.enterprise_customer_user.enterprise_customer.site
-            )
-            course_run = course_catalog_client.get_course_run(enterprise_enrollment.course_id)
+            course_run = get_course_run_for_enrollment(enterprise_enrollment)
             total_hours = 0.0
             if course_run and self.enterprise_configuration.transmit_total_hours:
                 total_hours = course_run.get("estimated_hours", 0.0)
@@ -66,7 +63,7 @@ class SapSuccessFactorsLearnerExporter(LearnerExporter):
                 SapSuccessFactorsLearnerDataTransmissionAudit(
                     enterprise_course_enrollment_id=enterprise_enrollment.id,
                     sapsf_user_id=sapsf_user_id,
-                    course_id=course_catalog_client.get_course_id(enterprise_enrollment.course_id),
+                    course_id=get_course_id_for_enrollment(enterprise_enrollment),
                     course_completed=course_completed,
                     completed_timestamp=completed_timestamp,
                     grade=grade,

--- a/tests/test_integrated_channels/test_catalog_service_utils.py
+++ b/tests/test_integrated_channels/test_catalog_service_utils.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for the catalog_service_utils used by integration channels.
+"""
+
+import unittest
+import mock
+import pytest
+
+from opaque_keys import InvalidKeyError
+
+from test_utils import factories
+from integrated_channels.catalog_service_utils import get_course_id_for_enrollment, get_course_run_for_enrollment
+
+
+A_GOOD_COURSE_ID = "edX/DemoX/Demo_Course"
+A_BAD_COURSE_ID = "this_shall_not_pass"
+A_LMS_USER = "a_lms_user"
+
+
+@pytest.mark.django_db
+class TestCatalogServiceUtils(unittest.TestCase):
+    """
+    Tests for lms_utils
+    """
+
+    def setUp(self):
+        self.username = A_LMS_USER
+        self.user = factories.UserFactory(username=self.username)
+        super().setUp()
+
+    def _create_enrollment(self, enterprise_customer_user):
+        """
+        Create EnterpriseCourseEnrollmentFactory instance
+        """
+        an_enrollment = factories.EnterpriseCourseEnrollmentFactory(
+            id=3,
+            enterprise_customer_user=enterprise_customer_user,
+        )
+        return an_enrollment
+
+    @mock.patch('integrated_channels.catalog_service_utils.get_course_catalog_api_service_client')
+    def test_get_course_id_for_enrollment_success(self, mock_get_catalog_client):
+        mock_get_catalog_client.return_value.get_course_id.return_value = A_GOOD_COURSE_ID
+
+        an_enterprise_customer_user = factories.EnterpriseCustomerUserFactory()
+        an_enrollment = self._create_enrollment(an_enterprise_customer_user)
+
+        assert get_course_id_for_enrollment(an_enrollment) == A_GOOD_COURSE_ID
+        mock_get_catalog_client.assert_called_with(site=an_enterprise_customer_user.enterprise_customer.site)
+
+    @mock.patch('integrated_channels.catalog_service_utils.get_course_catalog_api_service_client')
+    def test_get_course_run_for_enrollment_success(self, mock_get_catalog_client):
+        expected_course_run = {"estimated_hours": 4}
+        mock_get_catalog_client.return_value.get_course_run.return_value = expected_course_run
+
+        an_enterprise_customer_user = factories.EnterpriseCustomerUserFactory()
+        an_enrollment = self._create_enrollment(an_enterprise_customer_user)
+
+        assert get_course_run_for_enrollment(an_enrollment) == expected_course_run
+        mock_get_catalog_client.assert_called_with(site=an_enterprise_customer_user.enterprise_customer.site)

--- a/tests/test_integrated_channels/test_catalog_service_utils.py
+++ b/tests/test_integrated_channels/test_catalog_service_utils.py
@@ -7,7 +7,6 @@ import unittest
 
 import mock
 import pytest
-from opaque_keys import InvalidKeyError
 
 from integrated_channels.catalog_service_utils import get_course_id_for_enrollment, get_course_run_for_enrollment
 from test_utils import factories

--- a/tests/test_integrated_channels/test_catalog_service_utils.py
+++ b/tests/test_integrated_channels/test_catalog_service_utils.py
@@ -4,14 +4,13 @@ Tests for the catalog_service_utils used by integration channels.
 """
 
 import unittest
+
 import mock
 import pytest
-
 from opaque_keys import InvalidKeyError
 
-from test_utils import factories
 from integrated_channels.catalog_service_utils import get_course_id_for_enrollment, get_course_run_for_enrollment
-
+from test_utils import factories
 
 A_GOOD_COURSE_ID = "edX/DemoX/Demo_Course"
 A_BAD_COURSE_ID = "this_shall_not_pass"

--- a/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_learner_data.py
+++ b/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_learner_data.py
@@ -673,7 +673,7 @@ class TestLearnerExporter(unittest.TestCase):
         # Check that LMS enrollment populated as part of model used in audit check:
         expected_result = mock_course_enrollment_class.objects.get.return_value
         self.assertEqual(expected_result, enterprise_course_enrollment.course_enrollment)
-        assert mock_course_enrollment_class.objects.get.call_count == 2
+        assert mock_course_enrollment_class.objects.get.call_count == 1
 
         assert mock_course_api.call_count == 0
         assert mock_grades_api.call_count == 0

--- a/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_learner_data.py
+++ b/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_learner_data.py
@@ -10,7 +10,6 @@ import ddt
 import mock
 from freezegun import freeze_time
 from pytest import mark
-from slumber.exceptions import HttpNotFoundError
 
 from django.utils import timezone
 

--- a/tests/test_integrated_channels/test_lms_utils.py
+++ b/tests/test_integrated_channels/test_lms_utils.py
@@ -4,14 +4,13 @@ Tests for the lms_utils used by integration channels.
 """
 
 import unittest
+
 import mock
 import pytest
-
 from opaque_keys import InvalidKeyError
 
-from test_utils import factories
 from integrated_channels.lms_utils import get_course_certificate, get_single_user_grade
-
+from test_utils import factories
 
 A_GOOD_COURSE_ID = "edX/DemoX/Demo_Course"
 A_BAD_COURSE_ID = "this_shall_not_pass"

--- a/tests/test_integrated_channels/test_lms_utils.py
+++ b/tests/test_integrated_channels/test_lms_utils.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for the lms_utils used by integration channels.
+"""
+
+import unittest
+import mock
+import pytest
+
+from opaque_keys import InvalidKeyError
+
+from test_utils import factories
+from integrated_channels.lms_utils import get_course_certificate, get_single_user_grade
+
+
+A_GOOD_COURSE_ID = "edX/DemoX/Demo_Course"
+A_BAD_COURSE_ID = "this_shall_not_pass"
+A_LMS_USER = "a_lms_user"
+
+
+@pytest.mark.django_db
+class TestLMSUtils(unittest.TestCase):
+    """
+    Tests for lms_utils
+    """
+
+    def setUp(self):
+        self.username = A_LMS_USER
+        self.user = factories.UserFactory(username=self.username)
+        super().setUp()
+
+    @mock.patch('integrated_channels.lms_utils.get_certificate_for_user')
+    def test_get_course_certificate_success(self, mock_get_course_certificate):
+        a_cert = {
+            "username": A_LMS_USER,
+            "grade": "0.98",
+        }
+        mock_get_course_certificate.return_value = a_cert
+        cert = get_course_certificate(A_GOOD_COURSE_ID, self.user)
+        assert cert == a_cert
+        assert mock_get_course_certificate.call_count == 1
+
+    @mock.patch('integrated_channels.lms_utils.get_certificate_for_user')
+    def test_get_course_certificate_bad_course_id_throws(self, mock_get_course_certificate):
+        with pytest.raises(InvalidKeyError):
+            get_course_certificate(A_BAD_COURSE_ID, self.user)
+            assert mock_get_course_certificate.call_count == 0
+
+    @mock.patch('integrated_channels.lms_utils.CourseGradeFactory')
+    def test_get_single_user_grade_success(self, mock_course_grade_factory):
+        expected_grade = "0.8"
+        mock_course_grade_factory.return_value.read.return_value = expected_grade
+        single_user_grade = get_single_user_grade(A_GOOD_COURSE_ID, self.user)
+        assert single_user_grade == expected_grade
+
+    @mock.patch('integrated_channels.lms_utils.CourseGradeFactory')
+    def test_get_single_user_grade_bad_course_id_throws(self, mock_course_grade_factory):
+        with pytest.raises(InvalidKeyError):
+            get_single_user_grade(A_BAD_COURSE_ID, self.user)
+            assert mock_course_grade_factory.call_count == 0


### PR DESCRIPTION
Replace api calls with utils/database calls to fetch grade and cert info

### Not including (see comments below) in this PR:

These two remaining api calls should clear out all LMS api calls from IC code base (leaving just api calls to LMS-external services):
- [ ] Call lms util instead of REST api to get assessment grades (current call is `grades_api.get_course_assessment_grades`)
- [ ] Call lms util instead of REST Api for `get_course_details` , this one uses the `CourseApiClient` whose usage can also be removed from this codebase

Reason:  I want to test this outgoing PR in staging with at least one LMS first then will add a new PR to handle this piece to avoid making this PR too large to test.

### Included work:

- [x] Gather up calls from integrated_channels exporter to lms into integrated_channels.lms_utils file
- [x] Gather up calls from integrated_channels exporter  to catalog service into integrated_channels.catalog_service_utils file
- [x] Call lms util instead of REST api to get certificate for user 
- [x] Calls lms util instead of RET api to implement `_collect_grades_data`
- [x] Refactor code for better readability and reduced complexity
- [x] Refactor out some logging calls to improve readability and better prep for future logging enhancements
- [x] Removes the already unused (`self.enterprise_api`) property that refers to `EnterpriseApiClient` in Exporter 

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
