### PR TITLE
[ERTE-5] feat: Added enterprise uuid support in course enrollment

### DIFF
--- a/enterprise/api_client/lms.py
+++ b/enterprise/api_client/lms.py
@@ -212,7 +212,7 @@ class EnrollmentApiClient(JwtLmsApiClient):
         return any(course_mode for course_mode in course_modes if course_mode['slug'] == mode)
 
     @JwtLmsApiClient.refresh_token
-    def enroll_user_in_course(self, username, course_id, mode, cohort=None):
+    def enroll_user_in_course(self, username, course_id, mode, cohort=None, enterprise_uuid=None):
         """
         Call the enrollment API to enroll the user in the course specified by course_id.
 
@@ -221,6 +221,7 @@ class EnrollmentApiClient(JwtLmsApiClient):
             course_id (str): The string value of the course's unique identifier
             mode (str): The enrollment mode which should be used for the enrollment
             cohort (str): Add the user to this named cohort
+            enterprise_uuid (str): Add course enterprise uuid
 
         Returns:
             dict: A dictionary containing details of the enrollment, including course details, mode, username, etc.
@@ -233,6 +234,7 @@ class EnrollmentApiClient(JwtLmsApiClient):
                 'is_active': True,
                 'mode': mode,
                 'cohort': cohort,
+                'enterprise_uuid': enterprise_uuid
             }
         )
 

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -1021,7 +1021,8 @@ class EnterpriseCustomerUser(TimeStampedModel):
                 )
             )
             try:
-                enrollment_api_client.enroll_user_in_course(self.username, course_run_id, mode, cohort=cohort)
+                enrollment_api_client.enroll_user_in_course(self.username, course_run_id, mode, cohort=cohort,
+                                                            enterprise_uuid=str(self.enterprise_customer.uuid))
             except HttpClientError as exc:
                 succeeded = False
                 default_message = 'No error message provided'

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -1419,7 +1419,9 @@ def enroll_user(enterprise_customer, user, course_mode, *course_ids, **kwargs):
     succeeded = True
     for course_id in course_ids:
         try:
-            enrollment_client.enroll_user_in_course(user.username, course_id, course_mode)
+            enrollment_client.enroll_user_in_course(user.username, course_id, course_mode, cohort=None,
+                                                    enterprise_uuid=str(enterprise_customer_user.uuid)
+                                                    if hasattr(enterprise_customer_user, 'uuid') else None)
         except HttpClientError as exc:
             # Check if user is already enrolled then we should ignore exception
             if is_user_enrolled(user, course_id, course_mode):

--- a/test_utils/fake_enrollment_api.py
+++ b/test_utils/fake_enrollment_api.py
@@ -151,7 +151,7 @@ def get_course_details(course_id):
         return None
 
 
-def enroll_user_in_course(user, course_id, mode):
+def enroll_user_in_course(user, course_id, mode, cohort=None, enterprise_uuid=None):
     """
     Fake implementation.
     """
@@ -174,6 +174,8 @@ def enroll_user_in_course(user, course_id, mode):
         "course_details": course_details,
         "is_active": True,
         "mode": mode,
+        "cohort": cohort,
+        "enterprise_uuid": enterprise_uuid,
         "created": datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ")
     }
 

--- a/tests/test_admin/test_view.py
+++ b/tests/test_admin/test_view.py
@@ -903,6 +903,8 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
             user.username,
             course_id,
             mode,
+            cohort=None,
+            enterprise_uuid=None
         )
         if enrollment_exists:
             track_enrollment.assert_not_called()
@@ -975,6 +977,8 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
                     user.username,
                     course_id,
                     mode,
+                    cohort=None,
+                    enterprise_uuid=None
                 )
                 track_enrollment.assert_called_with('admin-enrollment', user.id, course_id)
                 self._assert_django_messages(response, set([
@@ -1070,6 +1074,8 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
             user.username,
             course_id,
             mode,
+            cohort=None,
+            enterprise_uuid=None
         )
         track_enrollment.assert_called_once_with('admin-enrollment', user.id, course_id)
         self._assert_django_messages(response, set([
@@ -1118,6 +1124,8 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
             user.username,
             course_id,
             mode,
+            cohort=None,
+            enterprise_uuid=None
         )
         track_enrollment.assert_called_once_with('admin-enrollment', user.id, course_id)
         self._assert_django_messages(response, {
@@ -1163,6 +1171,8 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
             user.username,
             course_id,
             mode,
+            cohort=None,
+            enterprise_uuid=None
         )
         track_enrollment.assert_not_called()
         self._assert_django_messages(response, {
@@ -1203,6 +1213,8 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
             user.username,
             course_id,
             mode,
+            cohort=None,
+            enterprise_uuid=None
         )
         track_enrollment.assert_not_called()
         self._assert_django_messages(response, {
@@ -1247,6 +1259,8 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
             user.username,
             course_id,
             mode,
+            cohort=None,
+            enterprise_uuid=None
         )
         track_enrollment.assert_called_once_with('admin-enrollment', user.id, course_id)
         self._assert_django_messages(response, set([
@@ -1691,7 +1705,9 @@ class TestEnterpriseCustomerManageLearnersViewPostBulkUpload(BaseTestEnterpriseC
         enrollment_instance.enroll_user_in_course.assert_called_once_with(
             user.username,
             course_id,
-            course_mode
+            course_mode,
+            cohort=None,
+            enterprise_uuid=None
         )
         track_enrollment.assert_called_once_with('admin-enrollment', user.id, course_id)
         pending_user_message = (
@@ -1746,7 +1762,9 @@ class TestEnterpriseCustomerManageLearnersViewPostBulkUpload(BaseTestEnterpriseC
         enrollment_instance.enroll_user_in_course.assert_called_once_with(
             user.username,
             course_id,
-            course_mode
+            course_mode,
+            cohort=None,
+            enterprise_uuid=None
         )
         track_enrollment.assert_called_once_with('admin-enrollment', user.id, course_id)
         pending_user_message = (
@@ -1794,7 +1812,9 @@ class TestEnterpriseCustomerManageLearnersViewPostBulkUpload(BaseTestEnterpriseC
         enrollment_instance.enroll_user_in_course.assert_called_once_with(
             user.username,
             course_id,
-            course_mode
+            course_mode,
+            cohort=None,
+            enterprise_uuid=None
         )
         track_enrollment.assert_called_once_with('admin-enrollment', user.id, course_id)
         pending_user_message = (

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -2540,7 +2540,12 @@ class TestEnterpriesCustomerCourseEnrollments(BaseTestEnterpriseAPIViews):
                     course_id=payload.get('course_run_id'),
                     source=EnterpriseEnrollmentSource.get_source(EnterpriseEnrollmentSource.API)
                 ).exists()
-
+                enterprise_course_enrollment = EnterpriseCourseEnrollment.objects.filter(
+                    enterprise_customer_user__user_id=user.id,
+                    course_id=payload.get('course_run_id'),
+                    source=EnterpriseEnrollmentSource.get_source(EnterpriseEnrollmentSource.API)
+                ).first()
+                enterprise_customer = enterprise_course_enrollment.enterprise_customer_user.enterprise_customer
                 mock_enrollment_client.return_value.get_course_enrollment.assert_called_once_with(
                     user.username, payload.get('course_run_id')
                 )
@@ -2549,6 +2554,7 @@ class TestEnterpriesCustomerCourseEnrollments(BaseTestEnterpriseAPIViews):
                     payload.get('course_run_id'),
                     payload.get('course_mode'),
                     cohort=payload.get('cohort'),
+                    enterprise_uuid=str(enterprise_customer.uuid)
                 )
         elif 'user_email' in payload and payload.get('is_active', True):
             # If a new user given via for user_email, check that the appropriate objects were created.

--- a/tests/test_enterprise/api_client/test_lms.py
+++ b/tests/test_enterprise/api_client/test_lms.py
@@ -89,7 +89,8 @@ def test_enroll_user_in_course():
     course_details = {"course_id": course_id}
     mode = "audit"
     cohort = "masters"
-    expected_response = dict(user=user, course_details=course_details, mode=mode, cohort=cohort, is_active=True)
+    expected_response = dict(user=user, course_details=course_details, mode=mode, cohort=cohort, is_active=True,
+                             enterprise_uuid=None)
     responses.add(
         responses.POST,
         _url(

--- a/tests/test_enterprise/test_signals.py
+++ b/tests/test_enterprise/test_signals.py
@@ -171,7 +171,8 @@ class TestUserPostSaveSignalHandler(EmptyCacheMixin, unittest.TestCase):
         assert PendingEnrollment.objects.count() == 0
         assert EnterpriseCourseEnrollment.objects.count() == 1
         mock_course_enrollment.return_value.enroll_user_in_course.assert_called_once_with(
-            user.username, course_id, 'audit', cohort=u'test_cohort'
+            user.username, course_id, 'audit', cohort=u'test_cohort',
+            enterprise_uuid=str(pending_link.enterprise_customer.uuid)
         )
         mock_track_enrollment.assert_called_once_with('pending-admin-enrollment', user.id, course_id)
 

--- a/tests/test_enterprise/views/test_course_enrollment_view.py
+++ b/tests/test_enterprise/views/test_course_enrollment_view.py
@@ -1332,7 +1332,8 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
                 self.user.username,
                 course_id,
                 'audit',
-                cohort=cohort_name
+                cohort=cohort_name,
+                enterprise_uuid=str(enterprise_customer.uuid)
             )
             # Check EnterpriseCourseEnrollment Source
             enterprise_course_enrollment = EnterpriseCourseEnrollment.objects.get(


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
