### PR TITLE
BOM-2247: Upgrade pip-tools

### DIFF
--- a/requirements/celery50.txt
+++ b/requirements/celery50.txt
@@ -1,9 +1,9 @@
-amqp==5.0.6
-billiard==3.6.4.0
-celery==5.0.4
-click-didyoumean==0.0.3
-click-repl==0.1.6
-click==7.1.2
-kombu==5.0.2
-prompt-toolkit==3.0.18
-vine==5.0.0
+amqp==5.0.6               # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, kombu
+billiard==3.6.4.0         # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, celery
+celery==5.0.4             # via -c requirements/constraints.txt, -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+click-didyoumean==0.0.3   # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, celery
+click-repl==0.1.6         # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, celery
+click==7.1.2              # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, celery, click-didyoumean, click-log, click-plugins, click-repl, code-annotations, edx-lint, pip-tools
+kombu==5.0.2              # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, celery
+prompt-toolkit==3.0.18    # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, click-repl
+vine==5.0.0               # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, amqp, celery

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,47 +4,22 @@
 #
 #    make upgrade
 #
-appdirs==1.4.4
-    # via virtualenv
-certifi==2020.12.5
-    # via requests
-chardet==4.0.0
-    # via requests
-codecov==2.1.11
-    # via -r requirements/ci.in
-coverage==5.5
-    # via codecov
-distlib==0.3.1
-    # via virtualenv
-filelock==3.0.12
-    # via
-    #   tox
-    #   virtualenv
-idna==2.10
-    # via requests
-packaging==20.9
-    # via tox
-pluggy==0.13.1
-    # via tox
-py==1.10.0
-    # via tox
-pyparsing==2.4.7
-    # via packaging
-requests==2.25.1
-    # via codecov
-six==1.15.0
-    # via
-    #   tox
-    #   virtualenv
-toml==0.10.2
-    # via tox
-tox-battery==0.6.1
-    # via -r requirements/ci.in
-tox==3.23.0
-    # via
-    #   -r requirements/ci.in
-    #   tox-battery
-urllib3==1.26.4
-    # via requests
-virtualenv==20.4.4
-    # via tox
+appdirs==1.4.4            # via virtualenv
+certifi==2020.12.5        # via requests
+chardet==4.0.0            # via requests
+codecov==2.1.11           # via -r requirements/ci.in
+coverage==5.5             # via codecov
+distlib==0.3.1            # via virtualenv
+filelock==3.0.12          # via tox, virtualenv
+idna==2.10                # via requests
+packaging==20.9           # via tox
+pluggy==0.13.1            # via tox
+py==1.10.0                # via tox
+pyparsing==2.4.7          # via packaging
+requests==2.25.1          # via codecov
+six==1.16.0               # via tox, virtualenv
+toml==0.10.2              # via tox
+tox-battery==0.6.1        # via -r requirements/ci.in
+tox==3.23.1               # via -r requirements/ci.in, tox-battery
+urllib3==1.26.4           # via requests
+virtualenv==20.4.6        # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,775 +4,153 @@
 #
 #    make upgrade
 #
