### PR TITLE
feat: :construction: Add enterprise to seeded users and roles

### DIFF
--- a/enterprise/management/commands/seed_enterprise_devstack_data.py
+++ b/enterprise/management/commands/seed_enterprise_devstack_data.py
@@ -265,12 +265,12 @@ class Command(BaseCommand):
         # Create one of each enterprise user type (i.e., learner, admin, operator)
         enterprise_users = [
             self._create_enterprise_user(
-                username="{}_{}".format(ENTERPRISE_LEARNER_ROLE,slug),
+                username="{}_{}".format(ENTERPRISE_LEARNER_ROLE, slug),
                 role=ENTERPRISE_LEARNER_ROLE,
                 enterprise_customer=enterprise_customer
             ),
             self._create_enterprise_user(
-                username="{}_{}".format(ENTERPRISE_ADMIN_ROLE,slug),
+                username="{}_{}".format(ENTERPRISE_ADMIN_ROLE, slug),
                 role=ENTERPRISE_ADMIN_ROLE,
                 enterprise_customer=enterprise_customer
 

--- a/enterprise/management/commands/seed_enterprise_devstack_data.py
+++ b/enterprise/management/commands/seed_enterprise_devstack_data.py
@@ -142,7 +142,7 @@ class Command(BaseCommand):
                 self._add_user_to_groups(user=user, role=role)
                 self._create_system_wide_role_assignment(
                     user=user,
-                    role=role, 
+                    role=role,
                     enterprise_customer=enterprise_customer)
                 self._create_feature_role_assignments(user=user, role=role)
                 return {
@@ -181,7 +181,7 @@ class Command(BaseCommand):
             'user': user,
             'role': system_role,
         }
-        if enterprise_customer != None:
+        if enterprise_customer is not None:
             kwargs['enterprise_customer'] = enterprise_customer
         # We use filter() here, because the model does not currently enforce uniqueness on (user, role).
         if not SystemWideEnterpriseUserRoleAssignment.objects.filter(**kwargs).exists():
@@ -219,8 +219,8 @@ class Command(BaseCommand):
 
     def _create_enterprise_linked_data(self, enterprise_users, enterprise_customer):
         """
-        Creates enterprise data for a given EnterpriseCustomer and its 
-        associated data, including an enterprise catalog, and initial users of
+        Creates enterprise data for a given EnterpriseCustomer
+        including an enterprise catalog and initial users of
         varying roles.
         """
         enterprise_catalog = self._create_catalog_for_enterprise(
@@ -275,10 +275,14 @@ class Command(BaseCommand):
                 enterprise_customer=enterprise_customer
 
             ),
+            # Creates a super admin who has the admin role on all enterprises.
             self._create_enterprise_user(
-                username="{}_{}".format(ENTERPRISE_OPERATOR_ROLE,slug),
-                role=ENTERPRISE_OPERATOR_ROLE,
-                enterprise_customer=enterprise_customer
+                username=ENTERPRISE_ADMIN_ROLE,
+                role=ENTERPRISE_ADMIN_ROLE
+            ),
+            self._create_enterprise_user(
+                username=ENTERPRISE_OPERATOR_ROLE,
+                role=ENTERPRISE_OPERATOR_ROLE
 
             ),
             # Make all of the service workers enterprise_openedx_operators for all enterprises
@@ -302,10 +306,11 @@ class Command(BaseCommand):
                     slug=slug,
                     index=i + 1,
                 ),
-                role=ENTERPRISE_LEARNER_ROLE
+                role=ENTERPRISE_LEARNER_ROLE,
+                enterprise_customer=enterprise_customer
             ))
 
-        LOGGER.info('\nCreating a new enterprise...')
+        LOGGER.info('\nCreating enterprise data...')
         enterprise = self._create_enterprise_linked_data(
             enterprise_users=enterprise_users, enterprise_customer=enterprise_customer)
 


### PR DESCRIPTION
Allows for repeated running of the following command for easy creation of fresh enterprise setup on devstack:
By default no system level enterprise_admin user will exist in seed data.

Usage: 
1. `make lms-shell` to get into the lms. 
2. `./manage.py lms seed_enterprise_devstack_data --name '"My Test Enterprise for Ticket 1234"`

Result will be an admin, learners, enterprise etc all keyed to the new enterprise only. 

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
