### PR TITLE
fix: :bug: ENT-4525 do not process enterprise enrollments without matching courseEnrollment

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing.
 
+[3.23.1]
+---------
+* Fix: filter out EnterpriseCourseEnrollments without corresponding CourseEnrollment records in learner portal view.
+
 [3.23.0]
 ---------
 * Added support for ``--enrollment-before`` and ``--no-commit`` params in ``email_drip_for_missing_dsc_records`` command.

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.23.0"
+__version__ = "3.23.1"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise_learner_portal/api/v1/views.py
+++ b/enterprise_learner_portal/api/v1/views.py
@@ -83,10 +83,12 @@ class EnterpriseCourseEnrollmentView(APIView):
             enterprise_customer_user=enterprise_customer_user
         )
 
-        course_overviews = get_course_overviews(enterprise_enrollments.values_list('course_id', flat=True))
+        filtered_enterprise_enrollments = [record for record in enterprise_enrollments if record.course_enrollment]
+
+        course_overviews = get_course_overviews([record['course_id'] for record in filtered_enterprise_enrollments])
 
         data = EnterpriseCourseEnrollmentSerializer(
-            enterprise_enrollments,
+            filtered_enterprise_enrollments,
             many=True,
             context={'request': request, 'course_overviews': course_overviews},
         ).data

--- a/enterprise_learner_portal/api/v1/views.py
+++ b/enterprise_learner_portal/api/v1/views.py
@@ -85,7 +85,7 @@ class EnterpriseCourseEnrollmentView(APIView):
 
         filtered_enterprise_enrollments = [record for record in enterprise_enrollments if record.course_enrollment]
 
-        course_overviews = get_course_overviews([record['course_id'] for record in filtered_enterprise_enrollments])
+        course_overviews = get_course_overviews([record.course_id for record in filtered_enterprise_enrollments])
 
         data = EnterpriseCourseEnrollmentSerializer(
             filtered_enterprise_enrollments,

--- a/tests/test_enterprise/management/test_email_drip_for_missing_dsc_records.py
+++ b/tests/test_enterprise/management/test_email_drip_for_missing_dsc_records.py
@@ -93,7 +93,7 @@ class EmailDripForMissingDscRecordsCommandTests(TestCase):
             mock_dsc_proxied_get
     ):
         """
-        Test that email drip event is fired for missing DSC records.
+        Test that email drip event is fired for missing DSC records
         """
         mock_get_course_properties.return_value = 'test_url', 'test_course'
 

--- a/tests/test_enterprise_learner_portal/api/test_views.py
+++ b/tests/test_enterprise_learner_portal/api/test_views.py
@@ -161,6 +161,28 @@ class TestEnterpriseCourseEnrollmentView(TestCase):
         assert resp.status_code == 404
         assert resp.json() == {'detail': 'Not found.'}
 
+    @mock.patch('enterprise_learner_portal.api.v1.serializers.get_certificate_for_user', mock.MagicMock())
+    @mock.patch('enterprise_learner_portal.api.v1.views.get_course_overviews')
+    def test_view_filters_out_invalid_enterprise_enrollments(self, mock_get_overviews):
+        """
+        View does not fail, and view filters out all enrollments whose course_enrollment
+        field is None
+        """
+        mock_get_overviews.return_value = {}
+
+        resp = self.client.get(
+            '{host}{path}?enterprise_id={enterprise_id}&is_active=true'.format(
+                host=settings.TEST_SERVER,
+                path=reverse('enterprise-learner-portal-course-enrollment-list'),
+                enterprise_id=str(self.enterprise_customer.uuid),
+                active_filter_value='true'
+            )
+        )
+        assert resp.status_code == 200
+        # since all enterprise_enrollments in this are with empty course_enrollment
+        # this check should fail if filtering is not working
+        assert resp.json() == []
+
     def test_view_requires_openedx_installation(self):
         """
         View should raise error if imports to helper methods fail.

--- a/tests/test_enterprise_learner_portal/api/test_views.py
+++ b/tests/test_enterprise_learner_portal/api/test_views.py
@@ -175,7 +175,6 @@ class TestEnterpriseCourseEnrollmentView(TestCase):
                 host=settings.TEST_SERVER,
                 path=reverse('enterprise-learner-portal-course-enrollment-list'),
                 enterprise_id=str(self.enterprise_customer.uuid),
-                active_filter_value='true'
             )
         )
         assert resp.status_code == 200


### PR DESCRIPTION
Why?
Learners cannot even get into a course page or the learner portal in general in any useful way. until this is fixed. This case occurs when the `enterprise_course_enrollments` endpoint is called and it encounters even 1 EnterpriseCourseEnrollment records, whose self.course_enrollment is None. This can happen for direct integrations, even though the exact root cause is not yet known. Still since the learner is not even enrolled officially yet, we should really not block the learner

This is a high value add change that makes learners able to use the learner poratl even while we investigate the underluing causes of the bad records.

What is included?

* - [x] The fix: Just a filtering of the enrollments once they are fetched, to exclude any with absent course_enrollment properties (it's a cached property not a foreign key)
* - [x] Needed test changes


### Testing notes

#### Accessing learner portal

I locally changed the value of the course id in an existing `student.CourseEnrollment` record that I already had, in the database for LMS locally, to an incorrect value, which basically amounts to the same result

I assigned one code to the learner using ecommerce page so I had something to work with, there is no license subsidy here
Then I visited http://localhost:8734/test-enterprise while logged in as that learner test_enterprise_2@example.com

reproduces the issue since the query to fetch course_enrollment records returns empty in that case

Once I apply this fix I am able to get into the learner portal and see this page

<img width="1041" alt="Screen Shot 2021-05-11 at 12 46 13 PM" src="https://user-images.githubusercontent.com/528166/117867659-a33ca100-b266-11eb-8bad-09e10e55901c.png">


#### Enrolling in a course thus accessed once learner is in this odd state:

I actually reproduced the situatoin in local by first ensureing there is a valid enterprisecourseenrollment for the learner but messing up the record in student.courseEnrollment table (changing the course_id) so that effectively there is no longer a courseEnrollment to be found

when I do that I get this screen instead of the screen I got from the case with courseEnrollment intact. It now says 'Enroll' and that makes sens ebecause the response of the `enterprise_course_enrollments` is now an empty array, instead of the prior response of 500

<img width="890" alt="Screen Shot 2021-05-11 at 4 36 28 PM" src="https://user-images.githubusercontent.com/528166/117881692-8c527a80-b277-11eb-84b9-9b3e2ead4292.png">


Now attempted to enroll the learner in this course:

I get the screen to enroll, but unable as of yet to proceed due to ecommerce running into problems. I might have reprovision or reset it some other way to verify enrollment fully

<img width="922" alt="Screen Shot 2021-05-11 at 4 47 08 PM" src="https://user-images.githubusercontent.com/528166/117883999-1e5b8280-b27a-11eb-95d8-410b189d2e10.png">


JIRA: ENT-4525

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