-alabaster==0.7.12
-    # via
-    #   -r requirements/doc.txt
-    #   sphinx
-amqp==5.0.6
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   kombu
-aniso8601==9.0.1
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   edx-tincan-py35
-appdirs==1.4.4
-    # via virtualenv
-astroid==2.5.3
-    # via
-    #   pylint
-    #   pylint-celery
-attrs==20.3.0
-    # via
-    #   -r requirements/test.txt
-    #   pytest
-babel==2.9.0
-    # via
-    #   -r requirements/doc.txt
-    #   sphinx
-billiard==3.6.4.0
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   celery
-bleach==3.3.0
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   readme-renderer
-celery==5.0.4
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-certifi==2020.12.5
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   requests
-cffi==1.14.5
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   cryptography
-chardet==4.0.0
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   diff-cover
-    #   doc8
-    #   requests
-click-didyoumean==0.0.3
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   celery
-click-log==0.3.2
-    # via edx-lint
-click-plugins==1.1.1
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   celery
-click-repl==0.1.6
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   celery
-click==7.1.2
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   celery
-    #   click-didyoumean
-    #   click-log
-    #   click-plugins
-    #   click-repl
-    #   code-annotations
-    #   edx-lint
-    #   pip-tools
-code-annotations==1.1.1
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   edx-lint
-coverage==5.5
-    # via
-    #   -r requirements/test.txt
-    #   pytest-cov
-cryptography==3.2.1
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   django-fernet-fields
-    #   pyjwt
-ddt==1.3.1
-    # via -r requirements/test.txt
-defusedxml==0.7.1
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   djangorestframework-xml
-diff-cover==5.0.1
-    # via -r requirements/test.txt
-distlib==0.3.1
-    # via virtualenv
-django-cache-memoize==0.1.8
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-django-config-models==2.1.1
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-django-countries==5.5
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-django-crum==0.7.9
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   edx-django-utils
-    #   edx-rbac
-django-fernet-fields==0.6
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-django-filter==2.4.0
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-django-ipware==3.0.2
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-django-model-utils==4.1.1
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   edx-rbac
-django-multi-email-field==0.6.2
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-django-object-actions==3.0.2
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-django-simple-history==2.12.0
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-django-waffle==2.1.0
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   edx-django-utils
-    #   edx-drf-extensions
-django==2.2.20
-    # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   code-annotations
-    #   django-config-models
-    #   django-crum
-    #   django-fernet-fields
-    #   django-filter
-    #   django-model-utils
-    #   django-multi-email-field
-    #   djangorestframework
-    #   drf-jwt
-    #   edx-django-utils
-    #   edx-drf-extensions
-    #   edx-i18n-tools
-    #   edx-lint
-    #   edx-opaque-keys
-    #   edx-rbac
-    #   jsonfield2
-    #   rest-condition
-djangorestframework-xml==2.0.0
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-djangorestframework==3.12.4
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   django-config-models
-    #   drf-jwt
-    #   edx-drf-extensions
-    #   rest-condition
-doc8==0.8.1
-    # via -r requirements/doc.txt
-docutils==0.16
-    # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   -r requirements/doc.txt
-    #   doc8
-    #   readme-renderer
-    #   restructuredtext-lint
-    #   sphinx
-drf-jwt==1.19.0
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   edx-drf-extensions
-edx-django-utils==3.16.0
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   django-config-models
-    #   edx-drf-extensions
-    #   edx-rest-api-client
-edx-drf-extensions==6.5.0
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   edx-rbac
-edx-i18n-tools==0.5.3
-    # via -r requirements/dev.in
-edx-lint==5.0.0
-    # via -r requirements/dev.in
-edx-opaque-keys[django]==2.2.0
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   edx-drf-extensions
-edx-rbac==1.4.2
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-edx-rest-api-client==5.3.0
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-edx-sphinx-theme==2.1.0
-    # via -r requirements/doc.txt
-edx-tincan-py35==1.0.0
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-factory-boy==3.2.0
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test.txt
-faker==8.1.0
-    # via
-    #   -r requirements/test.txt
-    #   factory-boy
-filelock==3.0.12
-    # via
-    #   tox
-    #   virtualenv
-freezegun==0.3.14
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test.txt
-future==0.18.2
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   pyjwkest
-idna==2.10
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   requests
-imagesize==1.2.0
-    # via
-    #   -r requirements/doc.txt
-    #   sphinx
-importlib-metadata==4.0.1
-    # via
-    #   -r requirements/test.txt
-    #   inflect
-inflect==3.0.2
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test.txt
-    #   jinja2-pluralize
-iniconfig==1.1.1
-    # via
-    #   -r requirements/test.txt
-    #   pytest
-isort==5.8.0
-    # via
-    #   -r requirements/dev.in
-    #   pylint
-jinja2-pluralize==0.3.0
-    # via
-    #   -r requirements/test.txt
-    #   diff-cover
-jinja2==2.11.3
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   code-annotations
-    #   diff-cover
-    #   jinja2-pluralize
-    #   sphinx
-jsondiff==1.3.0
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-jsonfield2==3.0.3
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-kombu==5.0.2
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   celery
-lazy-object-proxy==1.6.0
-    # via astroid
-markupsafe==1.1.1
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   jinja2
-mccabe==0.6.1
-    # via pylint
-mock==3.0.5
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test.txt
-more-itertools==8.7.0
-    # via
-    #   -r requirements/test.txt
-    #   zipp
-newrelic==6.2.0.156
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   edx-django-utils
-packaging==20.9
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   bleach
-    #   pytest
-    #   sphinx
-    #   tox
-path.py==12.5.0
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   edx-i18n-tools
-path==13.1.0
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   path.py
-pbr==5.5.1
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   stevedore
-pep517==0.10.0
-    # via pip-tools
-pillow==8.2.0
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-pip-tools==6.1.0
-    # via -r requirements/dev.in
-pkginfo==1.7.0
-    # via twine
-pluggy==0.13.1
-    # via
-    #   -r requirements/test.txt
-    #   diff-cover
-    #   pytest
-    #   tox
-pockets==0.9.1
-    # via
-    #   -r requirements/doc.txt
-    #   sphinxcontrib-napoleon
-polib==1.1.1
-    # via edx-i18n-tools
-prompt-toolkit==3.0.18
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   click-repl
-psutil==5.8.0
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   edx-django-utils
-py==1.10.0
-    # via
-    #   -r requirements/test.txt
-    #   pytest
-    #   pytest-catchlog
-    #   tox
-pycodestyle==2.7.0
-    # via -r requirements/dev.in
-pycparser==2.20
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   cffi
-pycryptodomex==3.10.1
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   pyjwkest
-pydocstyle==6.0.0
-    # via -r requirements/dev.in
-pygments==2.8.1
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test.txt
-    #   diff-cover
-    #   doc8
-    #   readme-renderer
-    #   sphinx
-pyjwkest==1.4.2
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   edx-drf-extensions
-pyjwt[crypto]==1.7.1
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   drf-jwt
-    #   edx-rest-api-client
-pylint-celery==0.3
-    # via edx-lint
-pylint-django==2.4.3
-    # via edx-lint
-pylint-plugin-utils==0.6
-    # via
-    #   pylint-celery
-    #   pylint-django
-pylint==2.7.4
-    # via
-    #   edx-lint
-    #   pylint-celery
-    #   pylint-django
-    #   pylint-plugin-utils
-pymongo==3.10.1
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   edx-opaque-keys
-pyparsing==2.4.7
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   packaging
-pytest-catchlog==1.2.2
-    # via -r requirements/test.txt
-pytest-cov==2.11.1
-    # via -r requirements/test.txt
-pytest-django==4.2.0
-    # via -r requirements/test.txt
-pytest==6.2.3
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test.txt
-    #   pytest-catchlog
-    #   pytest-cov
-    #   pytest-django
-python-dateutil==2.4.0
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   edx-drf-extensions
-    #   faker
-    #   freezegun
-python-slugify==4.0.1
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   code-annotations
-pytz==2021.1
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   babel
-    #   celery
-    #   django
-    #   edx-tincan-py35
-pyyaml==5.4.1
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   code-annotations
-    #   edx-i18n-tools
-readme-renderer==29.0
-    # via -r requirements/doc.txt
-requests-toolbelt==0.9.1
-    # via twine
-requests==2.25.1
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   edx-drf-extensions
-    #   edx-rest-api-client
-    #   pyjwkest
-    #   requests-toolbelt
-    #   responses
-    #   slumber
-    #   sphinx
-    #   tableauserverclient
-    #   twine
-responses==0.10.15
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test.txt
-rest-condition==1.0.3
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   edx-drf-extensions
-restructuredtext-lint==1.3.2
-    # via
-    #   -r requirements/doc.txt
-    #   doc8
-rules==2.2
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-semantic-version==2.8.5
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   edx-drf-extensions
-six==1.15.0
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   bleach
-    #   click-repl
-    #   cryptography
-    #   django-countries
-    #   django-simple-history
-    #   doc8
-    #   edx-drf-extensions
-    #   edx-i18n-tools
-    #   edx-lint
-    #   edx-rbac
-    #   edx-sphinx-theme
-    #   freezegun
-    #   mock
-    #   pockets
-    #   pyjwkest
-    #   python-dateutil
-    #   readme-renderer
-    #   responses
-    #   sphinxcontrib-napoleon
-    #   stevedore
-    #   tox
-    #   virtualenv
-slumber==0.7.1
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   edx-rest-api-client
-snowballstemmer==2.1.0
-    # via
-    #   -r requirements/doc.txt
-    #   pydocstyle
-    #   sphinx
-sphinx==2.4.1
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/doc.txt
-    #   edx-sphinx-theme
-sphinxcontrib-applehelp==1.0.2
-    # via
-    #   -r requirements/doc.txt
-    #   sphinx
-sphinxcontrib-devhelp==1.0.2
-    # via
-    #   -r requirements/doc.txt
-    #   sphinx
-sphinxcontrib-htmlhelp==1.0.3
-    # via
-    #   -r requirements/doc.txt
-    #   sphinx
-sphinxcontrib-jsmath==1.0.1
-    # via
-    #   -r requirements/doc.txt
-    #   sphinx
-sphinxcontrib-napoleon==0.6.1
-    # via -r requirements/doc.txt
-sphinxcontrib-qthelp==1.0.3
-    # via
-    #   -r requirements/doc.txt
-    #   sphinx
-sphinxcontrib-serializinghtml==1.1.4
-    # via
-    #   -r requirements/doc.txt
-    #   sphinx
-sqlparse==0.4.1
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   django
-stevedore==1.32.0
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   code-annotations
-    #   doc8
-    #   edx-django-utils
-    #   edx-opaque-keys
-tableauserverclient==0.15.0
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-testfixtures==6.17.1
-    # via
-    #   -r requirements/dev.in
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-text-unidecode==1.3
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   faker
-    #   python-slugify
-toml==0.10.2
-    # via
-    #   -r requirements/test.txt
-    #   pep517
-    #   pylint
-    #   pytest
-    #   tox
-tox-battery==0.6.1
-    # via -r requirements/dev.in
-tox==3.23.0
-    # via
-    #   -r requirements/dev.in
-    #   tox-battery
-tqdm==4.60.0
-    # via twine
-twine==1.11.0
-    # via -r requirements/dev.in
-unicodecsv==0.14.1
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-urllib3==1.26.4
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   requests
-vine==5.0.0
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   amqp
-    #   celery
-virtualenv==20.4.4
-    # via tox
-wcwidth==0.2.5
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   prompt-toolkit
-webencodings==0.5.1
-    # via
-    #   -r requirements/doc.txt
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.txt
-    #   bleach
-wheel==0.36.2
-    # via -r requirements/dev.in
-wrapt==1.12.1
-    # via astroid
-zipp==1.0.0
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test.txt
-    #   importlib-metadata
+alabaster==0.7.12         # via -r requirements/doc.txt, sphinx
+amqp==5.0.6               # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, kombu
+aniso8601==9.0.1          # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-tincan-py35
+appdirs==1.4.4            # via virtualenv
+astroid==2.5.6            # via pylint, pylint-celery
+attrs==21.2.0             # via -r requirements/test.txt, pytest
+babel==2.9.1              # via -r requirements/doc.txt, sphinx
+billiard==3.6.4.0         # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, celery
+bleach==3.3.0             # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, readme-renderer
+celery==5.0.4             # via -c requirements/constraints.txt, -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+certifi==2020.12.5        # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, requests
+cffi==1.14.5              # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, cryptography
+chardet==4.0.0            # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, diff-cover, doc8, requests
+click-didyoumean==0.0.3   # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, celery
+click-log==0.3.2          # via edx-lint
+click-plugins==1.1.1      # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, celery
+click-repl==0.1.6         # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, celery
+click==7.1.2              # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, celery, click-didyoumean, click-log, click-plugins, click-repl, code-annotations, edx-lint, pip-tools
+code-annotations==1.1.1   # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-lint
+coverage==5.5             # via -r requirements/test.txt, pytest-cov
+cryptography==3.2.1       # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, django-fernet-fields, pyjwt
+ddt==1.3.1                # via -r requirements/test.txt
+defusedxml==0.7.1         # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, djangorestframework-xml
+diff-cover==5.1.0         # via -r requirements/test.txt
+distlib==0.3.1            # via virtualenv
+django-cache-memoize==0.1.9  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+django-config-models==2.1.1  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+django-countries==5.5     # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+django-crum==0.7.9        # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-django-utils, edx-rbac
+django-fernet-fields==0.6  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+django-filter==2.4.0      # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+django-ipware==3.0.2      # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+django-model-utils==4.1.1  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-rbac
+django-multi-email-field==0.6.2  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+django-object-actions==3.0.2  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+django-simple-history==3.0.0  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+django-waffle==2.1.0      # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-django-utils, edx-drf-extensions
+django==2.2.20            # via -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt, -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, code-annotations, django-config-models, django-crum, django-fernet-fields, django-filter, django-model-utils, django-multi-email-field, djangorestframework, drf-jwt, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-rbac, jsonfield2, rest-condition
+djangorestframework-xml==2.0.0  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+djangorestframework==3.12.4  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, django-config-models, drf-jwt, edx-drf-extensions, rest-condition
+doc8==0.8.1               # via -r requirements/doc.txt
+docutils==0.16            # via -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt, -r requirements/doc.txt, doc8, readme-renderer, restructuredtext-lint, sphinx
+drf-jwt==1.19.0           # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-drf-extensions
+edx-django-utils==4.0.0   # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, django-config-models, edx-drf-extensions, edx-rest-api-client
+edx-drf-extensions==6.5.0  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-rbac
+edx-i18n-tools==0.5.3     # via -r requirements/dev.in
+edx-lint==5.0.0           # via -r requirements/dev.in
+edx-opaque-keys[django]==2.2.0  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-drf-extensions
+edx-rbac==1.4.2           # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+edx-rest-api-client==5.3.0  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+edx-sphinx-theme==2.1.0   # via -r requirements/doc.txt
+edx-tincan-py35==1.0.0    # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+factory-boy==3.2.0        # via -c requirements/constraints.txt, -r requirements/test.txt
+faker==8.1.2              # via -r requirements/test.txt, factory-boy
+filelock==3.0.12          # via tox, virtualenv
+freezegun==0.3.14         # via -c requirements/constraints.txt, -r requirements/test.txt
+future==0.18.2            # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, pyjwkest
+idna==2.10                # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, requests
+imagesize==1.2.0          # via -r requirements/doc.txt, sphinx
+importlib-metadata==4.0.1  # via -r requirements/test.txt, inflect
+inflect==3.0.2            # via -c requirements/constraints.txt, -r requirements/test.txt, jinja2-pluralize
+iniconfig==1.1.1          # via -r requirements/test.txt, pytest
+isort==5.8.0              # via -r requirements/dev.in, pylint
+jinja2-pluralize==0.3.0   # via -r requirements/test.txt, diff-cover
+jinja2==2.11.3            # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, code-annotations, diff-cover, jinja2-pluralize, sphinx
+jsondiff==1.3.0           # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+kombu==5.0.2              # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, celery
+lazy-object-proxy==1.6.0  # via astroid
+markupsafe==1.1.1         # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, jinja2
+mccabe==0.6.1             # via pylint
+mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.txt
+more-itertools==8.7.0     # via -r requirements/test.txt, zipp
+newrelic==6.2.0.156       # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-django-utils
+packaging==20.9           # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, bleach, pytest, sphinx, tox
+path.py==12.5.0           # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-i18n-tools
+path==13.1.0              # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, path.py
+pbr==5.6.0                # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, stevedore
+pep517==0.10.0            # via pip-tools
+pillow==8.2.0             # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+pip-tools==6.1.0          # via -r requirements/dev.in
+pkginfo==1.7.0            # via twine
+pluggy==0.13.1            # via -r requirements/test.txt, diff-cover, pytest, tox
+pockets==0.9.1            # via -r requirements/doc.txt, sphinxcontrib-napoleon
+polib==1.1.1              # via edx-i18n-tools
+prompt-toolkit==3.0.18    # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, click-repl
+psutil==5.8.0             # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-django-utils
+py==1.10.0                # via -r requirements/test.txt, pytest, pytest-catchlog, tox
+pycodestyle==2.7.0        # via -r requirements/dev.in
+pycparser==2.20           # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, cffi
+pycryptodomex==3.10.1     # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, pyjwkest
+pydocstyle==6.0.0         # via -r requirements/dev.in
+pygments==2.9.0           # via -r requirements/doc.txt, -r requirements/test.txt, diff-cover, doc8, readme-renderer, sphinx
+pyjwkest==1.4.2           # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-drf-extensions
+pyjwt[crypto]==1.7.1      # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, drf-jwt, edx-rest-api-client
+pylint-celery==0.3        # via edx-lint
+pylint-django==2.4.4      # via edx-lint
+pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
+pylint==2.8.2             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pymongo==3.10.1           # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-opaque-keys
+pyparsing==2.4.7          # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, packaging
+pytest-catchlog==1.2.2    # via -r requirements/test.txt
+pytest-cov==2.11.1        # via -r requirements/test.txt
+pytest-django==4.2.0      # via -r requirements/test.txt
+pytest==6.2.4             # via -c requirements/constraints.txt, -r requirements/test.txt, pytest-catchlog, pytest-cov, pytest-django
+python-dateutil==2.4.0    # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-drf-extensions, faker, freezegun
+python-slugify==4.0.1     # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, code-annotations
+pytz==2021.1              # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, babel, celery, django, edx-tincan-py35
+pyyaml==5.4.1             # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, code-annotations, edx-i18n-tools
+readme-renderer==29.0     # via -r requirements/doc.txt
+requests-toolbelt==0.9.1  # via twine
+requests==2.25.1          # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-toolbelt, responses, slumber, sphinx, tableauserverclient, twine
+responses==0.10.15        # via -c requirements/constraints.txt, -r requirements/test.txt
+rest-condition==1.0.3     # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-drf-extensions
+restructuredtext-lint==1.3.2  # via -r requirements/doc.txt, doc8
+rules==2.2                # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+semantic-version==2.8.5   # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-drf-extensions
+six==1.16.0               # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, bleach, click-repl, cryptography, django-countries, doc8, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-rbac, edx-sphinx-theme, freezegun, mock, pockets, pyjwkest, python-dateutil, readme-renderer, responses, sphinxcontrib-napoleon, stevedore, tox, virtualenv
+slumber==0.7.1            # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, edx-rest-api-client
+snowballstemmer==2.1.0    # via -r requirements/doc.txt, pydocstyle, sphinx
+sphinx==2.4.1             # via -c requirements/constraints.txt, -r requirements/doc.txt, edx-sphinx-theme
+sphinxcontrib-applehelp==1.0.2  # via -r requirements/doc.txt, sphinx
+sphinxcontrib-devhelp==1.0.2  # via -r requirements/doc.txt, sphinx
+sphinxcontrib-htmlhelp==1.0.3  # via -r requirements/doc.txt, sphinx
+sphinxcontrib-jsmath==1.0.1  # via -r requirements/doc.txt, sphinx
+sphinxcontrib-napoleon==0.6.1  # via -r requirements/doc.txt
+sphinxcontrib-qthelp==1.0.3  # via -r requirements/doc.txt, sphinx
+sphinxcontrib-serializinghtml==1.1.4  # via -r requirements/doc.txt, sphinx
+sqlparse==0.4.1           # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, django
+stevedore==1.32.0         # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, code-annotations, doc8, edx-django-utils, edx-opaque-keys
+tableauserverclient==0.15.0  # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+testfixtures==6.17.1      # via -r requirements/dev.in, -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+text-unidecode==1.3       # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, faker, python-slugify
+toml==0.10.2              # via -r requirements/test.txt, pep517, pylint, pytest, tox
+tox-battery==0.6.1        # via -r requirements/dev.in
+tox==3.23.1               # via -r requirements/dev.in, tox-battery
+tqdm==4.60.0              # via twine
+twine==1.11.0             # via -r requirements/dev.in
+unicodecsv==0.14.1        # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt
+urllib3==1.26.4           # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, requests
+vine==5.0.0               # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, amqp, celery
+virtualenv==20.4.6        # via tox
+wcwidth==0.2.5            # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, prompt-toolkit
+webencodings==0.5.1       # via -r requirements/doc.txt, -r requirements/test-master.txt, -r requirements/test.txt, bleach
+wheel==0.36.2             # via -r requirements/dev.in
+wrapt==1.12.1             # via astroid
+zipp==1.0.0               # via -c requirements/constraints.txt, -r requirements/test.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -1,1 +1,1 @@
-django==2.2.20
+django==2.2.20            # via -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt, -r requirements/test-master.txt, code-annotations, django-config-models, django-crum, django-fernet-fields, django-filter, django-model-utils, django-multi-email-field, djangorestframework, drf-jwt, edx-django-utils, edx-drf-extensions, edx-opaque-keys, edx-rbac, jsonfield2, rest-condition

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -4,383 +4,103 @@
 #
 #    make upgrade
 #
