### PR TITLE
fix: slumber underscore shenanigans

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,13 @@ Change Log
 
 Unreleased
 ----------
+* Nothing
+
+[3.26.5]
+--------
+* fix: Bypass slumber's getattr definition when requesting enrollments for usernames starting with '_'
+  (because slumber will raise an AttributeError from getattr when requesting a resource that starts with '_').
+
 [3.26.4]
 --------
 * removed unnecessary call to ecom in bulk enrollment (process of assigning a license already accounts for this)

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.26.4"
+__version__ = "3.26.5"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/tests/test_enterprise/api_client/test_lms.py
+++ b/tests/test_enterprise/api_client/test_lms.py
@@ -108,22 +108,24 @@ def test_enroll_user_in_course():
 @responses.activate
 @mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
 def test_get_course_enrollment():
-    user = "some_user"
-    course_id = "course-v1:edX+DemoX+Demo_Course"
-    course_details = {"course_id": course_id}
-    mode = "audit"
-    expected_response = dict(user=user, course_details=course_details, mode=mode)
-    responses.add(
-        responses.GET,
-        _url(
-            "enrollment",
-            "enrollment/{username},{course_id}".format(username=user, course_id=course_id),
-        ),
-        json=expected_response
-    )
-    client = lms_api.EnrollmentApiClient('some-user')
-    actual_response = client.get_course_enrollment(user, course_id)
-    assert actual_response == expected_response
+    for user in ["_some_user", "some_user"]:
+        # It's important that we test for usernames that begin with '_'
+        # to test the functionality of `_get_underscore_safe_endpoint()`.
+        course_id = "course-v1:edX+DemoX+Demo_Course"
+        course_details = {"course_id": course_id}
+        mode = "audit"
+        expected_response = dict(user=user, course_details=course_details, mode=mode)
+        responses.add(
+            responses.GET,
+            _url(
+                "enrollment",
+                "enrollment/{username},{course_id}".format(username=user, course_id=course_id),
+            ),
+            json=expected_response
+        )
+        client = lms_api.EnrollmentApiClient('some-user')
+        actual_response = client.get_course_enrollment(user, course_id)
+        assert actual_response == expected_response
 
 
 @responses.activate


### PR DESCRIPTION
**The problem**: Fetching course enrollments through our Enrollment API Client fails for users whose username starts with `_`. Seriously.

Slumber is just making `getattr` fail for resources that start with underscore: https://github.com/samgiles/slumber/blob/master/slumber/__init__.py#L29-L34 

This modifies the `EnrollmentApiClient` to do what slumber does _after_ raising an `AttributeError`, so that we'll get back a `slumber.Resource` object we can use to make our request:
```python
c = EnrollmentApiClient()
c.connect()
username = '_alex'
course_id = 'course-v1:abc'
endpoint = c._get_underscore_safe_endpoint('{},{}'.format(username, course_id))
endpoint.url()
# 'http://edx.devstack.lms:18000/api/enrollment/v1/enrollment/_alex,course-v1:abc'
c.get_course_enrollment(username, course_id)
# 2021-06-15 19:20:48,492 ERROR 1608 [enterprise.api_client.lms] [user None] [ip None] lms.py:325 - Course enrollment details not found for invalid username or course; username=[_alex], course=[course-v1:abc] 
# This 404 is fine, I requested a bogus username.
# Before this change, we'd get an AttributeError.
```

Fixes:
* Many of the failures captured in https://openedx.atlassian.net/browse/ENT-4455
* https://openedx.atlassian.net/browse/ENT-3129
**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [x] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
