### PR TITLE
maint: removing cornerstone from scheduled content metadata job

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,10 @@ Unreleased
 * Nothing
 
 
+[3.27.5]
+--------
+* Removing CSOD Integrated Channel from the list of supported channels for the content metadata transmission task.
+
 [3.27.4]
 --------
 * Add pagination handling to integrated channels Blackboard client

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.27.4"
+__version__ = "3.27.5"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/integrated_channel/management/commands/__init__.py
+++ b/integrated_channels/integrated_channel/management/commands/__init__.py
@@ -37,6 +37,19 @@ ASSESSMENT_LEVEL_REPORTING_INTEGRATED_CHANNEL_CHOICES = OrderedDict([
     )
 ])
 
+# Since Cornerstone is following pull content model we don't need to include CSOD customers in a content metadata
+# transmission job
+CONTENT_METADATA_JOB_INTEGRATED_CHANNEL_CHOICES = OrderedDict([
+    (integrated_channel_class.channel_code(), integrated_channel_class)
+    for integrated_channel_class in (
+        BlackboardEnterpriseCustomerConfiguration,
+        CanvasEnterpriseCustomerConfiguration,
+        DegreedEnterpriseCustomerConfiguration,
+        MoodleEnterpriseCustomerConfiguration,
+        SAPSuccessFactorsEnterpriseCustomerConfiguration,
+    )
+])
+
 
 class IntegratedChannelCommandMixin:
     """
@@ -74,9 +87,11 @@ class IntegratedChannelCommandMixin:
         See ``add_arguments`` for the accepted options.
         """
         assessment_level_support = options.get('assessment_level_support', False)
+        content_metadata_job_support = options.get('content_metadata_job_support', False)
         channel_classes = self.get_channel_classes(
             options.get('channel'),
             assessment_level_support=assessment_level_support,
+            content_metadata_job_support=content_metadata_job_support,
         )
         filter_kwargs = {
             'active': True,
@@ -108,7 +123,7 @@ class IntegratedChannelCommandMixin:
             ) from no_customer_exception
 
     @staticmethod
-    def get_channel_classes(channel_code, assessment_level_support=False):
+    def get_channel_classes(channel_code, assessment_level_support=False, content_metadata_job_support=False):
         """
         Assemble a list of integrated channel classes to transmit to.
 
@@ -118,6 +133,8 @@ class IntegratedChannelCommandMixin:
         """
         if assessment_level_support:
             channel_choices = ASSESSMENT_LEVEL_REPORTING_INTEGRATED_CHANNEL_CHOICES
+        elif content_metadata_job_support:
+            channel_choices = CONTENT_METADATA_JOB_INTEGRATED_CHANNEL_CHOICES
         else:
             channel_choices = INTEGRATED_CHANNEL_CHOICES
 

--- a/integrated_channels/integrated_channel/management/commands/transmit_content_metadata.py
+++ b/integrated_channels/integrated_channel/management/commands/transmit_content_metadata.py
@@ -38,6 +38,7 @@ class Command(IntegratedChannelCommandMixin, BaseCommand):
         Transmit the courseware data for the EnterpriseCustomer(s) to the active integration channels.
         """
         username = options['catalog_user']
+        options['content_metadata_job_support'] = True
 
         # Before we do a whole bunch of database queries, make sure that the user we were passed exists.
         try:

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -51,6 +51,7 @@ from integrated_channels.degreed.models import DegreedEnterpriseCustomerConfigur
 from integrated_channels.integrated_channel.exporters.learner_data import LearnerExporter
 from integrated_channels.integrated_channel.management.commands import (
     ASSESSMENT_LEVEL_REPORTING_INTEGRATED_CHANNEL_CHOICES,
+    CONTENT_METADATA_JOB_INTEGRATED_CHANNEL_CHOICES,
     INTEGRATED_CHANNEL_CHOICES,
     IntegratedChannelCommandMixin,
 )
@@ -115,6 +116,17 @@ class TestIntegratedChannelCommandMixin(unittest.TestCase):
         assert IntegratedChannelCommandMixin.get_channel_classes(
             channel,
             assessment_level_support=True,
+        ) == [channel_class]
+
+    def test_get_content_metadata_transmission_job_supported_channels(self):
+        """
+        Only retrieve channels that support the scheduled content metadata job.
+        """
+        channel = set(CONTENT_METADATA_JOB_INTEGRATED_CHANNEL_CHOICES).pop()
+        channel_class = CONTENT_METADATA_JOB_INTEGRATED_CHANNEL_CHOICES[channel]
+        assert IntegratedChannelCommandMixin.get_channel_classes(
+            channel,
+            content_metadata_job_support=True,
         ) == [channel_class]
 
 


### PR DESCRIPTION
[Jira](https://openedx.atlassian.net/browse/ENT-4643)

Background:
Because Cornerstone is following a pull content model, the overridden transmission essentially is a NOOP whenever a scheduled job tries to export and transmit data for CSOD customers. It does still query our enterprise catalog service constant and in an effort to mitigate that, this PR removes CSOD from the available channels in the scheduled transmission job.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
