### PR TITLE
feat: tableau auth view improvements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,12 @@ Unreleased
 ----------
 * Nothing.
 
+[3.22.8]
+--------
+* Add dashboard admin rbac role permission on tableau auth view so that only
+  enterprise dashboard admins can access this view.
+* Add support to generate tableau auth token based on incoming enterprise customer's uuid
+
 [3.22.7]
 --------
 * chore: upgrade edx-enterprise requirements

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.22.7"
+__version__ = "3.22.8"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/v1/urls.py
+++ b/enterprise/api/v1/urls.py
@@ -52,6 +52,11 @@ urlpatterns = [
         views.TableauAuthView.as_view(),
         name='tableau-token'
     ),
+    url(
+        r'^tableau_token/(?P<enterprise_uuid>[A-Za-z0-9-]+)$',
+        views.TableauAuthView.as_view(),
+        name='tableau-token'
+    ),
 ]
 
 urlpatterns += router.urls

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -10,7 +10,9 @@ from smtplib import SMTPException
 
 import ddt
 import mock
+import responses
 from faker import Faker
+from path import Path
 from pytest import mark, raises
 from rest_framework import status
 from rest_framework.reverse import reverse
@@ -65,6 +67,7 @@ from test_utils import (
     update_course_with_enterprise_context,
     update_program_with_enterprise_context,
 )
+from test_utils.decorators import mock_api_response
 from test_utils.factories import FAKER
 from test_utils.fake_enterprise_api import get_default_branding_object
 
@@ -4234,3 +4237,41 @@ class TestEnterpriseReportingConfigAPIViews(APITest):
 
         # Make sure the enterprise customer catalog was linked with the reporting configuration.
         assert [str(enterprise_catalog_2.uuid)] == ec_catalog_uuids
+
+    @mock_api_response(
+        responses.POST,
+        Path(settings.TABLEAU_URL) / 'trusted',
+        content_type='text/plain',
+        body='12345'
+    )
+    @mock.patch('enterprise.rules.crum.get_current_request')
+    @ddt.data(
+        (False, status.HTTP_403_FORBIDDEN),
+        (True, status.HTTP_200_OK),
+    )
+    @ddt.unpack
+    def test_tableau_auth_view(self, has_feature_role, expected_status, request_or_stub_mock):
+        """
+        Tests that the TableauAuthView::get endpoint works as expected.
+        """
+        user, enterprise_customer = self._create_user_and_enterprise_customer('test_user', 'test_password')
+
+        client = APIClient()
+        client.login(username='test_user', password='test_password')
+
+        if has_feature_role:
+            self._add_feature_role(user, ENTERPRISE_DASHBOARD_ADMIN_ROLE)
+
+        system_wide_role = ENTERPRISE_ADMIN_ROLE
+        request_or_stub_mock.return_value = self.get_request_with_jwt_cookie(system_wide_role=system_wide_role)
+
+        response = client.get(
+            '{server}{view_url}'.format(
+                server=settings.TEST_SERVER,
+                view_url=reverse('tableau-token', kwargs={'enterprise_uuid': enterprise_customer.uuid})
+            ),
+        )
+
+        assert response.status_code == expected_status
+        if has_feature_role:
+            assert response.json() == '12345'


### PR DESCRIPTION
**Description:**
* Add dashboard admin rbac role permission on tableau auth view so that only enterprise dashboard admins can access this view.
* Add support to generate tableau auth token based on incoming enterprise uuid

**JIRA:** https://openedx.atlassian.net/browse/ENT-4413

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
