### PR TITLE
ENT-3971: Leverage ENT-3970's Drip to email historical enrollments with DSC issue

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing.
 
+[3.23.0]
+---------
+* Added support for ``--enrollment-before`` and ``--no-commit`` params in ``email_drip_for_missing_dsc_records`` command.
+
 [3.22.16]
 ---------
 * Fixed Segment json string issue for DSC email drip

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.22.16"
+__version__ = "3.23.0"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/management/commands/email_drip_for_missing_dsc_records.py
+++ b/enterprise/management/commands/email_drip_for_missing_dsc_records.py
@@ -179,8 +179,7 @@ class Command(BaseCommand):
                 )
 
         LOGGER.info(
-            '[Absent DSC Email] Email sent for [%s] enrollments out of [%s] enrollments. DSC records sent to: [%s]'
-            'User: [%s], Course: [%s], Enterprise: [%s], DSC URL: [%s]',
+            '[Absent DSC Email] Emails sent for [%s] enrollments out of [%s] enrollments. DSC records sent to: [%s]',
             len(email_sent_records),
             enterprise_course_enrollments.count(),
             email_sent_records

--- a/enterprise/management/commands/email_drip_for_missing_dsc_records.py
+++ b/enterprise/management/commands/email_drip_for_missing_dsc_records.py
@@ -84,29 +84,87 @@ class Command(BaseCommand):
         )
         return dsc_url, course_title
 
+    def get_enterprise_course_enrollments(self, options):
+        """
+        Get EnterpriseCourseEnrollment records according to the options
+        """
+        enrollment_before = options['enrollment_before']
+        enterprise_course_enrollments = EnterpriseCourseEnrollment.objects.select_related(
+            'enterprise_customer_user'
+        )
+        if enrollment_before:
+            enterprise_course_enrollments = enterprise_course_enrollments.filter(created__date__lt=enrollment_before)
+        else:
+            past_date = date.today() - timedelta(days=PAST_NUM_DAYS)
+            enterprise_course_enrollments = enterprise_course_enrollments.filter(created__date=past_date)
+
+        return enterprise_course_enrollments
+
+    def emit_event(self, ec_user,  course_id, enterprise_customer, greeting_name):
+        """
+         Emit the Segment event which will be used by Braze to send the email
+        """
+        dsc_url, course_title = self._get_course_properties(ec_user.user, course_id, enterprise_customer)
+        utils.track_event(ec_user.user_id, 'edx.bi.user.consent.absent', {
+            'course': course_id,
+            'username': ec_user.username,
+            'enterprise_name': enterprise_customer.name,
+            'enterprise_uuid': str(enterprise_customer.uuid),
+            'dsc_url': dsc_url,
+            'course_title': course_title,
+            'user_email': ec_user.user_email,
+            'greeting_name': greeting_name
+        })
+        LOGGER.info(
+            '[Absent DSC Email] Segment event fired for missing data sharing consent. '
+            'User: [%s], Course: [%s], Enterprise: [%s], DSC URL: [%s]',
+            ec_user.username,
+            course_id,
+            str(enterprise_customer.uuid),
+            dsc_url
+        )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--no-commit',
+            action='store_true',
+            dest='no_commit',
+            default=False,
+            help='Dry Run, print log messages without committing anything.',
+        )
+        parser.add_argument(
+            '--enrollment-before',
+            action='store',
+            dest='enrollment_before',
+            default=None,
+            type=datetime.date.fromisoformat,
+            help='Specifies the date (format YYYY-MM-DD). Enrollments created before this date will receive DSC emails.'
+        )
+
     def handle(self, *args, **options):
         """
         Management command for sending an email to learners with a missing DSC. Designed to run daily.
 
         Example usage:
            $ ./manage.py email_drip_for_missing_dsc_records
+           $ ./manage.py email_drip_for_missing_dsc_records  --no-commit
+           $ ./manage.py email_drip_for_missing_dsc_records  --enrollment-before 2021-05-06 --no-commit
+           $ ./manage.py email_drip_for_missing_dsc_records  --enrollment-before 2021-05-06
         """
-        past_date = date.today() - timedelta(days=PAST_NUM_DAYS)
-        enterprise_course_enrollments = EnterpriseCourseEnrollment.objects.select_related(
-            'enterprise_customer_user'
-        ).filter(created__date=past_date)
+        should_commit = not options['no_commit']
 
+        email_sent_records = []
+
+        enterprise_course_enrollments = self.get_enterprise_course_enrollments(options)
         for enterprise_enrollment in enterprise_course_enrollments:
-            user = enterprise_enrollment.enterprise_customer_user.user
-            username = enterprise_enrollment.enterprise_customer_user.username
-            user_id = enterprise_enrollment.enterprise_customer_user.user_id
-            user_email = enterprise_enrollment.enterprise_customer_user.user_email
+            ec_user = enterprise_enrollment.enterprise_customer_user
+            username = ec_user.username
+            user_email = ec_user.user_email
             greeting_name = user_email
