### PR TITLE
feat: check for and only show enabled IDPs in Django Admin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,9 @@ Unreleased
 ----------
 * Nothing
 
+[3.27.5]
+--------
+* Filter available IDPs for Enterprise Customers by new boolean flag on ProviderConfig model.
 
 [3.27.4]
 --------

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.27.4"
+__version__ = "3.27.5"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -257,14 +257,6 @@ def get_identity_provider(provider_id):
         Instance of ProviderConfig or None.
     """
     try:
-        # pylint: disable=redefined-outer-name,import-outside-toplevel
-        from common.djangoapps.third_party_auth.provider import Registry
-    except ImportError as exception:
-        LOGGER.warning("Could not import Registry from common.djangoapps.third_party_auth.provider")
-        LOGGER.warning(exception)
-        Registry = None  # pylint: disable=redefined-outer-name
-
-    try:
         return Registry and Registry.get(provider_id)
     except ValueError:
         return None
@@ -277,17 +269,10 @@ def get_idp_choices():
     Return:
         A list of choices of all identity providers, None if it can not get any available identity provider.
     """
-    try:
-        # pylint: disable=redefined-outer-name,import-outside-toplevel
-        from common.djangoapps.third_party_auth.provider import Registry
-    except ImportError as exception:
-        LOGGER.warning("Could not import Registry from common.djangoapps.third_party_auth.provider")
-        LOGGER.warning(exception)
-        Registry = None  # pylint: disable=redefined-outer-name
 
     first = [("", "-" * 7)]
     if Registry:
-        return first + [(idp.provider_id, idp.name) for idp in Registry.enabled()]
+        return first + [(idp.provider_id, idp.name) for idp in Registry.enabled() if not idp.disable_for_enterprise_sso]
     return None
 
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -5,6 +5,7 @@ Tests for the `edx-enterprise` utility functions.
 
 import datetime
 import unittest
+from collections import namedtuple
 
 import ddt
 import mock
@@ -1709,6 +1710,15 @@ class TestEnterpriseUtils(unittest.TestCase):
         ``get_active_course_runs`` returns active course runs of given course's course runs.
         """
         assert utils.get_active_course_runs(course, users_all_enrolled_courses) == expected_course_run
+
+    @mock.patch('enterprise.utils.Registry')
+    def test_get_idp_choices(self, mock_registry):
+        Provider = namedtuple('SAMLProvider', 'provider_id, name, disable_for_enterprise_sso')
+        enabled_provider = Provider('12345', 'google', False)
+        disabled_provider = Provider('333333', 'facebook', True)
+
+        mock_registry.enabled.return_value = [enabled_provider, disabled_provider]
+        assert utils.get_idp_choices() == [("", "-" * 7)] + [(enabled_provider.provider_id, enabled_provider.name)]
 
 
 @mark.django_db


### PR DESCRIPTION
## Background
We want to ensure only certain IDPs are selectable for enterprise customers. The particular location we want to change is the Django Admin Enterprise Customer form where you can select an Identity Provider.
With the changes in this PR, if an IDP is disabled for use in enterprise, it will not be visible in the dropdown.

## Code Changes
- Adds conditional logic to the `get_idp_choices` method to utilize the new flag on the ProviderConfig model.
- Adds a test to actually test this method (it _kind_ of exists in the `test_forms` file, but not really testing the logic of the method).

## Testing Instructions
- In order to test this you need the branch for PR https://github.com/edx/edx-platform/pull/28261 locally
- Apply the migration from that PR
- Pick or make a provider (search for `Provider Configuration` in Django Admin and you'll find the 3 types under Third Party Auth. Pick any type, add or modify a provider) and check the box for "Disabled for Enterprise TPA" on the provider form.
- Verify this provider is not in the list of selectable providers in the Identity Provider section of an Enterprise Customer's details screen.
- Turn the setting back off and verify the provider _is_ selectable.

## Screenshots
### Provider Config Admin Form
![Screen Shot 2021-07-23 at 11 32 04 AM](https://user-images.githubusercontent.com/66267747/126805743-2fc0cf6a-0109-4338-ab19-fa498b1ff566.png)
### Enterprise IDP Selection
![Screen Shot 2021-07-23 at 11 32 26 AM](https://user-images.githubusercontent.com/66267747/126805753-b02a9616-be18-48c3-851c-60f265d2af21.png)

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
