### PR TITLE
feat: make enterprise customer uuid mandatory for tableau auth view

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing.
 
+[3.22.13]
+---------
+* Make enterprise customer uuid mandatory for `TableauAuthView`
+
 [3.22.12]
 ---------
 * Change the verbose name and help text for the ``enable_integrated_customer_learner_portal_search`` field on the ``EnterpriseCustomer`` model.

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.22.12"
+__version__ = "3.22.13"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/v1/urls.py
+++ b/enterprise/api/v1/urls.py
@@ -48,11 +48,6 @@ urlpatterns = [
         name='request-codes'
     ),
     url(
-        r'^tableau_token$',
-        views.TableauAuthView.as_view(),
-        name='tableau-token'
-    ),
-    url(
         r'^tableau_token/(?P<enterprise_uuid>[A-Za-z0-9-]+)$',
         views.TableauAuthView.as_view(),
         name='tableau-token'

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -1164,9 +1164,9 @@ class TableauAuthView(generics.GenericAPIView):
 
     @permission_required(
         'enterprise.can_access_admin_dashboard',
-        fn=lambda request, enterprise_uuid=None: enterprise_uuid
+        fn=lambda request, enterprise_uuid: enterprise_uuid
     )
-    def get(self, request, enterprise_uuid=None):
+    def get(self, request, enterprise_uuid):
         """
         Get the auth token against logged in user from tableau
         """


### PR DESCRIPTION
**Description:** Make enterprise customer uuid mandatory for tableau auth view.

**JIRA:** https://openedx.atlassian.net/browse/ENT-4485

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
