### PR TITLE
edx-abolger/ent 4103 log standardization

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,11 @@ Unreleased
 ----------
 * Nothing
 
+[3.26.7]
+--------
+* developer-only facing updates to standardize LMS Integrated Channels logging.
+
+
 [3.26.6]
 --------
 * added an update api call to assign tableau user roles

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.26.6"
+__version__ = "3.26.7"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/blackboard/exporters/learner_data.py
+++ b/integrated_channels/blackboard/exporters/learner_data.py
@@ -34,8 +34,9 @@ class BlackboardLearnerExporter(LearnerExporter):
         enterprise_customer_user = enterprise_enrollment.enterprise_customer_user
         if enterprise_customer_user.user_email is None:
             LOGGER.debug(
-                'No learner data was sent for user [%s] because a Blackboard user ID could not be found.',
-                enterprise_customer_user.username
+                'No learner data was sent for LMS User [%s] because a Blackboard user ID could not be found for customer [%s]',
+                enterprise_customer_user.user_id,
+                enterprise_customer_user.enterprise_customer.name
             )
             return None
         percent_grade = kwargs.get('grade_percent', None)
@@ -79,8 +80,9 @@ class BlackboardLearnerExporter(LearnerExporter):
         if enterprise_enrollment.enterprise_customer_user.user_email is None:
             # We need an email to find the user on blackboard.
             LOGGER.debug(
-                'No learner data was sent for user [%s] because a blackboard user ID could not be found.',
-                enterprise_enrollment.enterprise_customer_user.username
+                'No learner data was sent for LMS User [%s] because a Blackboard user ID could not be found for customer [%s]',
+                enterprise_enrollment.enterprise_customer_user.user_id,
+                enterprise_enrollment.enterprise_customer_user.enterprise_customer.name
             )
             return None
 

--- a/integrated_channels/blackboard/exporters/learner_data.py
+++ b/integrated_channels/blackboard/exporters/learner_data.py
@@ -34,7 +34,7 @@ class BlackboardLearnerExporter(LearnerExporter):
         enterprise_customer_user = enterprise_enrollment.enterprise_customer_user
         if enterprise_customer_user.user_email is None:
             LOGGER.debug(
-                'No learner data was sent for LMS User [%s] because a Blackboard user ID could not be found for customer [%s]',
+                'No learner data was sent for LMS User [%s] because Blackboard User ID not found for customer [%s]',
                 enterprise_customer_user.user_id,
                 enterprise_customer_user.enterprise_customer.name
             )
@@ -80,7 +80,7 @@ class BlackboardLearnerExporter(LearnerExporter):
         if enterprise_enrollment.enterprise_customer_user.user_email is None:
             # We need an email to find the user on blackboard.
             LOGGER.debug(
-                'No learner data was sent for LMS User [%s] because a Blackboard user ID could not be found for customer [%s]',
+                'No learner data was sent for LMS User [%s] because Blackboard User ID not found for customer [%s]',
                 enterprise_enrollment.enterprise_customer_user.user_id,
                 enterprise_enrollment.enterprise_customer_user.enterprise_customer.name
             )

--- a/integrated_channels/blackboard/exporters/learner_data.py
+++ b/integrated_channels/blackboard/exporters/learner_data.py
@@ -39,9 +39,9 @@ class BlackboardLearnerExporter(LearnerExporter):
                 enterprise_customer_user.user_id,
                 None,
                 ('get_learner_data_records finished. No learner data was sent because '
-                'Blackboard User ID not found for [{name}]'.format(
-                    name=enterprise_customer_user.enterprise_customer.name
-                ))))
+                 'Blackboard User ID not found for [{name}]'.format(
+                     name=enterprise_customer_user.enterprise_customer.name
+                 ))))
             return None
         percent_grade = kwargs.get('grade_percent', None)
         completed_timestamp = None
@@ -89,9 +89,9 @@ class BlackboardLearnerExporter(LearnerExporter):
                 enterprise_enrollment.enterprise_customer_user.user_id,
                 None,
                 ('get_learner_assessment_data_records finished. No learner data was sent because '
-                'Blackboard User ID not found for [{name}]'.format(
-                    name=enterprise_enrollment.enterprise_customer_user.enterprise_customer.name
-                ))))
+                 'Blackboard User ID not found for [{name}]'.format(
+                     name=enterprise_enrollment.enterprise_customer_user.enterprise_customer.name
+                 ))))
             return None
 
         blackboardLearnerAssessmentDataTransmissionAudit = apps.get_model(  # pylint: disable=invalid-name

--- a/integrated_channels/blackboard/exporters/learner_data.py
+++ b/integrated_channels/blackboard/exporters/learner_data.py
@@ -9,7 +9,7 @@ from django.apps import apps
 
 from integrated_channels.catalog_service_utils import get_course_id_for_enrollment
 from integrated_channels.integrated_channel.exporters.learner_data import LearnerExporter
-from integrated_channels.utils import parse_datetime_to_epoch_millis
+from integrated_channels.utils import generate_formatted_log, parse_datetime_to_epoch_millis
 
 LOGGER = getLogger(__name__)
 
@@ -33,11 +33,15 @@ class BlackboardLearnerExporter(LearnerExporter):
         """
         enterprise_customer_user = enterprise_enrollment.enterprise_customer_user
         if enterprise_customer_user.user_email is None:
-            LOGGER.debug(
-                'No learner data was sent for LMS User [%s] because Blackboard User ID not found for customer [%s]',
+            LOGGER.debug(generate_formatted_log(
+                'blackboard',
+                enterprise_customer_user.enterprise_customer.uuid,
                 enterprise_customer_user.user_id,
-                enterprise_customer_user.enterprise_customer.name
-            )
+                None,
+                ('get_learner_data_records finished. No learner data was sent because '
+                'Blackboard User ID not found for [{name}]'.format(
+                    name=enterprise_customer_user.enterprise_customer.name
+                ))))
             return None
         percent_grade = kwargs.get('grade_percent', None)
         completed_timestamp = None
@@ -79,11 +83,15 @@ class BlackboardLearnerExporter(LearnerExporter):
         """
         if enterprise_enrollment.enterprise_customer_user.user_email is None:
             # We need an email to find the user on blackboard.
-            LOGGER.debug(
-                'No learner data was sent for LMS User [%s] because Blackboard User ID not found for customer [%s]',
+            LOGGER.debug(generate_formatted_log(
+                'blackboard',
+                enterprise_enrollment.enterprise_customer_user.enterprise_customer.uuid,
                 enterprise_enrollment.enterprise_customer_user.user_id,
-                enterprise_enrollment.enterprise_customer_user.enterprise_customer.name
-            )
+                None,
+                ('get_learner_assessment_data_records finished. No learner data was sent because '
+                'Blackboard User ID not found for [{name}]'.format(
+                    name=enterprise_enrollment.enterprise_customer_user.enterprise_customer.name
+                ))))
             return None
 
         blackboardLearnerAssessmentDataTransmissionAudit = apps.get_model(  # pylint: disable=invalid-name

--- a/integrated_channels/blackboard/exporters/learner_data.py
+++ b/integrated_channels/blackboard/exporters/learner_data.py
@@ -38,7 +38,7 @@ class BlackboardLearnerExporter(LearnerExporter):
                 enterprise_customer_user.enterprise_customer.uuid,
                 enterprise_customer_user.user_id,
                 None,
-                ('get_learner_data_records finished. No learner data was sent because '
+                ('get_learner_data_records finished. No learner data was sent for this LMS User Id because '
                  'Blackboard User ID not found for [{name}]'.format(
                      name=enterprise_customer_user.enterprise_customer.name
                  ))))
@@ -88,8 +88,8 @@ class BlackboardLearnerExporter(LearnerExporter):
                 enterprise_enrollment.enterprise_customer_user.enterprise_customer.uuid,
                 enterprise_enrollment.enterprise_customer_user.user_id,
                 None,
-                ('get_learner_assessment_data_records finished. No learner data was sent because '
-                 'Blackboard User ID not found for [{name}]'.format(
+                ('get_learner_assessment_data_records finished. No learner data was sent for this LMS User Id because'
+                 ' Blackboard User ID not found for [{name}]'.format(
                      name=enterprise_enrollment.enterprise_customer_user.enterprise_customer.name
                  ))))
             return None

--- a/integrated_channels/canvas/exporters/learner_data.py
+++ b/integrated_channels/canvas/exporters/learner_data.py
@@ -36,8 +36,9 @@ class CanvasLearnerExporter(LearnerExporter):
         enterprise_customer_user = enterprise_enrollment.enterprise_customer_user
         if enterprise_customer_user.user_email is None:
             LOGGER.debug(
-                'No learner data was sent for user [%s] because a Canvas user ID could not be found.',
-                enterprise_customer_user.username
+                'No learner data was sent for LMS User [%s] because a Canvas user ID could not be found for customer [%s]',
+                enterprise_customer_user.user_id,
+                enterprise_customer_user.enterprise_customer.name
             )
             return None
         percent_grade = kwargs.get('grade_percent', None)
@@ -84,8 +85,9 @@ class CanvasLearnerExporter(LearnerExporter):
         if enterprise_customer_user.user_email is None:
             # We need an email to find the user on Canvas.
             LOGGER.debug(
-                'No learner data was sent for user [%s] because a Canvas user ID could not be found.',
-                enterprise_enrollment.enterprise_customer_user.username
+                'No learner data was sent for LMS User [%s] because a Canvas user ID could not be found for customer [%s]',
+                enterprise_enrollment.enterprise_customer_user.user_id,
+                enterprise_enrollment.enterprise_customer_user.enterprise_customer.name
             )
             return None
 

--- a/integrated_channels/canvas/exporters/learner_data.py
+++ b/integrated_channels/canvas/exporters/learner_data.py
@@ -36,7 +36,7 @@ class CanvasLearnerExporter(LearnerExporter):
         enterprise_customer_user = enterprise_enrollment.enterprise_customer_user
         if enterprise_customer_user.user_email is None:
             LOGGER.debug(
-                'No learner data was sent for LMS User [%s] because a Canvas user ID could not be found for customer [%s]',
+                'No learner data sent for LMS User [%s] because a Canvas user ID was not found for customer [%s]',
                 enterprise_customer_user.user_id,
                 enterprise_customer_user.enterprise_customer.name
             )
@@ -85,7 +85,7 @@ class CanvasLearnerExporter(LearnerExporter):
         if enterprise_customer_user.user_email is None:
             # We need an email to find the user on Canvas.
             LOGGER.debug(
-                'No learner data was sent for LMS User [%s] because a Canvas user ID could not be found for customer [%s]',
+                'No learner data sent for LMS User [%s] because a Canvas user ID was not found for customer [%s]',
                 enterprise_enrollment.enterprise_customer_user.user_id,
                 enterprise_enrollment.enterprise_customer_user.enterprise_customer.name
             )

--- a/integrated_channels/canvas/exporters/learner_data.py
+++ b/integrated_channels/canvas/exporters/learner_data.py
@@ -41,7 +41,7 @@ class CanvasLearnerExporter(LearnerExporter):
                 enterprise_customer_user.enterprise_customer.uuid,
                 enterprise_customer_user.user_id,
                 None,
-                ('get_learner_data_records finished. No learner data was sent because '
+                ('get_learner_data_records finished. No learner data was sent for this LMS User Id because '
                  'Canvas User ID not found for [{name}]'.format(
                      name=enterprise_customer_user.enterprise_customer.name
                  ))))
