### PR TITLE
fix: add list of enterprise catalog uuids to EnterpriseCustomerSerializer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing.
 
+[3.22.9]
+--------
+* Expose enterprise catalog uuids associated with an Enterprise Customer in the ``enterprise-customer`` API endpoint.
+
 [3.22.8]
 --------
 * Add dashboard admin rbac role permission on tableau auth view so that only

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.22.8"
+__version__ = "3.22.9"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -170,17 +170,25 @@ class EnterpriseCustomerSerializer(serializers.ModelSerializer):
             'enable_portal_subscription_management_screen', 'hide_course_original_price', 'enable_analytics_screen',
             'enable_integrated_customer_learner_portal_search',
             'enable_portal_lms_configurations_screen', 'sender_alias', 'identity_providers',
+            'enterprise_customer_catalogs',
         )
 
     identity_providers = EnterpriseCustomerIdentityProviderSerializer(many=True, read_only=True)
     site = SiteSerializer()
     branding_configuration = serializers.SerializerMethodField()
+    enterprise_customer_catalogs = serializers.SerializerMethodField()
 
     def get_branding_configuration(self, obj):
         """
         Return the serialized branding configuration object OR default object if null
         """
         return EnterpriseCustomerBrandingConfigurationSerializer(obj.safe_branding_configuration).data
+
+    def get_enterprise_customer_catalogs(self, obj):
+        """
+        Return list of catalog uuids associated with the enterprise customer.
+        """
+        return [str(catalog.uuid) for catalog in obj.enterprise_customer_catalogs.all()]
 
 
 class EnterpriseCustomerBasicSerializer(serializers.ModelSerializer):

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -158,7 +158,7 @@ class EnterpriseCustomerViewSet(EnterpriseReadWriteModelViewSet):
     # pylint: disable=invalid-name,unused-argument
     def basic_list(self, request, *arg, **kwargs):
         """
-            Enterprise Customer's Basic data list without pagination
+        Enterprise Customer's Basic data list without pagination
         """
         startswith = request.GET.get('startswith')
         queryset = self.get_queryset().order_by('name')

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -1123,6 +1123,7 @@ class TestEnterpriseCustomerListViews(BaseTestEnterpriseAPIViews):
                 'hide_course_original_price': False,
                 'sender_alias': 'Test Sender Alias',
                 'identity_providers': [],
+                'enterprise_customer_catalogs': [],
             }],
         ),
         (
@@ -1167,6 +1168,7 @@ class TestEnterpriseCustomerListViews(BaseTestEnterpriseAPIViews):
                     'hide_course_original_price': False,
                     'sender_alias': 'Test Sender Alias',
                     'identity_providers': [],
+                    'enterprise_customer_catalogs': [],
                 }
             }],
         ),
@@ -1227,6 +1229,52 @@ class TestEnterpriseCustomerListViews(BaseTestEnterpriseAPIViews):
                         "default_provider": False,
                     },
                 ],
+                'enterprise_customer_catalogs': [],
+            }],
+        ),
+        (
+            factories.EnterpriseCustomerCatalogFactory,
+            ENTERPRISE_CUSTOMER_LIST_ENDPOINT,
+            itemgetter('uuid'),
+            [{
+                'uuid': FAKE_UUIDS[0],
+                'enterprise_customer__uuid': FAKE_UUIDS[1],
+                'enterprise_customer__name': 'Test Enterprise Customer',
+                'enterprise_customer__slug': TEST_SLUG,
+                'enterprise_customer__active': True,
+                'enterprise_customer__enable_data_sharing_consent': True,
+                'enterprise_customer__enforce_data_sharing_consent': 'at_enrollment',
+                'enterprise_customer__site__domain': 'example.com',
+                'enterprise_customer__site__name': 'example.com',
+                'enterprise_customer__contact_email': 'fake@example.com',
+                'enterprise_customer__sender_alias': 'Test Sender Alias',
+            }],
+            [{
+                'uuid': FAKE_UUIDS[1], 'name': 'Test Enterprise Customer', 'slug': TEST_SLUG,
+                'active': True, 'enable_data_sharing_consent': True,
+                'enforce_data_sharing_consent': 'at_enrollment',
+                'branding_configuration': get_default_branding_object(FAKE_UUIDS[1], TEST_SLUG),
+                'enable_audit_enrollment': False,
+                'identity_provider': None,
+                'replace_sensitive_sso_username': False,
+                'enable_portal_code_management_screen': False,
+                'enable_portal_reporting_config_screen': False,
+                'enable_portal_saml_configuration_screen': False,
+                'enable_portal_lms_configurations_screen': False,
+                'enable_audit_data_reporting': False,
+                'site': {
+                    'domain': 'example.com', 'name': 'example.com'
+                },
+                'sync_learner_profile_data': False,
+                'enable_learner_portal': False,
+                'enable_integrated_customer_learner_portal_search': True,
+                'enable_portal_subscription_management_screen': False,
+                'enable_analytics_screen': False,
+                'contact_email': 'fake@example.com',
+                'hide_course_original_price': False,
+                'sender_alias': 'Test Sender Alias',
+                'identity_providers': [],
+                'enterprise_customer_catalogs': [FAKE_UUIDS[0]],
             }],
         ),
         (
@@ -1416,6 +1464,7 @@ class TestEnterpriseCustomerListViews(BaseTestEnterpriseAPIViews):
                 'hide_course_original_price': False,
                 'sender_alias': 'Test Sender Alias',
                 'identity_providers': [],
+                'enterprise_customer_catalogs': [],
             }
         else:
             assert response == expected_error


### PR DESCRIPTION
### Ticket

[ENT-4154](https://openedx.atlassian.net/browse/ENT-4154)

### Example API response (truncated)

```json
{
    "next": null,
    "previous": null,
    "count": 2,
    "num_pages": 1,
    "current_page": 1,
    "start": 0,
    "results": [
        {
            "uuid": "bdd488ad-3f6e-49b7-9fb4-99443afad65f",
            "name": "Test Enterprise",
            "slug": "test-enterprise",
            "enterprise_customer_catalogs": [
                "d0e5d354-205c-4cae-85c2-eb9abdf5b382"
            ]
        }
    ]
}
```

### Testing instructions

1. Ensure your devstack has at least one `EnterpriseCustomer` configured with an enterprise catalog.
2. Visit http://localhost:18000/enterprise/api/v1/enterprise-customer/.
3. Observe additional `enterprise_customer_catalogs` field in the response containing a list of catalog UUIDs.

### **Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
