### PR TITLE
ENT-4522: Added support for checking course access by learner

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Change Log
 Unreleased
 ----------
 
+[3.23.3]
+---------
+* Added a check for course access before sending Segment event for missing DSC.
+
 [3.23.2]
 ---------
 * Added new field reply_to in enterprise customer where learner's reply to enterprise emails will be delivered.

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.23.2"
+__version__ = "3.23.3"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/tests/test_enterprise/management/test_email_drip_for_missing_dsc_records.py
+++ b/tests/test_enterprise/management/test_email_drip_for_missing_dsc_records.py
@@ -86,8 +86,10 @@ class EmailDripForMissingDscRecordsCommandTests(TestCase):
     )
     @mock.patch('enterprise.management.commands.email_drip_for_missing_dsc_records.utils.track_event')
     @mock.patch('enterprise.management.commands.email_drip_for_missing_dsc_records.Command._get_course_properties')
+    @mock.patch('enterprise.management.commands.email_drip_for_missing_dsc_records.is_course_accessed')
     def test_email_drip_for_missing_dsc_records(
             self,
+            mock_is_course_accessed,
             mock_get_course_properties,
             mock_event_track,
             mock_dsc_proxied_get
@@ -96,7 +98,7 @@ class EmailDripForMissingDscRecordsCommandTests(TestCase):
         Test that email drip event is fired for missing DSC records
         """
         mock_get_course_properties.return_value = 'test_url', 'test_course'
-
+        mock_is_course_accessed.return_value = True
         # test when consent is present
         with LogCapture(LOGGER_NAME) as log:
             mock_dsc_proxied_get.return_value = DataSharingConsent()


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
