### PR TITLE
feat: log more specific information about HTTP client errors during enrollment

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,12 @@ Change Log
 Unreleased
 ----------
 
+[3.23.11]
+---------
+* Log more specific information about HTTP client errors that are caught when using the LMS
+  enrollment API.  Also send an exception event to the monitoring service when this happens, even
+  though we handle the exception "gracefully".
+
 [3.23.10]
 ---------
 * Send long dsc url in missing DSC email as individual params.

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.23.10"
+__version__ = "3.23.11"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name


### PR DESCRIPTION
Log more specific information about HTTP client errors that are caught when using the LMS
enrollment API.  Also send an exception event to the monitoring service when this happens, even
though we handle the exception "gracefully".

https://openedx.atlassian.net/browse/ENT-4455

The current logged exception message is
```
 Unable to create an LMS enrollment from the DSC view: 
Client Error 400: https://courses.edx.org/api/enrollment/v1/enrollment
```
...which is not helpful.  In the DSC `get()` handler, we do log some info about licensed enrollments failing (when catching the exception raised from `_enroll_learner_in_course()`, but that's only in the case that the enterprise customer has DSC disabled, and it doesn't tell us about _why_ the enrollment API objects to the client request.  This change makes it so that both the `get()` and `post()` handler of the DSC view will know _why_ enrollments fail.

With this change, we'll now get errors like this in our logs:
```
2021-06-04 14:10:01,343 ERROR 1365 [enterprise.views] [user 2] [ip 172.21.0.1] views.py:620 - Client Error while enrolling user edx in course-v1:edX+DemoX+Demo_Course via enrollment API: The [verified] course mode is expired or otherwise unavailable for course run [course-v1:edX+DemoX+Demo_Course].
Traceback (most recent call last):
  File "/edx/src/edx-enterprise/enterprise/views.py", line 597, in _enroll_learner_in_course
    enrollment_api_client.enroll_user_in_course(
  File "/edx/src/edx-enterprise/enterprise/api_client/lms.py", line 104, in inner
    return func(self, *args, **kwargs)
  File "/edx/src/edx-enterprise/enterprise/api_client/lms.py", line 229, in enroll_user_in_course
    return self.client.enrollment.post(
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/slumber/__init__.py", line 167, in post
    resp = self._request("POST", data=data, files=files, params=kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/slumber/__init__.py", line 101, in _request
    raise exception_class("Client Error %s: %s" % (resp.status_code, url), response=resp, content=resp.content)
slumber.exceptions.HttpClientError: Client Error 400: http://edx.devstack.lms:18000/api/enrollment/v1/enrollment
```
and we'll see errors accumulate in New Relic.

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [x] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