@@ -94,7 +94,7 @@ class CanvasLearnerExporter(LearnerExporter):
                 enterprise_enrollment.enterprise_customer_user.enterprise_customer.uuid,
                 enterprise_enrollment.enterprise_customer_user.user_id,
                 None,
-                ('get_learner_assessment_data_records finished. No learner data was sent because '
+                ('get_learner_assessment_data_records finished. No learner data was sent for this LMS User Id because '
                  'Canvas User ID not found for [{name}]'.format(
                      name=enterprise_enrollment.enterprise_customer_user.enterprise_customer.name
                  ))))

--- a/integrated_channels/canvas/exporters/learner_data.py
+++ b/integrated_channels/canvas/exporters/learner_data.py
@@ -10,6 +10,7 @@ from django.apps import apps
 
 from integrated_channels.catalog_service_utils import get_course_id_for_enrollment
 from integrated_channels.integrated_channel.exporters.learner_data import LearnerExporter
+from integrated_channels.utils import generate_formatted_log
 
 LOGGER = getLogger(__name__)
 
@@ -35,11 +36,15 @@ class CanvasLearnerExporter(LearnerExporter):
         """
         enterprise_customer_user = enterprise_enrollment.enterprise_customer_user
         if enterprise_customer_user.user_email is None:
-            LOGGER.debug(
-                'No learner data sent for LMS User [%s] because a Canvas user ID was not found for customer [%s]',
+            LOGGER.debug(generate_formatted_log(
+                'canvas',
+                enterprise_customer_user.enterprise_customer.uuid,
                 enterprise_customer_user.user_id,
-                enterprise_customer_user.enterprise_customer.name
-            )
+                None,
+                ('get_learner_data_records finished. No learner data was sent because '
+                'Canvas User ID not found for [{name}]'.format(
+                    name=enterprise_customer_user.enterprise_customer.name
+                ))))
             return None
         percent_grade = kwargs.get('grade_percent', None)
         completed_timestamp = completed_date.strftime("%F") if isinstance(completed_date, datetime) else None
@@ -84,11 +89,15 @@ class CanvasLearnerExporter(LearnerExporter):
         enterprise_customer_user = enterprise_enrollment.enterprise_customer_user
         if enterprise_customer_user.user_email is None:
             # We need an email to find the user on Canvas.
-            LOGGER.debug(
-                'No learner data sent for LMS User [%s] because a Canvas user ID was not found for customer [%s]',
+            LOGGER.debug(generate_formatted_log(
+                'canvas',
+                enterprise_enrollment.enterprise_customer_user.enterprise_customer.uuid,
                 enterprise_enrollment.enterprise_customer_user.user_id,
-                enterprise_enrollment.enterprise_customer_user.enterprise_customer.name
-            )
+                None,
+                ('get_learner_assessment_data_records finished. No learner data was sent because '
+                'Canvas User ID not found for [{name}]'.format(
+                    name=enterprise_enrollment.enterprise_customer_user.enterprise_customer.name
+                ))))
             return None
 
         CanvasLearnerAssessmentDataTransmissionAudit = apps.get_model(  # pylint: disable=invalid-name

--- a/integrated_channels/canvas/exporters/learner_data.py
+++ b/integrated_channels/canvas/exporters/learner_data.py
@@ -42,9 +42,9 @@ class CanvasLearnerExporter(LearnerExporter):
                 enterprise_customer_user.user_id,
                 None,
                 ('get_learner_data_records finished. No learner data was sent because '
-                'Canvas User ID not found for [{name}]'.format(
-                    name=enterprise_customer_user.enterprise_customer.name
-                ))))
+                 'Canvas User ID not found for [{name}]'.format(
+                     name=enterprise_customer_user.enterprise_customer.name
+                 ))))
             return None
         percent_grade = kwargs.get('grade_percent', None)
         completed_timestamp = completed_date.strftime("%F") if isinstance(completed_date, datetime) else None
@@ -95,9 +95,9 @@ class CanvasLearnerExporter(LearnerExporter):
                 enterprise_enrollment.enterprise_customer_user.user_id,
                 None,
                 ('get_learner_assessment_data_records finished. No learner data was sent because '
-                'Canvas User ID not found for [{name}]'.format(
-                    name=enterprise_enrollment.enterprise_customer_user.enterprise_customer.name
-                ))))
+                 'Canvas User ID not found for [{name}]'.format(
+                     name=enterprise_enrollment.enterprise_customer_user.enterprise_customer.name
+                 ))))
             return None
 
         CanvasLearnerAssessmentDataTransmissionAudit = apps.get_model(  # pylint: disable=invalid-name

--- a/integrated_channels/cornerstone/exporters/learner_data.py
+++ b/integrated_channels/cornerstone/exporters/learner_data.py
@@ -56,9 +56,9 @@ class CornerstoneLearnerExporter(LearnerExporter):
             ]
         except CornerstoneLearnerDataTransmissionAudit.DoesNotExist:
             LOGGER.info(
-                'No learner data was sent for user [%s] because Cornerstone user ID could not be found '
+                'No learner data was sent for LMS User [%s] because Cornerstone user ID could not be found '
                 'for customer [%s]',
-                enterprise_enrollment.enterprise_customer_user.username,
+                enterprise_enrollment.enterprise_customer_user.user_id,
                 enterprise_enrollment.enterprise_customer_user.enterprise_customer.name
             )
             return None

--- a/integrated_channels/cornerstone/exporters/learner_data.py
+++ b/integrated_channels/cornerstone/exporters/learner_data.py
@@ -61,7 +61,7 @@ class CornerstoneLearnerExporter(LearnerExporter):
                 enterprise_enrollment.enterprise_customer_user.enterprise_customer.uuid,
                 enterprise_enrollment.enterprise_customer_user.user_id,
                 None,
-                ('get_learner_data_records finished. No learner data was sent because '
+                ('get_learner_data_records finished. No learner data was sent for this LMS User Id because '
                  'Cornerstone User ID not found for [{name}]'.format(
                      name=enterprise_enrollment.enterprise_customer_user.enterprise_customer.name
                  ))))

--- a/integrated_channels/cornerstone/exporters/learner_data.py
+++ b/integrated_channels/cornerstone/exporters/learner_data.py
@@ -9,6 +9,7 @@ from django.apps import apps
 
 from integrated_channels.catalog_service_utils import get_course_id_for_enrollment
 from integrated_channels.integrated_channel.exporters.learner_data import LearnerExporter
+from integrated_channels.utils import generate_formatted_log
 
 LOGGER = getLogger(__name__)
 
@@ -55,10 +56,13 @@ class CornerstoneLearnerExporter(LearnerExporter):
                 csod_learner_data_transmission
             ]
         except CornerstoneLearnerDataTransmissionAudit.DoesNotExist:
-            LOGGER.info(
-                'No learner data was sent for LMS User [%s] because Cornerstone user ID could not be found '
-                'for customer [%s]',
+            LOGGER.info(generate_formatted_log(
+                'cornerstone',
+                enterprise_enrollment.enterprise_customer_user.enterprise_customer.uuid,
                 enterprise_enrollment.enterprise_customer_user.user_id,
-                enterprise_enrollment.enterprise_customer_user.enterprise_customer.name
-            )
+                None,
+                ('get_learner_data_records finished. No learner data was sent because '
+                 'Cornerstone User ID not found for [{name}]'.format(
+                     name=enterprise_enrollment.enterprise_customer_user.enterprise_customer.name
+                 ))))
             return None

--- a/integrated_channels/degreed/exporters/learner_data.py
+++ b/integrated_channels/degreed/exporters/learner_data.py
@@ -59,7 +59,8 @@ class DegreedLearnerExporter(LearnerExporter):
                 )
             ]
         LOGGER.debug(
-            'No learner data was sent for user [%s] because a Degreed user ID could not be found.',
-            enterprise_enrollment.enterprise_customer_user.username
+            'No learner data was sent for LMS User [%s] because a Degreed user ID could not be found for customer [%s]',
+            enterprise_enrollment.enterprise_customer_user.user_id,
+            enterprise_enrollment.enterprise_customer_user.enterprise_customer.name
         )
         return None

--- a/integrated_channels/degreed/exporters/learner_data.py
+++ b/integrated_channels/degreed/exporters/learner_data.py
@@ -10,6 +10,7 @@ from django.apps import apps
 
 from integrated_channels.catalog_service_utils import get_course_id_for_enrollment
 from integrated_channels.integrated_channel.exporters.learner_data import LearnerExporter
+from integrated_channels.utils import generate_formatted_log
 
 LOGGER = getLogger(__name__)
 
@@ -58,9 +59,13 @@ class DegreedLearnerExporter(LearnerExporter):
                     completed_timestamp=completed_timestamp,
                 )
             ]
-        LOGGER.debug(
-            'No learner data was sent for LMS User [%s] because a Degreed user ID could not be found for customer [%s]',
+        LOGGER.info(generate_formatted_log(
+            'degreed',
+            enterprise_enrollment.enterprise_customer_user.enterprise_customer.uuid,
             enterprise_enrollment.enterprise_customer_user.user_id,
-            enterprise_enrollment.enterprise_customer_user.enterprise_customer.name
-        )
+            None,
+            ('get_learner_data_records finished. No learner data was sent because '
+             'Degreed User ID not found for [{name}]'.format(
+                 name=enterprise_enrollment.enterprise_customer_user.enterprise_customer.name
+             ))))
         return None

--- a/integrated_channels/degreed/exporters/learner_data.py
+++ b/integrated_channels/degreed/exporters/learner_data.py
@@ -64,7 +64,7 @@ class DegreedLearnerExporter(LearnerExporter):
             enterprise_enrollment.enterprise_customer_user.enterprise_customer.uuid,
             enterprise_enrollment.enterprise_customer_user.user_id,
             None,
-            ('get_learner_data_records finished. No learner data was sent because '
+            ('get_learner_data_records finished. No learner data was sent for this LMS User Id because '
              'Degreed User ID not found for [{name}]'.format(
                  name=enterprise_enrollment.enterprise_customer_user.enterprise_customer.name
              ))))

--- a/integrated_channels/integrated_channel/exporters/learner_data.py
+++ b/integrated_channels/integrated_channel/exporters/learner_data.py
@@ -93,9 +93,9 @@ class LearnerExporter(Exporter):
         """
         Collect assessment level learner data for the ``EnterpriseCustomer`` where data sharing consent is granted.
 
-        Yields a learner assessment data object for each subsection within a course under an enrollment, containing:
+        Yields a ``LearnerDataTransmissionAudit`` object for each subsection within a course under an enrollment, containing:
 