-alabaster==0.7.12
-    # via sphinx
-amqp==5.0.6
-    # via
-    #   -r requirements/test-master.txt
-    #   kombu
-aniso8601==9.0.1
-    # via
-    #   -r requirements/test-master.txt
-    #   edx-tincan-py35
-babel==2.9.0
-    # via sphinx
-billiard==3.6.4.0
-    # via
-    #   -r requirements/test-master.txt
-    #   celery
-bleach==3.3.0
-    # via
-    #   -r requirements/test-master.txt
-    #   readme-renderer
-celery==5.0.4
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test-master.txt
-certifi==2020.12.5
-    # via
-    #   -r requirements/test-master.txt
-    #   requests
-cffi==1.14.5
-    # via
-    #   -r requirements/test-master.txt
-    #   cryptography
-chardet==4.0.0
-    # via
-    #   -r requirements/test-master.txt
-    #   doc8
-    #   requests
-click-didyoumean==0.0.3
-    # via
-    #   -r requirements/test-master.txt
-    #   celery
-click-plugins==1.1.1
-    # via
-    #   -r requirements/test-master.txt
-    #   celery
-click-repl==0.1.6
-    # via
-    #   -r requirements/test-master.txt
-    #   celery
-click==7.1.2
-    # via
-    #   -r requirements/test-master.txt
-    #   celery
-    #   click-didyoumean
-    #   click-plugins
-    #   click-repl
-    #   code-annotations
-code-annotations==1.1.1
-    # via -r requirements/test-master.txt
-cryptography==3.2.1
-    # via
-    #   -r requirements/test-master.txt
-    #   django-fernet-fields
-    #   pyjwt
-defusedxml==0.7.1
-    # via
-    #   -r requirements/test-master.txt
-    #   djangorestframework-xml
-django-cache-memoize==0.1.8
-    # via -r requirements/test-master.txt
-django-config-models==2.1.1
-    # via -r requirements/test-master.txt
-django-countries==5.5
-    # via -r requirements/test-master.txt
-django-crum==0.7.9
-    # via
-    #   -r requirements/test-master.txt
-    #   edx-django-utils
-    #   edx-rbac
-django-fernet-fields==0.6
-    # via -r requirements/test-master.txt
-django-filter==2.4.0
-    # via -r requirements/test-master.txt
-django-ipware==3.0.2
-    # via -r requirements/test-master.txt
-django-model-utils==4.1.1
-    # via
-    #   -r requirements/test-master.txt
-    #   edx-rbac
-django-multi-email-field==0.6.2
-    # via -r requirements/test-master.txt
-django-object-actions==3.0.2
-    # via -r requirements/test-master.txt
-django-simple-history==2.12.0
-    # via -r requirements/test-master.txt
-django-waffle==2.1.0
-    # via
-    #   -r requirements/test-master.txt
-    #   edx-django-utils
-    #   edx-drf-extensions
-django==2.2.20
-    # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   -r requirements/test-master.txt
-    #   code-annotations
-    #   django-config-models
-    #   django-crum
-    #   django-fernet-fields
-    #   django-filter
-    #   django-model-utils
-    #   django-multi-email-field
-    #   djangorestframework
-    #   drf-jwt
-    #   edx-django-utils
-    #   edx-drf-extensions
-    #   edx-opaque-keys
-    #   edx-rbac
-    #   jsonfield2
-    #   rest-condition
-djangorestframework-xml==2.0.0
-    # via -r requirements/test-master.txt
-djangorestframework==3.12.4
-    # via
-    #   -r requirements/test-master.txt
-    #   django-config-models
-    #   drf-jwt
-    #   edx-drf-extensions
-    #   rest-condition
-doc8==0.8.1
-    # via -r requirements/doc.in
-docutils==0.16
-    # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   -r requirements/doc.in
-    #   doc8
-    #   readme-renderer
-    #   restructuredtext-lint
-    #   sphinx
-drf-jwt==1.19.0
-    # via
-    #   -r requirements/test-master.txt
-    #   edx-drf-extensions
-edx-django-utils==3.16.0
-    # via
-    #   -r requirements/test-master.txt
-    #   django-config-models
-    #   edx-drf-extensions
-    #   edx-rest-api-client
-edx-drf-extensions==6.5.0
-    # via
-    #   -r requirements/test-master.txt
-    #   edx-rbac
-edx-opaque-keys[django]==2.2.0
-    # via
-    #   -r requirements/test-master.txt
-    #   edx-drf-extensions
-edx-rbac==1.4.2
-    # via -r requirements/test-master.txt
-edx-rest-api-client==5.3.0
-    # via -r requirements/test-master.txt
-edx-sphinx-theme==2.1.0
-    # via -r requirements/doc.in
-edx-tincan-py35==1.0.0
-    # via -r requirements/test-master.txt
-future==0.18.2
-    # via
-    #   -r requirements/test-master.txt
-    #   pyjwkest
-idna==2.10
-    # via
-    #   -r requirements/test-master.txt
-    #   requests
-imagesize==1.2.0
-    # via sphinx
-jinja2==2.11.3
-    # via
-    #   -r requirements/test-master.txt
-    #   code-annotations
-    #   sphinx
-jsondiff==1.3.0
-    # via -r requirements/test-master.txt
-jsonfield2==3.0.3
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test-master.txt
-kombu==5.0.2
-    # via
-    #   -r requirements/test-master.txt
-    #   celery
-markupsafe==1.1.1
-    # via
-    #   -r requirements/test-master.txt
-    #   jinja2
-newrelic==6.2.0.156
-    # via
-    #   -r requirements/test-master.txt
-    #   edx-django-utils
-packaging==20.9
-    # via
-    #   -r requirements/test-master.txt
-    #   bleach
-    #   sphinx
-path.py==12.5.0
-    # via -r requirements/test-master.txt
-path==13.1.0
-    # via
-    #   -r requirements/test-master.txt
-    #   path.py
-pbr==5.5.1
-    # via
-    #   -r requirements/test-master.txt
-    #   stevedore
-pillow==8.2.0
-    # via -r requirements/test-master.txt
-pockets==0.9.1
-    # via sphinxcontrib-napoleon
-prompt-toolkit==3.0.18
-    # via
-    #   -r requirements/test-master.txt
-    #   click-repl
-psutil==5.8.0
-    # via
-    #   -r requirements/test-master.txt
-    #   edx-django-utils
-pycparser==2.20
-    # via
-    #   -r requirements/test-master.txt
-    #   cffi
-pycryptodomex==3.10.1
-    # via
-    #   -r requirements/test-master.txt
-    #   pyjwkest
-pygments==2.8.1
-    # via
-    #   doc8
-    #   readme-renderer
-    #   sphinx
-pyjwkest==1.4.2
-    # via
-    #   -r requirements/test-master.txt
-    #   edx-drf-extensions
-pyjwt[crypto]==1.7.1
-    # via
-    #   -r requirements/test-master.txt
-    #   drf-jwt
-    #   edx-rest-api-client
-pymongo==3.10.1
-    # via
-    #   -r requirements/test-master.txt
-    #   edx-opaque-keys
-pyparsing==2.4.7
-    # via
-    #   -r requirements/test-master.txt
-    #   packaging
-python-dateutil==2.4.0
-    # via
-    #   -r requirements/test-master.txt
-    #   edx-drf-extensions
-python-slugify==4.0.1
-    # via
-    #   -r requirements/test-master.txt
-    #   code-annotations
-pytz==2021.1
-    # via
-    #   -r requirements/test-master.txt
-    #   babel
-    #   celery
-    #   django
-    #   edx-tincan-py35
-pyyaml==5.4.1
-    # via
-    #   -r requirements/test-master.txt
-    #   code-annotations
-readme-renderer==29.0
-    # via -r requirements/doc.in
-requests==2.25.1
-    # via
-    #   -r requirements/test-master.txt
-    #   edx-drf-extensions
-    #   edx-rest-api-client
-    #   pyjwkest
-    #   slumber
-    #   sphinx
-    #   tableauserverclient
-rest-condition==1.0.3
-    # via
-    #   -r requirements/test-master.txt
-    #   edx-drf-extensions
-restructuredtext-lint==1.3.2
-    # via doc8
-rules==2.2
-    # via -r requirements/test-master.txt
-semantic-version==2.8.5
-    # via
-    #   -r requirements/test-master.txt
-    #   edx-drf-extensions
-six==1.15.0
-    # via
-    #   -r requirements/test-master.txt
-    #   bleach
-    #   click-repl
-    #   cryptography
-    #   django-countries
-    #   django-simple-history
-    #   doc8
-    #   edx-drf-extensions
-    #   edx-rbac
-    #   edx-sphinx-theme
-    #   pockets
-    #   pyjwkest
-    #   python-dateutil
-    #   readme-renderer
-    #   sphinxcontrib-napoleon
-    #   stevedore
-slumber==0.7.1
-    # via
-    #   -r requirements/test-master.txt
-    #   edx-rest-api-client
-snowballstemmer==2.1.0
-    # via sphinx
-sphinx==2.4.1
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/doc.in
-    #   edx-sphinx-theme
-sphinxcontrib-applehelp==1.0.2
-    # via sphinx
-sphinxcontrib-devhelp==1.0.2
-    # via sphinx
-sphinxcontrib-htmlhelp==1.0.3
-    # via sphinx
-sphinxcontrib-jsmath==1.0.1
-    # via sphinx
-sphinxcontrib-napoleon==0.6.1
-    # via -r requirements/doc.in
-sphinxcontrib-qthelp==1.0.3
-    # via sphinx
-sphinxcontrib-serializinghtml==1.1.4
-    # via sphinx
-sqlparse==0.4.1
-    # via
-    #   -r requirements/test-master.txt
-    #   django
-stevedore==1.32.0
-    # via
-    #   -r requirements/test-master.txt
-    #   code-annotations
-    #   doc8
-    #   edx-django-utils
-    #   edx-opaque-keys
-tableauserverclient==0.15.0
-    # via -r requirements/test-master.txt
-testfixtures==6.17.1
-    # via -r requirements/test-master.txt
-text-unidecode==1.3
-    # via
-    #   -r requirements/test-master.txt
-    #   python-slugify
-unicodecsv==0.14.1
-    # via -r requirements/test-master.txt
-urllib3==1.26.4
-    # via
-    #   -r requirements/test-master.txt
-    #   requests
-vine==5.0.0
-    # via
-    #   -r requirements/test-master.txt
-    #   amqp
-    #   celery
-wcwidth==0.2.5
-    # via
-    #   -r requirements/test-master.txt
-    #   prompt-toolkit
-webencodings==0.5.1
-    # via
-    #   -r requirements/test-master.txt
-    #   bleach
+alabaster==0.7.12         # via sphinx
+amqp==5.0.6               # via -r requirements/test-master.txt, kombu
+aniso8601==9.0.1          # via -r requirements/test-master.txt, edx-tincan-py35
+babel==2.9.1              # via sphinx
+billiard==3.6.4.0         # via -r requirements/test-master.txt, celery
+bleach==3.3.0             # via -r requirements/test-master.txt, readme-renderer
+celery==5.0.4             # via -c requirements/constraints.txt, -r requirements/test-master.txt
+certifi==2020.12.5        # via -r requirements/test-master.txt, requests
+cffi==1.14.5              # via -r requirements/test-master.txt, cryptography
+chardet==4.0.0            # via -r requirements/test-master.txt, doc8, requests
+click-didyoumean==0.0.3   # via -r requirements/test-master.txt, celery
+click-plugins==1.1.1      # via -r requirements/test-master.txt, celery
+click-repl==0.1.6         # via -r requirements/test-master.txt, celery
+click==7.1.2              # via -r requirements/test-master.txt, celery, click-didyoumean, click-plugins, click-repl, code-annotations
+code-annotations==1.1.1   # via -r requirements/test-master.txt
+cryptography==3.2.1       # via -r requirements/test-master.txt, django-fernet-fields, pyjwt
+defusedxml==0.7.1         # via -r requirements/test-master.txt, djangorestframework-xml
+django-cache-memoize==0.1.9  # via -r requirements/test-master.txt
+django-config-models==2.1.1  # via -r requirements/test-master.txt
+django-countries==5.5     # via -r requirements/test-master.txt
+django-crum==0.7.9        # via -r requirements/test-master.txt, edx-django-utils, edx-rbac
+django-fernet-fields==0.6  # via -r requirements/test-master.txt
+django-filter==2.4.0      # via -r requirements/test-master.txt
+django-ipware==3.0.2      # via -r requirements/test-master.txt
+django-model-utils==4.1.1  # via -r requirements/test-master.txt, edx-rbac
+django-multi-email-field==0.6.2  # via -r requirements/test-master.txt
+django-object-actions==3.0.2  # via -r requirements/test-master.txt
+django-simple-history==3.0.0  # via -r requirements/test-master.txt
+django-waffle==2.1.0      # via -r requirements/test-master.txt, edx-django-utils, edx-drf-extensions
+django==2.2.20            # via -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt, -r requirements/test-master.txt, code-annotations, django-config-models, django-crum, django-fernet-fields, django-filter, django-model-utils, django-multi-email-field, djangorestframework, drf-jwt, edx-django-utils, edx-drf-extensions, edx-opaque-keys, edx-rbac, jsonfield2, rest-condition
+djangorestframework-xml==2.0.0  # via -r requirements/test-master.txt
+djangorestframework==3.12.4  # via -r requirements/test-master.txt, django-config-models, drf-jwt, edx-drf-extensions, rest-condition
+doc8==0.8.1               # via -r requirements/doc.in
+docutils==0.16            # via -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt, -r requirements/doc.in, doc8, readme-renderer, restructuredtext-lint, sphinx
+drf-jwt==1.19.0           # via -r requirements/test-master.txt, edx-drf-extensions
+edx-django-utils==4.0.0   # via -r requirements/test-master.txt, django-config-models, edx-drf-extensions, edx-rest-api-client
+edx-drf-extensions==6.5.0  # via -r requirements/test-master.txt, edx-rbac
+edx-opaque-keys[django]==2.2.0  # via -r requirements/test-master.txt, edx-drf-extensions
+edx-rbac==1.4.2           # via -r requirements/test-master.txt
+edx-rest-api-client==5.3.0  # via -r requirements/test-master.txt
+edx-sphinx-theme==2.1.0   # via -r requirements/doc.in
+edx-tincan-py35==1.0.0    # via -r requirements/test-master.txt
+future==0.18.2            # via -r requirements/test-master.txt, pyjwkest
+idna==2.10                # via -r requirements/test-master.txt, requests
+imagesize==1.2.0          # via sphinx
+jinja2==2.11.3            # via -r requirements/test-master.txt, code-annotations, sphinx
+jsondiff==1.3.0           # via -r requirements/test-master.txt
+jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/test-master.txt
+kombu==5.0.2              # via -r requirements/test-master.txt, celery
+markupsafe==1.1.1         # via -r requirements/test-master.txt, jinja2
+newrelic==6.2.0.156       # via -r requirements/test-master.txt, edx-django-utils
+packaging==20.9           # via -r requirements/test-master.txt, bleach, sphinx
+path.py==12.5.0           # via -r requirements/test-master.txt
+path==13.1.0              # via -r requirements/test-master.txt, path.py
+pbr==5.6.0                # via -r requirements/test-master.txt, stevedore
+pillow==8.2.0             # via -r requirements/test-master.txt
+pockets==0.9.1            # via sphinxcontrib-napoleon
+prompt-toolkit==3.0.18    # via -r requirements/test-master.txt, click-repl
+psutil==5.8.0             # via -r requirements/test-master.txt, edx-django-utils
+pycparser==2.20           # via -r requirements/test-master.txt, cffi
+pycryptodomex==3.10.1     # via -r requirements/test-master.txt, pyjwkest
+pygments==2.9.0           # via doc8, readme-renderer, sphinx
+pyjwkest==1.4.2           # via -r requirements/test-master.txt, edx-drf-extensions
+pyjwt[crypto]==1.7.1      # via -r requirements/test-master.txt, drf-jwt, edx-rest-api-client
+pymongo==3.10.1           # via -r requirements/test-master.txt, edx-opaque-keys
+pyparsing==2.4.7          # via -r requirements/test-master.txt, packaging
+python-dateutil==2.4.0    # via -r requirements/test-master.txt, edx-drf-extensions
+python-slugify==4.0.1     # via -r requirements/test-master.txt, code-annotations
+pytz==2021.1              # via -r requirements/test-master.txt, babel, celery, django, edx-tincan-py35
+pyyaml==5.4.1             # via -r requirements/test-master.txt, code-annotations
+readme-renderer==29.0     # via -r requirements/doc.in
+requests==2.25.1          # via -r requirements/test-master.txt, edx-drf-extensions, edx-rest-api-client, pyjwkest, slumber, sphinx, tableauserverclient
+rest-condition==1.0.3     # via -r requirements/test-master.txt, edx-drf-extensions
+restructuredtext-lint==1.3.2  # via doc8
+rules==2.2                # via -r requirements/test-master.txt
+semantic-version==2.8.5   # via -r requirements/test-master.txt, edx-drf-extensions
+six==1.16.0               # via -r requirements/test-master.txt, bleach, click-repl, cryptography, django-countries, doc8, edx-drf-extensions, edx-rbac, edx-sphinx-theme, pockets, pyjwkest, python-dateutil, readme-renderer, sphinxcontrib-napoleon, stevedore
+slumber==0.7.1            # via -r requirements/test-master.txt, edx-rest-api-client
+snowballstemmer==2.1.0    # via sphinx
+sphinx==2.4.1             # via -c requirements/constraints.txt, -r requirements/doc.in, edx-sphinx-theme
+sphinxcontrib-applehelp==1.0.2  # via sphinx
+sphinxcontrib-devhelp==1.0.2  # via sphinx
+sphinxcontrib-htmlhelp==1.0.3  # via sphinx
+sphinxcontrib-jsmath==1.0.1  # via sphinx
+sphinxcontrib-napoleon==0.6.1  # via -r requirements/doc.in
+sphinxcontrib-qthelp==1.0.3  # via sphinx
+sphinxcontrib-serializinghtml==1.1.4  # via sphinx
+sqlparse==0.4.1           # via -r requirements/test-master.txt, django
+stevedore==1.32.0         # via -r requirements/test-master.txt, code-annotations, doc8, edx-django-utils, edx-opaque-keys
+tableauserverclient==0.15.0  # via -r requirements/test-master.txt
+testfixtures==6.17.1      # via -r requirements/test-master.txt
+text-unidecode==1.3       # via -r requirements/test-master.txt, python-slugify
+unicodecsv==0.14.1        # via -r requirements/test-master.txt
+urllib3==1.26.4           # via -r requirements/test-master.txt, requests
+vine==5.0.0               # via -r requirements/test-master.txt, amqp, celery
+wcwidth==0.2.5            # via -r requirements/test-master.txt, prompt-toolkit
+webencodings==0.5.1       # via -r requirements/test-master.txt, bleach
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/edx-platform-constraints.txt
+++ b/requirements/edx-platform-constraints.txt
@@ -5,11 +5,12 @@
 #
 #    make upgrade
 #
