### PR TITLE
ENT-4391: Added management command for tracking users without DSC

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing.
 
+[3.22.0]
+--------
+* Added a management command to send emails to learners with missing DSC
+
 [3.21.4]
 --------
 * allow searching of enterprise customer records with hyphenated uuid

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.21.4"
+__version__ = "3.22.0"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/management/commands/email_drip_for_missing_dsc_records.py
+++ b/enterprise/management/commands/email_drip_for_missing_dsc_records.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+"""
+Django management command for sending an email to learners with missing DataSharingConsent records.
+"""
+import logging
+from datetime import date, timedelta
+
+from django.core.management import BaseCommand
+
+from consent.models import DataSharingConsent, ProxyDataSharingConsent
+from enterprise import utils
+from enterprise.models import EnterpriseCourseEnrollment
+
+LOGGER = logging.getLogger(__name__)
+
+PAST_NUM_DAYS = 1
+
+
+class Command(BaseCommand):
+    """
+    Django management command for sending an email to learners with missing DataSharingConsent records
+    """
+
+    def handle(self, *args, **options):
+        """
+        Management command for sending an email to learners with a missing DSC. Designed to run daily.
+
+        Example usage:
+           $ ./manage.py email_drip_for_missing_dsc_records
+        """
+        past_date = date.today() - timedelta(days=PAST_NUM_DAYS)
+        enterprise_course_enrollments = EnterpriseCourseEnrollment.objects.select_related(
+            'enterprise_customer_user'
+        ).filter(created__date=past_date)
+
+        for enterprise_enrollment in enterprise_course_enrollments:
+            username = enterprise_enrollment.enterprise_customer_user.username
+            user_id = enterprise_enrollment.enterprise_customer_user.user_id
+            course_id = enterprise_enrollment.course_id
+            enterprise_customer = enterprise_enrollment.enterprise_customer_user.enterprise_customer
+            consent = DataSharingConsent.objects.proxied_get(
+                username=username,
+                course_id=course_id,
+                enterprise_customer=enterprise_customer
+            )
+            # Emit the Segment event which will be used by Braze to send the email
+            if isinstance(consent, ProxyDataSharingConsent):
+                utils.track_event(user_id, 'edx.bi.user.consent.absent', {
+                    'course': course_id,
+                    'username': username,
+                    'enterprise_name': enterprise_customer.name,
+                    'enterprise_uuid': enterprise_customer.uuid
+                })
+                LOGGER.info(
+                    '[Absent DSC Email] Email sent for missing data sharing consent. '
+                    'User: [%s], Course: [%s], Enterprise: [%s]',
+                    username,
+                    course_id,
+                    enterprise_customer.uuid
+                )

--- a/tests/test_enterprise/management/test_email_drip_for_missing_dsc_records.py
+++ b/tests/test_enterprise/management/test_email_drip_for_missing_dsc_records.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for the django management command `email_drip_for_missing_dsc_records`.
+"""
+import random
+from datetime import timedelta
+
+import mock
+from pytest import mark
+
+from django.core.management import call_command
+from django.test import TestCase
+from django.utils import timezone
+
+from consent.models import DataSharingConsent, ProxyDataSharingConsent
+from enterprise.management.commands.email_drip_for_missing_dsc_records import PAST_NUM_DAYS
+from test_utils.factories import (
+    EnterpriseCourseEnrollmentFactory,
+    EnterpriseCustomerFactory,
+    EnterpriseCustomerUserFactory,
+    UserFactory,
+)
+
+
+@mark.django_db
+class EmailDripForMissingDscRecordsCommandTests(TestCase):
+    """
+    Test command `email_drip_for_missing_dsc_records`.
+    """
+    command = 'email_drip_for_missing_dsc_records'
+
+    def create_enrollments(self, num_learners, update_date=False):
+        """
+        Create test users and enrollments in database
+
+        """
+        course_ids = [
+            'course-v1:edX+DemoX+Demo_Course',
+            'course-v1:edX+Python+1T2019',
+            'course-v1:edX+React+2T2019',
+        ]
+        enterprise_customer = EnterpriseCustomerFactory(
+            name='Starfleet Academy',
+            enable_data_sharing_consent=True,
+            enforce_data_sharing_consent='at_enrollment',
+        )
+        learners = []
+        for __ in range(num_learners):
+            user = UserFactory.create(is_staff=False, is_active=True)
+            learners.append(user)
+        learners_data = []
+        for learner in learners:
+            course_id = random.choice(course_ids)
+            learners_data.append(
+                {
+                    'ENTERPRISE_UUID': enterprise_customer.uuid,
+                    'EMAIL': learner.email,
+                    'USERNAME': learner.username,
+                    'USER_ID': learner.id,
+                    'COURSE_ID': course_id
+                }
+            )
+            enterprise_customer_user = EnterpriseCustomerUserFactory(
+                user_id=learner.id,
+                enterprise_customer=enterprise_customer
+            )
+
+            enterprise_course_enrollment = EnterpriseCourseEnrollmentFactory(
+                enterprise_customer_user=enterprise_customer_user,
+                course_id=course_id,
+            )
+            if update_date:
+                enterprise_course_enrollment.created = timezone.now().date() - timedelta(days=PAST_NUM_DAYS)
+                enterprise_course_enrollment.save()
+
+    def setUp(self):
+        super().setUp()
+        self.create_enrollments(num_learners=3, update_date=False)
+        self.create_enrollments(num_learners=3, update_date=True)
+
+    @mock.patch(
+        'enterprise.management.commands.email_drip_for_missing_dsc_records.DataSharingConsent.objects.proxied_get'
+    )
+    @mock.patch('enterprise.management.commands.email_drip_for_missing_dsc_records.utils.track_event')
+    def test_email_drip_for_missing_dsc_records(self, mock_event_track, mock_dsc_proxied_get):
+        """
+        Test that email drip event is fired for missing DSC records.
+        """
+        mock_dsc_proxied_get.return_value = DataSharingConsent()
+        call_command(self.command)
+        self.assertEqual(mock_event_track.call_count, 0)
+        mock_dsc_proxied_get.return_value = ProxyDataSharingConsent()
+        call_command(self.command)
+        self.assertEqual(mock_event_track.call_count, 3)


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
