### PR TITLE
BUG: catalog query param should not be stringified when None

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing.
 
+[3.22.5]
+--------
+* Fix: no longer stringifying `None` values passed to enterprise catalog creations calls
+
 [3.22.4]
 --------
 * Fix: learner_data exporter bug fix and refactor for cleaner enrollment filtering

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.22.4"
+__version__ = "3.22.5"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/management/commands/migrate_enterprise_catalogs.py
+++ b/enterprise/management/commands/migrate_enterprise_catalogs.py
@@ -65,6 +65,8 @@ class Command(BaseCommand):
                     # in enterprise-catalog if it is a new catalog
                     should_raise_exception=False,
                 )
+                catalog_query = enterprise_catalog.enterprise_catalog_query
+                catalog_query_uuid = str(catalog_query.uuid) if catalog_query else None
                 if not response:
                     # catalog with matching uuid does NOT exist in enterprise-catalog
                     # service, so we should create a new catalog
@@ -76,7 +78,7 @@ class Command(BaseCommand):
                         enterprise_catalog.content_filter,
                         enterprise_catalog.enabled_course_modes,
                         enterprise_catalog.publish_audit_enrollment_urls,
-                        str(enterprise_catalog.enterprise_catalog_query.uuid),
+                        catalog_query_uuid,
                     )
                 else:
                     # catalog with matching uuid does exist in enterprise-catalog
@@ -88,7 +90,7 @@ class Command(BaseCommand):
                         'content_filter': enterprise_catalog.content_filter,
                         'enabled_course_modes': enterprise_catalog.enabled_course_modes,
                         'publish_audit_enrollment_urls': enterprise_catalog.publish_audit_enrollment_urls,
-                        'catalog_query_uuid': str(enterprise_catalog.enterprise_catalog_query.uuid),
+                        'catalog_query_uuid': catalog_query_uuid,
                     }
                     client.update_enterprise_catalog(
                         str(enterprise_catalog.uuid),

--- a/enterprise/signals.py
+++ b/enterprise/signals.py
@@ -257,7 +257,7 @@ def update_enterprise_catalog_data(sender, instance, **kwargs):     # pylint: di
     Algolia.
     """
     catalog_uuid = instance.uuid
-    catalog_query_uuid = instance.enterprise_catalog_query.uuid if instance.enterprise_catalog_query else None
+    catalog_query_uuid = str(instance.enterprise_catalog_query.uuid) if instance.enterprise_catalog_query else None
 
     try:
         catalog_client = EnterpriseCatalogApiClient()
@@ -286,7 +286,7 @@ def update_enterprise_catalog_data(sender, instance, **kwargs):     # pylint: di
                 instance.content_filter,
                 instance.enabled_course_modes,
                 instance.publish_audit_enrollment_urls,
-                str(catalog_query_uuid)
+                catalog_query_uuid
             )
         else:
             # catalog with matching uuid does exist in enterprise-catalog
@@ -298,7 +298,7 @@ def update_enterprise_catalog_data(sender, instance, **kwargs):     # pylint: di
                 'content_filter': instance.content_filter,
                 'enabled_course_modes': instance.enabled_course_modes,
                 'publish_audit_enrollment_urls': instance.publish_audit_enrollment_urls,
-                'catalog_query_uuid': str(catalog_query_uuid),
+                'catalog_query_uuid': catalog_query_uuid,
             }
             catalog_client.update_enterprise_catalog(catalog_uuid, **update_fields)
         # Refresh catalog on all creates and updates


### PR DESCRIPTION
**Merge checklist:**
Related to adding ent catalog query uuid to the creation request to `enterrpise-catalog` work

- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