+acid-xblock==0.2.1        # via -r requirements/edx/base.in
 analytics-python==1.2.9   # via -r requirements/edx/base.in
 aniso8601==9.0.1          # via edx-tincan-py35, tincan
 appdirs==1.4.4            # via fs
-attrs==20.3.0             # via -r requirements/edx/base.in, edx-ace
-babel==2.9.0              # via -r requirements/edx/base.in, enmerkar, enmerkar-underscore
+attrs==21.1.0             # via -r requirements/edx/base.in, edx-ace
+babel==2.9.1              # via -r requirements/edx/base.in, enmerkar, enmerkar-underscore
 beautifulsoup4==4.9.3     # via pynliner
 bleach==3.3.0             # via -r requirements/edx/base.in, django-wiki, edx-enterprise, lti-consumer-xblock, ora2, xblock-drag-and-drop-v2, xblock-poll
 boto3==1.4.8              # via -r requirements/edx/base.in, django-ses, fs-s3fs, ora2
@@ -54,14 +55,14 @@ django-ratelimit==3.0.1   # via -r requirements/edx/base.in
 django-require==1.0.11    # via -r requirements/edx/base.in
 django-sekizai==2.0.0     # via -r requirements/edx/base.in, django-wiki
 django-ses==2.0.0         # via -r requirements/edx/base.in
-django-simple-history==2.12.0  # via -r requirements/edx/base.in, edx-enterprise, edx-organizations, ora2
+django-simple-history==3.0.0  # via -r requirements/edx/base.in, edx-enterprise, edx-organizations, ora2
 django-splash==1.0.0      # via -r requirements/edx/base.in
 django-statici18n==2.0.1  # via -r requirements/edx/base.in
 django-storages==1.8      # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, edxval
 django-user-tasks==1.3.2  # via -r requirements/edx/base.in
 django-waffle==2.1.0      # via -r requirements/edx/base.in, edx-django-utils, edx-drf-extensions, edx-enterprise, edx-proctoring, edx-toggles
 django-webpack-loader==0.7.0  # via -r requirements/edx/base.in, edx-proctoring
