### PR TITLE
fix(integrated_channels): :bug: fix forward for parameter rename bug

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.26.10]
+--------
+* Fix forward for parameter rename changing the signals API in 3.26.7
+
 [3.26.9]
 --------
 * Added support to use default idp in Enterprise slug login if there are multiple.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ Unreleased
 * Nothing
 
 [3.26.10]
---------
+---------
 * Fix forward for parameter rename changing the signals API in 3.26.7
 
 [3.26.9]

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.26.9"
+__version__ = "3.26.10"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/integrated_channel/tasks.py
+++ b/integrated_channels/integrated_channel/tasks.py
@@ -116,15 +116,15 @@ def transmit_learner_data(username, channel_code, channel_pk):
 
 @shared_task
 @set_code_owner_attribute
-def transmit_single_learner_data(learner_username, course_run_id):
+def transmit_single_learner_data(username, course_run_id):
     """
     Task to send single learner data to each linked integrated channel.
 
     Arguments:
-        learner_username (str): The username of the learner whose data it should send.
+        username (str): The username of the learner whose data it should send.
         course_run_id (str): The course run id of the course it should send data for.
     """
-    user = User.objects.get(username=learner_username)
+    user = User.objects.get(username=username)
     enterprise_customer_uuids = get_enterprise_uuids_for_user_and_course(user, course_run_id, active=True)
 
     # Transmit the learner data to each integrated channel for each related customer.

--- a/tests/test_integrated_channels/test_integrated_channel/test_transmitters/test_learner_data.py
+++ b/tests/test_integrated_channels/test_integrated_channel/test_transmitters/test_learner_data.py
@@ -10,6 +10,7 @@ import mock
 from pytest import mark
 
 from integrated_channels.integrated_channel.exporters.learner_data import LearnerExporter
+from integrated_channels.integrated_channel.tasks import transmit_single_learner_data
 from integrated_channels.integrated_channel.transmitters.learner_data import LearnerTransmitter
 from test_utils import factories
 
@@ -37,6 +38,23 @@ class TestLearnerDataTransmitter(unittest.TestCase):
         )
 
         self.learner_transmitter = LearnerTransmitter(self.enterprise_config)
+
+    def test_transmit_single_learner_data_signal_kwargs(self):
+        """ transmit_single_learner_data is called with kwargs as a shared task from OpenEdx,
+        so test that interface hasn't changed. """
+
+        edx_platform_api_signal_kwargs = {
+            'username': "fake_username",
+            'course_run_id': "TEST_COURSE_RUN_KEY"
+        }
+        # If you change the arg names to transmit_single_learner_data
+        # this test will now fail with a TypeError:
+        try:
+            transmit_single_learner_data(**edx_platform_api_signal_kwargs)
+        except TypeError:
+            assert False  # if we see a Type error, the test should fail because we failed with bad keyword parameters
+        except Exception:   # pylint: disable=broad-except
+            pass  # otherwise it's because we set the test up with no data.
 
     @mock.patch("integrated_channels.integrated_channel.models.LearnerDataTransmissionAudit")
     @mock.patch("integrated_channels.utils.is_already_transmitted")


### PR DESCRIPTION
Caused in 3.26.7

**Merge checklist:**
- [n/a ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [n/a ] `make static` has been run to update webpack bundling if any static content was updated
- [n/a] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [n/a ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