-        * ``enterprise_enrollment``: ``EnterpriseCourseEnrollment`` object.
+        * ``enterprise_course_enrollment_id``: The id reference to the ``EnterpriseCourseEnrollment `` object.
         * ``course_id``: The string ID of the course under the enterprise enrollment.
         * ``subsection_id``: The string ID of the subsection within the course.
         * ``grade``: string grade recorded for the learner in the course.
@@ -133,10 +133,10 @@ class LearnerExporter(Exporter):
         Collect a single assessment level learner data for the ``EnterpriseCustomer`` where data sharing consent is
         granted.
 
-        Yields a learner assessment data object for each subsection of the course that the learner is enrolled in,
+        Yields a ``LearnerDataTransmissionAudit`` object for each subsection of the course that the learner is enrolled in,
         containing:
 
-        * ``enterprise_enrollment``: ``EnterpriseCourseEnrollment`` object.
+        * ``enterprise_course_enrollment_id``: The id reference to the ``EnterpriseCourseEnrollment `` object.
         * ``course_id``: The string ID of the course under the enterprise enrollment.
         * ``subsection_id``: The string ID of the subsection within the course.
         * ``grade``: string grade recorded for the learner in the course.
@@ -158,12 +158,6 @@ class LearnerExporter(Exporter):
 
         # We are transmitting for a single enrollment, so grab just the one.
         enterprise_enrollment = enrollment_queryset.first()
-
-        generate_formatted_log(
-            'Beginning single exportation of learner data for enrollment: {enrollment}'.format(
-                enrollment=enterprise_enrollment.id
-            )
-        )
 
         already_transmitted = is_already_transmitted(
             TransmissionAudit,
@@ -456,6 +450,7 @@ class LearnerExporter(Exporter):
     ):
         """
         Generate a learner assessment data transmission audit with fields properly filled in.
+        Returns a list of LearnerDataTransmissionAudit objects.
         """
         # pylint: disable=invalid-name
         LearnerDataTransmissionAudit = apps.get_model('integrated_channel', 'LearnerDataTransmissionAudit')

--- a/integrated_channels/integrated_channel/exporters/learner_data.py
+++ b/integrated_channels/integrated_channel/exporters/learner_data.py
@@ -658,6 +658,7 @@ class LearnerExporterUtility:
         """ Returns the ID of the LMS User for the EnterpriseCourseEnrollment id passed in
         or None if EnterpriseCourseEnrollment not found """
         try:
-            return EnterpriseCourseEnrollment.objects.get(id=enterprise_course_enrollment_id).enterprise_customer_user.user_id
+            return EnterpriseCourseEnrollment.objects.get(
+                id=enterprise_course_enrollment_id).enterprise_customer_user.user_id
         except EnterpriseCourseEnrollment.DoesNotExist:
             return None

--- a/integrated_channels/integrated_channel/exporters/learner_data.py
+++ b/integrated_channels/integrated_channel/exporters/learner_data.py
@@ -95,7 +95,7 @@ class LearnerExporter(Exporter):
 
         Yields a ``LearnerDataTransmissionAudit`` for each subsection in a course under an enrollment, containing:
 
-        * ``enterprise_course_enrollment_id``: The id reference to the ``EnterpriseCourseEnrollment `` object.
+        * ``enterprise_course_enrollment_id``: The id reference to the ``EnterpriseCourseEnrollment`` object.
         * ``course_id``: The string ID of the course under the enterprise enrollment.
         * ``subsection_id``: The string ID of the subsection within the course.
         * ``grade``: string grade recorded for the learner in the course.
@@ -130,13 +130,13 @@ class LearnerExporter(Exporter):
 
     def single_assessment_level_export(self, **kwargs):
         """
-        Collect a assessment level learner data for the ``EnterpriseCustomer`` where data sharing consent is
+        Collect an assessment level learner data for the ``EnterpriseCustomer`` where data sharing consent is
         granted.
 
         Yields a ``LearnerDataTransmissionAudit`` for each subsection of the course that the learner is enrolled in,
         containing:
 
-        * ``enterprise_course_enrollment_id``: The id reference to the ``EnterpriseCourseEnrollment `` object.
+        * ``enterprise_course_enrollment_id``: The id reference to the ``EnterpriseCourseEnrollment`` object.
         * ``course_id``: The string ID of the course under the enterprise enrollment.
         * ``subsection_id``: The string ID of the subsection within the course.
         * ``grade``: string grade recorded for the learner in the course.
@@ -156,7 +156,7 @@ class LearnerExporter(Exporter):
             course_id=course_run_id,
         ).order_by('course_id')
 
-        # We are transmitting for a enrollment, so grab just the one.
+        # We are transmitting for an enrollment, so grab just the one.
         enterprise_enrollment = enrollment_queryset.first()
 
         already_transmitted = is_already_transmitted(
@@ -431,6 +431,10 @@ class LearnerExporter(Exporter):
         """
         Generate a learner assessment data transmission audit with fields properly filled in.
         Returns a list of LearnerDataTransmissionAudit objects.
+
+        enterprise_enrollment: the ``EnterpriseCourseEnrollment`` object we are getting a learner's data for.
+        assessment_grade_data: A dict with keys corresponding to different edX course subsections.
+        See _collect_assessment_grades_data for the formatted data returned as the value for a given key.
         """
         # pylint: disable=invalid-name
         LearnerDataTransmissionAudit = apps.get_model('integrated_channel', 'LearnerDataTransmissionAudit')

--- a/integrated_channels/integrated_channel/tasks.py
+++ b/integrated_channels/integrated_channel/tasks.py
@@ -22,6 +22,40 @@ LOGGER = get_task_logger(__name__)
 User = auth.get_user_model()  # pylint: disable=invalid-name
 
 
+def _log_batch_task_start(task_name, channel_code, job_user_id, integrated_channel_full_config, extra_message=''):
+    """
+    Logs a consistent message on the start of a batch integrated channel task.
+    """
+
+    LOGGER.info(
+        '[Integrated Channel: {channel_name}] Batch {task_name} started '
+        '(api user: {job_user_id}). Configuration: {configuration}. {details}'.format(
+            channel_name=channel_code,
+            task_name=task_name,
+            job_user_id=job_user_id,
+            configuration=integrated_channel_full_config,
+            details=extra_message
+        ))
+
+
+def _log_batch_task_finish(task_name, channel_code, job_user_id,
+                           integrated_channel_full_config, duration_seconds, extra_message=''):
+    """
+    Logs a consistent message on the end of a batch integrated channel task.
+    """
+
+    LOGGER.info(
+        '[Integrated Channel: {channel_name}] Batch {task_name} finished in {duration_seconds} '
+        '(api user: {job_user_id}). Configuration: {configuration}. {details}'.format(
+            channel_name=channel_code,
+            task_name=task_name,
+            job_user_id=job_user_id,
+            configuration=integrated_channel_full_config,
+            duration_seconds=duration_seconds,
+            details=extra_message
+        ))
+
+
 @shared_task
 @set_code_owner_attribute
 def transmit_content_metadata(username, channel_code, channel_pk):
@@ -29,7 +63,7 @@ def transmit_content_metadata(username, channel_code, channel_pk):
     Task to send content metadata to each linked integrated channel.
 
     Arguments:
-        username (str): The username of the User to be used for making API requests to retrieve content metadata.
+        username (str): The username of the User for making API requests to retrieve content metadata.
         channel_code (str): Capitalized identifier for the integrated channel.
         channel_pk (str): Primary key for identifying integrated channel.
 
@@ -37,25 +71,22 @@ def transmit_content_metadata(username, channel_code, channel_pk):
     start = time.time()
     api_user = User.objects.get(username=username)
     integrated_channel = INTEGRATED_CHANNEL_CHOICES[channel_code].objects.get(pk=channel_pk)
-    LOGGER.info('[Integrated Channel] Content metadata transmission started.'
-                ' Configuration: {configuration}'.format(configuration=integrated_channel))
+
+    _log_batch_task_start('transmit_content_metadata', channel_code, api_user.id, integrated_channel)
+
     try:
         integrated_channel.transmit_content_metadata(api_user)
     except Exception:  # pylint: disable=broad-except
         LOGGER.exception(
-            '[Integrated Channel] Transmission of content metadata failed.'
-            ' ChannelCode: {channel_code}, ChannelId: {channel_id}, Username: {user}'.format(
-                user=username,
-                channel_code=channel_code,
-                channel_id=channel_pk
-            ))
+            '[Integrated Channel: {channel_name}] Batch transmit_content_metadata failed with exception. '
+            '(api user: {job_user_id}). Configuration: {configuration}'.format(
+                channel_name=channel_code,
+                job_user_id=api_user.id,
+                configuration=integrated_channel
+            ), exc_info=True)
+
     duration = time.time() - start
-    LOGGER.info(
-        '[Integrated Channel] Content metadata transmission task finished. Configuration: {configuration},'
-        'Duration: {duration}'.format(
-            configuration=integrated_channel,
-            duration=duration
-        ))
+    _log_batch_task_finish('transmit_content_metadata', channel_code, api_user.id, integrated_channel, duration)
 
 
 @shared_task
@@ -73,65 +104,48 @@ def transmit_learner_data(username, channel_code, channel_pk):
     start = time.time()
     api_user = User.objects.get(username=username)
     integrated_channel = INTEGRATED_CHANNEL_CHOICES[channel_code].objects.get(pk=channel_pk)
-    generate_formatted_log(
-        'Batch processing learners for integrated channel. Configuration: {configuration}'.format(
-            configuration=integrated_channel,
-        ),
-        channel_name=channel_code,
-        enterprise_customer_identifier=api_user.username
-    )
+    _log_batch_task_start('transmit_learner_data', channel_code, api_user.id, integrated_channel)
 
-    # Note: learner data transmission code paths don't raise any uncaught exception, so we don't need a broad
-    # try-except block here.
+    # Note: learner data transmission code paths don't raise any uncaught exception,
+    # so we don't need a broad try-except block here.
     integrated_channel.transmit_learner_data(api_user)
 
     duration = time.time() - start
-    generate_formatted_log(
-        'Batch learner data transmission task finished. Configuration: {configuration},'
-        ' Duration: {duration}'.format(
-            configuration=integrated_channel,
-            duration=duration
-        ),
-        channel_name=channel_code,
-        enterprise_customer_identifier=api_user.username
-    )
+    _log_batch_task_finish('transmit_learner_data', channel_code, api_user.id, integrated_channel, duration)
 
 
 @shared_task
 @set_code_owner_attribute
-def transmit_single_learner_data(username, course_run_id):
+def transmit_single_learner_data(learner_username, course_run_id):
     """
-    Task to send single learner data to each linked integrated channel.
+    Task to send learner data to each linked integrated channel.
 
     Arguments:
