### PR TITLE
refactor: Refactor part 2 to remove additional remaining api calls to LMS via REST

### DIFF
--- a/integrated_channels/lms_utils.py
+++ b/integrated_channels/lms_utils.py
@@ -8,15 +8,15 @@ from opaque_keys.edx.keys import CourseKey
 try:
     from lms.djangoapps.certificates.api import get_certificate_for_user
     from lms.djangoapps.grades.course_grade_factory import CourseGradeFactory
+    from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
     from openedx.core.djangoapps.content.course_overviews.models.CourseOverview import (
         get_from_id,
-        DoesNotExist,
     )
 except ImportError:
     get_certificate_for_user = None
     CourseGradeFactory = None
     get_from_id = None
-    DoesNotExist = None
+    CourseOverview = None
 
 from enterprise.utils import NotConnectedToOpenEdX
 
@@ -91,7 +91,7 @@ def get_course_details(course_id):
     try:
         course_key = CourseKey.from_string(course_id)
         course_overview = get_from_id(course_key)
-    except DoesNotExist:
+    except CourseOverview.DoesNotExist:
         return None, COURSE_OVERVIEW_NOT_FOUND.format(course_key=course_key)
     except InvalidKeyError:
         return None, COURSE_KEY_INVALID.format(course_key=course_key)

--- a/integrated_channels/lms_utils.py
+++ b/integrated_channels/lms_utils.py
@@ -2,18 +2,15 @@
 A utility collection for calls from integrated_channels to LMS APIs
 If integrated_channels calls LMS APIs, put them here for better tracking.
 """
-from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 
 try:
     from lms.djangoapps.certificates.api import get_certificate_for_user
     from lms.djangoapps.grades.course_grade_factory import CourseGradeFactory
     from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
-    from openedx.core.djangoapps.content.course_overviews.models.CourseOverview import get_from_id
 except ImportError:
     get_certificate_for_user = None
     CourseGradeFactory = None
-    get_from_id = None
     CourseOverview = None
 
 from enterprise.utils import NotConnectedToOpenEdX
@@ -23,12 +20,14 @@ COURSE_OVERVIEW_NOT_FOUND = 'CourseOverview could not be found for course_key: {
 COURSE_KEY_INVALID = 'Invalid course_key: {course_key}'
 
 
-def get_course_certificate(course_id, user):
+def get_course_certificate(course_key, user):
     """
     A course certificate for a user (must be a django.contrib.auth.User instance).
-    If there is a problem finding the course, throws a opaque_keys.InvalidKeyError
     If there is a problem loading the get_certificate_for_user function, throws NotConnectedToOpenEdX
-
+    If issues with course_key string, throws a InvalidKeyError
+    Arguments:
+        course_key (string): course key
+        user (django.contrib.auth.User): user instance
     Returns a certificate as a dict, for example:
         {
             "username": "bob",
@@ -46,18 +45,19 @@ def get_course_certificate(course_id, user):
             'To use this function, this package must be '
             'installed in an Open edX environment.'
         )
-    course_key = CourseKey.from_string(course_id)
-    user_cert = get_certificate_for_user(username=user.username, course_key=course_key)
+    course_id = CourseKey.from_string(course_key)
+    user_cert = get_certificate_for_user(username=user.username, course_key=course_id)
     return user_cert
 
 
-def get_single_user_grade(course_id, user):
+def get_single_user_grade(course_key, user):
     """
     Returns a grade for the user (must be a django.contrib.auth.User instance).
     If there is a problem loading the CourseGradeFactory class, throws NotConnectedToOpenEdX
-
+    If issues with course_key string, throws a InvalidKeyError
     Args:
-        course_key (CourseLocator): The course to retrieve user grades for.
+        course_key (string): string course key
+        user (django.contrib.auth.User): user instance
 
     Returns:
         A serializable list of grade responses
@@ -67,31 +67,29 @@ def get_single_user_grade(course_id, user):
             'To use this function, this package must be '
             'installed in an Open edX environment.'
         )
-    course_key = CourseKey.from_string(course_id)
-    course_grade = CourseGradeFactory().read(user, course_key=course_key)
+    course_id = CourseKey.from_string(course_key)
+    course_grade = CourseGradeFactory().read(user, course_key=course_id)
     return course_grade
 
 
-def get_course_details(course_id):
+def get_course_details(course_key):
     """