-            if hasattr(user, 'first_name') and user.first_name:
-                greeting_name = user.first_name
+            if hasattr(ec_user, 'first_name') and ec_user.first_name:
+                greeting_name = ec_user.first_name
             course_id = enterprise_enrollment.course_id
-            enterprise_customer = enterprise_enrollment.enterprise_customer_user.enterprise_customer
-            dsc_url, course_title = self._get_course_properties(user, course_id, enterprise_customer)
+            enterprise_customer = ec_user.enterprise_customer
             consent = DataSharingConsent.objects.proxied_get(
                 username=username,
                 course_id=course_id,
@@ -114,21 +172,17 @@ class Command(BaseCommand):
             )
             # Emit the Segment event which will be used by Braze to send the email
             if isinstance(consent, ProxyDataSharingConsent):
-                utils.track_event(user_id, 'edx.bi.user.consent.absent', {
-                    'course': course_id,
-                    'username': username,
-                    'enterprise_name': enterprise_customer.name,
-                    'enterprise_uuid': str(enterprise_customer.uuid),
-                    'dsc_url': dsc_url,
-                    'course_title': course_title,
-                    'user_email': user_email,
-                    'greeting_name': greeting_name
-                })
-                LOGGER.info(
-                    '[Absent DSC Email] Segment event fired for missing data sharing consent. '
-                    'User: [%s], Course: [%s], Enterprise: [%s], DSC URL: [%s]',
-                    username,
-                    course_id,
-                    str(enterprise_customer.uuid),
-                    dsc_url
+                if should_commit:
+                    self.emit_event(ec_user,  course_id, enterprise_customer, greeting_name)
+                email_sent_records.append(
+                    f'User: {username}, Course: {course_id}, Enterprise: {enterprise_customer.uuid}'
                 )
+
+        LOGGER.info(
+            '[Absent DSC Email] Email sent for [%s] enrollments out of [%s] enrollments. DSC records sent to: [%s]'
+            'User: [%s], Course: [%s], Enterprise: [%s], DSC URL: [%s]',
+            len(email_sent_records),
+            enterprise_course_enrollments.count(),
+            email_sent_records
+        )
+

--- a/enterprise/management/commands/email_drip_for_missing_dsc_records.py
+++ b/enterprise/management/commands/email_drip_for_missing_dsc_records.py
@@ -100,7 +100,7 @@ class Command(BaseCommand):
 
         return enterprise_course_enrollments
 
-    def emit_event(self, ec_user,  course_id, enterprise_customer, greeting_name):
+    def emit_event(self, ec_user, course_id, enterprise_customer, greeting_name):
         """
          Emit the Segment event which will be used by Braze to send the email
         """
@@ -173,7 +173,7 @@ class Command(BaseCommand):
             # Emit the Segment event which will be used by Braze to send the email
             if isinstance(consent, ProxyDataSharingConsent):
                 if should_commit:
-                    self.emit_event(ec_user,  course_id, enterprise_customer, greeting_name)
+                    self.emit_event(ec_user, course_id, enterprise_customer, greeting_name)
                 email_sent_records.append(
                     f'User: {username}, Course: {course_id}, Enterprise: {enterprise_customer.uuid}'
                 )

--- a/enterprise/management/commands/email_drip_for_missing_dsc_records.py
+++ b/enterprise/management/commands/email_drip_for_missing_dsc_records.py
@@ -184,4 +184,3 @@ class Command(BaseCommand):
             enterprise_course_enrollments.count(),
             email_sent_records
         )
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,9 @@
       }
     },
     "@edx/brand": {
-      "version": "npm:@edx/brand-edx.org@1.4.1",
-      "resolved": "https://registry.npmjs.org/@edx/brand-edx.org/-/brand-edx.org-1.4.1.tgz",
-      "integrity": "sha512-m69B6uT7InYx4YjB/ttBYsnlUpmk0Pr12X4mtImtEMJiA0cGuiqC9ywr8UJOavMj4/D8vUuREC+57G8XazIjMw=="
+      "version": "npm:@edx/brand-edx.org@1.6.1",
+      "resolved": "https://registry.npmjs.org/@edx/brand-edx.org/-/brand-edx.org-1.6.1.tgz",
+      "integrity": "sha512-GTddzcmQwBn30s4dBPKPbuvJAYERF3YW+B0yo9LNPvyRpQjI2dOfOsnzCuqroqDh72lEK+PFtVAEYTH9mu1Zjg=="
     },
     "@edx/paragon": {
       "version": "12.3.0",


### PR DESCRIPTION
added support for enrollment_before and --no-commit in email_drip_for_missing_dsc_records command

https://openedx.atlassian.net/browse/ENT-3971

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