-django==2.2.20            # via -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt, -r requirements/edx/base.in, code-annotations, django-appconf, django-classy-tags, django-config-models, django-cors-headers, django-crum, django-fernet-fields, django-filter, django-method-override, django-model-utils, django-mptt, django-multi-email-field, django-mysql, django-oauth-toolkit, django-pyfs, django-ratelimit-backend, django-sekizai, django-ses, django-splash, django-statici18n, django-storages, django-user-tasks, django-wiki, djangorestframework, drf-jwt, drf-yasg, edx-ace, edx-api-doc-tools, edx-bulk-grades, edx-celeryutils, edx-completion, edx-django-release-util, edx-django-sites-extensions, edx-django-utils, edx-drf-extensions, edx-enterprise, edx-event-routing-backends, edx-i18n-tools, edx-milestones, edx-opaque-keys, edx-organizations, edx-proctoring, edx-rbac, edx-search, edx-submissions, edx-toggles, edx-when, edxval, enmerkar, enmerkar-underscore, event-tracking, help-tokens, jsonfield2, lti-consumer-xblock, ora2, rest-condition, super-csv, xss-utils
+django==2.2.20            # via -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt, -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, code-annotations, django-appconf, django-classy-tags, django-config-models, django-cors-headers, django-crum, django-fernet-fields, django-filter, django-method-override, django-model-utils, django-mptt, django-multi-email-field, django-mysql, django-oauth-toolkit, django-pyfs, django-ratelimit-backend, django-sekizai, django-ses, django-splash, django-statici18n, django-storages, django-user-tasks, django-wiki, djangorestframework, drf-jwt, drf-yasg, edx-ace, edx-api-doc-tools, edx-bulk-grades, edx-celeryutils, edx-completion, edx-django-release-util, edx-django-sites-extensions, edx-django-utils, edx-drf-extensions, edx-enterprise, edx-event-routing-backends, edx-i18n-tools, edx-milestones, edx-opaque-keys, edx-organizations, edx-proctoring, edx-rbac, edx-search, edx-submissions, edx-toggles, edx-when, edxval, enmerkar, enmerkar-underscore, event-tracking, help-tokens, jsonfield2, lti-consumer-xblock, ora2, rest-condition, super-csv, xss-utils
 djangorestframework==3.12.4  # via -r requirements/edx/base.in, django-config-models, django-user-tasks, drf-jwt, drf-yasg, edx-api-doc-tools, edx-completion, edx-drf-extensions, edx-enterprise, edx-organizations, edx-proctoring, edx-submissions, ora2, rest-condition, super-csv
 docopt==0.6.2             # via xmodule
 docutils==0.16            # via -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt, botocore
@@ -77,16 +78,16 @@ edx-celeryutils==1.0.0    # via -r requirements/edx/base.in, super-csv
 edx-completion==4.0.3     # via -r requirements/edx/base.in
 edx-django-release-util==1.0.0  # via -r requirements/edx/base.in
 edx-django-sites-extensions==3.0.0  # via -r requirements/edx/base.in
-edx-django-utils==3.16.0  # via -r requirements/edx/base.in, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-toggles, edx-when, ora2, super-csv
+edx-django-utils==4.0.0   # via -r requirements/edx/base.in, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-toggles, edx-when, ora2, super-csv
 edx-drf-extensions==6.5.0  # via -r requirements/edx/base.in, edx-completion, edx-enterprise, edx-organizations, edx-proctoring, edx-rbac, edx-when, edxval
-edx-enterprise==3.22.6    # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
+edx-enterprise==3.22.16   # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
 edx-event-routing-backends==4.0.1  # via -r requirements/edx/base.in
 edx-i18n-tools==0.5.3     # via ora2
 edx-milestones==0.3.1     # via -r requirements/edx/base.in
 edx-opaque-keys[django]==2.2.0  # via -r requirements/edx/paver.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, lti-consumer-xblock, xmodule
 edx-organizations==6.9.0  # via -r requirements/edx/base.in
 edx-proctoring-proctortrack==1.0.5  # via -r requirements/edx/base.in
-edx-proctoring==3.8.5     # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, edx-proctoring-proctortrack
+edx-proctoring==3.8.9     # via -r requirements/edx/base.in, edx-proctoring-proctortrack
 edx-rest-api-client==5.3.0  # via -r requirements/edx/base.in, edx-enterprise, edx-proctoring
 edx-search==3.0.0         # via -r requirements/edx/base.in
 edx-sga==0.16.0           # via -r requirements/edx/base.in
@@ -95,7 +96,7 @@ edx-toggles==4.1.0        # via -r requirements/edx/base.in, edx-completion, edx
 edx-user-state-client==1.3.0  # via -r requirements/edx/base.in
 edx-when==2.0.0           # via -r requirements/edx/base.in, edx-proctoring
 edxval==2.0.3             # via -r requirements/edx/base.in
-elasticsearch==7.12.0     # via edx-search
+elasticsearch==7.12.1     # via edx-search
 enmerkar-underscore==2.0.0  # via -r requirements/edx/base.in
 enmerkar==0.7.1           # via enmerkar-underscore
 event-tracking==1.0.4     # via -r requirements/edx/base.in, edx-event-routing-backends, edx-proctoring, edx-search
@@ -131,11 +132,11 @@ markupsafe==1.1.1         # via -r requirements/edx/paver.txt, chem, jinja2, mak
 maxminddb==1.5.4          # via -c requirements/edx/../constraints.txt, geoip2
 mock==4.0.3               # via -r requirements/edx/paver.txt, xblock-drag-and-drop-v2, xblock-poll
 git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a#egg=MongoDBProxy==0.1.0+edx.2  # via -r requirements/edx/github.in
-mongoengine==0.23.0       # via -r requirements/edx/base.in
+mongoengine==0.23.1       # via -r requirements/edx/base.in
 mpmath==1.2.1             # via sympy
 mysqlclient==2.0.3        # via -r requirements/edx/base.in
 newrelic==6.2.0.156       # via -r requirements/edx/base.in, edx-django-utils
-nltk==3.6.1               # via -r requirements/edx/../edx-sandbox/shared.txt, chem
+nltk==3.6.2               # via -r requirements/edx/../edx-sandbox/shared.txt, chem
 nodeenv==1.6.0            # via -r requirements/edx/base.in
 numpy==1.20.2             # via chem, openedx-calc, scipy
 oauthlib==3.0.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, django-oauth-toolkit, lti-consumer-xblock, requests-oauthlib, social-auth-core
@@ -145,7 +146,7 @@ packaging==20.9           # via bleach, drf-yasg
 path.py==12.5.0           # via edx-enterprise, edx-i18n-tools, ora2, staff-graded-xblock, xmodule
 path==13.1.0              # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.txt, path.py
 paver==1.3.4              # via -r requirements/edx/paver.txt
-pbr==5.5.1                # via -r requirements/edx/paver.txt, stevedore
+pbr==5.6.0                # via -r requirements/edx/paver.txt, stevedore
 piexif==1.1.3             # via -r requirements/edx/base.in
 pillow==8.2.0             # via -r requirements/edx/base.in, edx-enterprise, edx-organizations
 polib==1.1.1              # via edx-i18n-tools
@@ -154,9 +155,9 @@ pycontracts==1.8.12       # via -r requirements/edx/base.in, edx-user-state-clie
 pycountry==20.7.3         # via -r requirements/edx/base.in
 pycparser==2.20           # via -r requirements/edx/../edx-sandbox/shared.txt, cffi
 pycryptodomex==3.10.1     # via -r requirements/edx/base.in, edx-proctoring, lti-consumer-xblock, pyjwkest
-pygments==2.8.1           # via -r requirements/edx/base.in
+pygments==2.9.0           # via -r requirements/edx/base.in
 pyjwkest==1.4.2           # via -r requirements/edx/base.in, edx-drf-extensions, lti-consumer-xblock
-pyjwt[crypto]==1.7.1      # via -r requirements/edx/base.in, drf-jwt, edx-rest-api-client, social-auth-core
+pyjwt[crypto]==1.7.1      # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, drf-jwt, edx-proctoring, edx-rest-api-client, social-auth-core
 pylatexenc==2.10          # via olxcleaner
 pymongo==3.10.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, -r requirements/edx/paver.txt, edx-opaque-keys, event-tracking, mongodbproxy, mongoengine
 pynliner==0.8.0           # via -r requirements/edx/base.in
@@ -165,7 +166,7 @@ pysrt==1.1.2              # via -r requirements/edx/base.in, edxval
 python-dateutil==2.4.0    # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, analytics-python, botocore, edx-ace, edx-drf-extensions, edx-enterprise, edx-event-routing-backends, edx-proctoring, icalendar, olxcleaner, ora2, xblock
 python-levenshtein==0.12.2  # via -r requirements/edx/base.in
 python-memcached==1.59    # via -r requirements/edx/paver.txt
-python-slugify==4.0.1     # via code-annotations
+python-slugify==4.0.1     # via -c requirements/edx/../constraints.txt, code-annotations
 python-swiftclient==3.11.1  # via ora2
 python3-openid==3.2.0 ; python_version >= "3"  # via -r requirements/edx/base.in, social-auth-core
 python3-saml==1.9.0       # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
@@ -183,20 +184,20 @@ ruamel.yaml.clib==0.2.2   # via ruamel.yaml
 ruamel.yaml==0.17.4       # via drf-yasg
 rules==2.2                # via -r requirements/edx/base.in, edx-enterprise, edx-proctoring
 s3transfer==0.1.13        # via boto3
-sailthru-client==2.2.3    # via -r requirements/edx/base.in, edx-ace
-scipy==1.6.2              # via chem, openedx-calc
+sailthru-client==2.2.3    # via edx-ace
+scipy==1.6.3              # via chem, openedx-calc
 semantic-version==2.8.5   # via edx-drf-extensions
 shapely==1.7.1            # via -r requirements/edx/base.in
 simplejson==3.17.2        # via -r requirements/edx/base.in, sailthru-client, super-csv, xblock-utils
-six==1.15.0               # via -r requirements/edx/../edx-sandbox/shared.txt, -r requirements/edx/base.in, -r requirements/edx/paver.txt, analytics-python, bleach, chem, codejail, crowdsourcehinter-xblock, cryptography, django-countries, django-simple-history, edx-ace, edx-bulk-grades, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-milestones, edx-rbac, event-tracking, fs, fs-s3fs, html5lib, isodate, libsass, paver, pycontracts, pyjwkest, python-dateutil, python-memcached, python-swiftclient, social-auth-app-django, social-auth-core, stevedore, xblock
+six==1.16.0               # via -r requirements/edx/../edx-sandbox/shared.txt, -r requirements/edx/base.in, -r requirements/edx/paver.txt, analytics-python, bleach, chem, codejail, crowdsourcehinter-xblock, cryptography, django-countries, edx-ace, edx-bulk-grades, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-milestones, edx-rbac, event-tracking, fs, fs-s3fs, html5lib, isodate, libsass, paver, pycontracts, pyjwkest, python-dateutil, python-memcached, python-swiftclient, social-auth-app-django, social-auth-core, stevedore, xblock
 slumber==0.7.1            # via edx-bulk-grades, edx-enterprise, edx-rest-api-client
 social-auth-app-django==4.0.0  # via -r requirements/edx/base.in
-social-auth-core==4.0.2   # via -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt, -r requirements/edx/base.in, social-auth-app-django
+social-auth-core==3.4.0   # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, social-auth-app-django
 sorl-thumbnail==12.7.0    # via -r requirements/edx/base.in, django-wiki
 sortedcontainers==2.3.0   # via -r requirements/edx/base.in
 soupsieve==2.2.1          # via beautifulsoup4
 sqlparse==0.4.1           # via -r requirements/edx/base.in, django
-staff-graded-xblock==1.5  # via -r requirements/edx/base.in
+staff-graded-xblock==1.5.1  # via -r requirements/edx/base.in
 stevedore==1.32.0         # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, -r requirements/edx/paver.txt, code-annotations, edx-ace, edx-django-utils, edx-enterprise, edx-opaque-keys
 super-csv==2.0.1          # via -r requirements/edx/base.in, edx-bulk-grades
 sympy==1.6.2              # via -c requirements/edx/../constraints.txt, symmath
@@ -209,7 +210,7 @@ uritemplate==3.0.1        # via coreapi, drf-yasg
 urllib3==1.26.4           # via -r requirements/edx/paver.txt, elasticsearch, geoip2, requests
 user-util==1.0.0          # via -r requirements/edx/base.in
 voluptuous==0.12.1        # via ora2
