### PR TITLE
feat: When a course is found in concluded/completed state, update instead of create ENT-4594

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.26.12]
+---------
+* Canvas integrated channel now supports create_or_update pattern for courses. Detects/logs deleted courses.
+
 [3.26.11]
 ---------
 * Removed ``ENABLE_MULTIPLE_USER_ENTERPRISES_FEATURE`` waffle switch

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.26.11"
+__version__ = "3.26.12"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/canvas/client.py
+++ b/integrated_channels/canvas/client.py
@@ -19,6 +19,9 @@ from integrated_channels.utils import generate_formatted_log, refresh_session_if
 LOGGER = logging.getLogger(__name__)
 
 
+MESSAGE_WHEN_COURSE_WAS_DELETED = 'Course was deleted previously, skipping create/update'
+
+
 class CanvasAPIClient(IntegratedChannelApiClient):
     """
     Client for connecting to Canvas.
@@ -136,7 +139,7 @@ class CanvasAPIClient(IntegratedChannelApiClient):
                     )
                 )
                 status_code = 200
-                response_text = 'Course was deleted previously, skipping create/update'
+                response_text = MESSAGE_WHEN_COURSE_WAS_DELETED
             else:
                 # 'unpublished', 'completed' or 'available' cases
                 LOGGER.warning(

--- a/integrated_channels/canvas/client.py
+++ b/integrated_channels/canvas/client.py
@@ -73,7 +73,7 @@ class CanvasAPIClient(IntegratedChannelApiClient):
     @staticmethod
     def course_fetch_endpoint(canvas_base_url, canvas_account_id):
         """
