### PR TITLE
feat: passing catalog query uuids into update/create requests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing.
 
+[3.22.3]
+--------
+* Feature: including EnterpriseCatalogQuery UUID field in request payload to enterprise-catalog on EnterpriseCatalog updates
+
 [3.22.2]
 --------
 * Feature: new UUID field on EnterpriseCatalogQuery model (and update to all existing query objects)

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.22.2"
+__version__ = "3.22.3"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api_client/enterprise_catalog.py
+++ b/enterprise/api_client/enterprise_catalog.py
@@ -44,7 +44,8 @@ class EnterpriseCatalogApiClient(JwtLmsApiClient):
             title,
             content_filter,
             enabled_course_modes,
-            publish_audit_enrollment_urls):
+            publish_audit_enrollment_urls,
+            catalog_query_uuid):
         """Creates an enterprise catalog."""
         endpoint = getattr(self.client, self.ENTERPRISE_CATALOG_ENDPOINT)
         post_data = {
@@ -55,6 +56,7 @@ class EnterpriseCatalogApiClient(JwtLmsApiClient):
             'content_filter': content_filter,
             'enabled_course_modes': enabled_course_modes,
             'publish_audit_enrollment_urls': json.dumps(publish_audit_enrollment_urls),
+            'catalog_query_uuid': catalog_query_uuid,
         }
         try:
             LOGGER.info(

--- a/enterprise/management/commands/migrate_enterprise_catalogs.py
+++ b/enterprise/management/commands/migrate_enterprise_catalogs.py
@@ -76,6 +76,7 @@ class Command(BaseCommand):
                         enterprise_catalog.content_filter,
                         enterprise_catalog.enabled_course_modes,
                         enterprise_catalog.publish_audit_enrollment_urls,
+                        str(enterprise_catalog.enterprise_catalog_query.uuid),
                     )
                 else:
                     # catalog with matching uuid does exist in enterprise-catalog
@@ -87,6 +88,7 @@ class Command(BaseCommand):
                         'content_filter': enterprise_catalog.content_filter,
                         'enabled_course_modes': enterprise_catalog.enabled_course_modes,
                         'publish_audit_enrollment_urls': enterprise_catalog.publish_audit_enrollment_urls,