+    Args:
+        course_key (string): string course key
     Returns:
         Tuple with values:
             course_overview or None
             error_code or None (if there is an error fetching course details)
 
     If there is a problem loading the CourseOverview class, throws NotConnectedToOpenEdX
+    If issues with course_key string, throws a InvalidKeyError
+    If course details not found, throws CourseOverview.DoesNotExist
     """
-    if not get_from_id:
+    if not CourseOverview:
         raise NotConnectedToOpenEdX(
             'To use this function, this package must be '
             'installed in an Open edX environment.'
         )
-    try:
-        course_key = CourseKey.from_string(course_id)
-        course_overview = get_from_id(course_key)
-    except CourseOverview.DoesNotExist:
-        return None, COURSE_OVERVIEW_NOT_FOUND.format(course_key=course_key)
-    except InvalidKeyError:
-        return None, COURSE_KEY_INVALID.format(course_key=course_key)
-    else:
-        return course_overview, None
+    course_id = CourseKey.from_string(course_key)
+    course_overview = CourseOverview.get_from_id(course_id)
+    return course_overview

--- a/integrated_channels/lms_utils.py
+++ b/integrated_channels/lms_utils.py
@@ -51,5 +51,5 @@ def get_single_user_grade(course_id, user):
     if not CourseGradeFactory:
         return None
     course_key = CourseKey.from_string(course_id)
-    course_grade = CourseGradeFactory().read(user.username, course_key=course_key)
+    course_grade = CourseGradeFactory().read(user, course_key=course_key)
     return course_grade

--- a/integrated_channels/lms_utils.py
+++ b/integrated_channels/lms_utils.py
@@ -9,9 +9,7 @@ try:
     from lms.djangoapps.certificates.api import get_certificate_for_user
     from lms.djangoapps.grades.course_grade_factory import CourseGradeFactory
     from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
-    from openedx.core.djangoapps.content.course_overviews.models.CourseOverview import (
-        get_from_id,
-    )
+    from openedx.core.djangoapps.content.course_overviews.models.CourseOverview import get_from_id
 except ImportError:
     get_certificate_for_user = None
     CourseGradeFactory = None

--- a/integrated_channels/lms_utils.py
+++ b/integrated_channels/lms_utils.py
@@ -8,11 +8,15 @@ from opaque_keys.edx.keys import CourseKey
 try:
     from lms.djangoapps.certificates.api import get_certificate_for_user
     from lms.djangoapps.grades.course_grade_factory import CourseGradeFactory
-    from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+    from openedx.core.djangoapps.content.course_overviews.models.CourseOverview import (
+        get_from_id,
+        DoesNotExist,
+    )
 except ImportError:
     get_certificate_for_user = None
     CourseGradeFactory = None
-    CourseOverview = None
+    get_from_id = None
+    DoesNotExist = None
 
 from enterprise.utils import NotConnectedToOpenEdX
 
@@ -79,15 +83,15 @@ def get_course_details(course_id):
 
     If there is a problem loading the CourseOverview class, throws NotConnectedToOpenEdX
     """
-    if not CourseOverview:
+    if not get_from_id:
         raise NotConnectedToOpenEdX(
             'To use this function, this package must be '
             'installed in an Open edX environment.'
         )
     try:
         course_key = CourseKey.from_string(course_id)
-        course_overview = CourseOverview.get_from_id(course_key)
-    except CourseOverview.DoesNotExist:
+        course_overview = get_from_id(course_key)
+    except DoesNotExist:
         return None, COURSE_OVERVIEW_NOT_FOUND.format(course_key=course_key)
     except InvalidKeyError:
         return None, COURSE_KEY_INVALID.format(course_key=course_key)

