### PR TITLE
fix: delete learner role for a single customer when ECU record is deleted or unlinked

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,9 +17,16 @@ Unreleased
 ----------
 * Nothing
 
-[3.27.2]
+
+[3.27.3]
 ---------
 * Adds flag to SAP Success Factors customer configuration to switch SAP endpoints for learner completion calls.
+
+[3.27.2]
+---------
+
+* Ensure deletion and unlinking of a ``EnterpriseCustomerUser`` record only deletes the ``enterprise_learner`` system-wide role for that
+  particular ``EnterpriseCustomerUser``, as opposed to all ``enterprise_learner`` roles associated with the user.
 
 [3.27.1]
 ---------

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.27.2"
+__version__ = "3.27.3"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/signals.py
+++ b/enterprise/signals.py
@@ -158,10 +158,9 @@ def assign_or_delete_enterprise_learner_role(sender, instance, **kwargs):     # 
         )
     elif not kwargs['created'] and not instance.linked:
         # EnterpriseCustomerUser record was updated but is not linked, so delete the enterprise_learner role
-        # TODO: ENT-3914 | Add `enterprise_customer=instance.enterprise_customer`,
-        # so that we delete a specific instance of a role assignment
         roles_api.delete_learner_role_assignment(
-            instance.user,
+            user=instance.user,
+            enterprise_customer=instance.enterprise_customer,
         )
 
 
@@ -173,10 +172,9 @@ def delete_enterprise_learner_role_assignment(sender, instance, **kwargs):     #
     if not instance.user:
         return
 
-    # TODO: ENT-3914 | Add `enterprise_customer=instance.enterprise_customer`,
-    # so that we delete a specific instance of a role assignment
     roles_api.delete_learner_role_assignment(
-        instance.user,
+        user=instance.user,
+        enterprise_customer=instance.enterprise_customer,
     )
 
 

--- a/tests/test_enterprise/test_signals.py
+++ b/tests/test_enterprise/test_signals.py
@@ -450,6 +450,9 @@ class TestEnterpriseLearnerRoleSignals(unittest.TestCase):
         self.enterprise_customer = EnterpriseCustomerFactory(
             name='Team Titans',
         )
+        self.second_enterprise_customer = EnterpriseCustomerFactory(
+            name='Duke',
+        )
         super().setUp()
 
     def test_assign_enterprise_learner_role_success(self):
@@ -599,6 +602,68 @@ class TestEnterpriseLearnerRoleSignals(unittest.TestCase):
             role=self.enterprise_learner_role
         )
         self.assertFalse(learner_role_assignment.exists())
+
+    def test_delete_single_enterprise_learner_role_assignment(self):
+        """
+        Test that when `EnterpriseCustomerUser` record is deleted, `delete_enterprise_learner_role_assignment`
+        also deletes the enterprise learner role assignment associated with the user's previously linked enterprise
+        customer. However. it should *not* delete the enterprise learner role assignment associated with other
+        enterprise customers.
+        """
+        # Create a new EnterpriseCustomerUser record.
+        EnterpriseCustomerUserFactory(
+            user_id=self.learner_user.id,
+            enterprise_customer=self.enterprise_customer,
+        )
+
+        # Create a EnterpriseCustomerUser record such that the user is linked to multiple enterprises.
+        EnterpriseCustomerUserFactory(
+            user_id=self.learner_user.id,
+            enterprise_customer=self.second_enterprise_customer,
+        )
+
+        enterprise_customer_user = EnterpriseCustomerUser.objects.filter(
+            user_id=self.learner_user.id
+        )
+        self.assertTrue(enterprise_customer_user.exists())
+
+        # Verify that a new learner role assignment is created for both linked enterprise customers.
+        learner_role_assignment = SystemWideEnterpriseUserRoleAssignment.objects.filter(
+            user=self.learner_user,
+            role=self.enterprise_learner_role,
+            enterprise_customer=self.enterprise_customer,
+        )
+        self.assertTrue(learner_role_assignment.exists())
+        second_learner_role_assignment = SystemWideEnterpriseUserRoleAssignment.objects.filter(
+            user=self.learner_user,
+            role=self.enterprise_learner_role,
+            enterprise_customer=self.second_enterprise_customer,
+        )
+        self.assertTrue(second_learner_role_assignment.exists())
+
+        # Delete EnterpriseCustomerUser record.
+        enterprise_customer_user.delete()
+
+        # Verify that enterprise_customer_user is deleted
+        enterprise_customer_user = EnterpriseCustomerUser.objects.filter(
+            user_id=self.learner_user.id
+        )
+        self.assertFalse(enterprise_customer_user.exists())
+
+        # Also verify that appropriate learner role assignment is deleted, but the other
+        # learner role assignment remains.
+        learner_role_assignment = SystemWideEnterpriseUserRoleAssignment.objects.filter(
+            user=self.learner_user,
+            role=self.enterprise_learner_role,
+            enterprise_customer=self.enterprise_customer,
+        )
+        self.assertFalse(learner_role_assignment.exists())
+        learner_role_assignment = SystemWideEnterpriseUserRoleAssignment.objects.filter(
+            user=self.learner_user,
+            role=self.enterprise_learner_role,
+            enterprise_customer=self.second_enterprise_customer,
+        )
+        self.assertTrue(learner_role_assignment.exists())
 
     def test_delete_enterprise_learner_role_assignment_no_role_assignment(self):
         """


### PR DESCRIPTION
**Description:**

ENT-4347

Prior to this change, when an `EnterpriseCustomerUser` is deleted or unlinked, their `enterprise_learner` system-wide roles are deleted for ALL enterprise customers. This PR ensures the `enterprise_learner` role only for the deleted/unlinked `EnterpriseCustomerUser` is removed.

**Testing Instructions**

1. Using two separate Enterprise Customers, create an `EnterpriseCustomerUser` record for each using the same user. This results in the user being linked to multiple enterprises at once, with 2 `enterprise_learner` system-wide roles.
2. Delete one of those `EnterpriseCustomerUser` records and verify that only the `enterprise_learner` system-wide role for the no longer existent `EnterpriseCustomerUser` was deleted.

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [x] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