+                        'catalog_query_uuid': str(enterprise_catalog.enterprise_catalog_query.uuid),
                     }
                     client.update_enterprise_catalog(
                         str(enterprise_catalog.uuid),

--- a/enterprise/signals.py
+++ b/enterprise/signals.py
@@ -257,6 +257,8 @@ def update_enterprise_catalog_data(sender, instance, **kwargs):     # pylint: di
     Algolia.
     """
     catalog_uuid = instance.uuid
+    catalog_query_uuid = instance.enterprise_catalog_query.uuid if instance.enterprise_catalog_query else None
+
     try:
         catalog_client = EnterpriseCatalogApiClient()
         if kwargs['created']:
@@ -284,6 +286,7 @@ def update_enterprise_catalog_data(sender, instance, **kwargs):     # pylint: di
                 instance.content_filter,
                 instance.enabled_course_modes,
                 instance.publish_audit_enrollment_urls,
+                str(catalog_query_uuid)
             )
         else:
             # catalog with matching uuid does exist in enterprise-catalog
@@ -295,6 +298,7 @@ def update_enterprise_catalog_data(sender, instance, **kwargs):     # pylint: di
                 'content_filter': instance.content_filter,
                 'enabled_course_modes': instance.enabled_course_modes,
                 'publish_audit_enrollment_urls': instance.publish_audit_enrollment_urls,
+                'catalog_query_uuid': str(catalog_query_uuid),
             }
             catalog_client.update_enterprise_catalog(catalog_uuid, **update_fields)
         # Refresh catalog on all creates and updates

--- a/test_utils/factories.py
+++ b/test_utils/factories.py
@@ -350,6 +350,24 @@ class LicensedEnterpriseCourseEnrollmentFactory(factory.django.DjangoModelFactor
     is_revoked = False
 
 
+class EnterpriseCatalogQueryFactory(factory.django.DjangoModelFactory):
+    """
+    EnterpriseCatalogQuery factory.
+
+    Creates an instance of EnterpriseCatalogQuery with minimal boilerplate.
+    """
+
+    class Meta:
+        """
+        Meta for EnterpriseCatalogQuery.
+        """
+
+        model = EnterpriseCatalogQuery
+
+    title = factory.Faker('sentence', nb_words=4)
+    uuid = factory.LazyAttribute(lambda x: UUID(FAKER.uuid4()))
+
+
 class EnterpriseCustomerCatalogFactory(factory.django.DjangoModelFactory):
     """
     EnterpriseCustomerCatalog factory.
@@ -366,23 +384,7 @@ class EnterpriseCustomerCatalogFactory(factory.django.DjangoModelFactory):
 
     uuid = factory.LazyAttribute(lambda x: UUID(FAKER.uuid4()))
     enterprise_customer = factory.SubFactory(EnterpriseCustomerFactory)
-
-
-class EnterpriseCatalogQueryFactory(factory.django.DjangoModelFactory):
-    """
-    EnterpriseCatalogQuery factory.
-
-    Creates an instance of EnterpriseCatalogQuery with minimal boilerplate.
-    """
-
-    class Meta:
-        """
-        Meta for EnterpriseCatalogQuery.
-        """
-
-        model = EnterpriseCatalogQuery
-
-    title = factory.Faker('sentence', nb_words=4)
+    enterprise_catalog_query = factory.SubFactory(EnterpriseCatalogQueryFactory)
 
 
 class DataSharingConsentFactory(factory.django.DjangoModelFactory):

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -1773,7 +1773,8 @@ class TestEntepriseCustomerCatalogs(BaseTestEnterpriseAPIViews):
                     fake_catalog_api.FAKE_SEARCH_ALL_PROGRAM_RESULT_1['uuid'],
                     fake_catalog_api.FAKE_SEARCH_ALL_PROGRAM_RESULT_2['uuid']
                 ]
-            }
+            },
+            enterprise_catalog_query=None,
         )
 
         mock_catalog_api_client.return_value = mock.Mock(

--- a/tests/test_enterprise/api_client/test_enterprise_catalog.py
+++ b/tests/test_enterprise/api_client/test_enterprise_catalog.py
@@ -51,6 +51,7 @@ def test_create_enterprise_catalog():
         'content_filter': {"content_type": "course"},
         'enabled_course_modes': ["verified"],
         'publish_audit_enrollment_urls': 'false',
+        'catalog_query_uuid': None
     }
     responses.add(
         responses.POST,
@@ -65,7 +66,8 @@ def test_create_enterprise_catalog():
         expected_response['title'],
         expected_response['content_filter'],
         expected_response['enabled_course_modes'],
-        expected_response['publish_audit_enrollment_urls']
+        expected_response['publish_audit_enrollment_urls'],
+        expected_request['catalog_query_uuid']
     )
     assert actual_response == expected_response
     request = responses.calls[0][0]

