### PR TITLE
fix: ENT-4383: proxy login view now correctly passes along tpa_hint param to /login

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing.
 
+[3.22.6]
+--------
+* Fix: tpa_hint now correctly passed along to the `/login` endpoint in Enterprise proxy login view
+
 [3.22.5]
 --------
 * Fix: no longer stringifying `None` values passed to enterprise catalog creations calls

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.22.5"
+__version__ = "3.22.6"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -1067,15 +1067,14 @@ class EnterpriseProxyLoginView(View):
             # Add the tpa_hint to the redirect's 'next' query parameter
             # Redirect will be to the Enterprise Customer's TPA provider
             query_dict['tpa_hint'] = tpa_hint
-            new_query = urlencode(query_dict, doseq=True)
         else:
             # If there's no linked IDP or multiple IDPs are linked and no tpa_hint provided in query_param
             # Add Enterprise Customer UUID and proxy_login to the redirect's query parameters
             # Redirect will be to the edX Logistration with Enterprise Proxy Login sidebar
             query_dict['enterprise_customer'] = [str(enterprise_customer.uuid)]
             query_dict['proxy_login'] = [True]
-            new_query = urlencode(query_dict, doseq=True)
 
+        new_query = urlencode(query_dict, doseq=True)
         new_redirect_to = urlunsplit((scheme, netloc, path, new_query, fragment))
         return redirect(new_redirect_to)
 

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -75,6 +75,7 @@ from enterprise.utils import (
     is_course_run_enrollable,
     track_enrollment,
     ungettext_min_max,
+    update_query_parameters,
 )
 from integrated_channels.cornerstone.utils import create_cornerstone_learner_data
 
@@ -1067,6 +1068,12 @@ class EnterpriseProxyLoginView(View):
             # Add the tpa_hint to the redirect's 'next' query parameter
             # Redirect will be to the Enterprise Customer's TPA provider
             query_dict['tpa_hint'] = tpa_hint
+
+            # also add tpa_hint to the next url being sent
+            tpa_next_param = {
+                'tpa_hint': tpa_hint,
+            }
+            query_dict['next'] = update_query_parameters(str(query_dict['next']), tpa_next_param)
         else:
             # If there's no linked IDP or multiple IDPs are linked and no tpa_hint provided in query_param
             # Add Enterprise Customer UUID and proxy_login to the redirect's query parameters

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -75,7 +75,6 @@ from enterprise.utils import (
     is_course_run_enrollable,
     track_enrollment,
     ungettext_min_max,
-    update_query_parameters,
 )
 from integrated_channels.cornerstone.utils import create_cornerstone_learner_data
 
@@ -1067,18 +1066,16 @@ class EnterpriseProxyLoginView(View):
         if tpa_hint:
             # Add the tpa_hint to the redirect's 'next' query parameter
             # Redirect will be to the Enterprise Customer's TPA provider
-            tpa_next_param = {
-                'tpa_hint': tpa_hint,
-            }
-            query_dict['next'] = update_query_parameters(str(query_dict['next']), tpa_next_param)
+            query_dict['tpa_hint'] = tpa_hint
+            new_query = urlencode(query_dict, doseq=True)
         else:
             # If there's no linked IDP or multiple IDPs are linked and no tpa_hint provided in query_param
             # Add Enterprise Customer UUID and proxy_login to the redirect's query parameters
             # Redirect will be to the edX Logistration with Enterprise Proxy Login sidebar
             query_dict['enterprise_customer'] = [str(enterprise_customer.uuid)]
             query_dict['proxy_login'] = [True]
+            new_query = urlencode(query_dict, doseq=True)
 
-        new_query = urlencode(query_dict, doseq=True)
         new_redirect_to = urlunsplit((scheme, netloc, path, new_query, fragment))
         return redirect(new_redirect_to)
 

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -1065,11 +1065,11 @@ class EnterpriseProxyLoginView(View):
         tpa_hint = enterprise_customer.get_tpa_hint(tpa_hint_param)
 
         if tpa_hint:
-            # Add the tpa_hint to the redirect's 'next' query parameter
+            # Add the tpa_hint to the redirect's query parameters listing
             # Redirect will be to the Enterprise Customer's TPA provider
             query_dict['tpa_hint'] = tpa_hint
 
-            # also add tpa_hint to the next url being sent
+            # Also add tpa_hint to the next url being sent
             tpa_next_param = {
                 'tpa_hint': tpa_hint,
             }