-watchdog==2.0.2           # via -r requirements/edx/paver.txt
+watchdog==2.1.0           # via -r requirements/edx/paver.txt
 web-fragments==1.0.0      # via -r requirements/edx/base.in, crowdsourcehinter-xblock, edx-sga, staff-graded-xblock, xblock, xblock-utils
 webencodings==0.5.1       # via bleach, html5lib
 webob==1.8.7              # via xblock, xmodule
@@ -218,7 +219,7 @@ git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.3.4#egg=xblock-d
 git+https://github.com/open-craft/xblock-poll@922cd36fb1c3cfe00b4ce03b19a13185d136447d#egg=xblock-poll==1.10.2  # via -r requirements/edx/github.in
 xblock-utils==2.1.2       # via -r requirements/edx/base.in, edx-sga, lti-consumer-xblock, staff-graded-xblock, xblock-drag-and-drop-v2, xblock-google-drive
 xblock==1.4.0             # via -r requirements/edx/base.in, acid-xblock, crowdsourcehinter-xblock, done-xblock, edx-completion, edx-sga, edx-user-state-client, edx-when, lti-consumer-xblock, ora2, rate-xblock, staff-graded-xblock, xblock-discussion, xblock-drag-and-drop-v2, xblock-google-drive, xblock-poll, xblock-utils
-xmlsec==1.3.9             # via python3-saml
+xmlsec==1.3.10            # via python3-saml
 xss-utils==0.2.0          # via -r requirements/edx/base.in
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/js_test.txt
+++ b/requirements/js_test.txt
@@ -4,62 +4,27 @@
 #
 #    make upgrade
 #
-cheroot==8.5.2
-    # via cherrypy
-cherrypy==18.6.0
-    # via jasmine
-glob2==0.7
-    # via jasmine-core
-jaraco.classes==3.2.1
-    # via
-    #   -r requirements/js_test.in
-    #   jaraco.collections
-jaraco.collections==3.3.0
-    # via
-    #   -r requirements/js_test.in
-    #   cherrypy
-jaraco.functools==3.3.0
-    # via
-    #   -r requirements/js_test.in
-    #   cheroot
-    #   jaraco.text
-    #   tempora
-jaraco.text==3.5.0
-    # via jaraco.collections
-jasmine-core==3.6.0
-    # via jasmine
-jasmine==3.5.0
-    # via -r requirements/js_test.in
-jinja2==2.11.3
-    # via jasmine
-markupsafe==1.1.1
-    # via jinja2
-more-itertools==8.7.0
-    # via
-    #   cheroot
-    #   cherrypy
-    #   jaraco.classes
-    #   jaraco.functools
-ordereddict==1.1
-    # via jasmine-core
-portend==2.7.1
-    # via cherrypy
-pytz==2021.1
-    # via tempora
-pyyaml==5.4.1
-    # via jasmine
-selenium==3.141.0
-    # via jasmine
-six==1.15.0
-    # via cheroot
-tempora==4.0.2
-    # via
-    #   -r requirements/js_test.in
-    #   portend
-urllib3==1.26.4
-    # via selenium
-zc.lockfile==2.0
-    # via cherrypy
+cheroot==8.5.2            # via cherrypy
+cherrypy==18.6.0          # via jasmine
+glob2==0.7                # via jasmine-core
+jaraco.classes==3.2.1     # via -r requirements/js_test.in, jaraco.collections
+jaraco.collections==3.3.0  # via -r requirements/js_test.in, cherrypy
+jaraco.functools==3.3.0   # via -r requirements/js_test.in, cheroot, jaraco.text, tempora
+jaraco.text==3.5.0        # via jaraco.collections
+jasmine-core==3.7.1       # via jasmine
+jasmine==3.7.0            # via -r requirements/js_test.in
+jinja2==2.11.3            # via jasmine
+markupsafe==1.1.1         # via jinja2
+more-itertools==8.7.0     # via cheroot, cherrypy, jaraco.classes, jaraco.functools
+ordereddict==1.1          # via jasmine-core
+portend==2.7.1            # via cherrypy
+pytz==2021.1              # via tempora
+pyyaml==5.4.1             # via jasmine
+selenium==3.141.0         # via jasmine
+six==1.16.0               # via cheroot
+tempora==4.0.2            # via -r requirements/js_test.in, portend
+urllib3==1.26.4           # via selenium
+zc.lockfile==2.0          # via cherrypy
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -4,342 +4,81 @@
 #
 #    make upgrade
 #
-amqp==5.0.6
-    # via kombu
-aniso8601==9.0.1
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   edx-tincan-py35
-billiard==3.6.4.0
-    # via celery
-bleach==3.3.0
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   -r requirements/base.in
-celery==5.0.4
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.in
-certifi==2020.12.5
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   requests
-cffi==1.14.5
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   cryptography
-chardet==4.0.0
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   requests
-click-didyoumean==0.0.3
-    # via celery
-click-plugins==1.1.1
-    # via celery
-click-repl==0.1.6
-    # via celery
-click==7.1.2
-    # via
-    #   celery
-    #   click-didyoumean
-    #   click-plugins
-    #   click-repl
-    #   code-annotations
-code-annotations==1.1.1
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   -r requirements/base.in
-cryptography==3.2.1
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   -r requirements/base.in
-    #   django-fernet-fields
-    #   pyjwt
-defusedxml==0.7.1
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   djangorestframework-xml
-django-cache-memoize==0.1.8
-    # via -r requirements/base.in
-django-config-models==2.1.1
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   -r requirements/base.in
-django-countries==5.5
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   -r requirements/base.in
-django-crum==0.7.9
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   -r requirements/base.in
-    #   edx-django-utils
-    #   edx-rbac
-django-fernet-fields==0.6
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   -r requirements/base.in
-django-filter==2.4.0
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   -r requirements/base.in
-django-ipware==3.0.2
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   -r requirements/base.in
-django-model-utils==4.1.1
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   -r requirements/base.in
-    #   edx-rbac
-django-multi-email-field==0.6.2
-    # via -r requirements/base.in
-django-object-actions==3.0.2
-    # via -r requirements/base.in
-django-simple-history==2.12.0
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   -r requirements/base.in
-django-waffle==2.1.0
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   -r requirements/base.in
-    #   edx-django-utils
-    #   edx-drf-extensions
-django==2.2.20
-    # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   -c requirements/edx-platform-constraints.txt
-    #   -r requirements/base.in
-    #   code-annotations
-    #   django-config-models
-    #   django-crum
-    #   django-fernet-fields
-    #   django-filter
-    #   django-model-utils
-    #   django-multi-email-field
-    #   djangorestframework
-    #   drf-jwt
-    #   edx-django-utils
-    #   edx-drf-extensions
-    #   edx-opaque-keys
-    #   edx-rbac
-    #   jsonfield2
-    #   rest-condition
-djangorestframework-xml==2.0.0
-    # via -r requirements/base.in
-djangorestframework==3.12.4
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   -r requirements/base.in
-    #   django-config-models
-    #   drf-jwt
-    #   edx-drf-extensions
-    #   rest-condition
-drf-jwt==1.19.0
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   edx-drf-extensions
-edx-django-utils==3.16.0
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   -r requirements/base.in
-    #   django-config-models
-    #   edx-drf-extensions
-    #   edx-rest-api-client
-edx-drf-extensions==6.5.0
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   -r requirements/base.in
-    #   edx-rbac
-edx-opaque-keys[django]==2.2.0
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   -r requirements/base.in
-    #   edx-drf-extensions
-edx-rbac==1.4.2
-    # via -r requirements/base.in
-edx-rest-api-client==5.3.0
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   -r requirements/base.in
-edx-tincan-py35==1.0.0
-    # via -r requirements/base.in
-future==0.18.2
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   -r requirements/base.in
-    #   pyjwkest
-idna==2.10
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   requests
-jinja2==2.11.3
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   code-annotations
-jsondiff==1.3.0
-    # via -r requirements/base.in
-jsonfield2==3.0.3
-    # via
-    #   -c requirements/constraints.txt
-    #   -c requirements/edx-platform-constraints.txt
-    #   -r requirements/base.in
-kombu==5.0.2
-    # via celery
-markupsafe==1.1.1
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   jinja2
-newrelic==6.2.0.156
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   edx-django-utils
-packaging==20.9
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   bleach
-path.py==12.5.0
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   -r requirements/base.in
-path==13.1.0
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   path.py
-pbr==5.5.1
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   stevedore
-pillow==8.2.0
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   -r requirements/base.in
-prompt-toolkit==3.0.18
-    # via click-repl
-psutil==5.8.0
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   edx-django-utils
-pycparser==2.20
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   cffi
-pycryptodomex==3.10.1
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   pyjwkest
-pyjwkest==1.4.2
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   edx-drf-extensions
-pyjwt[crypto]==1.7.1
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   drf-jwt
-    #   edx-rest-api-client
-pymongo==3.10.1
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   edx-opaque-keys
-pyparsing==2.4.7
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   packaging
-python-dateutil==2.4.0
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   -r requirements/base.in
-    #   edx-drf-extensions
-python-slugify==4.0.1
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   code-annotations
-pytz==2021.1
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   -r requirements/base.in
-    #   celery
-    #   django
-    #   edx-tincan-py35
-pyyaml==5.4.1
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   code-annotations
-requests==2.25.1
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   -r requirements/base.in
-    #   edx-drf-extensions
-    #   edx-rest-api-client
-    #   pyjwkest
-    #   slumber
-    #   tableauserverclient
-rest-condition==1.0.3
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   edx-drf-extensions
-rules==2.2
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   -r requirements/base.in
-semantic-version==2.8.5
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   edx-drf-extensions
-six==1.15.0
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   -r requirements/base.in
-    #   bleach
-    #   click-repl
-    #   cryptography
-    #   django-countries
-    #   django-simple-history
-    #   edx-drf-extensions
-    #   edx-rbac
-    #   pyjwkest
-    #   python-dateutil
-    #   stevedore
-slumber==0.7.1
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   -r requirements/base.in
-    #   edx-rest-api-client
-sqlparse==0.4.1
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   django
-stevedore==1.32.0
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   -r requirements/base.in
-    #   code-annotations
-    #   edx-django-utils
-    #   edx-opaque-keys
-tableauserverclient==0.15.0
-    # via -r requirements/base.in
-testfixtures==6.17.1
-    # via -r requirements/base.in
-text-unidecode==1.3
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   python-slugify
-unicodecsv==0.14.1
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   -r requirements/base.in
-urllib3==1.26.4
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   requests
-vine==5.0.0
-    # via
-    #   amqp
-    #   celery
-wcwidth==0.2.5
-    # via prompt-toolkit
-webencodings==0.5.1
-    # via
-    #   -c requirements/edx-platform-constraints.txt
-    #   bleach
+amqp==5.0.6               # via kombu
+aniso8601==9.0.1          # via -c requirements/edx-platform-constraints.txt, edx-tincan-py35
+billiard==3.6.4.0         # via celery
+bleach==3.3.0             # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
+celery==5.0.4             # via -c requirements/constraints.txt, -r requirements/base.in
+certifi==2020.12.5        # via -c requirements/edx-platform-constraints.txt, requests
+cffi==1.14.5              # via -c requirements/edx-platform-constraints.txt, cryptography
+chardet==4.0.0            # via -c requirements/edx-platform-constraints.txt, requests
+click-didyoumean==0.0.3   # via celery
+click-plugins==1.1.1      # via celery
+click-repl==0.1.6         # via celery
+click==7.1.2              # via celery, click-didyoumean, click-plugins, click-repl, code-annotations
+code-annotations==1.1.1   # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
+cryptography==3.2.1       # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, django-fernet-fields, pyjwt
+defusedxml==0.7.1         # via -c requirements/edx-platform-constraints.txt, djangorestframework-xml
+django-cache-memoize==0.1.9  # via -r requirements/base.in
+django-config-models==2.1.1  # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
+django-countries==5.5     # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
+django-crum==0.7.9        # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, edx-django-utils, edx-rbac
+django-fernet-fields==0.6  # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
+django-filter==2.4.0      # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
+django-ipware==3.0.2      # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
+django-model-utils==4.1.1  # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, edx-rbac
+django-multi-email-field==0.6.2  # via -r requirements/base.in
+django-object-actions==3.0.2  # via -r requirements/base.in
+django-simple-history==3.0.0  # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
+django-waffle==2.1.0      # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, edx-django-utils, edx-drf-extensions
+django==2.2.20            # via -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt, -c requirements/edx-platform-constraints.txt, -r requirements/base.in, code-annotations, django-config-models, django-crum, django-fernet-fields, django-filter, django-model-utils, django-multi-email-field, djangorestframework, drf-jwt, edx-django-utils, edx-drf-extensions, edx-opaque-keys, edx-rbac, jsonfield2, rest-condition
+djangorestframework-xml==2.0.0  # via -r requirements/base.in
+djangorestframework==3.12.4  # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, django-config-models, drf-jwt, edx-drf-extensions, rest-condition
+drf-jwt==1.19.0           # via -c requirements/edx-platform-constraints.txt, edx-drf-extensions
+edx-django-utils==4.0.0   # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, django-config-models, edx-drf-extensions, edx-rest-api-client
+edx-drf-extensions==6.5.0  # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, edx-rbac
+edx-opaque-keys[django]==2.2.0  # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, edx-drf-extensions
+edx-rbac==1.4.2           # via -r requirements/base.in
+edx-rest-api-client==5.3.0  # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
+edx-tincan-py35==1.0.0    # via -r requirements/base.in
+future==0.18.2            # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, pyjwkest
+idna==2.10                # via -c requirements/edx-platform-constraints.txt, requests
+jinja2==2.11.3            # via -c requirements/edx-platform-constraints.txt, code-annotations
+jsondiff==1.3.0           # via -r requirements/base.in
+jsonfield2==3.0.3         # via -c requirements/constraints.txt, -c requirements/edx-platform-constraints.txt, -r requirements/base.in
+kombu==5.0.2              # via celery
+markupsafe==1.1.1         # via -c requirements/edx-platform-constraints.txt, jinja2
+newrelic==6.2.0.156       # via -c requirements/edx-platform-constraints.txt, edx-django-utils
+packaging==20.9           # via -c requirements/edx-platform-constraints.txt, bleach
+path.py==12.5.0           # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
+path==13.1.0              # via -c requirements/edx-platform-constraints.txt, path.py
+pbr==5.6.0                # via -c requirements/edx-platform-constraints.txt, stevedore
+pillow==8.2.0             # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
+prompt-toolkit==3.0.18    # via click-repl
+psutil==5.8.0             # via -c requirements/edx-platform-constraints.txt, edx-django-utils
+pycparser==2.20           # via -c requirements/edx-platform-constraints.txt, cffi
+pycryptodomex==3.10.1     # via -c requirements/edx-platform-constraints.txt, pyjwkest
+pyjwkest==1.4.2           # via -c requirements/edx-platform-constraints.txt, edx-drf-extensions
+pyjwt[crypto]==1.7.1      # via -c requirements/edx-platform-constraints.txt, drf-jwt, edx-rest-api-client
+pymongo==3.10.1           # via -c requirements/edx-platform-constraints.txt, edx-opaque-keys
+pyparsing==2.4.7          # via -c requirements/edx-platform-constraints.txt, packaging
+python-dateutil==2.4.0    # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, edx-drf-extensions
+python-slugify==4.0.1     # via -c requirements/edx-platform-constraints.txt, code-annotations
+pytz==2021.1              # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, celery, django, edx-tincan-py35
+pyyaml==5.4.1             # via -c requirements/edx-platform-constraints.txt, code-annotations
+requests==2.25.1          # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, edx-drf-extensions, edx-rest-api-client, pyjwkest, slumber, tableauserverclient
+rest-condition==1.0.3     # via -c requirements/edx-platform-constraints.txt, edx-drf-extensions
+rules==2.2                # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
+semantic-version==2.8.5   # via -c requirements/edx-platform-constraints.txt, edx-drf-extensions
+six==1.16.0               # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, bleach, click-repl, cryptography, django-countries, edx-drf-extensions, edx-rbac, pyjwkest, python-dateutil, stevedore
+slumber==0.7.1            # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, edx-rest-api-client
+sqlparse==0.4.1           # via -c requirements/edx-platform-constraints.txt, django
+stevedore==1.32.0         # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in, code-annotations, edx-django-utils, edx-opaque-keys
+tableauserverclient==0.15.0  # via -r requirements/base.in
+testfixtures==6.17.1      # via -r requirements/base.in
+text-unidecode==1.3       # via -c requirements/edx-platform-constraints.txt, python-slugify
+unicodecsv==0.14.1        # via -c requirements/edx-platform-constraints.txt, -r requirements/base.in
+urllib3==1.26.4           # via -c requirements/edx-platform-constraints.txt, requests
+vine==5.0.0               # via amqp, celery
+wcwidth==0.2.5            # via prompt-toolkit
+webencodings==0.5.1       # via -c requirements/edx-platform-constraints.txt, bleach

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,387 +4,94 @@
 #
 #    make upgrade
 #
