### PR TITLE
fix: improves performance of enterprise role assignment admin page

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,13 @@ Unreleased
 ----------
 * Nothing.
 
+[3.22.6]
+--------
+* Improves performance of enterprise role assignment admin page
+* Deletes custom get_search_results() method, since ``enterprise_customer__name`` is now a viable search field
+* Improves pagination by asking for an estimated row count from Mysql ``INFORMATION_SCHEMA.TABLES``
+* Turns 1 + N query into 1 query via proper use of ``list_select_related``
+
 [3.22.5]
 --------
 * Fix: no longer stringifying `None` values passed to enterprise catalog creations calls

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.22.5"
+__version__ = "3.22.6"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name


### PR DESCRIPTION
### Overview
* Deletes custom get_search_results() method, since `enterprise_customer__name` is now a viable search field
* Improves pagination by asking for an estimated row count from Mysql INFORMATION_SCHEMA.TABLES
* Turns 1 + N query into 1 query via proper use of list_select_related

https://openedx.atlassian.net/browse/ENT-4384

### Queries now performed in the list view
1. Select all the roles (very quick, small number of roles) for dropdown/filter.
2. Get an estimate of total rows from INFORMATION_SCHEMA (very quick)
2a. If the list is actually a search result, we'll do a real `count()` against the filtered queryset.  This will typically be a small queryset - most usage is to find assignments for specific learners, or all assignments for an enterprise customer.
3. One query to get assignments and all related objects, ordered by the PK of the main table, limited to 25 records at a time - this takes 10 seconds or less on the read-replica.  Prior to this change, we were effectively making this query twice: once to get the total count of records, and once to load the page of 25 records.

### To test locally
* Install this branch of enterprise into your local LMS container.  Restart the devserver.
* Go to http://localhost:18000/admin/enterprise/systemwideenterpriseuserroleassignment/?q=piper
* Open the Django Toolbar and click on the SQL tab - you'll get a list of all queries run when loading a page.

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [x] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