--- a/tests/test_enterprise/test_signals.py
+++ b/tests/test_enterprise/test_signals.py
@@ -313,7 +313,7 @@ class TestDefaultContentFilter(unittest.TestCase):
         Test that `EnterpriseCustomerCatalog`.content_filter is saved with correct default content filter.
         """
         with override_settings(ENTERPRISE_CUSTOMER_CATALOG_DEFAULT_CONTENT_FILTER=default_content_filter):
-            enterprise_catalog = EnterpriseCustomerCatalogFactory()
+            enterprise_catalog = EnterpriseCustomerCatalogFactory(enterprise_catalog_query=None)
             assert enterprise_catalog.content_filter == expected_content_filter
 
 
@@ -772,7 +772,8 @@ class TestEnterpriseCatalogSignals(unittest.TestCase):
             enterprise_catalog.title,
             enterprise_catalog.content_filter,
             enterprise_catalog.enabled_course_modes,
-            enterprise_catalog.publish_audit_enrollment_urls
+            enterprise_catalog.publish_audit_enrollment_urls,
+            str(enterprise_catalog.enterprise_catalog_query.uuid)
         )
         api_client_mock.return_value.refresh_catalogs.assert_called_with([enterprise_catalog])
 
@@ -792,7 +793,8 @@ class TestEnterpriseCatalogSignals(unittest.TestCase):
             enterprise_catalog.title,
             enterprise_catalog.content_filter,
             enterprise_catalog.enabled_course_modes,
-            enterprise_catalog.publish_audit_enrollment_urls
+            enterprise_catalog.publish_audit_enrollment_urls,
+            str(enterprise_catalog.enterprise_catalog_query.uuid),
         )
         api_client_mock.return_value.refresh_catalogs.assert_called_with([enterprise_catalog])
 
@@ -812,7 +814,8 @@ class TestEnterpriseCatalogSignals(unittest.TestCase):
             title=enterprise_catalog.title,
             content_filter=enterprise_catalog.content_filter,
             enabled_course_modes=enterprise_catalog.enabled_course_modes,
-            publish_audit_enrollment_urls=enterprise_catalog.publish_audit_enrollment_urls
+            publish_audit_enrollment_urls=enterprise_catalog.publish_audit_enrollment_urls,
+            catalog_query_uuid=str(enterprise_catalog.enterprise_catalog_query.uuid)
         )
         api_client_mock.return_value.refresh_catalogs.assert_called_with([enterprise_catalog])
 
@@ -864,7 +867,8 @@ class TestEnterpriseCatalogSignals(unittest.TestCase):
             title=enterprise_catalog_2.title,
             content_filter=enterprise_catalog_2.content_filter,
             enabled_course_modes=enterprise_catalog_2.enabled_course_modes,
-            publish_audit_enrollment_urls=enterprise_catalog_2.publish_audit_enrollment_urls
+            publish_audit_enrollment_urls=enterprise_catalog_2.publish_audit_enrollment_urls,
+            catalog_query_uuid=str(test_query.uuid)
         )
         api_client_mock.return_value.refresh_catalogs.assert_called_with([enterprise_catalog_2])
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1386,7 +1386,7 @@ class TestEnterpriseCustomerCatalog(unittest.TestCase):
         the discovery service API
         """
         mock_catalog_api = mock_catalog_api_class.return_value
-        enterprise_catalog = factories.EnterpriseCustomerCatalogFactory()
+        enterprise_catalog = factories.EnterpriseCustomerCatalogFactory(enterprise_catalog_query=None)
         enterprise_catalog.get_paginated_content(QueryDict())
         default_catalog_content_filter = get_default_catalog_content_filter()
         query_param = {"exclude_expired_course_run": True}
@@ -1415,7 +1415,10 @@ class TestEnterpriseCustomerCatalog(unittest.TestCase):
         catalog_query_content_filter = {"content_type": "course", "partner": "edx"}
         catalog_content_filter = {"content_type": "course_run", "partner": "dummy"}
         catalog_query = factories.EnterpriseCatalogQueryFactory(content_filter=catalog_query_content_filter)
-        catalog = factories.EnterpriseCustomerCatalogFactory(content_filter=catalog_content_filter)
+        catalog = factories.EnterpriseCustomerCatalogFactory(
+            content_filter=catalog_content_filter,
+            enterprise_catalog_query=None
+        )
         self.assertEqual(catalog.get_content_filter(), catalog_content_filter)
 
         catalog.enterprise_catalog_query = catalog_query


### PR DESCRIPTION
Fixes: [ENT-4428](https://openedx.atlassian.net/browse/ENT-4428)

Pass catalog query uuid into the update/create request to ent-catalog

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