-    # via
-    #   -r requirements/test-master.txt
-    #   kombu
-aniso8601==9.0.1
-    # via
-    #   -r requirements/test-master.txt
-    #   edx-tincan-py35
-attrs==20.3.0
-    # via pytest
-    # via
-    #   -r requirements/test-master.txt
-    #   celery
-bleach==3.3.0
-    # via -r requirements/test-master.txt
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test-master.txt
-certifi==2020.12.5
-    # via
-    #   -r requirements/test-master.txt
-    #   requests
-cffi==1.14.5
-    # via
-    #   -r requirements/test-master.txt
-    #   cryptography
-chardet==4.0.0
-    # via
-    #   -r requirements/test-master.txt
-    #   diff-cover
-    #   requests
-    # via
-    #   -r requirements/test-master.txt
-    #   celery
-click-plugins==1.1.1
-    # via
-    #   -r requirements/test-master.txt
-    #   celery
-    # via
-    #   -r requirements/test-master.txt
-    #   celery
-    # via
-    #   -r requirements/test-master.txt
-    #   celery
-    #   click-didyoumean
-    #   click-plugins
-    #   click-repl
-    #   code-annotations
-code-annotations==1.1.1
-    # via -r requirements/test-master.txt
-coverage==5.5
-    # via pytest-cov
-cryptography==3.2.1
-    # via
-    #   -r requirements/test-master.txt
-    #   django-fernet-fields
-    #   pyjwt
-ddt==1.3.1
-    # via -r requirements/test.in
-defusedxml==0.7.1
-    # via
-    #   -r requirements/test-master.txt
-    #   djangorestframework-xml
-diff-cover==5.0.1
-    # via -r requirements/test.in
-django-cache-memoize==0.1.8
-    # via -r requirements/test-master.txt
-django-config-models==2.1.1
-    # via -r requirements/test-master.txt
-django-countries==5.5
-    # via -r requirements/test-master.txt
-django-crum==0.7.9
-    # via
-    #   -r requirements/test-master.txt
-    #   edx-django-utils
-    #   edx-rbac
-django-fernet-fields==0.6
-    # via -r requirements/test-master.txt
-django-filter==2.4.0
-    # via -r requirements/test-master.txt
-django-ipware==3.0.2
-    # via -r requirements/test-master.txt
-django-model-utils==4.1.1
-    # via
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.in
-    #   edx-rbac
-django-multi-email-field==0.6.2
-    # via -r requirements/test-master.txt
-django-object-actions==3.0.2
-    # via -r requirements/test-master.txt
-django-simple-history==2.12.0
-    # via -r requirements/test-master.txt
-django-waffle==2.1.0
-    # via
-    #   -r requirements/test-master.txt
-    #   edx-django-utils
-    #   edx-drf-extensions
-    # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   -r requirements/test-master.txt
-    #   code-annotations
-    #   django-config-models
-    #   django-crum
-    #   django-fernet-fields
-    #   django-filter
-    #   django-model-utils
-    #   django-multi-email-field
-    #   djangorestframework
-    #   drf-jwt
-    #   edx-django-utils
-    #   edx-drf-extensions
-    #   edx-opaque-keys
-    #   edx-rbac
-    #   jsonfield2
-    #   rest-condition
-djangorestframework-xml==2.0.0
-    # via -r requirements/test-master.txt
-djangorestframework==3.12.4
-    # via
-    #   -r requirements/test-master.txt
-    #   django-config-models
-    #   drf-jwt
-    #   edx-drf-extensions
-    #   rest-condition
-drf-jwt==1.19.0
-    # via
-    #   -r requirements/test-master.txt
-    #   edx-drf-extensions
-edx-django-utils==3.16.0
-    # via
-    #   -r requirements/test-master.txt
-    #   django-config-models
-    #   edx-drf-extensions
-    #   edx-rest-api-client
-edx-drf-extensions==6.5.0
-    # via
-    #   -r requirements/test-master.txt
-    #   edx-rbac
-edx-opaque-keys[django]==2.2.0
-    # via
-    #   -r requirements/test-master.txt
-    #   edx-drf-extensions
-edx-rbac==1.4.2
-    # via -r requirements/test-master.txt
-edx-rest-api-client==5.3.0
-    # via -r requirements/test-master.txt
-edx-tincan-py35==1.0.0
-    # via -r requirements/test-master.txt
-factory-boy==3.2.0
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test.in
-faker==8.1.0
-    # via factory-boy
-freezegun==0.3.14
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test.in
-future==0.18.2
-    # via
-    #   -r requirements/test-master.txt
-    #   pyjwkest
-idna==2.10
-    # via
-    #   -r requirements/test-master.txt
-    #   requests
-importlib-metadata==4.0.1
-    # via inflect
-inflect==3.0.2
-    # via
-    #   -c requirements/constraints.txt
-    #   jinja2-pluralize
-iniconfig==1.1.1
-    # via pytest
-jinja2-pluralize==0.3.0
-    # via diff-cover
-jinja2==2.11.3
-    # via
-    #   -r requirements/test-master.txt
-    #   code-annotations
-    #   diff-cover
-    #   jinja2-pluralize
-jsondiff==1.3.0
-    # via -r requirements/test-master.txt
-jsonfield2==3.0.3
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test-master.txt
-    # via
-    #   -r requirements/test-master.txt
-    #   celery
-markupsafe==1.1.1
-    # via
-    #   -r requirements/test-master.txt
-    #   jinja2
-mock==3.0.5
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test.in
-more-itertools==8.7.0
-    # via zipp
-newrelic==6.2.0.156
-    # via
-    #   -r requirements/test-master.txt
-    #   edx-django-utils
-packaging==20.9
-    # via
-    #   -r requirements/test-master.txt
-    #   bleach
-    #   pytest
-path.py==12.5.0
-    # via -r requirements/test-master.txt
-path==13.1.0
-    # via
-    #   -r requirements/test-master.txt
-    #   path.py
-pbr==5.5.1
-    # via
-    #   -r requirements/test-master.txt
-    #   stevedore
-pillow==8.2.0
-    # via -r requirements/test-master.txt
-pluggy==0.13.1
-    # via
-    #   diff-cover
-    #   pytest
-    # via
-    #   -r requirements/test-master.txt
-    #   click-repl
-psutil==5.8.0
-    # via
-    #   -r requirements/test-master.txt
-    #   edx-django-utils
-py==1.10.0
-    # via
-    #   pytest
-    #   pytest-catchlog
-pycparser==2.20
-    # via
-    #   -r requirements/test-master.txt
-    #   cffi
-pycryptodomex==3.10.1
-    # via
-    #   -r requirements/test-master.txt
-    #   pyjwkest
-pygments==2.8.1
-    # via diff-cover
-pyjwkest==1.4.2
-    # via
-    #   -r requirements/test-master.txt
-    #   edx-drf-extensions
-pyjwt[crypto]==1.7.1
-    # via
-    #   -r requirements/test-master.txt
-    #   drf-jwt
-    #   edx-rest-api-client
-pymongo==3.10.1
-    # via
-    #   -r requirements/test-master.txt
-    #   edx-opaque-keys
-pyparsing==2.4.7
-    # via
-    #   -r requirements/test-master.txt
-    #   packaging
-pytest-catchlog==1.2.2
-    # via -r requirements/test.in
-pytest-cov==2.11.1
-    # via -r requirements/test.in
-pytest-django==4.2.0
-    # via -r requirements/test.in
-pytest==6.2.3
-    # via
-    #   -c requirements/constraints.txt
-    #   pytest-catchlog
-    #   pytest-cov
-    #   pytest-django
-python-dateutil==2.4.0
-    # via
-    #   -r requirements/test-master.txt
-    #   edx-drf-extensions
-    #   faker
-    #   freezegun
-python-slugify==4.0.1
-    # via
-    #   -r requirements/test-master.txt
-    #   code-annotations
-pytz==2021.1
-    # via
-    #   -r requirements/test-master.txt
-    #   celery
-    #   django
-    #   edx-tincan-py35
-pyyaml==5.4.1
-    # via
-    #   -r requirements/test-master.txt
-    #   code-annotations
-requests==2.25.1
-    # via
-    #   -r requirements/test-master.txt
-    #   edx-drf-extensions
-    #   edx-rest-api-client
-    #   pyjwkest
-    #   responses
-    #   slumber
-    #   tableauserverclient
-responses==0.10.15
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test.in
-rest-condition==1.0.3
-    # via
-    #   -r requirements/test-master.txt
-    #   edx-drf-extensions
-rules==2.2
-    # via -r requirements/test-master.txt
-semantic-version==2.8.5
-    # via
-    #   -r requirements/test-master.txt
-    #   edx-drf-extensions
-six==1.15.0
-    # via
-    #   -r requirements/test-master.txt
-    #   bleach
-    #   click-repl
-    #   cryptography
-    #   django-countries
-    #   django-simple-history
-    #   edx-drf-extensions
-    #   edx-rbac
-    #   freezegun
-    #   mock
-    #   pyjwkest
-    #   python-dateutil
-    #   responses
-    #   stevedore
-slumber==0.7.1
-    # via
-    #   -r requirements/test-master.txt
-    #   edx-rest-api-client
-sqlparse==0.4.1
-    # via
-    #   -r requirements/test-master.txt
-    #   django
-stevedore==1.32.0
-    # via
-    #   -r requirements/test-master.txt
-    #   code-annotations
-    #   edx-django-utils
-    #   edx-opaque-keys
-tableauserverclient==0.15.0
-    # via -r requirements/test-master.txt
-testfixtures==6.17.1
-    # via
-    #   -r requirements/test-master.txt
-    #   -r requirements/test.in
-text-unidecode==1.3
-    # via
-    #   -r requirements/test-master.txt
-    #   faker
-    #   python-slugify
-toml==0.10.2
-    # via pytest
-unicodecsv==0.14.1
-    # via -r requirements/test-master.txt
-urllib3==1.26.4
-    # via
-    #   -r requirements/test-master.txt
-    #   requests
-    # via
-    #   -r requirements/test-master.txt
-    #   amqp
-    #   celery
-wcwidth==0.2.5
-    # via
-    #   -r requirements/test-master.txt
-    #   prompt-toolkit
-webencodings==0.5.1
-    # via
-    #   -r requirements/test-master.txt
-    #   bleach
-zipp==1.0.0
-    # via
-    #   -c requirements/constraints.txt
-    #   importlib-metadata
+aniso8601==9.0.1          # via -r requirements/test-master.txt, edx-tincan-py35
+attrs==21.2.0             # via pytest
+bleach==3.3.0             # via -r requirements/test-master.txt
+certifi==2020.12.5        # via -r requirements/test-master.txt, requests
+cffi==1.14.5              # via -r requirements/test-master.txt, cryptography
+chardet==4.0.0            # via -r requirements/test-master.txt, diff-cover, requests
+click-plugins==1.1.1      # via -r requirements/test-master.txt, celery
+code-annotations==1.1.1   # via -r requirements/test-master.txt
+coverage==5.5             # via pytest-cov
+cryptography==3.2.1       # via -r requirements/test-master.txt, django-fernet-fields, pyjwt
+ddt==1.3.1                # via -r requirements/test.in
+defusedxml==0.7.1         # via -r requirements/test-master.txt, djangorestframework-xml
+diff-cover==5.1.0         # via -r requirements/test.in
+django-cache-memoize==0.1.9  # via -r requirements/test-master.txt
+django-config-models==2.1.1  # via -r requirements/test-master.txt
+django-countries==5.5     # via -r requirements/test-master.txt
+django-crum==0.7.9        # via -r requirements/test-master.txt, edx-django-utils, edx-rbac
+django-fernet-fields==0.6  # via -r requirements/test-master.txt
+django-filter==2.4.0      # via -r requirements/test-master.txt
+django-ipware==3.0.2      # via -r requirements/test-master.txt
+django-model-utils==4.1.1  # via -r requirements/test-master.txt, -r requirements/test.in, edx-rbac
+django-multi-email-field==0.6.2  # via -r requirements/test-master.txt
+django-object-actions==3.0.2  # via -r requirements/test-master.txt
+django-simple-history==3.0.0  # via -r requirements/test-master.txt
+django-waffle==2.1.0      # via -r requirements/test-master.txt, edx-django-utils, edx-drf-extensions
+djangorestframework-xml==2.0.0  # via -r requirements/test-master.txt
+djangorestframework==3.12.4  # via -r requirements/test-master.txt, django-config-models, drf-jwt, edx-drf-extensions, rest-condition
+drf-jwt==1.19.0           # via -r requirements/test-master.txt, edx-drf-extensions
+edx-django-utils==4.0.0   # via -r requirements/test-master.txt, django-config-models, edx-drf-extensions, edx-rest-api-client
+edx-drf-extensions==6.5.0  # via -r requirements/test-master.txt, edx-rbac
+edx-opaque-keys[django]==2.2.0  # via -r requirements/test-master.txt, edx-drf-extensions
+edx-rbac==1.4.2           # via -r requirements/test-master.txt
+edx-rest-api-client==5.3.0  # via -r requirements/test-master.txt
+edx-tincan-py35==1.0.0    # via -r requirements/test-master.txt
+factory-boy==3.2.0        # via -c requirements/constraints.txt, -r requirements/test.in
+faker==8.1.2              # via factory-boy
+freezegun==0.3.14         # via -c requirements/constraints.txt, -r requirements/test.in
+future==0.18.2            # via -r requirements/test-master.txt, pyjwkest
+idna==2.10                # via -r requirements/test-master.txt, requests
+importlib-metadata==4.0.1  # via inflect
+inflect==3.0.2            # via -c requirements/constraints.txt, jinja2-pluralize
+iniconfig==1.1.1          # via pytest
+jinja2-pluralize==0.3.0   # via diff-cover
+jinja2==2.11.3            # via -r requirements/test-master.txt, code-annotations, diff-cover, jinja2-pluralize
+jsondiff==1.3.0           # via -r requirements/test-master.txt
+jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/test-master.txt
+markupsafe==1.1.1         # via -r requirements/test-master.txt, jinja2
+mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.in
+more-itertools==8.7.0     # via zipp
+newrelic==6.2.0.156       # via -r requirements/test-master.txt, edx-django-utils
+packaging==20.9           # via -r requirements/test-master.txt, bleach, pytest
+path.py==12.5.0           # via -r requirements/test-master.txt
+path==13.1.0              # via -r requirements/test-master.txt, path.py
+pbr==5.6.0                # via -r requirements/test-master.txt, stevedore
+pillow==8.2.0             # via -r requirements/test-master.txt
+pluggy==0.13.1            # via diff-cover, pytest
+psutil==5.8.0             # via -r requirements/test-master.txt, edx-django-utils
+py==1.10.0                # via pytest, pytest-catchlog
+pycparser==2.20           # via -r requirements/test-master.txt, cffi
+pycryptodomex==3.10.1     # via -r requirements/test-master.txt, pyjwkest
+pygments==2.9.0           # via diff-cover
+pyjwkest==1.4.2           # via -r requirements/test-master.txt, edx-drf-extensions
+pyjwt[crypto]==1.7.1      # via -r requirements/test-master.txt, drf-jwt, edx-rest-api-client
+pymongo==3.10.1           # via -r requirements/test-master.txt, edx-opaque-keys
+pyparsing==2.4.7          # via -r requirements/test-master.txt, packaging
+pytest-catchlog==1.2.2    # via -r requirements/test.in
+pytest-cov==2.11.1        # via -r requirements/test.in
+pytest-django==4.2.0      # via -r requirements/test.in
+pytest==6.2.4             # via -c requirements/constraints.txt, pytest-catchlog, pytest-cov, pytest-django
+python-dateutil==2.4.0    # via -r requirements/test-master.txt, edx-drf-extensions, faker, freezegun
+python-slugify==4.0.1     # via -r requirements/test-master.txt, code-annotations
+pytz==2021.1              # via -r requirements/test-master.txt, celery, django, edx-tincan-py35
+pyyaml==5.4.1             # via -r requirements/test-master.txt, code-annotations
+requests==2.25.1          # via -r requirements/test-master.txt, edx-drf-extensions, edx-rest-api-client, pyjwkest, responses, slumber, tableauserverclient
+responses==0.10.15        # via -c requirements/constraints.txt, -r requirements/test.in
+rest-condition==1.0.3     # via -r requirements/test-master.txt, edx-drf-extensions
+rules==2.2                # via -r requirements/test-master.txt
+semantic-version==2.8.5   # via -r requirements/test-master.txt, edx-drf-extensions
+six==1.16.0               # via -r requirements/test-master.txt, bleach, click-repl, cryptography, django-countries, edx-drf-extensions, edx-rbac, freezegun, mock, pyjwkest, python-dateutil, responses, stevedore
+slumber==0.7.1            # via -r requirements/test-master.txt, edx-rest-api-client
+sqlparse==0.4.1           # via -r requirements/test-master.txt, django
+stevedore==1.32.0         # via -r requirements/test-master.txt, code-annotations, edx-django-utils, edx-opaque-keys
+tableauserverclient==0.15.0  # via -r requirements/test-master.txt
+testfixtures==6.17.1      # via -r requirements/test-master.txt, -r requirements/test.in
+text-unidecode==1.3       # via -r requirements/test-master.txt, faker, python-slugify
+toml==0.10.2              # via pytest
+unicodecsv==0.14.1        # via -r requirements/test-master.txt
+urllib3==1.26.4           # via -r requirements/test-master.txt, requests
+wcwidth==0.2.5            # via -r requirements/test-master.txt, prompt-toolkit
+webencodings==0.5.1       # via -r requirements/test-master.txt, bleach
+zipp==1.0.0               # via -c requirements/constraints.txt, importlib-metadata


### PR DESCRIPTION
Currently, we are have pinned pip to version 20.1.1 in configuration, which is compatible with pip-tools < 6.0 So in this PR we are upgrading pip-tools to 5.5* according to this compatibility chart
https://github.com/jazzband/pip-tools/#versions-and-compatibility

Relevant JIRA: https://openedx.atlassian.net/browse/BOM-2247