### PR TITLE
fix: :bug: Change delete to conclude, when processing delete_content_metadata

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Change Log
 Unreleased
 ----------
 
+[3.23.7]
+---------
+* Canvas integrated channel now 'concludes' course when sending deletion event, instead of 'delete'.
+
 [3.23.6]
 ---------
 * Optimised handling of conditions defining the absence of a DSC.

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.23.6"
+__version__ = "3.23.7"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/canvas/client.py
+++ b/integrated_channels/canvas/client.py
@@ -240,7 +240,7 @@ class CanvasAPIClient(IntegratedChannelApiClient):
         Args:
             url (str): The canvas url to send delete requests to.
         """
-        delete_response = self.session.delete(url, data='{"event":"delete"}')
+        delete_response = self.session.delete(url, data='{"event":"conclude"}')
         if delete_response.status_code >= 400:
             raise ClientError(delete_response.text, delete_response.status_code)
         return delete_response.status_code, delete_response.text

--- a/integrated_channels/canvas/client.py
+++ b/integrated_channels/canvas/client.py
@@ -236,6 +236,9 @@ class CanvasAPIClient(IntegratedChannelApiClient):
     def _delete(self, url):
         """
         Make a DELETE request using the session object to the Canvas course delete endpoint.
+        this actually only 'conclude's a course. See this link for difference between
+        conclude and delete. Conclude allows bringing course back to 'offer' state
+        https://canvas.instructure.com/doc/api/courses.html#method.courses.destroy
 
         Args:
             url (str): The canvas url to send delete requests to.


### PR DESCRIPTION
Going forward only conclude courses instead of delete, so we can bring it back to 'offer' state later with an update operatoin or create_or_update operation

Ref: https://canvas.instructure.com/doc/api/courses.html#method.courses.destroy

JIRA: ENT-4593

### Test plan

* send over a course: sent this one:
sent this https://edx.instructure.com/courses/6074/settings
* remove from catalog to 'conclude' it
 removed `        "edX+99887766"` from catalog

* transmit again

```
Preparing to transmit deletion of [2] content metadata items with plugin configuration [<CanvasEnterpriseCustomerConfiguration for Enterprise Test Enterprise>]: [['course-v1:edX+99887766+2T2021', 'edX+99887766']]
```
there were two items: one for course and one for course run


* verify course shows in concluded state in canvas

checked that these pages show course as 'unconclude' meaning they are concluded status:

https://edx.instructure.com/courses/6074/settings
https://edx.instructure.com/courses/6072/settings


What will not work as of this PR:
* add course back to catalog, (for now transmit should fail in create), this will be fixed in a future PR

Exactly as expected we get

```
 \"edX+99887766\" is already in use","message":"Integration ID \"edX+99887766\" is already in use"}]}}] and status code [400]
2021-05-27 18:54:27,210 ERROR 6554 [integrated_channels.integrated_channel.transmitters.content_metadata] [user None] [ip None] content_metadata.py:138 - {"errors":{"integration_id":[{"attribute":"integration_id","type":"Integration ID \"edX+99887766\" is already in use","message":"Integration ID \"edX+99887766\" is already in use"}]}}
Traceback (most recent call last):
  File "/edx/src/edx-enterprise/integrated_channels/integrated_channel/transmitters/content_metadata.py", line 127, in _transmit_create
    self.client.create_content_metadata(serialized_chunk)
  File "/edx/src/edx-enterprise/integrated_channels/canvas/client.py", line 84, in create_content_metadata
    status_code, response_text = self._post(self.course_create_url, serialized_data)
  File "/edx/src/edx-enterprise/integrated_channels/canvas/client.py", line 219, in _post
    raise ClientError(post_response.text, post_response.status_code)
```


**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