-        username (str): The username of the learner whose data it should send.
+        learner_username (str): The username of the learner whose data it should send.
         course_run_id (str): The course run id of the course it should send data for.
     """
-    user = User.objects.get(username=username)
+    user = User.objects.get(username=learner_username)
     enterprise_customer_uuids = get_enterprise_uuids_for_user_and_course(user, course_run_id, active=True)
 
     # Transmit the learner data to each integrated channel for each related customer.
     # Starting Export. N customer is usually 1 but multiple are supported in codebase.
     for enterprise_customer_uuid in enterprise_customer_uuids:
-        LOGGER.info('[Integrated Channel] Single learner data transmission started.'
-                    ' Course: {course_run}, Username: {username}, Customer:{enterprise_uuid}'.format(
-                        course_run=course_run_id,
-                        username=username,
-                        enterprise_uuid=enterprise_customer_uuid
-                    ))
-
         channel_utils = IntegratedChannelCommandUtils()
-        # Transmit the learner data to each integrated channelStarting Export
-        for channel in channel_utils.get_integrated_channels(
-                {'channel': None, 'enterprise_customer': enterprise_customer_uuid}
-        ):
+        enterprise_integrated_channels = channel_utils.get_integrated_channels(
+            {'channel': None, 'enterprise_customer': enterprise_customer_uuid}
+        )
+        for channel in enterprise_integrated_channels:
             integrated_channel = INTEGRATED_CHANNEL_CHOICES[channel.channel_code()].objects.get(pk=channel.pk)
-            LOGGER.info(
-                '[Integrated Channel] Processing learner for transmission. Configuration: {configuration},'
-                ' User: {user_id}, Customer: {enterprise_uuid}'.format(
-                    configuration=integrated_channel,
-                    user_id=user.id,
-                    enterprise_uuid=enterprise_customer_uuid))
+
+            LOGGER.info(generate_formatted_log(
+                integrated_channel.channel_code(),
+                enterprise_customer_uuid,
+                user.id,
+                course_run_id,
+                'transmit_single_learner_data for channels {} started.'
+                .format([c.channel_code() for c in enterprise_integrated_channels])
+            ))
+
             integrated_channel.transmit_single_learner_data(
                 learner_to_transmit=user,
                 course_run_id=course_run_id,
@@ -139,23 +153,31 @@ def transmit_single_learner_data(username, course_run_id):
                 grade='Pass',
                 is_passing=True
             )
+            LOGGER.info(generate_formatted_log(
+                integrated_channel.channel_code(),
+                enterprise_customer_uuid,
+                user.id,
+                course_run_id,
+                "transmit_single_learner_data finished."
+            ))
 
 
 @shared_task
 @set_code_owner_attribute
 def transmit_single_subsection_learner_data(username, course_run_id, subsection_id, grade):
     """
-    Task to send a single assessment level learner data record to each linked integrated channel. This task is fired off
-    when an enterprise learner completes a subsection of their course, and as such only sends the data for that sub-
-    section.
+    Task to send a assessment level learner data record to each linked
+    integrated channel. This task is fired off
+    when an enterprise learner completes a subsection of their course, and
+    only sends the data for that sub-section.
 
     Arguments:
         username (str): The username of the learner whose data it should send.
         course_run_id  (str): The course run id of the course it should send data for.
-        subsection_id (str): The subsection id that the learner completed and whose grades are being reported.
+        subsection_id (str): The completed subsection id whose grades are being reported.
         grade (str): The grade received, used to ensure we are not sending duplicate transmissions.
     """
-    start = time.time()
+
     user = User.objects.get(username=username)
     enterprise_customer_uuids = get_enterprise_uuids_for_user_and_course(user, course_run_id, active=True)
     channel_utils = IntegratedChannelCommandUtils()
@@ -163,20 +185,21 @@ def transmit_single_subsection_learner_data(username, course_run_id, subsection_
     # Transmit the learner data to each integrated channel for each related customer.
     # Starting Export. N customer is usually 1 but multiple are supported in codebase.
     for enterprise_customer_uuid in enterprise_customer_uuids:
-        for channel in channel_utils.get_integrated_channels(
-                {'channel': None, 'enterprise_customer': enterprise_customer_uuid, 'assessment_level_support': True}
-        ):
+        enterprise_integrated_channels = channel_utils.get_integrated_channels(
+            {'channel': None, 'enterprise_customer': enterprise_customer_uuid, 'assessment_level_support': True}
+        )
+
+        for channel in enterprise_integrated_channels:
+            start = time.time()
             integrated_channel = INTEGRATED_CHANNEL_CHOICES[channel.channel_code()].objects.get(pk=channel.pk)
 
-            LOGGER.info(
-                'Beginning single learner data transmission task. Channel: {channel}, Customer: {enterprise_uuid}, '
-                'Course: {course_run}, Username: {username}, Subsection_id: {subsection}'.format(
-                    channel=channel.channel_code(),
-                    username=username,
-                    course_run=course_run_id,
-                    enterprise_uuid=enterprise_customer_uuid,
-                    subsection=subsection_id
-                ))
+            LOGGER.info(generate_formatted_log(
+                channel.channel_code(),
+                enterprise_customer_uuid,
+                user.id,
+                course_run_id,
+                'transmit_single_subsection_learner_data for Subsection_id: {} started.'.format(subsection_id)
+            ))
 
             integrated_channel.transmit_single_subsection_learner_data(
                 learner_to_transmit=user,
@@ -185,48 +208,40 @@ def transmit_single_subsection_learner_data(username, course_run_id, subsection_
                 subsection_id=subsection_id
             )
 
-        duration = time.time() - start
-        LOGGER.info(
-            '[Integrated Channel] Single learner data transmission task finished.'
-            'Customer: {enterprise_uuid}, Course: {course_run}, Duration: {duration}, Username: {username}'.format(
-                username=username,
-                course_run=course_run_id,
-                duration=duration,
-                enterprise_uuid=enterprise_customer_uuid
+            duration = time.time() - start
+            LOGGER.info(generate_formatted_log(
+                None,
+                enterprise_customer_uuid,
+                user.id,
+                course_run_id,
+                'transmit_single_subsection_learner_data for channels {channels} and for Subsection_id: '
+                '{subsection_id} finished in {duration}s.'.format(
+                        channels=[c.channel_code() for c in enterprise_integrated_channels],
+                        subsection_id=subsection_id,
+                        duration=duration)
             ))
 
 
 @shared_task
 @set_code_owner_attribute
-def transmit_subsection_learner_data(username, channel_code, channel_pk):
+def transmit_subsection_learner_data(job_username, channel_code, channel_pk):
     """
     Task to send assessment level learner data to a linked integrated channel.
 
     Arguments:
-        username (str): The username of the User to be used for making API requests for learner data.
+        job_username (str): The username of the User making API requests for learner data.
         channel_code (str): Capitalized identifier for the integrated channel
         channel_pk (str): Primary key for identifying integrated channel
     """
     start = time.time()
-    api_user = User.objects.get(username=username)
+    api_user = User.objects.get(username=job_username)
     integrated_channel = INTEGRATED_CHANNEL_CHOICES[channel_code].objects.get(pk=channel_pk)
-    generate_formatted_log(
-        'Batch processing assessment level reporting for integrated channel. Configuration: {configuration}'.format(
-            configuration=integrated_channel,
-        ),
-        channel_name=channel_code,
-        enterprise_customer_identifier=api_user.username
-    )
+    _log_batch_task_start('transmit_subsection_learner_data', channel_code, api_user.id, integrated_channel)
 
     # Exceptions during transmission are caught and saved within the audit so no need to try/catch here
     integrated_channel.transmit_subsection_learner_data(api_user)
     duration = time.time() - start
-    LOGGER.info(
-        '[Integrated Channel] Bulk learner data transmission task finished.'
-        'Duration: {duration}, Username: {username}'.format(
-            username=username,
-            duration=duration)
-    )
+    _log_batch_task_finish('transmit_subsection_learner_data', channel_code, api_user.id, integrated_channel, duration)
 
 
 @shared_task
@@ -242,15 +257,12 @@ def unlink_inactive_learners(channel_code, channel_pk):
     """
     start = time.time()
     integrated_channel = INTEGRATED_CHANNEL_CHOICES[channel_code].objects.get(pk=channel_pk)
-    LOGGER.info('Processing learners to unlink inactive users using configuration: [%s]', integrated_channel)
+
+    _log_batch_task_start('unlink_inactive_learners', channel_code, None, integrated_channel)
 
     # Note: learner data transmission code paths don't raise any uncaught exception, so we don't need a broad
     # try-except block here.
     integrated_channel.unlink_inactive_learners()
 
     duration = time.time() - start
-    LOGGER.info(
-        'Unlink inactive learners task for integrated channel configuration [%s] took [%s] seconds',
-        integrated_channel,
-        duration
-    )
+    _log_batch_task_finish('unlink_inactive_learners', channel_code, None, integrated_channel, duration)

--- a/integrated_channels/integrated_channel/tasks.py
+++ b/integrated_channels/integrated_channel/tasks.py
@@ -118,7 +118,7 @@ def transmit_learner_data(username, channel_code, channel_pk):
 @set_code_owner_attribute
 def transmit_single_learner_data(learner_username, course_run_id):
     """
-    Task to send learner data to each linked integrated channel.
+    Task to send single learner data to each linked integrated channel.
 
     Arguments:
         learner_username (str): The username of the learner whose data it should send.
@@ -142,8 +142,7 @@ def transmit_single_learner_data(learner_username, course_run_id):
                 enterprise_customer_uuid,
                 user.id,
                 course_run_id,
-                'transmit_single_learner_data for channels {} started.'
-                .format([c.channel_code() for c in enterprise_integrated_channels])
+                'transmit_single_learner_data started.'
             ))
 
             integrated_channel.transmit_single_learner_data(
@@ -166,7 +165,7 @@ def transmit_single_learner_data(learner_username, course_run_id):
 @set_code_owner_attribute
 def transmit_single_subsection_learner_data(username, course_run_id, subsection_id, grade):
     """
-    Task to send a assessment level learner data record to each linked
+    Task to send an assessment level learner data record to each linked
     integrated channel. This task is fired off
     when an enterprise learner completes a subsection of their course, and
     only sends the data for that sub-section.

--- a/integrated_channels/integrated_channel/transmitters/learner_data.py
+++ b/integrated_channels/integrated_channel/transmitters/learner_data.py
@@ -9,8 +9,9 @@ from django.apps import apps
 
 from integrated_channels.exceptions import ClientError
 from integrated_channels.integrated_channel.client import IntegratedChannelApiClient
+from integrated_channels.integrated_channel.exporters.learner_data import LearnerExporterUtility
 from integrated_channels.integrated_channel.transmitters import Transmitter
-from integrated_channels.utils import is_already_transmitted
+from integrated_channels.utils import generate_formatted_log, is_already_transmitted
 
 LOGGER = logging.getLogger(__name__)
 
@@ -32,27 +33,41 @@ class LearnerTransmitter(Transmitter):
             client=client
         )
 
