### PR TITLE
bug: fixing client to handle paginated responses from Blackboard

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,18 +18,21 @@ Unreleased
 * Nothing
 
 
+[3.27.4]
+--------
+* Add pagination handling to integrated channels Blackboard client
+
 [3.27.3]
----------
+--------
 * Adds flag to SAP Success Factors customer configuration to switch SAP endpoints for learner completion calls.
 
 [3.27.2]
----------
-
+--------
 * Ensure deletion and unlinking of a ``EnterpriseCustomerUser`` record only deletes the ``enterprise_learner`` system-wide role for that
   particular ``EnterpriseCustomerUser``, as opposed to all ``enterprise_learner`` roles associated with the user.
 
 [3.27.1]
----------
+--------
 * Updates bulk enrollment email template.
 
 [3.27.0]

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.27.3"
+__version__ = "3.27.4"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name


### PR DESCRIPTION
[Jira](https://openedx.atlassian.net/browse/ENT-4635)

**Background:**
Through some investigations of the API documentation, we discovered that BB does indeed paginate their responses. In testing with our local instance it seems like the default size for an instance is `200` but it is unclear if this is customizable by the customer, so to be safe all sizes should be taken into account. Before this PR, if the number of assignments within a course got too high, we would not be able to verify the existence of further assignments. This would trigger our gradebook column (Blackboard's representation of our assignments) creation process, which would fail with a unique key integrity error. As such all further grade reporting would fail to be reported. 

**Code Changes in this PR**
- The Blackboard client now checks for the existence of a `next page` within the API response
- The Blackboard client will request next pages from the customer's instance until it:
    -  a) finds the assignment gradebook column
    -  b) exhausts all pages from the API
    - c) hits the page limit (250)
- Unit tests that cover the pagination traversal

**What this PR does NOT do**
The [Jira](https://openedx.atlassian.net/browse/ENT-4635) ticket specifies that we have transmitted duplicate assignments as a result of the lack of pagination handling and thus all customer instances need to be sanitize of duplicate assessment reporting (as Canvas needed recently). Through testing I have determined that this is improbable as Blackboard, unlike Canvas, has unique key restraints on the gradebook columns making it impossible to retransmit assignments with the same `externalID`. Thus any deduplication work has been left out of this PR.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