--- a/integrated_channels/lms_utils.py
+++ b/integrated_channels/lms_utils.py
@@ -15,10 +15,6 @@ except ImportError:
 
 from enterprise.utils import NotConnectedToOpenEdX
 
-# Constants
-COURSE_OVERVIEW_NOT_FOUND = 'CourseOverview could not be found for course_key: {course_key}'
-COURSE_KEY_INVALID = 'Invalid course_key: {course_key}'
-
 
 def get_course_certificate(course_key, user):
     """

--- a/tests/test_integrated_channels/test_cornerstone/test_exporters/test_learner_data.py
+++ b/tests/test_integrated_channels/test_cornerstone/test_exporters/test_learner_data.py
@@ -134,7 +134,12 @@ class TestCornerstoneLearnerExporter(unittest.TestCase):
     @mock.patch('integrated_channels.cornerstone.client.requests.post')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.get_course_certificate')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.get_course_details')
-    def test_api_client_called_with_appropriate_payload(self, mock_get_course_details, mock_get_course_certificate, mock_post_request):
+    def test_api_client_called_with_appropriate_payload(
+        self,
+        mock_get_course_details,
+        mock_get_course_certificate,
+        mock_post_request
+    ):
         """
         Test sending of course completion data to cornerstone progress API
         """

--- a/tests/test_integrated_channels/test_cornerstone/test_exporters/test_learner_data.py
+++ b/tests/test_integrated_channels/test_cornerstone/test_exporters/test_learner_data.py
@@ -200,7 +200,11 @@ class TestCornerstoneLearnerExporter(unittest.TestCase):
     @mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.get_course_certificate')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.get_course_details')
-    def test_transmit_single_learner_data_performs_only_one_transmission(self, mock_get_course_details, mock_get_course_certificate):
+    def test_transmit_single_learner_data_performs_only_one_transmission(
+        self,
+        mock_get_course_details,
+        mock_get_course_certificate
+    ):
         """
         Test sending single user's data should only update one `CornerstoneLearnerDataTransmissionAudit` entry
         """

--- a/tests/test_integrated_channels/test_lms_utils.py
+++ b/tests/test_integrated_channels/test_lms_utils.py
@@ -10,7 +10,11 @@ import pytest
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 
-from integrated_channels.lms_utils import get_course_certificate, get_single_user_grade
+from integrated_channels.lms_utils import (
+    get_course_certificate,
+    get_single_user_grade,
+    get_course_details,
+)
 from test_utils import factories
 
 A_GOOD_COURSE_ID = "edX/DemoX/Demo_Course"
@@ -62,3 +66,11 @@ class TestLMSUtils(unittest.TestCase):
         with pytest.raises(InvalidKeyError):
             get_single_user_grade(A_BAD_COURSE_ID, self.user)
             assert mock_course_grade_factory.call_count == 0
+
+    @mock.patch('integrated_channels.lms_utils.get_from_id')
+    def test_get_course_details_success(self, mock_get_from_id):
+        course_overview = {'field': 'value'}
+        mock_get_from_id.return_value = course_overview
+        result_course_overview, error = get_course_details(A_GOOD_COURSE_ID)
+        assert result_course_overview == course_overview
+        assert error is None

--- a/tests/test_integrated_channels/test_lms_utils.py
+++ b/tests/test_integrated_channels/test_lms_utils.py
@@ -63,10 +63,11 @@ class TestLMSUtils(unittest.TestCase):
             get_single_user_grade(A_BAD_COURSE_ID, self.user)
             assert mock_course_grade_factory.call_count == 0
 
-    @mock.patch('integrated_channels.lms_utils.get_from_id')
-    def test_get_course_details_success(self, mock_get_from_id):
+    @mock.patch('integrated_channels.lms_utils.CourseOverview')
+    def test_get_course_details_success(self, mock_course_overview):
         course_overview = {'field': 'value'}
+        mock_get_from_id = mock_course_overview.return_value.get_from_id
         mock_get_from_id.return_value = course_overview
-        result_course_overview, error = get_course_details(A_GOOD_COURSE_ID)
-        assert result_course_overview == course_overview
-        assert error is None
+        result_course_overview = get_course_details(A_GOOD_COURSE_ID)
+        assert result_course_overview.return_value == course_overview
+        assert mock_course_overview.return_value.get_from_id.call_count == 1

--- a/tests/test_integrated_channels/test_lms_utils.py
+++ b/tests/test_integrated_channels/test_lms_utils.py
@@ -69,5 +69,5 @@ class TestLMSUtils(unittest.TestCase):
         mock_get_from_id = mock_course_overview.return_value.get_from_id
         mock_get_from_id.return_value = course_overview
         result_course_overview = get_course_details(A_GOOD_COURSE_ID)
-        assert result_course_overview.return_value == course_overview
-        assert mock_course_overview.return_value.get_from_id.call_count == 1
+        # todo could not find a way to mock the classmethod this test needs to improve
+        assert result_course_overview is not None

--- a/tests/test_integrated_channels/test_lms_utils.py
+++ b/tests/test_integrated_channels/test_lms_utils.py
@@ -8,6 +8,7 @@ import unittest
 import mock
 import pytest
 from opaque_keys import InvalidKeyError
+from opaque_keys.edx.keys import CourseKey
 
 from integrated_channels.lms_utils import get_course_certificate, get_single_user_grade
 from test_utils import factories
@@ -51,6 +52,10 @@ class TestLMSUtils(unittest.TestCase):
         mock_course_grade_factory.return_value.read.return_value = expected_grade
         single_user_grade = get_single_user_grade(A_GOOD_COURSE_ID, self.user)
         assert single_user_grade == expected_grade
+        mock_course_grade_factory.return_value.read.assert_called_with(
+            self.user,
+            course_key=CourseKey.from_string(A_GOOD_COURSE_ID)
+        )
 
     @mock.patch('integrated_channels.lms_utils.CourseGradeFactory')
     def test_get_single_user_grade_bad_course_id_throws(self, mock_course_grade_factory):

--- a/tests/test_integrated_channels/test_lms_utils.py
+++ b/tests/test_integrated_channels/test_lms_utils.py
@@ -66,8 +66,7 @@ class TestLMSUtils(unittest.TestCase):
     @mock.patch('integrated_channels.lms_utils.CourseOverview')
     def test_get_course_details_success(self, mock_course_overview):
         course_overview = {'field': 'value'}
-        mock_get_from_id = mock_course_overview.return_value.get_from_id
+        mock_get_from_id = mock_course_overview.get_from_id
         mock_get_from_id.return_value = course_overview
         result_course_overview = get_course_details(A_GOOD_COURSE_ID)
-        # todo could not find a way to mock the classmethod this test needs to improve
-        assert result_course_overview is not None
+        assert result_course_overview == course_overview

--- a/tests/test_integrated_channels/test_lms_utils.py
+++ b/tests/test_integrated_channels/test_lms_utils.py
@@ -10,11 +10,7 @@ import pytest
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 
-from integrated_channels.lms_utils import (
-    get_course_certificate,
-    get_single_user_grade,
-    get_course_details,
-)
+from integrated_channels.lms_utils import get_course_certificate, get_course_details, get_single_user_grade
 from test_utils import factories
 
 A_GOOD_COURSE_ID = "edX/DemoX/Demo_Course"


### PR DESCRIPTION
## Includes

Update:
Going to do a separate PR for this one:
   - [ ] Call lms util instead of REST api to get assessment grades (current call is `grades_api.get_course_assessment_grades`)
 The above needs a edx-platform PR to be merged first

This PR only includes the following:
- [x] Remaining refactors from https://github.com/edx/edx-enterprise/pull/1199
   - [x] Call lms util instead of REST Api for `get_course_details` , this one uses the `CourseApiClient` whose usage can also be removed from this codebase
- [x] Bug fix for bug found in staging testing and test

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
