### PR TITLE
fix: If no course_enrollment linked object, don't fail is_active. ENT-4525

### DIFF
--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -1683,7 +1683,9 @@ class EnterpriseCourseEnrollment(TimeStampedModel):
         """
         Returns True iff this enrollment is currently active.
         """
-        return self.course_enrollment.is_active
+        if self.course_enrollment:
+            return self.course_enrollment.is_active
+        return None
 
     @property
     def mode(self):


### PR DESCRIPTION
__Why?__

When there is no underlying `CourseEnrollment` object to be found (apparently this can happen with direct integrations), this causes a 500 error which ruins the user experience. We instead want to return is_active:None when that situation exists.

This fix may not be sufficient to address the ENT-4525 fully but it's worth a try to let the user into the learner portal at least, without showing a unhelpful 500 error page.

Also, we still need to investigate why we create such `EnterpriseCourseEnrollment` records without `CourseEnrollment` records

I am not investing in a test for this one because it will first be interesting to test this against this customer's learner portal to ensure we can get to a course listing page.

ENT-4525

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