-        Returns endpoint to GET to for course fetch
+        Returns endpoint to fetch all courses for the specified Canvas account
         """
         return '{}/api/v1/accounts/{}/courses'.format(
             canvas_base_url,
@@ -338,6 +338,10 @@ class CanvasAPIClient(IntegratedChannelApiClient):
           under the current subaccount
           Will even return courses that are in the 'deleted' state in Canvas, so we can correctly
           skip these courses in logic for create_or_update when needed.
+
+          Note: we do not need to follow pagination here since it would be extremely unlikely
+          that searching by a specific edx_course_id results in many records, we generally only
+          expect 1 record to come back anyway.
         """
         url = "{}/api/v1/accounts/{}/courses/?search_term={}".format(
             self.enterprise_configuration.canvas_base_url,

--- a/integrated_channels/canvas/client.py
+++ b/integrated_channels/canvas/client.py
@@ -404,8 +404,7 @@ class CanvasAPIClient(IntegratedChannelApiClient):
 
     def _get_course_id_from_edx_course_id(self, edx_course_id):
         """
-        To obtain course ID we have to request all courses associated with the integrated
-        account and match the one with our edx_course_id (integration_id).
+        Uses the Canvas search api to find a course by edx_course_id
 
         Args:
             edx_course_id (string): Course ID to search by

--- a/integrated_channels/canvas/client.py
+++ b/integrated_channels/canvas/client.py
@@ -11,10 +11,10 @@ from six.moves.urllib.parse import quote_plus, urljoin  # pylint: disable=import
 
 from django.apps import apps
 
+from integrated_channels.canvas.utils import CanvasUtil
 from integrated_channels.exceptions import ClientError
 from integrated_channels.integrated_channel.client import IntegratedChannelApiClient
 from integrated_channels.utils import generate_formatted_log, refresh_session_if_expired
-from integrated_channels.canvas.utils import CanvasUtil
 
 LOGGER = logging.getLogger(__name__)
 

--- a/integrated_channels/canvas/client.py
+++ b/integrated_channels/canvas/client.py
@@ -124,6 +124,8 @@ class CanvasAPIClient(IntegratedChannelApiClient):
                     'not attempting to create/update',
                     edx_course_id,
                 )
+                status_code = 200
+                response_text = 'Course was deleted previously, skipping create/update'
             else:
                 # 'unpublished', 'completed' or 'available' cases
                 LOGGER.warning(
@@ -342,8 +344,10 @@ class CanvasAPIClient(IntegratedChannelApiClient):
           Note: we do not need to follow pagination here since it would be extremely unlikely
           that searching by a specific edx_course_id results in many records, we generally only
           expect 1 record to come back anyway.
+
+          The `&state[]=all` is added so we can also fetch priorly 'delete'd courses
         """
-        url = "{}/api/v1/accounts/{}/courses/?search_term={}".format(
+        url = "{}/api/v1/accounts/{}/courses/?search_term={}&state[]=all".format(
             self.enterprise_configuration.canvas_base_url,
             self.enterprise_configuration.canvas_account_id,
             quote(edx_course_id),

--- a/integrated_channels/canvas/utils.py
+++ b/integrated_channels/canvas/utils.py
@@ -1,0 +1,173 @@
+'''Collection of static util methods for various Canvas operations'''
+import logging
+from http import HTTPStatus
+from requests.utils import quote
+from integrated_channels.exceptions import ClientError
+
+from integrated_channels.utils import generate_formatted_log
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class CanvasUtil:
+    """
+    A util to make various util functions related to Canvas easier and co-located.
+
+    Every method in this class is static and stateless. They all need at least
+        - enterprise_configuration
+        - session
+    plus additional relevant arguments.
+
+    Usage example:
+        canvas_api_client._create_session() # if needed
+        CanvasUtil.find_course_in_account(
+            canvas_api_client.enterprise_configuration,
+            canvas_api_client.session,
+            course_id,
+            account_id,
+        )
+    """
+
+    @staticmethod
+    def find_root_canvas_account(enterprise_configuration, session):
+        """
+        Attempts to find root account id from Canvas.
+
+        Arguments:
+          - enterprise_configuration (EnterpriseCustomerPluginConfiguration)
+          - session (requests.Session)
+
+        If root account cannot be found, returns None
+        """
+        url = "{}/api/v1/accounts".format(enterprise_configuration.canvas_base_url)
+        resp = session.get(url)
+        all_accounts = resp.json()
+        root_account = None
+        for account in all_accounts:
+            if account['parent_account_id'] is None:
+                root_account = account
+                break
+        return root_account
+
+    @staticmethod
+    def find_course_in_account(enterprise_configuration, session, canvas_account_id, edx_course_id):
+        """
+        Search course by edx_course_id (used as integration_id in canvas) under provided account.
+        It will even return courses that are in the 'deleted' state in Canvas, so we can correctly
+        skip these courses in logic as needed.
+
+        Note: we do not need to follow pagination here since it would be extremely unlikely
+        that searching by a specific edx_course_id results in many records, we generally only
+        expect 1 record to come back anyway.
+
+        Arguments:
+          - enterprise_configuration (EnterpriseCustomerPluginConfiguration)
+          - session (requests.Session)
+          - canvas_account_id (Number) : account to search courses in
+          - edx_course_id (str) : edX course key
+
+        Ref: https://canvas.instructure.com/doc/api/accounts.html#method.accounts.courses_api
+
+        The `&state[]=all` is added so we can also fetch priorly 'delete'd courses as well
+        """
+        url = "{}/api/v1/accounts/{}/courses/?search_term={}&state[]=all".format(
+            enterprise_configuration.canvas_base_url,
+            canvas_account_id,
+            quote(edx_course_id),
+        )
+        resp = session.get(url)
+        all_courses_response = resp.json()
+
+        if resp.status_code >= 400:
+            message = 'Failed to find a course under Canvas account: {account_id}'.format(
+                account_id=canvas_account_id
+            )
+            if 'reason' in all_courses_response:
+                message = '{} : Reason = {}'.format(message, all_courses_response['reason'])
+            elif 'errors' in all_courses_response:
+                message = '{} : Errors = {}'.format(message, str(all_courses_response['errors']))
+            raise ClientError(
+                message,
+                resp.status_code
+            )
+
+        course_found = None
+        for course in all_courses_response:
+            if course['integration_id'] == edx_course_id:
+                course_found = course
+                break
+        return course_found
+
+    @staticmethod
+    def get_course_id_from_edx_course_id(enterprise_configuration, session, edx_course_id):
+        """
+        Uses the Canvas search api to find a course by edx_course_id
+
+        Arguments:
+          - enterprise_configuration (EnterpriseCustomerPluginConfiguration)
+          - session (requests.Session)
+          - edx_course_id (str) : edX course key
+
+        Returns:
+            canvas_course_id (string): id from Canvas
+        """
+        course = CanvasUtil.find_course_by_course_id(
+            enterprise_configuration,
+            session,
+            edx_course_id,
+        )
+
+        if not course:
+            raise ClientError(
+                "No Canvas courses found with associated edx course ID: {}.".format(
+                    edx_course_id
+                ),
+                HTTPStatus.NOT_FOUND.value
+            )
+        return course['id']
+
+    @staticmethod
+    def find_course_by_course_id(
+        enterprise_configuration,
+        session,
+        edx_course_id,
+    ):
+        """
+        First attempts to find courase under current account id
+        As fallback, to account for cases where course was priorly transmitted to a different
+        account, it also searches under the root account for the course.
+
+        Arguments:
+          - enterprise_configuration (EnterpriseCustomerPluginConfiguration)
+          - session (requests.Session)
+          - edx_course_id (str) : edX course key
+
+        Returns:
+        - Course dict if the course found in Canvas,
+        - None otherwise
+        """
+        course = CanvasUtil.find_course_in_account(
+            enterprise_configuration,
+            session,
+            enterprise_configuration.canvas_account_id,
+            edx_course_id,
+        )
+        if not course:
+            # now let's try the root account instead (searches under all subaccounts)
+            root_canvas_account = CanvasUtil.find_root_canvas_account(enterprise_configuration, session)
+            course = CanvasUtil.find_course_in_account(
+                enterprise_configuration,
+                session,
+                root_canvas_account['id'],
+                edx_course_id,
+            )
+            if course:
+                LOGGER.info(generate_formatted_log(
+                    'canvas',
+                    enterprise_configuration.enterprise_customer.uuid,
+                    None,
+                    edx_course_id,
+                    'Found course under root Canvas account'
+                ))
+        return course

--- a/integrated_channels/canvas/utils.py
+++ b/integrated_channels/canvas/utils.py
@@ -1,11 +1,11 @@
 '''Collection of static util methods for various Canvas operations'''
 import logging
 from http import HTTPStatus
+
 from requests.utils import quote
+
 from integrated_channels.exceptions import ClientError
-
 from integrated_channels.utils import generate_formatted_log
-
 
 LOGGER = logging.getLogger(__name__)
 

--- a/integrated_channels/utils.py
+++ b/integrated_channels/utils.py
@@ -247,7 +247,6 @@ def generate_formatted_log(
     Arguments:
     - channel_name (str): The name of the integrated channel
     - enterprise_customer_uuid (str): UUID of the relevant EnterpriseCustomer
-    - enterprise_customer_identifer (str): Identifying name of the EnterpriseCustomer
     - lms_user_id (str): The LMS User id (if applicable) related to the message
     - course_or_course_run_key (str): The course key (if applicable) for the message
     - message (str): The string to be formatted and logged

--- a/tests/test_integrated_channels/test_canvas/test_client.py
+++ b/tests/test_integrated_channels/test_canvas/test_client.py
@@ -504,7 +504,7 @@ class TestCanvasApiClient(unittest.TestCase):
 
     @mock.patch.object(CanvasUtil, 'find_course_by_course_id')
     def test_existing_course_is_ignored_if_deleted(self, mock_find_course_by_course_id):
-        # to simulate finding an existing course with workflow_state != 'deleted'
+        # to simulate finding an existing course with workflow_state == 'deleted'
         mock_find_course_by_course_id.return_value = {
             'workflow_state': 'deleted',
             'id': 111,

--- a/tests/test_integrated_channels/test_canvas/test_client.py
+++ b/tests/test_integrated_channels/test_canvas/test_client.py
@@ -13,7 +13,6 @@ import pytest
 import responses
 from freezegun import freeze_time
 from requests.models import Response
-from requests.utils import quote
 from six.moves.urllib.parse import urljoin  # pylint: disable=import-error
 
 from django.utils import timezone

--- a/tests/test_integrated_channels/test_canvas/test_utils.py
+++ b/tests/test_integrated_channels/test_canvas/test_utils.py
@@ -4,20 +4,14 @@ Tests for utils in integrated_channels.canvas.
 """
 import copy
 import datetime
-import json
 import random
 import unittest
-from unittest.mock import patch
 
 import pytest
-import responses
-from freezegun import freeze_time
 from requests.models import Response
-from requests.sessions import Session
 
 from django.utils import timezone
 
-from integrated_channels.canvas.client import CanvasAPIClient
 from integrated_channels.canvas.utils import CanvasUtil
 from integrated_channels.exceptions import ClientError
 from integrated_channels.utils import refresh_session_if_expired

--- a/tests/test_integrated_channels/test_canvas/test_utils.py
+++ b/tests/test_integrated_channels/test_canvas/test_utils.py
@@ -4,24 +4,23 @@ Tests for utils in integrated_channels.canvas.
 """
 import copy
 import datetime
-
-from requests.sessions import Session
-from integrated_channels.utils import refresh_session_if_expired
-from integrated_channels.canvas.utils import CanvasUtil
 import json
 import random
 import unittest
+from unittest.mock import patch
 
 import pytest
 import responses
 from freezegun import freeze_time
 from requests.models import Response
-from unittest.mock import patch
+from requests.sessions import Session
 
 from django.utils import timezone
 
 from integrated_channels.canvas.client import CanvasAPIClient
+from integrated_channels.canvas.utils import CanvasUtil
 from integrated_channels.exceptions import ClientError
+from integrated_channels.utils import refresh_session_if_expired
 from test_utils import factories
 
 NOW = datetime.datetime(2017, 1, 2, 3, 4, 5, tzinfo=timezone.utc)


### PR DESCRIPTION
This change eliminates the failures encountered during create_content_metadata when a course is previously concluded (via a previous delete attempt). Instead, now we do a detection of course state before attempting to create it, and instead we update it if it's one of the following states in Canvas:
`'unpublished', 'completed' or 'available' `

- [x] This also brings a course back from completed to 'offer' state after which the course is now once again available for enrolling in Canvas
- [x] Also add detection of 'deleted' courses previously missed, since that allows us to log that a course has previojsly been 'deleted' as opposed to say 'concluded' (or 'completed'). We take no action on deleted courses other than logging for now
- [x] This can now even locate courses in other subaccount under the root account, as a fallback, in case not found under current subaccount.
- [x] Also, update_content_metadata and delete_content_metadata also use the same method I refactored `_get_course_id_from_edx_course_id` hence they will also benefit from being able to find a course in other subaccounts
- [x] Automated tests added. 

# Testing notes

After removing a course from catalog, verified it was in 'completed' workflow_state now. Then added back to catalog and ran transmit_content_metadata task and saw this in logs

```
2021-06-23 03:34:26,542 WARNING 49226 [integrated_channels.canvas.client] [user None] [ip None] client.py:129 - Course with canvas_id = 6072, integration_id = course-v1:edX+99887766+2T2021 found in workflow_state=completed,attempting to update instead of creating it
2021-06-23 03:34:27,026 WARNING 49226 [integrated_channels.canvas.client] [user None] [ip None] client.py:129 - Course with canvas_id = 6074, integration_id = edX+99887766 found in workflow_state=completed,attempting to update instead of creating it
2021-06-23 03:34:27,259 INFO 49226 [integrated_channels.integrated_channel.tasks] [user None] [ip None] tasks.py:47 - [Integrated Channel: CANVAS] Batch transmit_content_metadata finished in 1.3078796863555908 (api user: 3). Configuration: <CanvasEnterpriseCustomerConfiguration for Enterprise Test Enterprise>.
```

Then verified course in canvas went from ('concluded' or) 'completed' state to 'available'
Also verified via Canvas UI that course button now says 'Conclude this course', instead of 'Unconclude this course'

This payload obtained from `https://edx.instructure.com//api/v1/courses/6072?include=course_image&include=self_enrollment` shows the course state after the second round of transmit_content_metadata (there were no failures!)

```
{
    "id": 6072,
    "name": "bulk enroll test course",
    "account_id": 109,
    "uuid": "HkGD3EsTg8ihhoWArHlQRDMY8Aqy1hLqUfXUm62A",
    "start_at": "2021-05-26T16:00:00Z",
    "grading_standard_id": null,
    "is_public": true,
    "created_at": "2021-05-27T18:48:25Z",
    "course_code": "course-v1:edX+99887766+2T2021",
    "default_view": "syllabus",
    "root_account_id": 1,
    "enrollment_term_id": 1,
    "self_enrollment": true,
    "license": null,
    "grade_passback_setting": null,
    "end_at": "2022-08-27T16:00:00Z",
    "public_syllabus": false,
    "public_syllabus_to_auth": false,
    "storage_quota_mb": 500,
    "is_public_to_auth_users": false,
    "homeroom_course": false,
    "course_color": null,
    "hide_final_grades": false,
    "apply_assignment_group_weights": false,
    "calendar": {
        "ics": "https://edx.instructure.com/feeds/calendars/course_HkGD3EsTg8ihhoWArHlQRDMY8Aqy1hLqUfXUm62A.ics"
    },
    "time_zone": "America/Denver",
    "blueprint": false,
    "template": false,
    "sis_course_id": null,
    "sis_import_id": null,
    "integration_id": "course-v1:edX+99887766+2T2021",
    "enrollments": [],
    "workflow_state": "available",
    "restrict_enrollments_to_course_dates": false
}
```



__Also checked deleted course state handling__

Deleted a course in Canvas using the 'delete' (not conclude) option. Verified course returned now as 'workflow_state' = 'deleted' then ran a job (after clearing local tx records. This time instead of faiing to create it simply logged

```
2021-06-24 14:53:33,220 WARNING 51939 [integrated_channels.canvas.client] [user None] [ip None] client.py:122 - Course with integration_id = course-v1:edX+99887766+2T2021 found in deleted state,not attempting to create/update
```


__Finding course under root account instead of current subaccount__

I have to now add automated tests, but tested this out manually with various cases such as:

- deleted a course in canvas, then verified it can find it and log/ignore in that case (we still add a success tx record in this case)
- made a course unpublished in canvas, and it correctly detects state and updates course, instead of creating it
- forced it to try and find course under root account (by using a different canvas account id where course does not exist, and it did go find the course under root account id in that case)


```
2021-06-25 01:57:38,882 INFO 61047 [integrated_channels.canvas.client] [user None] [ip None] client.py:437 - [integrated_channel:canvas][integrated_channel_enterprise_customer_uuid:873fec72-5a21-4f95-ac19-e3d67f9c4777][integrated_channel_lms_user:None][integrated_channel_course_key:course-v1:edX+99887766+2T2021]Found course under root Canvas account
2021-06-25 01:57:38,883 ERROR 61047 [integrated_channels.canvas.client] [user None] [ip None] client.py:123 - [integrated_channel:canvas][integrated_channel_enterprise_customer_uuid:873fec72-5a21-4f95-ac19-e3d67f9c4777][integrated_channel_lms_user:None][integrated_channel_course_key:course-v1:edX+99887766+2T2021]Course with integration_id = course-v1:edX+99887766+2T2021 found in deleted state, not attempting to create/update
```



__Also I manually moved a course to a different subaccount in Canvas side__

Then remove the tx record to force it to create a course and voila! it found the course and instead updated it back from the concluded to offer state

ENT-4594

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