+    def _generate_common_params(self, **kwargs):
+        """ Pulls labeled common params out of kwargs """
+        app_label = kwargs.get('app_label', 'integrated_channel')
+        enterprise_customer_uuid = self.enterprise_configuration.enterprise_customer.uuid or None
+        lms_user_id = kwargs.get('learner_to_transmit', None)
+        return app_label, enterprise_customer_uuid, lms_user_id
+
     def single_learner_assessment_grade_transmit(self, exporter, **kwargs):
         """
-        Send a single assessment level grade information to the integrated channel using the client.
+        Send a assessment level grade information to the integrated channel using the client.
 
         Args:
-            exporter: The learner assessment data exporter used to send to the integrated channel.
+            exporter: The ``LearnerExporter`` instance used to send to the integrated channel.
             kwargs: Contains integrated channel-specific information for customized transmission variables.
                 - app_label: The app label of the integrated channel for whom to store learner data records for.
                 - model_name: The name of the specific learner data record model to use.
-                - remote_user_id: The remote ID field name of the learner on the audit model.
+                - remote_user_id: The remote ID field name on the audit model that will map to the learner.
         """
+        app_label, enterprise_customer_uuid, lms_user_id = self._generate_common_params(**kwargs)
         TransmissionAudit = apps.get_model(  # pylint: disable=invalid-name
-            app_label=kwargs.get('app_label', 'integrated_channel'),
+            app_label=app_label,
             model_name=kwargs.get('model_name', 'LearnerDataTransmissionAudit'),
         )
         kwargs.update(
             TransmissionAudit=TransmissionAudit,
         )
 
-        # Even though we're transmitting a single learner, they can have records per assessment (multiple per course).
+        # Even though we're transmitting a learner, they can have records per assessment (multiple per course).
         for learner_data in exporter.single_assessment_level_export(**kwargs):
