### PR TITLE
fix: log exception stack trace during DSC licensed-enrollment flow...

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Change Log
 Unreleased
 ----------
 
+[3.25.2]
+--------
+* Log exception stack trace during DSC licensed-enrollment flow, so that
+  we can look at log messages and understand what exactly is failing.
+
 [3.25.1]
 --------
 * bug fix, properly handle API response pagination from Canvas.

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.25.1"
+__version__ = "3.25.2"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -761,7 +761,7 @@ class GrantDataSharingPermissions(View):
                             license_uuid=license_uuid
                         )
                     )
-                    LOGGER.error(log_message)
+                    LOGGER.exception(log_message)
                     return redirect(failure_url)
 
             try:


### PR DESCRIPTION
…so that we can look at log messages and understand what exactly is failing. ENT-4455

We can see log messages of the form "Failed to enroll licensed learner into course", but there's no associated log message from the HttpClientError on line 610 of the same file.  So there' some other exception that we're broadly swallowing without a specific error message or stack trace.

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [x] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
