### PR TITLE
Fix: ENT-4545 | updated time objects to be timezone aware in email_drip_for_missing_dsc_records

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,11 @@ Unreleased
 ----------
 * Nothing
 
+[3.28.5]
+---------
+* Fixed datetime issue in email_drip_for_missing_dsc_records.
+
+
 [3.28.4]
 ---------
 * Integrated channels: audit track completion status now based on incomplete non-gated content

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.28.4"
+__version__ = "3.28.5"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/enterprise/management/commands/email_drip_for_missing_dsc_records.py
+++ b/enterprise/management/commands/email_drip_for_missing_dsc_records.py
@@ -4,12 +4,13 @@ Django management command for sending an email to learners with missing DataShar
 """
 import datetime
 import logging
-from datetime import date, timedelta
+from datetime import timedelta
 from urllib.parse import urljoin
 
 from django.conf import settings
 from django.core.management import BaseCommand
 from django.urls import reverse
+from django.utils import timezone
 
 from consent.models import DataSharingConsent, ProxyDataSharingConsent
 from enterprise import utils
@@ -88,7 +89,7 @@ class Command(BaseCommand):
                 enterprise_customer_user__enterprise_customer__enable_data_sharing_consent=True
             )
         else:
-            past_date = date.today() - timedelta(days=past_num_days)
+            past_date = timezone.now().date() - timedelta(days=past_num_days)
             enrollments_with_dsc_enabled = EnterpriseCourseEnrollment.objects.select_related(
                 'enterprise_customer_user').filter(
                 created__date=past_date,

--- a/tests/test_enterprise/management/test_email_drip_for_missing_dsc_records.py
+++ b/tests/test_enterprise/management/test_email_drip_for_missing_dsc_records.py
@@ -31,7 +31,7 @@ class EmailDripForMissingDscRecordsCommandTests(TestCase):
     """
     command = 'email_drip_for_missing_dsc_records'
 
-    def create_enrollments(self, num_learners, enrollment_date):
+    def create_enrollments(self, num_learners, enrollment_time):
         """
         Create test users and enrollments in database
 
@@ -71,14 +71,16 @@ class EmailDripForMissingDscRecordsCommandTests(TestCase):
                 enterprise_customer_user=enterprise_customer_user,
                 course_id=course_id,
             )
-            enterprise_course_enrollment.created = enrollment_date
+            enterprise_course_enrollment.created = enrollment_time
             enterprise_course_enrollment.save()
 
     def setUp(self):
         super().setUp()
-        today = timezone.now().date()
-        self.create_enrollments(num_learners=3, enrollment_date=today - timedelta(days=1))
-        self.create_enrollments(num_learners=5, enrollment_date=today - timedelta(days=10))
+        now = timezone.now()
+        # creating enrollments for yesterday.
+        self.create_enrollments(num_learners=3, enrollment_time=now - timedelta(days=1))
+        # creating enrollments for 10 days before.
+        self.create_enrollments(num_learners=5, enrollment_time=now - timedelta(days=10))
 
     @mock.patch(
         'enterprise.management.commands.email_drip_for_missing_dsc_records.DataSharingConsent.objects.proxied_get'


### PR DESCRIPTION
We were using time zone aware time in the test but not in command that could have caused flakiness.