+            LOGGER.info(generate_formatted_log(
+                app_label, enterprise_customer_uuid, lms_user_id, learner_data.course_id,
+                'create_assessment_reporting started for enrollment {enrollment_id}'.format(
+                        enrollment_id=learner_data.enterprise_course_enrollment_id,
+                        )))
+
             serialized_payload = learner_data.serialize(enterprise_configuration=self.enterprise_configuration)
             try:
                 code, body = self.client.create_assessment_reporting(
@@ -62,7 +77,15 @@ class LearnerTransmitter(Transmitter):
             except ClientError as client_error:
                 code = client_error.status_code
                 body = client_error.message
-                self.handle_transmission_error(learner_data, client_error)
+                self.handle_transmission_error(learner_data, client_error,
+                                               app_label, enterprise_customer_uuid, lms_user_id, learner_data.course_id)
+
+            except Exception:
+                # Log additional data to help debug failures but just have Exception bubble
+                self._log_exception_supplemental_data(
+                    learner_data, 'create_assessment_reporting', app_label,
+                    enterprise_customer_uuid, lms_user_id, learner_data.course_id)
+                raise
 
             learner_data.status = str(code)
             learner_data.error_message = body if code >= 400 else ''
@@ -81,8 +104,9 @@ class LearnerTransmitter(Transmitter):
                 - model_name: The name of the specific learner data record model to use.
                 - remote_user_id: The remote ID field name of the learner on the audit model.
         """
+        app_label, enterprise_customer_uuid, _ = self._generate_common_params(**kwargs)
         TransmissionAudit = apps.get_model(  # pylint: disable=invalid-name
-            app_label=kwargs.get('app_label', 'integrated_channel'),
+            app_label=app_label,
             model_name=kwargs.get('model_name', 'LearnerDataTransmissionAudit'),
         )
         kwargs.update(
@@ -94,6 +118,8 @@ class LearnerTransmitter(Transmitter):
         for learner_data in exporter.bulk_assessment_level_export():
             serialized_payload = learner_data.serialize(enterprise_configuration=self.enterprise_configuration)
             enterprise_enrollment_id = learner_data.enterprise_course_enrollment_id
+            lms_user_id = LearnerExporterUtility.lms_user_id_for_ent_course_enrollment_id(
+                enterprise_enrollment_id)
 
             # Check the last transmission for the current enrollment and see if the old grades match the new ones
             if is_already_transmitted(
@@ -103,7 +129,10 @@ class LearnerTransmitter(Transmitter):
                     learner_data.subsection_id
             ):
                 # We've already sent a completion status for this enrollment
-                LOGGER.info('Skipping previously sent enterprise enrollment {}'.format(enterprise_enrollment_id))
+                LOGGER.info(generate_formatted_log(
+                    app_label, enterprise_customer_uuid, lms_user_id, learner_data.course_id,
+                    'Skipping previously sent EnterpriseCourseEnrollment {}'.format(enterprise_enrollment_id)
+                ))
                 continue
 
             try:
@@ -111,15 +140,24 @@ class LearnerTransmitter(Transmitter):
                     getattr(learner_data, kwargs.get('remote_user_id')),
                     serialized_payload
                 )
-                LOGGER.info(
-                    'Successfully sent completion status call for enterprise enrollment {}'.format(
+                LOGGER.info(generate_formatted_log(
+                    app_label, enterprise_customer_uuid, lms_user_id, learner_data.course_id,
+                    'create_assessment_reporting successfully completed for EnterpriseCourseEnrollment {}'.format(
                         enterprise_enrollment_id,
                     )
-                )
+                ))
             except ClientError as client_error:
                 code = client_error.status_code
                 body = client_error.message
-                self.handle_transmission_error(learner_data, client_error)
+                self.handle_transmission_error(learner_data, client_error, app_label,
+                                               enterprise_customer_uuid, lms_user_id, learner_data.course_id)
+
+            except Exception:
+                # Log additional data to help debug failures but just have Exception bubble
+                self._log_exception_supplemental_data(
+                    learner_data, 'create_assessment_reporting', app_label,
+                    enterprise_customer_uuid, lms_user_id, learner_data.course_id)
+                raise
 
             learner_data.status = str(code)
             learner_data.error_message = body if code >= 400 else ''
@@ -137,8 +175,9 @@ class LearnerTransmitter(Transmitter):
                 - model_name: The name of the specific learner data record model to use.
                 - remote_user_id: The remote ID field name of the learner on the audit model.
         """
+        app_label, enterprise_customer_uuid, _ = self._generate_common_params(**kwargs)
         TransmissionAudit = apps.get_model(  # pylint: disable=invalid-name
-            app_label=kwargs.get('app_label', 'integrated_channel'),
+            app_label=app_label,
             model_name=kwargs.get('model_name', 'LearnerDataTransmissionAudit'),
         )
         kwargs.update(
@@ -153,9 +192,11 @@ class LearnerTransmitter(Transmitter):
         # If it fails, the one with the course run id will be attempted and (presumably) succeed.
         for learner_data in payload.export(**kwargs):
             serialized_payload = learner_data.serialize(enterprise_configuration=self.enterprise_configuration)
-            LOGGER.debug('Attempting to transmit serialized payload: %s', serialized_payload)
 
             enterprise_enrollment_id = learner_data.enterprise_course_enrollment_id
+            lms_user_id = LearnerExporterUtility.lms_user_id_for_ent_course_enrollment_id(
+                enterprise_enrollment_id)
+
             if learner_data.completed_timestamp is None:
                 # The user has not completed the course, so we shouldn't send a completion status call
                 LOGGER.info('Skipping in-progress enterprise enrollment {}'.format(enterprise_enrollment_id))
@@ -164,7 +205,9 @@ class LearnerTransmitter(Transmitter):
             grade = getattr(learner_data, 'grade', None)
             if is_already_transmitted(TransmissionAudit, enterprise_enrollment_id, grade):
                 # We've already sent a completion status for this enrollment
-                LOGGER.info('Skipping previously sent enterprise enrollment {}'.format(enterprise_enrollment_id))
+                LOGGER.info(generate_formatted_log(
+                    app_label, enterprise_customer_uuid, lms_user_id, learner_data.course_id,
+                    'Skipping previously sent enterprise enrollment {}'.format(enterprise_enrollment_id)))
                 continue
 
             try:
@@ -172,32 +215,53 @@ class LearnerTransmitter(Transmitter):
                     getattr(learner_data, kwargs.get('remote_user_id')),
                     serialized_payload
                 )
-                LOGGER.info(
+                LOGGER.info(generate_formatted_log(
+                    app_label, enterprise_customer_uuid, lms_user_id, learner_data.course_id,
                     'Successfully sent completion status call for enterprise enrollment {}'.format(
                         enterprise_enrollment_id,
                     )
-                )
+                ))
             except ClientError as client_error:
                 code = client_error.status_code
                 body = client_error.message
-                self.handle_transmission_error(learner_data, client_error)
+                self.handle_transmission_error(learner_data, client_error, app_label,
+                                               enterprise_customer_uuid, lms_user_id, learner_data.course_id)
+
+            except Exception:
+                # Log additional data to help debug failures but have Exception bubble
+                self._log_exception_supplemental_data(
+                    learner_data, 'create_assessment_reporting', app_label,
+                    enterprise_customer_uuid, lms_user_id, learner_data.course_id)
+                raise
 
             learner_data.status = str(code)
             learner_data.error_message = body if code >= 400 else ''
 
             learner_data.save()
 
-    def handle_transmission_error(self, learner_data, client_exception):
+    def _log_exception_supplemental_data(self, learner_data, operation_name,
+                                         integrated_channel_name, enterprise_customer_uuid, learner_id, course_id):
+        """ Logs extra payload and parameter data to help debug which learner data caused an exception. """
+        LOGGER.exception(generate_formatted_log(
+            integrated_channel_name, enterprise_customer_uuid, learner_id, course_id,
+            '{operation_name} failed with Exception for '
+            'enterprise enrollment {enrollment_id} with payload {payload}'.format(
+                operation_name=operation_name,
+                enrollment_id=learner_data.enterprise_course_enrollment_id,
+                payload=learner_data
+            )), exc_info=True)
+
+    def handle_transmission_error(self, learner_data, client_exception,
+                                  integrated_channel_name, enterprise_customer_uuid, learner_id, course_id):
         """Handle the case where the transmission fails."""
-        LOGGER.exception(
-            (
-                'Failed to send completion status call for enterprise enrollment %s'
-                'with payload %s'
-                '\nError message: %s'
-                '\nError status code: %s'
-            ),
-            learner_data.enterprise_course_enrollment_id,
-            learner_data,
-            client_exception.message,
-            client_exception.status_code
-        )
+        LOGGER.exception(generate_formatted_log(
+            integrated_channel_name, enterprise_customer_uuid, learner_id, course_id,
+            'Failed to send completion status call for enterprise enrollment {}'
+            'with payload {}'
+            '\nError message: {}'
+            '\nError status code: {}'.format(
+                learner_data.enterprise_course_enrollment_id,
+                learner_data,
+                client_exception.message,
+                client_exception.status_code
+            )))

--- a/integrated_channels/integrated_channel/transmitters/learner_data.py
+++ b/integrated_channels/integrated_channel/transmitters/learner_data.py
@@ -42,7 +42,7 @@ class LearnerTransmitter(Transmitter):
 
     def single_learner_assessment_grade_transmit(self, exporter, **kwargs):
         """
-        Send a assessment level grade information to the integrated channel using the client.
+        Send an assessment level grade information to the integrated channel using the client.
 
         Args:
             exporter: The ``LearnerExporter`` instance used to send to the integrated channel.

--- a/integrated_channels/moodle/exporters/learner_data.py
+++ b/integrated_channels/moodle/exporters/learner_data.py
@@ -38,8 +38,9 @@ class MoodleLearnerExporter(LearnerExporter):
 
         if enterprise_customer.user_email is None:
             LOGGER.debug(
-                'No learner data was sent for user [%s] because a Moodle user ID could not be found.',
-                enterprise_customer.username
+                'No learner data was sent for LMS User [%s] because a Moodle user ID could not be found for customer [%s]',
+                enterprise_enrollment.enterprise_customer_user.user_id,
+                enterprise_customer.name
             )
             return None
 

--- a/integrated_channels/moodle/exporters/learner_data.py
+++ b/integrated_channels/moodle/exporters/learner_data.py
@@ -9,7 +9,7 @@ from django.apps import apps
 
 from integrated_channels.catalog_service_utils import get_course_id_for_enrollment
 from integrated_channels.integrated_channel.exporters.learner_data import LearnerExporter
-from integrated_channels.utils import parse_datetime_to_epoch_millis, generate_formatted_log
+from integrated_channels.utils import generate_formatted_log, parse_datetime_to_epoch_millis
 
 LOGGER = getLogger(__name__)
 

--- a/integrated_channels/moodle/exporters/learner_data.py
+++ b/integrated_channels/moodle/exporters/learner_data.py
@@ -42,7 +42,7 @@ class MoodleLearnerExporter(LearnerExporter):
                 enterprise_learner.enterprise_customer.uuid,
                 enterprise_learner.user_id,
                 None,
-                ('get_learner_data_records finished. No learner data was sent because '
+                ('get_learner_data_records finished. No learner data was sent for this LMS User Id because '
                  'Moodle User ID not found for [{name}]'.format(
                      name=enterprise_enrollment.enterprise_customer_user.enterprise_customer.name
                  ))))

--- a/integrated_channels/moodle/exporters/learner_data.py
+++ b/integrated_channels/moodle/exporters/learner_data.py
@@ -38,7 +38,7 @@ class MoodleLearnerExporter(LearnerExporter):
 
         if enterprise_customer.user_email is None:
             LOGGER.debug(
-                'No learner data was sent for LMS User [%s] because a Moodle user ID could not be found for customer [%s]',
+                'No learner data sent for LMS User [%s] because a Canvas user ID was not found for customer [%s]',
                 enterprise_enrollment.enterprise_customer_user.user_id,
                 enterprise_customer.name
             )

--- a/integrated_channels/sap_success_factors/client.py
+++ b/integrated_channels/sap_success_factors/client.py
@@ -319,8 +319,9 @@ class SAPSuccessFactorsAPIClient(IntegratedChannelApiClient):  # pylint: disable
             sap_inactive_learners = response.json()
         except ValueError as error:
             raise ClientError(response, response.status_code) from error
-        except (ConnectionError, Timeout):
-            LOGGER.warning(
+        except (ConnectionError, Timeout) as exc:
+            LOGGER.error(exc)
+            LOGGER.error(
                 'Unable to fetch inactive learners from SAP searchStudent API with url '
                 '"{%s}".', search_student_paginated_url,
             )
@@ -328,7 +329,7 @@ class SAPSuccessFactorsAPIClient(IntegratedChannelApiClient):  # pylint: disable
 
         if 'error' in sap_inactive_learners:
             try:
-                LOGGER.warning(
+                LOGGER.error(
                     'SAP searchStudent API for customer %s and base url %s returned response with '
                     'error message "%s" and with error code "%s".',
                     self.enterprise_configuration.enterprise_customer.name,
@@ -337,7 +338,7 @@ class SAPSuccessFactorsAPIClient(IntegratedChannelApiClient):  # pylint: disable
                     sap_inactive_learners['error'].get('code'),
                 )
             except AttributeError:
-                LOGGER.warning(
+                LOGGER.error(
                     'SAP searchStudent API for customer %s and base url %s returned response with '
                     'error message "%s" and with error code "%s".',
                     self.enterprise_configuration.enterprise_customer.name,

--- a/integrated_channels/sap_success_factors/transmitters/learner_data.py
+++ b/integrated_channels/sap_success_factors/transmitters/learner_data.py
@@ -54,9 +54,9 @@ class SapSuccessFactorsLearnerTransmitter(LearnerTransmitter):
                 ecu.active = False
                 ecu.save()
                 LOGGER.warning(
-                    'User %s with ID %s and email %s is a former employee of %s '
+                    'User with LMS ID %s, ECU ID %s is a former employee of %s '
                     'and has been marked inactive in SAPSF. Now marking inactive internally.',
-                    ecu.username, ecu.user_id, ecu.user_email, ecu.enterprise_customer
+                    ecu.user_id, ecu.id, ecu.enterprise_customer
                 )
                 return
         super().handle_transmission_error(learner_data, client_exception)

--- a/integrated_channels/utils.py
+++ b/integrated_channels/utils.py
@@ -232,24 +232,37 @@ def get_subjects_from_content_metadata(content_metadata_item):
     return list(subjects)
 
 
-def generate_formatted_log(message, channel_name=None, enterprise_customer_identifier=None, is_error=False):
+def generate_formatted_log(
+    channel_name,
+    enterprise_customer_uuid,
+    lms_user_id,
+    course_or_course_run_key,
+    message
+):
     """
-    Formats and logs a message for the integrated channels.
+    Formats and returns a standardized message for the integrated channels.
+    'None' may be passed as a value to any format field, but all fields are mandatory to
+    encourage log standardization.
 
     Arguments:
-        - message (str): The string to be formatted and logged
-        - (OPTIONAL) channel_name (str): The name of the integrated channel which is being logged for
-        - (OPTIONAL) enterprise_customer_identifier (str): Either the ID or name of the Enterprise Customer
-        for whom the chanel is transmitting data.
-        - (OPTIONAL) is_error (bool): If specified, determines whether to log an error or info message.
+    - channel_name (str): The name of the integrated channel
+    - enterprise_customer_uuid (str): UUID of the relevant EnterpriseCustomer
+    - enterprise_customer_identifer (str): Identifying name of the EnterpriseCustomer
+    - lms_user_id (str): The LMS User id (if applicable) related to the message
+    - course_or_course_run_key (str): The course key (if applicable) for the message
+    - message (str): The string to be formatted and logged
+
     """
-    log_message = '[Integrated Channel] [ENT CUSTOMER: {enterprise_customer_identifier}] ' \
-                  '[CHANNEL: {channel_name}]: {message}'.format(
-                      enterprise_customer_identifier=enterprise_customer_identifier,
-                      channel_name=channel_name,
-                      message=message,
-                  )
-    LOGGER.error(log_message) if is_error else LOGGER.info(log_message)  # pylint: disable=expression-not-assigned
+    return '[Integrated Channel: {channel_name}]'\
+        '[ENT CUSTOMER: {enterprise_customer_uuid}]' \
+        '[User: {lms_user_id}]'\
+        '[Course: {course_or_course_run_key}]{message}'.format(
+            enterprise_customer_uuid=enterprise_customer_uuid,
+            channel_name=channel_name,
+            message=message,
+            lms_user_id=lms_user_id,
+            course_or_course_run_key=course_or_course_run_key
+        )
 
 
 def refresh_session_if_expired(oauth_access_token_function, session=None, expires_at=None):

--- a/integrated_channels/utils.py
+++ b/integrated_channels/utils.py
@@ -253,10 +253,10 @@ def generate_formatted_log(
     - message (str): The string to be formatted and logged
 
     """
-    return '[Integrated Channel: {channel_name}]'\
-        '[ENT CUSTOMER: {enterprise_customer_uuid}]' \
-        '[User: {lms_user_id}]'\
-        '[Course: {course_or_course_run_key}]{message}'.format(
+    return '[integrated_channel:{channel_name}]'\
+        '[integrated_channel_enterprise_customer_uuid:{enterprise_customer_uuid}]' \
+        '[integrated_channel_lms_user:{lms_user_id}]'\
+        '[integrated_channel_course_key:{course_or_course_run_key}]{message}'.format(
             enterprise_customer_uuid=enterprise_customer_uuid,
             channel_name=channel_name,
             message=message,

--- a/test_utils/__init__.py
+++ b/test_utils/__init__.py
@@ -409,3 +409,26 @@ class EmptyCacheMixin:
     def setUp(self):
         super().setUp()
         caches['default'].clear()
+
+
+class ReturnValueSpy:
+    """
+    Helper class to be used with mock and patch so that inner commands may be inspected.
+    Useful for integration tests. Example Usage with a management command:
+    def test():
+        with patch('low_level_class.my_m', ReturnValueSpy(goo)) as goo_mock:
+            x = foo()
+            x = foo()
+            print(goo_mock.return_values)
+            assert goo_mock.return_values == [3, 3]
+
+    """
+
+    def __init__(self, func):
+        self.func = func
+        self.return_values = []
+
+    def __call__(self, *args, **kwargs):
+        answer = self.func(*args, **kwargs)
+        self.return_values.append(answer)
+        return answer

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -17,6 +17,7 @@ from faker import Factory as FakerFactory
 from freezegun import freeze_time
 from pytest import mark, raises
 from requests.compat import urljoin
+from requests.utils import quote
 from testfixtures import LogCapture
 
 from django.contrib import auth
@@ -53,8 +54,10 @@ from integrated_channels.integrated_channel.management.commands import (
     INTEGRATED_CHANNEL_CHOICES,
     IntegratedChannelCommandMixin,
 )
+from integrated_channels.sap_success_factors.client import SAPSuccessFactorsAPIClient
+from integrated_channels.sap_success_factors.exporters.learner_data import SapSuccessFactorsLearnerManger
 from integrated_channels.sap_success_factors.models import SAPSuccessFactorsEnterpriseCustomerConfiguration
-from test_utils import factories
+from test_utils import ReturnValueSpy, factories
 from test_utils.fake_catalog_api import CourseDiscoveryApiTestMixin, setup_course_catalog_api_client_mock
 from test_utils.fake_enterprise_api import EnterpriseMockMixin
 
@@ -75,6 +78,11 @@ LOG_OVERRIDES = [
 
 for log_name, log_level in LOG_OVERRIDES:
     logging.getLogger(log_name).setLevel(log_level)
+
+
+class InstrumentedConnectionError(ConnectionError):
+    """ Patched connection error to use when checking if a request.ConnectionError was caught
+    and handled properly. """
 
 
 @ddt.ddt
@@ -1145,11 +1153,12 @@ class TestUnlinkSAPLearnersManagementCommand(unittest.TestCase, EnterpriseMockMi
             username=self.user.username,
             course_id=self.course_run_id
         )
-        self.sap_search_student_url = '{sapsf_base_url}/{search_students_path}?$filter={search_filter}'.format(
-            sapsf_base_url=self.sapsf.sapsf_base_url.rstrip('/'),
-            search_students_path=self.sapsf_global_configuration.search_student_api_path.rstrip('/'),
-            search_filter='criteria/isActive eq False&$select=studentID',
-        )
+        self.sap_search_student_url = \
+            '{sapsf_base_url}/{search_students_path}?$filter={search_filter}&$select=studentID'.format(
+                sapsf_base_url=self.sapsf.sapsf_base_url.rstrip('/'),
+                search_students_path=self.sapsf_global_configuration.search_student_api_path.rstrip('/'),
+                search_filter=quote('criteria/isActive eq False'),
+            )
         self.search_student_paginated_url = '{sap_search_student_url}&{pagination_criterion}'.format(
             sap_search_student_url=self.sap_search_student_url,
             pagination_criterion='$count=true&$top={page_size}&$skip={start_at}'.format(
@@ -1173,15 +1182,6 @@ class TestUnlinkSAPLearnersManagementCommand(unittest.TestCase, EnterpriseMockMi
             # Because there are no SAP IntegratedChannels, the process will
             # end without any processing.
             assert not log_capture.records
-
-    def assert_info_logs_sap_learners_unlink(self, expected_messages):
-        """
-        DRY method to verify log messages for management command "unlink_inactive_sap_learners".
-        """
-        with LogCapture(level=logging.INFO) as log_capture:
-            call_command('unlink_inactive_sap_learners')
-            for index, message in enumerate(expected_messages):
-                assert message in log_capture.records[index].getMessage()
 
     @responses.activate
     @ddt.data(
@@ -1252,31 +1252,22 @@ class TestUnlinkSAPLearnersManagementCommand(unittest.TestCase, EnterpriseMockMi
                 content_type='application/json',
             )
 
-        expected_messages = [
-            'Processing learners to unlink inactive users using configuration: [{}]'.format(self.sapsf),
-            'SAP SF searchStudent API returned [1] inactive learners of total [1500] starting from [0] for '
-            'enterprise customer [{}]'.format(self.enterprise_customer.name),
-            'SAP SF searchStudent API returned [1] inactive learners of total [1500] starting from [500] for '
-            'enterprise customer [{}]'.format(self.enterprise_customer.name),
-            'SAP SF searchStudent API returned [1] inactive learners of total [1500] starting from [1000] for '
-            'enterprise customer [{}]'.format(self.enterprise_customer.name),
-            'Found [{}] SAP inactive learners for enterprise customer [{}]'.format(
-                len(inactive_sap_learners), self.enterprise_customer.name
-            ),
-            'Enterprise learner {{{email}}} successfully unlinked from Enterprise '
-            'Customer {{Veridian Dynamics}}'.format(email=User.objects.get(username='C-3PO').email),
-            'Learner with email [{}] and SAP student id [Only-Edx-Learner] is not linked with enterprise [{}]'.format(
-                User.objects.get(username='Only-Edx-Learner').email, self.enterprise_customer.name
-            ),
-            'No social auth data found for inactive user with SAP student id [Only-Inactive-Sap-Learner] '
-            'of enterprise customer [{}] with identity providers [{}]'.format(
-                self.enterprise_customer.name,
-                ', '.join(provider.provider_id for provider in self.enterprise_customer.identity_providers)
-            ),
-            'Unlink inactive learners task for integrated channel configuration '
-            '[{}] took [0.0] seconds'.format(self.sapsf)
-        ]
-        self.assert_info_logs_sap_learners_unlink(expected_messages)
+        # Glass box test: inspect that internals of this process are doing what we expect:
+        with mock.patch.object(SAPSuccessFactorsEnterpriseCustomerConfiguration,
+                               'unlink_inactive_learners',
+                               wraps=self.sapsf.unlink_inactive_learners) as mock_unlink_inactive_learners:
+            get_inactive_learners_fx = SapSuccessFactorsLearnerManger(self.sapsf).client.get_inactive_sap_learners
+            spy = ReturnValueSpy(get_inactive_learners_fx)  # create a spy to store the return value when called
+            # Send in our spy to use instead:
+            with mock.patch.object(SAPSuccessFactorsAPIClient,
+                                   'get_inactive_sap_learners',
+                                   wraps=spy) as mock_get_inactive_learners:
+                call_command('unlink_inactive_sap_learners')
+                # Verify that management command uses the correct SAP config object
+                mock_unlink_inactive_learners.assert_any_call()
+                # Verify that when we DID try to unlink the inactive learners, inactive learners were found to unlink:
+                mock_get_inactive_learners.assert_any_call()
+                assert len(spy.return_values[0]) == len(inactive_sap_learners)
 
         # Now verify that only inactive SAP learners have been unlinked
         for unlinked_sap_learner_username in unlinked_sap_learners:
@@ -1305,13 +1296,11 @@ class TestUnlinkSAPLearnersManagementCommand(unittest.TestCase, EnterpriseMockMi
         enterprise_catalog_uuid = str(self.enterprise_customer.enterprise_customer_catalogs.first().uuid)
         self.mock_enterprise_customer_catalogs(enterprise_catalog_uuid)
 
-        expected_messages = [
-            'Processing learners to unlink inactive users using configuration: '
-            '[<SAPSuccessFactorsEnterpriseCustomerConfiguration for Enterprise Veridian Dynamics>]',
-            'Unable to fetch inactive learners from SAP searchStudent API with '
-            'url "{%s}".' % self.search_student_paginated_url
-        ]
-        self.assert_info_logs_sap_learners_unlink(expected_messages)
+        # Note: because we didn't use 'responses.add' in unit test, ANY request library call
+        # made will throw a ConnectionError. See https://github.com/getsentry/responses/blob/master/README.rst
+        # What we're verifying here is that our call will still complete because the ConnectionError gets caught:
+        call_command('unlink_inactive_sap_learners')
+        assert True
 
     @responses.activate
     @freeze_time(NOW)
@@ -1352,16 +1341,35 @@ class TestUnlinkSAPLearnersManagementCommand(unittest.TestCase, EnterpriseMockMi
             content_type='application/json',
         )
 
-        expected_messages = [
-            'Processing learners to unlink inactive users using configuration: [{}]'.format(self.sapsf),
-            'SAP SF searchStudent API returned [1] inactive learners of total [1] starting from [0] '
-            'for enterprise customer [{}]'.format(self.enterprise_customer.name),
-            'Found [1] SAP inactive learners for enterprise customer [{}]'.format(self.enterprise_customer.name),
-            'Enterprise customer [{}] has no associated identity provider'.format(self.enterprise_customer.name),
-            'Unlink inactive learners task for integrated channel configuration '
-            '[{}] took [0.0] seconds'.format(self.sapsf)
-        ]
-        self.assert_info_logs_sap_learners_unlink(expected_messages)
+        # Glass box test: inspect that internals of this process are doing what we expect:
+        with mock.patch.object(SAPSuccessFactorsEnterpriseCustomerConfiguration,
+                               'unlink_inactive_learners',
+                               wraps=self.sapsf.unlink_inactive_learners) as mock_unlink_inactive_learners:
+            get_providers_fx = SapSuccessFactorsLearnerManger(self.sapsf)._get_identity_providers  # pylint: disable=protected-access
+            provider_spy = ReturnValueSpy(get_providers_fx)  # create a spy to store the return value when called
+
+            get_inactive_learners_fx = SapSuccessFactorsLearnerManger(self.sapsf).client.get_inactive_sap_learners
+            spy = ReturnValueSpy(get_inactive_learners_fx)  # create a spy to store the return value when called
+            # Send in our spies to use instead:
+            with mock.patch.object(SAPSuccessFactorsAPIClient,
+                                   'get_inactive_sap_learners',
+                                   wraps=spy) as mock_get_inactive_learners:
+                with mock.patch.object(SapSuccessFactorsLearnerManger,
+                                       '_get_identity_providers',
+                                       wraps=provider_spy) as mock_get_providers:
+
+                    call_command('unlink_inactive_sap_learners')
+                    # Verify that management command uses the correct SAP config object
+                    mock_unlink_inactive_learners.assert_any_call()
+                    # Verify that when we DID try to unlink the inactive learners,
+                    #  1 inactive learner (with config name self.user.username)
+                    # was found to unlink
+                    mock_get_inactive_learners.assert_any_call()
+                    assert spy.return_values[0][0]['studentID'] == self.user.username
+
+                    # Verify that we checked and then detected that an Enterprise has no associated identity provider:
+                    mock_get_providers.assert_any_call()
+                    assert provider_spy.return_values[0] is None
 
     @responses.activate
     @freeze_time(NOW)
@@ -1374,7 +1382,7 @@ class TestUnlinkSAPLearnersManagementCommand(unittest.TestCase, EnterpriseMockMi
             sapsf_get_oauth_access_token_mock,
     ):  # pylint: disable=invalid-name
         """
-        Test the unlink inactive sap learners task with error response from SAPSF.
+        Test the unlink inactive sap learners task with error response from SAPSF catches the error
         """
         sapsf_get_oauth_access_token_mock.return_value = "token", datetime.utcnow()
         sapsf_update_content_metadata_mock.return_value = 200, '{}'
@@ -1397,24 +1405,23 @@ class TestUnlinkSAPLearnersManagementCommand(unittest.TestCase, EnterpriseMockMi
             status=400,
             content_type='application/json',
         )
-        expected_messages = [
-            'Processing learners to unlink inactive users using configuration: [{}]'.format(self.sapsf),
-            '''SAP searchStudent API for customer Veridian Dynamics '''
-            '''and base url http://enterprise.successfactors.com/ returned response with error message '''
-            '''"The property 'InvalidProperty', used in '''
-            '''a query expression, is not defined in type 'com.sap.lms.odata.Student'." and with error code "None".''',
-            'Found [{}] SAP inactive learners for enterprise customer [{}]'.format(0, self.enterprise_customer.name),
-        ]
-        self.assert_info_logs_sap_learners_unlink(expected_messages)
+
+        call_command('unlink_inactive_sap_learners')
+        calls_to_search_url = [c for c in responses.calls if
+                               c.request.url.startswith(self.search_student_paginated_url)]
+
+        # Test that we called the erroring out URL, but that we caught the error
+        # (because the previous call_command did not error out with an exception)
+        assert len(calls_to_search_url) > 0
 
 
-@ddt.ddt
-@mark.django_db
+@ ddt.ddt
+@ mark.django_db
 class TestMigrateEnterpriseUserRolesCommand(unittest.TestCase):
     """
     Test the assign_enterprise_user_roles management command.
     """
-    @factory.django.mute_signals(signals.post_save)
+    @ factory.django.mute_signals(signals.post_save)
     def setUp(self):
         super().setUp()
 
@@ -1459,13 +1466,13 @@ class TestMigrateEnterpriseUserRolesCommand(unittest.TestCase):
         )
         self.assertEqual(user_role_assignments.count(), user_role_assignment_count)
 
-    @ddt.data(
+    @ ddt.data(
         ('enterprise_admin@example.com', ENTERPRISE_ADMIN_ROLE, False),
         ('enterprise_operator@example.com', ENTERPRISE_OPERATOR_ROLE, False),
         ('enterprise_learner@example.com', ENTERPRISE_LEARNER_ROLE, False),
         ('enterprise_enrollment_api_admin@example.com', ENTERPRISE_ENROLLMENT_API_ADMIN_ROLE, True)
     )
-    @ddt.unpack
+    @ ddt.unpack
     def test_assign_enterprise_user_roles_success(self, user_email, role_name, is_feature_role):
         """
         Tests `assign_enterprise_user_roles` command runs with expected results.
@@ -1480,13 +1487,13 @@ class TestMigrateEnterpriseUserRolesCommand(unittest.TestCase):
         # Verify new respective role assignment records are created for the role.
         self._assert_role_assignments(user, role_name, 1, is_feature_role)
 
-    @ddt.data(
+    @ ddt.data(
         ('enterprise_admin@example.com', ENTERPRISE_ADMIN_ROLE, False),
         ('enterprise_operator@example.com', ENTERPRISE_OPERATOR_ROLE, False),
         ('enterprise_learner@example.com', ENTERPRISE_LEARNER_ROLE, False),
         ('enterprise_enrollment_api_admin@example.com', ENTERPRISE_ENROLLMENT_API_ADMIN_ROLE, True)
     )
-    @ddt.unpack
+    @ ddt.unpack
     def test_assign_enterprise_user_roles_rerun(self, user_email, role_name, is_feature_role):
         """
         Tests running `assign_enterprise_user_roles` command again gives expected results.
@@ -1507,7 +1514,7 @@ class TestMigrateEnterpriseUserRolesCommand(unittest.TestCase):
         # Verify no new respective role assignment records are created.
         self._assert_role_assignments(user, role_name, 1, is_feature_role)
 
-    @ddt.data(
+    @ ddt.data(
         (
             '_get_enterprise_customer_users_batch',
             User.objects.filter(pk__in=EnterpriseCustomerUser.objects.values('user_id'))
@@ -1525,7 +1532,7 @@ class TestMigrateEnterpriseUserRolesCommand(unittest.TestCase):
             User.objects.filter(groups__name=ENTERPRISE_ENROLLMENT_API_ACCESS_GROUP, is_staff=False)
         )
     )
-    @ddt.unpack
+    @ ddt.unpack
     def test_get_users_batch(self, get_batch_method, batch_query):
         """
         Test that batch methods should return the correct query_set based on start and end inidices provided.
@@ -1566,13 +1573,13 @@ class TestMigrateEnterpriseUserRolesCommand(unittest.TestCase):
         assert str(excinfo.value) == error
 
 
-@ddt.ddt
-@mark.django_db
+@ ddt.ddt
+@ mark.django_db
 class TestUpdateRoleAssignmentsCommand(unittest.TestCase):
     """
     Test the `update_role_assignments_with_customers`  management command.
     """
-    @factory.django.mute_signals(signals.post_save)
+    @ factory.django.mute_signals(signals.post_save)
     def setUp(self):
         super().setUp()
         self.cleanup_test_objects()
@@ -1725,7 +1732,7 @@ class TestUpdateRoleAssignmentsCommand(unittest.TestCase):
         self._learner_assertions()
         self._operator_assertions()
 
-    @ddt.data(
+    @ ddt.data(
         ENTERPRISE_LEARNER_ROLE, ENTERPRISE_ADMIN_ROLE, ENTERPRISE_OPERATOR_ROLE
     )
     def test_command_with_role_argument(self, role_name):

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -80,11 +80,6 @@ for log_name, log_level in LOG_OVERRIDES:
     logging.getLogger(log_name).setLevel(log_level)
 
 
-class InstrumentedConnectionError(ConnectionError):
-    """ Patched connection error to use when checking if a request.ConnectionError was caught
-    and handled properly. """
-
-
 @ddt.ddt
 class TestIntegratedChannelCommandMixin(unittest.TestCase):
     """

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -1410,13 +1410,13 @@ class TestUnlinkSAPLearnersManagementCommand(unittest.TestCase, EnterpriseMockMi
         assert len(calls_to_search_url) > 0
 
 
-@ ddt.ddt
+@ddt.ddt
 @ mark.django_db
 class TestMigrateEnterpriseUserRolesCommand(unittest.TestCase):
     """
     Test the assign_enterprise_user_roles management command.
     """
-    @ factory.django.mute_signals(signals.post_save)
+    @factory.django.mute_signals(signals.post_save)
     def setUp(self):
         super().setUp()
 
@@ -1461,13 +1461,13 @@ class TestMigrateEnterpriseUserRolesCommand(unittest.TestCase):
         )
         self.assertEqual(user_role_assignments.count(), user_role_assignment_count)
 
-    @ ddt.data(
+    @ddt.data(
         ('enterprise_admin@example.com', ENTERPRISE_ADMIN_ROLE, False),
         ('enterprise_operator@example.com', ENTERPRISE_OPERATOR_ROLE, False),
         ('enterprise_learner@example.com', ENTERPRISE_LEARNER_ROLE, False),
         ('enterprise_enrollment_api_admin@example.com', ENTERPRISE_ENROLLMENT_API_ADMIN_ROLE, True)
     )
-    @ ddt.unpack
+    @ddt.unpack
     def test_assign_enterprise_user_roles_success(self, user_email, role_name, is_feature_role):
         """
         Tests `assign_enterprise_user_roles` command runs with expected results.
@@ -1482,13 +1482,13 @@ class TestMigrateEnterpriseUserRolesCommand(unittest.TestCase):
         # Verify new respective role assignment records are created for the role.
         self._assert_role_assignments(user, role_name, 1, is_feature_role)
 
-    @ ddt.data(
+    @ddt.data(
         ('enterprise_admin@example.com', ENTERPRISE_ADMIN_ROLE, False),
         ('enterprise_operator@example.com', ENTERPRISE_OPERATOR_ROLE, False),
         ('enterprise_learner@example.com', ENTERPRISE_LEARNER_ROLE, False),
         ('enterprise_enrollment_api_admin@example.com', ENTERPRISE_ENROLLMENT_API_ADMIN_ROLE, True)
     )
-    @ ddt.unpack
+    @ddt.unpack
     def test_assign_enterprise_user_roles_rerun(self, user_email, role_name, is_feature_role):
         """
         Tests running `assign_enterprise_user_roles` command again gives expected results.
@@ -1509,7 +1509,7 @@ class TestMigrateEnterpriseUserRolesCommand(unittest.TestCase):
         # Verify no new respective role assignment records are created.
         self._assert_role_assignments(user, role_name, 1, is_feature_role)
 
-    @ ddt.data(
+    @ddt.data(
         (
             '_get_enterprise_customer_users_batch',
             User.objects.filter(pk__in=EnterpriseCustomerUser.objects.values('user_id'))
@@ -1527,7 +1527,7 @@ class TestMigrateEnterpriseUserRolesCommand(unittest.TestCase):
             User.objects.filter(groups__name=ENTERPRISE_ENROLLMENT_API_ACCESS_GROUP, is_staff=False)
         )
     )
-    @ ddt.unpack
+    @ddt.unpack
     def test_get_users_batch(self, get_batch_method, batch_query):
         """
         Test that batch methods should return the correct query_set based on start and end inidices provided.
@@ -1568,13 +1568,13 @@ class TestMigrateEnterpriseUserRolesCommand(unittest.TestCase):
         assert str(excinfo.value) == error
 
 
-@ ddt.ddt
+@ddt.ddt
 @ mark.django_db
 class TestUpdateRoleAssignmentsCommand(unittest.TestCase):
     """
     Test the `update_role_assignments_with_customers`  management command.
     """
-    @ factory.django.mute_signals(signals.post_save)
+    @factory.django.mute_signals(signals.post_save)
     def setUp(self):
         super().setUp()
         self.cleanup_test_objects()
@@ -1727,7 +1727,7 @@ class TestUpdateRoleAssignmentsCommand(unittest.TestCase):
         self._learner_assertions()
         self._operator_assertions()
 
-    @ ddt.data(
+    @ddt.data(
         ENTERPRISE_LEARNER_ROLE, ENTERPRISE_ADMIN_ROLE, ENTERPRISE_OPERATOR_ROLE
     )
     def test_command_with_role_argument(self, role_name):

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -1411,7 +1411,7 @@ class TestUnlinkSAPLearnersManagementCommand(unittest.TestCase, EnterpriseMockMi
 
 
 @ddt.ddt
-@ mark.django_db
+@mark.django_db
 class TestMigrateEnterpriseUserRolesCommand(unittest.TestCase):
     """
     Test the assign_enterprise_user_roles management command.
@@ -1569,7 +1569,7 @@ class TestMigrateEnterpriseUserRolesCommand(unittest.TestCase):
 
 
 @ddt.ddt
-@ mark.django_db
+@mark.django_db
 class TestUpdateRoleAssignmentsCommand(unittest.TestCase):
     """
     Test the `update_role_assignments_with_customers`  management command.


### PR DESCRIPTION
refactor(integrated_channels): 🔊 configure top level channel logs to always print standard config information

Types of changes you will see in this PR:
1. Modify top level/batch integrated channels logs to always log a standard set of information of integrated channels.
2. Modify as many log statements as possible to remove LMS username and LMS user email in favor of LMS user id. 
3. Modify tests to avoid test acceptance criteria based on logs.
4. Adding standardized stack trace information to Logger.error statements instead of either ignoring it or suppressing it in favor of home-grown error formats.
5. Updates to docstrings and log messages that give Python object type information about what has gone wrong for better debugging.
6. A standardized format for non-error messages of the form `<method_name> <started/finished/failed>. <details>` for easier tracing from logs of what is going on.
7. Some additional parameters added to methods if it was necessary for complete logging.
8. A specific format for logging batch tasks in some places to distinguish the log from logging something related to a particular learner or course of the form: `Batch <method_name> <started/finished/failed>. <details>`
9. Does change code logic in the case of duration time logged so that start and end logs have times that actually match (in some log cases, records for starting+finishing a task were not 1-1, making the existing duration field useless as a tool for log exploration


This PR does _not_:
(1) fully replace Integrated channels logs for all 7 integrated channels with the new format. Those can be done 1 by 1 as needed now that a format exists.
(2) Remove 100% of formatted email from logs _in cases where there is no matching LMS User, as if it did (in the case of a misspelling, for example) we would not be able to debug the problem- there is no external reference to be had in some of these cases._ 
(3) Re-enable the existing but skipped log-based tests around learner data integration, because those tests are some kind of catch all with no criteria in the source code, and should be removed and written with actual criteria. 


**Merge checklist:**
- [ n/a ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ n/a ] `make static` has been run to update webpack bundling if any static content was updated
- [ n/a ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ n/a ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [n/a  ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