--- a/tests/test_enterprise/views/test_enterprise_proxy_login_view.py
+++ b/tests/test_enterprise/views/test_enterprise_proxy_login_view.py
@@ -82,24 +82,33 @@ class TestEnterpriseProxyLoginView(TestCase):
         expected_url = LMS_LOGIN_URL + '?' + query_params.urlencode()
         self.assertRedirects(response, expected_url, fetch_redirect_response=False)
 
-    @ddt.data(
-        {'use_next': True},  # 'next' query param is passed in URL
-        {'use_next': False},  # 'next' query param not passed, default to LP URL with slug
-    )
-    @ddt.unpack
-    def test_tpa_redirect(self, use_next):
+    def test_tpa_redirect_no_next_param(self):
         """
-        Verify the view adds the next param and the tpa_hint to the redirect if the enterprise has an identity provider.
+        When 'next' url param is absent:
+          The proxy login redirects to default learner portal url,
+          url should contain: ?next=<learner portal url>&<tpa_hint=customer idp>
         """
-        url = self._get_url_with_params(use_next=use_next)
+        url = self._get_url_with_params(use_next=False)
         response = self.client.get(url)
         query_params = QueryDict(mutable=True)
-        if use_next:
-            next_url = self.next_url
-        else:
-            learner_portal_url = settings.ENTERPRISE_LEARNER_PORTAL_BASE_URL
-            next_url = learner_portal_url + '/' + self.enterprise_customer.slug
-        query_params['next'] = f'{next_url}?tpa_hint={self.enterprise_customer.identity_provider}'
+        learner_portal_url = settings.ENTERPRISE_LEARNER_PORTAL_BASE_URL
+        next_url = learner_portal_url + '/' + self.enterprise_customer.slug
+        query_params['next'] = next_url
+        query_params['tpa_hint'] = self.enterprise_customer.identity_provider
+        expected_url = LMS_LOGIN_URL + '?' + query_params.urlencode()
+        self.assertRedirects(response, expected_url, fetch_redirect_response=False)
+
+    def test_tpa_redirect_with_next_param(self):
+        """
+        When 'next' url param is present:
+          The proxy login redirects to the provided next url,
+          url should contain: ?next=<provided next param>&<tpa_hint=customer idp>
+        """
+        url = self._get_url_with_params(use_next=True, next_override=self.next_url)
+        response = self.client.get(url)
+        query_params = QueryDict(mutable=True)
+        query_params['next'] = self.next_url
+        query_params['tpa_hint'] = self.enterprise_customer.identity_provider
         expected_url = LMS_LOGIN_URL + '?' + query_params.urlencode()
         self.assertRedirects(response, expected_url, fetch_redirect_response=False)
 
@@ -133,13 +142,17 @@ class TestEnterpriseProxyLoginView(TestCase):
             identity_provider.enterprise_customer = enterprise_customer
             identity_provider.save()
 
-        url = self._get_url_with_params(enterprise_slug_override=enterprise_customer.slug, tpa_hint=tpa_hint_param)
+        url = self._get_url_with_params(
+            enterprise_slug_override=enterprise_customer.slug,
+            tpa_hint=tpa_hint_param,
+        )
         response = self.client.get(url)
         query_params = QueryDict(mutable=True)
         next_url = self.next_url
 
         if redirected_tpa_hint:
-            query_params['next'] = f'{next_url}?tpa_hint={redirected_tpa_hint}'
+            query_params['next'] = next_url
+            query_params['tpa_hint'] = redirected_tpa_hint
         else:
             query_params['enterprise_customer'] = str(enterprise_customer.uuid)
             query_params['proxy_login'] = True


### PR DESCRIPTION
Passes tpa_hint param to the next url in the redirect sequence. Before the fix, it was being urlencoded as part of the 'next' param and therefore not picked up by the /login endpoint. This change retains the prior behavior but also adds `tpa_hint` as a url param to the redirect_uri which needs it

All in all, this really just amounts to adding the param `&tpa_hint=saml-default-saml-config-bpant` to the redirect_uri as it stands today without changing the value of the `next` parameter passed to it

JIRA: https://openedx.atlassian.net/browse/ENT-4383

###  Testing notes 

Locally, verified that, on visiting learner portal: http://localhost:8734/saml-customer 

* before fix: I ended up at a url like this:  `http://localhost:18000/login?next=http%3A%2F%2Flocalhost%3A8734%2Fsaml-customer%3Ftpa_hint%3Dsaml-default-saml-config-bpant`
* after fix: I now get redirected to: `/login?next=http%3A%2F%2Flocalhost%3A8734%2Fsaml-customer%3Ftpa_hint%3Dsaml-default-saml-config-bpant&tpa_hint=saml-default-saml-config-bpant`

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
