### PR TITLE
fix: don't call into email_marketing anymore

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing.
 
+[3.22.11]
+---------
+* No longer call into the removed email_marketing platform djangoapp
+
 [3.22.10]
 ---------
 * Use Braze for sending data sharing consent drop emails, add the DSC link inside the drip email.

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.22.10"
+__version__ = "3.22.11"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -74,9 +74,7 @@ from enterprise.validators import (
 
 try:
     from common.djangoapps.student.models import CourseEnrollment
-    from lms.djangoapps.email_marketing.tasks import update_user
 except ImportError:
-    update_user = None
     CourseEnrollment = None
 
 LOGGER = getLogger(__name__)
@@ -810,16 +808,6 @@ class EnterpriseCustomerUserManager(models.Manager):
             link_record = self.get(enterprise_customer=enterprise_customer, user_id=existing_user.id)
             link_record.linked = False
             link_record.save()
-
-            if update_user:
-                # Remove the SailThru flags for enterprise learner.
-                update_user.delay(
-                    sailthru_vars={
-                        'is_enterprise_learner': False,
-                        'enterprise_name': None,
-                    },
-                    email=user_email
-                )
 
         except User.DoesNotExist:
             # not capturing DoesNotExist intentionally to signal to view that link does not exist


### PR DESCRIPTION
It's been removed in platform

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
