### PR TITLE
feat: emails in a celery task, for calls to `EnterpriseCustomer#notify_enrolled_learners()`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.27.10]
+--------
+* Use celery tasks for emails sent using EnterpriseCustomer#notify_enrolled_learners method
+
 [3.27.9]
 --------
 * Fix SAP Course Completion payload format again.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ Unreleased
 * Nothing
 
 [3.27.10]
---------
+---------
 * Use celery tasks for emails sent using EnterpriseCustomer's notify_enrolled_learners method
 
 [3.27.9]

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,7 +19,7 @@ Unreleased
 
 [3.27.10]
 --------
-* Use celery tasks for emails sent using EnterpriseCustomer#notify_enrolled_learners method
+* Use celery tasks for emails sent using EnterpriseCustomer's notify_enrolled_learners method
 
 [3.27.9]
 --------

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.27.9"
+__version__ = "3.27.10"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -320,10 +320,10 @@ class EnterpriseCustomerViewSet(EnterpriseReadWriteModelViewSet):
                 track_enrollment(PATHWAY_CUSTOMER_ADMIN_ENROLLMENT, request.user.id, course_run)
                 if serializer.validated_data.get('notify'):
                     email_items = enterprise_customer.prepare_notification_content(
-                        catalog_api_user=request.user,
-                        course_id=course_run,
-                        users=pending_users | existing_users,
-                        admin_enrollment=True,
+                        request.user,
+                        course_run,
+                        pending_users | existing_users,
+                        True,
                     )
                     notify_enrolled_learners.delay(enterprise_customer.uuid, True, email_items)
 

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -3,7 +3,6 @@
 Views for enterprise api version 1 endpoint.
 """
 
-from enterprise.tasks import notify_enrolled_learners
 from logging import getLogger
 from smtplib import SMTPException
 
@@ -58,6 +57,7 @@ from enterprise.api.v1.permissions import IsInEnterpriseGroup
 from enterprise.api_client.lms import EnrollmentApiClient
 from enterprise.constants import COURSE_KEY_URL_PATTERN, PATHWAY_CUSTOMER_ADMIN_ENROLLMENT
 from enterprise.errors import AdminNotificationAPIRequestError, CodesAPIRequestError
+from enterprise.tasks import notify_enrolled_learners
 from enterprise.utils import (
     NotConnectedToOpenEdX,
     enroll_licensed_users_in_courses,

--- a/enterprise/api_client/lms.py
+++ b/enterprise/api_client/lms.py
@@ -3,7 +3,6 @@
 Utilities to get details from the course catalog API.
 """
 
-import datetime
 import logging
 from functools import wraps
 from time import time
@@ -15,7 +14,6 @@ from slumber.exceptions import HttpNotFoundError, SlumberBaseException
 from slumber.utils import copy_kwargs, url_join
 
 from django.conf import settings
-from django.utils import timezone
 
 from enterprise.constants import COURSE_MODE_SORT_ORDER, EXCLUDED_COURSE_MODES
 from enterprise.utils import NotConnectedToOpenEdX, get_enterprise_worker_user

--- a/enterprise/api_client/lms.py
+++ b/enterprise/api_client/lms.py
@@ -32,8 +32,6 @@ except ImportError:
 
 
 LOGGER = logging.getLogger(__name__)
-LMS_API_DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
-LMS_API_DATETIME_FORMAT_WITHOUT_TIMEZONE = '%Y-%m-%dT%H:%M:%S'
 
 
 class NoAuthenticationLmsApiClient:
@@ -588,28 +586,3 @@ class NoAuthLMSClient(NoAuthenticationLmsApiClient):
             dict: Response containing LMS service health.
         """
         return self.client.heartbeat.get()
-
-
-def parse_lms_api_datetime(datetime_string, datetime_format=LMS_API_DATETIME_FORMAT):
-    """
-    Parse a received datetime into a timezone-aware, Python datetime object.
-
-    Arguments:
-        datetime_string: A string to be parsed.
-        datetime_format: A datetime format string to be used for parsing
-
-    """
-    if isinstance(datetime_string, datetime.datetime):
-        date_time = datetime_string
-    else:
-        try:
-            date_time = datetime.datetime.strptime(datetime_string, datetime_format)
-        except ValueError:
-            date_time = datetime.datetime.strptime(datetime_string, LMS_API_DATETIME_FORMAT_WITHOUT_TIMEZONE)
-
-    # If the datetime format didn't include a timezone, then set to UTC.
-    # Note that if we're using the default LMS_API_DATETIME_FORMAT, it ends in 'Z',
-    # which denotes UTC for ISO-8661.
-    if date_time.tzinfo is None:
-        date_time = date_time.replace(tzinfo=timezone.utc)
-    return date_time

--- a/enterprise/constants.py
+++ b/enterprise/constants.py
@@ -173,3 +173,6 @@ AVAILABLE_LANGUAGES = [
     ('en', u'English'),
     ('es-419', u'Español (Latinoamérica)'),  # Spanish (Latin America)
 ]
+
+LMS_API_DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
+LMS_API_DATETIME_FORMAT_WITHOUT_TIMEZONE = '%Y-%m-%dT%H:%M:%S'

--- a/enterprise/management/commands/email_drip_for_missing_dsc_records.py
+++ b/enterprise/management/commands/email_drip_for_missing_dsc_records.py
@@ -14,9 +14,8 @@ from django.urls import reverse
 from consent.models import DataSharingConsent, ProxyDataSharingConsent
 from enterprise import utils
 from enterprise.api_client.discovery import CourseCatalogApiClient
-from enterprise.api_client.lms import parse_lms_api_datetime
 from enterprise.models import EnterpriseCourseEnrollment
-from enterprise.utils import get_configuration_value
+from enterprise.utils import get_configuration_value, parse_lms_api_datetime
 
 try:
     from openedx.features.enterprise_support.utils import is_course_accessed

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -61,7 +61,6 @@ from enterprise.utils import (
     CourseEnrollmentDowngradeError,
     CourseEnrollmentPermissionError,
     NotConnectedToOpenEdX,
-    create_dict_from_user,
     get_configuration_value,
     get_ecommerce_worker_user,
     get_enterprise_worker_user,
@@ -685,7 +684,7 @@ class EnterpriseCustomer(TimeStampedModel):
                 ugettext("Course details were not found for course key {} - Course Catalog API returned nothing. "
                          "Proceeding with enrollment, but notifications won't be sent").format(course_id)
             )
-            return
+            return []
 
         dashboard_url = None
         course_name = course_details.get('title')

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -26,7 +26,6 @@ from django.apps import apps
 from django.conf import settings
 from django.contrib import auth
 from django.contrib.sites.models import Site
-from django.core import mail
 from django.core.exceptions import NON_FIELD_ERRORS, ObjectDoesNotExist, ValidationError
 from django.core.files.storage import default_storage
 from django.core.validators import MaxValueValidator, MinValueValidator
@@ -36,18 +35,17 @@ from django.urls import reverse
 from django.utils import timezone
 from django.utils.encoding import force_bytes, force_text, python_2_unicode_compatible
 from django.utils.functional import cached_property, lazy
-from django.utils.http import urlencode, urlquote
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ugettext, ugettext_lazy as _
 
 from model_utils.models import TimeStampedModel
+from enterprise.tasks import send_enterprise_email_notification
 
 from enterprise import utils
 from enterprise.api_client.discovery import CourseCatalogApiClient, get_course_catalog_api_service_client
 from enterprise.api_client.ecommerce import EcommerceApiClient
 from enterprise.api_client.enterprise_catalog import EnterpriseCatalogApiClient
-from enterprise.api_client.lms import EnrollmentApiClient, ThirdPartyAuthApiClient, parse_lms_api_datetime
+from enterprise.api_client.lms import EnrollmentApiClient, ThirdPartyAuthApiClient
 from enterprise.constants import (
     ALL_ACCESS_CONTEXT,
     AVAILABLE_LANGUAGES,
@@ -66,6 +64,8 @@ from enterprise.utils import (
     get_enterprise_worker_user,
     get_platform_logo_url,
     get_user_valid_idp,
+    send_email_notification_message,
+    serialize_notification_content,
     track_enrollment,
 )
 from enterprise.validators import (
@@ -657,100 +657,6 @@ class EnterpriseCustomer(TimeStampedModel):
         else:
             PendingEnrollment.objects.filter(user=pending_ecu, course_id__in=course_ids).delete()
 
-    def prepare_notification_content(self, catalog_api_user, course_id, users, admin_enrollment=False):
-        """
-        Prepare serializable contents to send emails with (if using tasks to send emails)
-
-        Returns: A list of dictionary objects that are of the form:
-          {
-              "user": user
-                "enrolled_in": {
-                    'name': course_name,
-                    'url': destination_url,
-                    'type': 'course',
-                    'start': course_start,
-                },
-                "dashboard_url": dashboard_url,
-                "enterprise_customer_uuid": self.uuid,
-                "admin_enrollment": admin_enrollment,
-          }
-          where user is one of
-              - 1: { 'first_name': name, 'username': user_name, 'email': email } (similar to a User object)
-              - 2: { 'user_email' : user_email } (similar to a PendingEnterpriseCustomerUser object)
-        """
-        course_details = CourseCatalogApiClient(catalog_api_user, self.site).get_course_run(course_id)
-        if not course_details:
-            LOGGER.warning(
-                ugettext("Course details were not found for course key {} - Course Catalog API returned nothing. "
-                         "Proceeding with enrollment, but notifications won't be sent").format(course_id)
-            )
-            return []
-
-        dashboard_url = None
-        course_name = course_details.get('title')
-        if admin_enrollment:
-            course_path = 'course/{course_id}'.format(course_id=course_id)
-            dashboard_url = utils.get_configuration_value_for_site(
-                self.site,
-                'ENTERPRISE_LEARNER_PORTAL_BASE_URL',
-                settings.ENTERPRISE_LEARNER_PORTAL_BASE_URL
-            )
-            destination_url = '{site}/{login_or_register}?next=/{slug}/{course_path}'.format(
-                site=dashboard_url,
-                login_or_register='{login_or_register}',  # We don't know the value at this time
-                slug=self.slug,
-                course_path=course_path
-            )
-        else:
-            course_path = '/courses/{course_id}/course'.format(course_id=course_id)
-            params = {}
-            # add tap_hint if there is only one IdP attached with enterprise_customer
-            if self.has_single_idp:
-                params = {'tpa_hint': self.identity_providers.first().provider_id}
-
-            elif self.has_multiple_idps and self.default_provider_idp:
-                params = {'tpa_hint': self.default_provider_idp.provider_id}
-            course_path = urlquote("{}?{}".format(course_path, urlencode(params)))
-
-            lms_root_url = utils.get_configuration_value_for_site(
-                self.site,
-                'LMS_ROOT_URL',
-                settings.LMS_ROOT_URL
-            )
-            destination_url = '{site}/{login_or_register}?next={course_path}'.format(
-                site=lms_root_url,
-                login_or_register='{login_or_register}',  # We don't know the value at this time
-                course_path=course_path
-            )
-
-        try:
-            course_start = parse_lms_api_datetime(course_details.get('start'))
-        except (TypeError, ValueError):
-            course_start = None
-            LOGGER.exception(
-                'None or empty value passed as course start date.\nCourse Details:\n{course_details}'.format(
-                    course_details=course_details,
-                )
-            )
-
-        email_items = []
-        for user in users:
-            login_or_register = 'register' if isinstance(user, PendingEnterpriseCustomerUser) else 'login'
-            destination_url = destination_url.format(login_or_register=login_or_register)
-            email_items.append({
-                "user": utils.create_dict_from_user(user),
-                "enrolled_in": {
-                    'name': course_name,
-                    'url': destination_url,
-                    'type': 'course',
-                    'start': course_start,
-                },
-                "dashboard_url": dashboard_url,
-                "enterprise_customer_uuid": self.uuid,
-                "admin_enrollment": admin_enrollment,
-            })
-        return email_items
-
     def notify_enrolled_learners(self, catalog_api_user, course_id, users, admin_enrollment=False):
         """
         Notify learners about a course in which they've been enrolled.
@@ -758,29 +664,25 @@ class EnterpriseCustomer(TimeStampedModel):
         Args:
             catalog_api_user: The user for calling the Catalog API
             course_id: The specific course the learners were enrolled in
-            users: An iterable of the users or pending users who were enrolled
+            users: An iterable of the users (or pending users) who were enrolled
             admin_enrollment: Default False. Set to true if using bulk enrollment, for example.
                 When true, we use the admin enrollment template instead.
         """
-        email_items = self.prepare_notification_content(
-            catalog_api_user,
+        course_details = CourseCatalogApiClient(catalog_api_user, self.site).get_course_run(course_id)
+        if not course_details:
+            LOGGER.warning(
+                ugettext("Course details were not found for course key {} - Course Catalog API returned nothing. "
+                         "Proceeding with enrollment, but notifications won't be sent").format(course_id)
+            )
+            return
+        email_items = serialize_notification_content(
+            self,
+            course_details,
             course_id,
             users,
             admin_enrollment,
         )
-        # the model cannot call the tasks/ notify_enrolled_learners()
-        # due to circular dep. Eventually all usages of `notify_enrolled_learners` should use
-        # the task instead of calling this method directly
-        with mail.get_connection() as email_conn:
-            for item in email_items:
-                utils.send_email_notification_message(
-                    item['user'],
-                    item['enrolled_in'],
-                    item['dashboard_url'],
-                    self.uuid,
-                    email_connection=email_conn,
-                    admin_enrollment=admin_enrollment,
-                )
+        send_enterprise_email_notification.delay(self.uuid, admin_enrollment, email_items)
 
 
 class EnterpriseCustomerUserManager(models.Manager):

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -36,10 +36,10 @@ from django.utils import timezone
 from django.utils.encoding import force_bytes, force_text, python_2_unicode_compatible
 from django.utils.functional import cached_property, lazy
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext, ugettext_lazy as _
+from django.utils.translation import ugettext
+from django.utils.translation import ugettext_lazy as _
 
 from model_utils.models import TimeStampedModel
-from enterprise.tasks import send_enterprise_email_notification
 
 from enterprise import utils
 from enterprise.api_client.discovery import CourseCatalogApiClient, get_course_catalog_api_service_client
@@ -53,6 +53,7 @@ from enterprise.constants import (
     DefaultColors,
     json_serialized_course_modes,
 )
+from enterprise.tasks import send_enterprise_email_notification
 from enterprise.utils import (
     ADMIN_ENROLL_EMAIL_TEMPLATE_TYPE,
     SELF_ENROLL_EMAIL_TEMPLATE_TYPE,

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -64,7 +64,6 @@ from enterprise.utils import (
     get_enterprise_worker_user,
     get_platform_logo_url,
     get_user_valid_idp,
-    send_email_notification_message,
     serialize_notification_content,
     track_enrollment,
 )

--- a/enterprise/tasks.py
+++ b/enterprise/tasks.py
@@ -3,7 +3,6 @@
 Django tasks.
 """
 
-from enterprise.utils import send_email_notification_message
 from logging import getLogger
 
 from celery import shared_task
@@ -12,6 +11,8 @@ from edx_django_utils.monitoring import set_code_owner_attribute
 from django.apps import apps
 from django.core import mail
 from django.db import IntegrityError
+
+from enterprise.utils import send_email_notification_message
 
 LOGGER = getLogger(__name__)
 

--- a/enterprise/tasks.py
+++ b/enterprise/tasks.py
@@ -106,6 +106,7 @@ def create_enterprise_enrollment(course_id, enterprise_customer_user_id):
 def enterprise_customer_user_model():
     """
     Returns the ``EnterpriseCustomerUser`` class.
+    This function is needed to avoid circular ref issues when model classes call tasks in this module.
     """
     return apps.get_model('enterprise', 'EnterpriseCustomerUser')  # pylint: disable=invalid-name
 
@@ -113,6 +114,7 @@ def enterprise_customer_user_model():
 def enterprise_course_enrollment_model():
     """
     Returns the ``EnterpriseCourseEnrollment`` class.
+    This function is needed to avoid circular ref issues when model classes call tasks in this module.
     """
     return apps.get_model('enterprise', 'EnterpriseCourseEnrollment')  # pylint: disable=invalid-name
 
@@ -120,5 +122,6 @@ def enterprise_course_enrollment_model():
 def enterprise_enrollment_source_model():
     """
     Returns the ``EnterpriseEnrollmentSource`` class.
+    This function is needed to avoid circular ref issues when model classes call tasks in this module.
     """
     return apps.get_model('enterprise', 'EnterpriseEnrollmentSource')  # pylint: disable=invalid-name

--- a/enterprise/tasks.py
+++ b/enterprise/tasks.py
@@ -56,7 +56,7 @@ def create_enterprise_enrollment(course_id, enterprise_customer_user_id):
     """
     Create enterprise enrollment for user if course_id part of catalog for the ENT customer.
     """
-    enterprise_customer_user = enterprise_customer_model().objects.get(
+    enterprise_customer_user = enterprise_customer_user_model().objects.get(
         id=enterprise_customer_user_id
     )
     # Prevent duplicate records from being created if possible
@@ -103,11 +103,11 @@ def create_enterprise_enrollment(course_id, enterprise_customer_user_id):
             )
 
 
-def enterprise_customer_model():
+def enterprise_customer_user_model():
     """
-    Returns the ``EnterpriseCustomer`` class.
+    Returns the ``EnterpriseCustomerUser`` class.
     """
-    return apps.get_model('enterprise', 'EnterpriseCustomer')  # pylint: disable=invalid-name
+    return apps.get_model('enterprise', 'EnterpriseCustomerUser')  # pylint: disable=invalid-name
 
 
 def enterprise_course_enrollment_model():

--- a/enterprise/tasks.py
+++ b/enterprise/tasks.py
@@ -3,29 +3,28 @@
 Django tasks.
 """
 
+from enterprise.utils import send_email_notification_message
 from logging import getLogger
 
 from celery import shared_task
 from edx_django_utils.monitoring import set_code_owner_attribute
 
+from django.apps import apps
 from django.core import mail
 from django.db import IntegrityError
-
-from enterprise.models import EnterpriseCourseEnrollment, EnterpriseCustomerUser, EnterpriseEnrollmentSource
-from enterprise.utils import send_email_notification_message
 
 LOGGER = getLogger(__name__)
 
 
 @shared_task
 @set_code_owner_attribute
-def notify_enrolled_learners(
+def send_enterprise_email_notification(
     enterprise_customer_uuid,
     admin_enrollment,
     email_items,
 ):
     """
-    Send enrollment notifications to specified learners
+    Send enrollment email notifications to specified learners
 
     Arguments:
         * enterprise_customer_uuid (UUID)
@@ -56,12 +55,12 @@ def create_enterprise_enrollment(course_id, enterprise_customer_user_id):
     """
     Create enterprise enrollment for user if course_id part of catalog for the ENT customer.
     """
-    enterprise_customer_user = EnterpriseCustomerUser.objects.get(
+    enterprise_customer_user = enterprise_customer_model().objects.get(
         id=enterprise_customer_user_id
     )
     # Prevent duplicate records from being created if possible
     # before we need to make a call to discovery
-    if EnterpriseCourseEnrollment.objects.filter(
+    if enterprise_course_enrollment_model().objects.filter(
             enterprise_customer_user=enterprise_customer_user,
             course_id=course_id,
     ).exists():
@@ -87,11 +86,13 @@ def create_enterprise_enrollment(course_id, enterprise_customer_user_id):
         # we believe a Source of ENROLLMENT_TASK is more clear.
 
         try:
-            EnterpriseCourseEnrollment.objects.get_or_create(
+            enterprise_course_enrollment_model().objects.get_or_create(
                 course_id=course_id,
                 enterprise_customer_user=enterprise_customer_user,
                 defaults={
-                    'source': EnterpriseEnrollmentSource.get_source(EnterpriseEnrollmentSource.ENROLLMENT_TASK),
+                    'source': enterprise_enrollment_source_model().get_source(
+                        enterprise_enrollment_source_model().ENROLLMENT_TASK,
+                    ),
                 }
             )
         except IntegrityError:
@@ -99,3 +100,24 @@ def create_enterprise_enrollment(course_id, enterprise_customer_user_id):
                 "IntegrityError on attempt at EnterpriseCourseEnrollment for user with id [%s] "
                 "and course id [%s]", enterprise_customer_user.user_id, course_id,
             )
+
+
+def enterprise_customer_model():
+    """
+    Returns the ``EnterpriseCustomer`` class.
+    """
+    return apps.get_model('enterprise', 'EnterpriseCustomer')  # pylint: disable=invalid-name
+
+
+def enterprise_course_enrollment_model():
+    """
+    Returns the ``EnterpriseCourseEnrollment`` class.
+    """
+    return apps.get_model('enterprise', 'EnterpriseCourseEnrollment')  # pylint: disable=invalid-name
+
+
+def enterprise_enrollment_source_model():
+    """
+    Returns the ``EnterpriseEnrollmentSource`` class.
+    """
+    return apps.get_model('enterprise', 'EnterpriseEnrollmentSource')  # pylint: disable=invalid-name

--- a/enterprise/tasks.py
+++ b/enterprise/tasks.py
@@ -28,14 +28,13 @@ def notify_enrolled_learners(
     Send enrollment notifications to specified learners
 
     Arguments:
-        * email_items: list of dictionary objects with fields:
+        * enterprise_customer_uuid (UUID)
+        * admin_enrollment=False : If True, this indicates admin based enrollment (e.g., bulk enrollment)
         *
-        *   enterprise_customer_uuid (string)
-        *   course_id (string)
-        *   user (dict) : one of the formats:
-              - 1: { 'first_name': name, 'username': user_name, 'email': email } (similar to a User object)
-              - 2: { 'user_email' : user_email } (similar to a PendingEnterpriseCustomerUser object)
-        *   admin_enrollment=False : If True, this indicates admin based enrollment (e.g., bulk enrollment)
+        * email_items: list of dictionary objects with keys:
+        *   user (dict)
+        *   enrolled_in (dict): name and optionally other keys needed by templates
+        *   dashboard_url (str)
     """
     with mail.get_connection() as email_conn:
         for item in email_items:

--- a/enterprise/tasks.py
+++ b/enterprise/tasks.py
@@ -32,7 +32,9 @@ def notify_enrolled_learners(
         * admin_enrollment=False : If True, this indicates admin based enrollment (e.g., bulk enrollment)
         *
         * email_items: list of dictionary objects with keys:
-        *   user (dict)
+        *   user (dict): a dict with either of the following forms:
+              - 1: { 'first_name': name, 'username': user_name, 'email': email } (similar to a User object)
+              - 2: { 'user_email' : user_email } (similar to a PendingEnterpriseCustomerUser object)
         *   enrolled_in (dict): name and optionally other keys needed by templates
         *   dashboard_url (str)
     """

--- a/enterprise/tasks.py
+++ b/enterprise/tasks.py
@@ -3,20 +3,16 @@
 Django tasks.
 """
 
-from django.core import mail
-from enterprise.utils import send_email_notification_message
 from logging import getLogger
 
 from celery import shared_task
 from edx_django_utils.monitoring import set_code_owner_attribute
 
+from django.core import mail
 from django.db import IntegrityError
 
-from enterprise.models import (
-    EnterpriseCourseEnrollment,
-    EnterpriseCustomerUser,
-    EnterpriseEnrollmentSource,
-)
+from enterprise.models import EnterpriseCourseEnrollment, EnterpriseCustomerUser, EnterpriseEnrollmentSource
+from enterprise.utils import send_email_notification_message
 
 LOGGER = getLogger(__name__)
 

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -30,6 +30,7 @@ from django.forms.models import model_to_dict
 from django.http import Http404
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
+from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 from django.utils.html import format_html
 from django.utils.http import urlencode, urlquote

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -26,11 +26,13 @@ from django.core import mail
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.core.validators import validate_email
 from django.db import utils
+from django.forms.models import model_to_dict
 from django.http import Http404
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.utils.dateparse import parse_datetime
 from django.utils.html import format_html
+from django.utils.http import urlencode, urlquote
 from django.utils.text import slugify
 from django.utils.translation import ugettext as _
 from django.utils.translation import ungettext
@@ -38,6 +40,8 @@ from django.utils.translation import ungettext
 from enterprise.constants import (
     ALLOWED_TAGS,
     DEFAULT_CATALOG_CONTENT_FILTER,
+    LMS_API_DATETIME_FORMAT,
+    LMS_API_DATETIME_FORMAT_WITHOUT_TIMEZONE,
     PATHWAY_CUSTOMER_ADMIN_ENROLLMENT,
     PROGRAM_TYPE_DESCRIPTION,
     CourseModes,
@@ -455,23 +459,104 @@ def find_enroll_email_template(enterprise_customer, template_type):
     return enterprise_template_config
 
 
-def create_dict_from_user(user):
+def serialize_notification_content(
+    enterprise_customer,
+    course_details,
+    course_id,
+    users,
+    admin_enrollment=False,
+):
     """
-    Returns one of the following based on the type of user object:
-        - 1: { 'first_name': name, 'username': user_name, 'email': email } (if User object)
-        - 2: { 'user_email' : user_email } (if PendingEnterpriseCustomerUser object)
+    Prepare serializable contents to send emails with (if using tasks to send emails)
+
+    Arguments:
+    * enterprise_customer (enterprise.models.EnterpriseCustomer)
+    * course_details (dict): With at least 'title' and 'start' keys (usually obtained via CourseCatalogApiClient)
+    * course_id (str)
+    * users (list): list of users to enroll (each user should be a User or PendingEnterpriseCustomerUser)
+
+    Returns: A list of dictionary objects that are of the form:
+      {
+        "user": user
+        "enrolled_in": {
+            'name': course_name,
+            'url': destination_url,
+            'type': 'course',
+            'start': course_start,
+        },
+        "dashboard_url": dashboard_url,
+        "enterprise_customer_uuid": self.uuid,
+        "admin_enrollment": admin_enrollment,
+      }
+      where user is one of
+          - 1: { 'first_name': name, 'username': user_name, 'email': email } (dict of User object)
+          - 2: { 'user_email' : user_email } (dict of PendingEnterpriseCustomerUser object)
     """
-    if hasattr(user, 'first_name') and hasattr(user, 'username'):
-        return {
-            'first_name': user.first_name,
-            'username': user.username,
-            'email': user.email,
-        }
-    if hasattr(user, 'user_email'):
-        return {
-            'user_email': user.user_email
-        }
-    raise TypeError("Invalid object, need either User or PendingEnterpriseCustomerUser type object")
+    dashboard_url = None
+    course_name = course_details.get('title')
+    if admin_enrollment:
+        course_path = 'course/{course_id}'.format(course_id=course_id)
+        dashboard_url = get_configuration_value_for_site(
+            enterprise_customer.site,
+            'ENTERPRISE_LEARNER_PORTAL_BASE_URL',
+            settings.ENTERPRISE_LEARNER_PORTAL_BASE_URL
+        )
+        destination_url = '{site}/{login_or_register}?next=/{slug}/{course_path}'.format(
+            site=dashboard_url,
+            login_or_register='{login_or_register}',  # We don't know the value at this time
+            slug=enterprise_customer.slug,
+            course_path=course_path
+        )
+    else:
+        course_path = '/courses/{course_id}/course'.format(course_id=course_id)
+        params = {}
+        # add tap_hint if there is only one IdP attached with enterprise_customer
+        if enterprise_customer.has_single_idp:
+            params = {'tpa_hint': enterprise_customer.identity_providers.first().provider_id}
+
+        elif enterprise_customer.has_multiple_idps and enterprise_customer.default_provider_idp:
+            params = {'tpa_hint': enterprise_customer.default_provider_idp.provider_id}
+        course_path = urlquote("{}?{}".format(course_path, urlencode(params)))
+
+        lms_root_url = get_configuration_value_for_site(
+            enterprise_customer.site,
+            'LMS_ROOT_URL',
+            settings.LMS_ROOT_URL
+        )
+        destination_url = '{site}/{login_or_register}?next={course_path}'.format(
+            site=lms_root_url,
+            login_or_register='{login_or_register}',  # We don't know the value at this time
+            course_path=course_path
+        )
+
+    try:
+        course_start = parse_lms_api_datetime(course_details.get('start'))
+    except (TypeError, ValueError):
+        course_start = None
+        LOGGER.exception(
+            'None or empty value passed as course start date.\nCourse Details:\n{course_details}'.format(
+                course_details=course_details,
+            )
+        )
+
+    email_items = []
+    for user in users:
+        is_pending_user = hasattr(user, 'user_email') and not hasattr(user, 'first_name')
+        login_or_register = 'register' if is_pending_user else 'login'
+        destination_url = destination_url.format(login_or_register=login_or_register)
+        email_items.append({
+            "user": model_to_dict(user),
+            "enrolled_in": {
+                'name': course_name,
+                'url': destination_url,
+                'type': 'course',
+                'start': course_start,
+            },
+            "dashboard_url": dashboard_url,
+            "enterprise_customer_uuid": enterprise_customer.uuid,
+            "admin_enrollment": admin_enrollment,
+        })
+    return email_items
 
 
 def send_email_notification_message(
@@ -1983,3 +2068,28 @@ def get_best_mode_from_course_key(course_key):
         else CourseModes.AUDIT
 
     return best_course_mode
+
+
+def parse_lms_api_datetime(datetime_string, datetime_format=LMS_API_DATETIME_FORMAT):
+    """
+    Parse a received datetime into a timezone-aware, Python datetime object.
+
+    Arguments:
+        datetime_string: A string to be parsed.
+        datetime_format: A datetime format string to be used for parsing
+
+    """
+    if isinstance(datetime_string, datetime.datetime):
+        date_time = datetime_string
+    else:
+        try:
+            date_time = datetime.datetime.strptime(datetime_string, datetime_format)
+        except ValueError:
+            date_time = datetime.datetime.strptime(datetime_string, LMS_API_DATETIME_FORMAT_WITHOUT_TIMEZONE)
+
+    # If the datetime format didn't include a timezone, then set to UTC.
+    # Note that if we're using the default LMS_API_DATETIME_FORMAT, it ends in 'Z',
+    # which denotes UTC for ISO-8661.
+    if date_time.tzinfo is None:
+        date_time = date_time.replace(tzinfo=timezone.utc)
+    return date_time

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -461,15 +461,15 @@ def create_dict_from_user(user):
         - 1: { 'first_name': name, 'username': user_name, 'email': email } (if User object)
         - 2: { 'user_email' : user_email } (if PendingEnterpriseCustomerUser object)
     """
-    if 'first_name' in user and 'username' in user:
+    if hasattr(user, 'first_name') and hasattr(user, 'username'):
         return {
-            'first_name': user['first_name'],
-            'username': user['username'],
-            'email': user['email'],
+            'first_name': user.first_name,
+            'username': user.username,
+            'email': user.email,
         }
-    elif 'user_email' in user:
+    if hasattr(user, 'user_email'):
         return {
-            'user_email': user['user_email']
+            'user_email': user.user_email
         }
     raise TypeError("Invalid object, need either User or PendingEnterpriseCustomerUser type object")
 

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -33,7 +33,7 @@ from django.urls import reverse
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 from django.utils.html import format_html
-from django.utils.http import urlencode, urlquote
+from django.utils.http import urlquote
 from django.utils.text import slugify
 from django.utils.translation import ugettext as _
 from django.utils.translation import ungettext

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -546,7 +546,7 @@ def serialize_notification_content(
         login_or_register = 'register' if is_pending_user else 'login'
         destination_url = destination_url.format(login_or_register=login_or_register)
         email_items.append({
-            "user": model_to_dict(user),
+            "user": model_to_dict(user, fields=['first_name', 'username', 'user_email', 'email']),
             "enrolled_in": {
                 'name': course_name,
                 'url': destination_url,

--- a/integrated_channels/sap_success_factors/exporters/content_metadata.py
+++ b/integrated_channels/sap_success_factors/exporters/content_metadata.py
@@ -7,8 +7,7 @@ from logging import getLogger
 
 from django.utils.translation import ugettext_lazy as _
 
-from enterprise.api_client.lms import parse_lms_api_datetime
-from enterprise.utils import get_closest_course_run, is_course_run_available_for_enrollment
+from enterprise.utils import get_closest_course_run, is_course_run_available_for_enrollment, parse_lms_api_datetime
 from enterprise.views import CourseEnrollmentView
 from integrated_channels.integrated_channel.exporters.content_metadata import ContentMetadataExporter
 from integrated_channels.sap_success_factors.exporters.utils import transform_language_code

--- a/integrated_channels/utils.py
+++ b/integrated_channels/utils.py
@@ -16,7 +16,7 @@ from six.moves import range
 from django.utils import timezone
 from django.utils.html import strip_tags
 
-from enterprise.api_client.lms import parse_lms_api_datetime
+from enterprise.utils import parse_lms_api_datetime
 
 UNIX_EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
 UNIX_MIN_DATE_STRING = '1970-01-01T00:00:00Z'

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -3590,7 +3590,7 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
             )
         mock_calls = [_make_call(course_run, unique_ent_customer_users) for course_run in unique_course_keys]
 
-        mock_notify_task.assert_has_calls(mock_calls)
+        mock_notify_task.assert_has_calls(mock_calls, any_order=True)
 
     @mock.patch('enterprise.api.v1.views.enroll_licensed_users_in_courses')
     @mock.patch('enterprise.api.v1.views.get_best_mode_from_course_key')

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -27,7 +27,6 @@ from six.moves.urllib.parse import (  # pylint: disable=import-error,ungrouped-i
 
 from django.conf import settings
 from django.contrib.auth.models import Permission
-from django.db import IntegrityError
 from django.test import override_settings
 from django.utils import timezone
 
@@ -3476,8 +3475,8 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
 
         # verify notification sent correctly for each course to applicable learners
         if 'notify' in body:
-            unique_course_keys = set([item['course_run_key'] for item in body['licenses_info']])
-            unique_learners = set([item['email'] for item in body['licenses_info']])
+            unique_course_keys = {item['course_run_key'] for item in body['licenses_info']}
+            unique_learners = {item['email'] for item in body['licenses_info']}
             unique_ent_customer_users = set()
             for learner in unique_learners:
                 try:

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -3536,8 +3536,8 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
     ):
         """
         Tests the bulk enrollment endpoint at enroll_learners_in_courses.
-        This test currently does not create any users so is testing the pending
-        enrollments case.
+        Explicitly checks that notification is invoked precisely once per course,
+        with the associated learners included
         """
         enterprise_customer = factories.EnterpriseCustomerFactory(
             uuid=FAKE_UUIDS[0],

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -3448,10 +3448,13 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
         This test currently does not create any users so is testing the pending
         enrollments case.
         """
-        factories.EnterpriseCustomerFactory(
+        ent_customer = factories.EnterpriseCustomerFactory(
             uuid=FAKE_UUIDS[0],
             name="test_enterprise"
         )
+
+        email_items = [{}]
+        mock_prepare_notification_content.return_value = email_items
 
         permission = Permission.objects.get(name='Can add Enterprise Customer')
         self.user.user_permissions.add(permission)
@@ -3477,7 +3480,11 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
 
         if 'notify' in body:
             mock_prepare_notification_content.assert_called_once()
-            mock_notify_enroll_learners_task.assert_called_once()
+            mock_notify_enroll_learners_task.assert_called_once_with(
+                uuid.UUID(FAKE_UUIDS[0]),
+                True,
+                email_items,
+            )
         else:
             mock_prepare_notification_content.assert_not_called()
             mock_notify_enroll_learners_task.assert_not_called()

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -3487,7 +3487,7 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
             )
         else:
             mock_prepare_notification.assert_not_called()
-            mock_notify_enroll_learners_task.assert_not_called()
+            mock_notify_task.assert_not_called()
 
     @mock.patch('enterprise.api.v1.views.enroll_licensed_users_in_courses')
     @mock.patch('enterprise.api.v1.views.get_best_mode_from_course_key')

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -3308,7 +3308,6 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
         {
             'body': {
                 'licenses_info': [{'email': 'abc@test.com', 'course_run_key': 'course-v1:edX+DemoX+Demo_Course'}]
-
             },
             'expected_code': 400,
             'expected_response': {
@@ -3339,8 +3338,7 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
                     'email': 'abc@test.com',
                     'course_run_key': 'course-v1:edX+DemoX+Demo_Course',
                     'license_uuid': '5a88bdcade7c4ecb838f8111b68e18ac'
-                }],
-                'notify': 'true',
+                }]
             },
             'expected_code': 202,
             'expected_response': {
@@ -3446,6 +3444,101 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
         This test currently does not create any users so is testing the pending
         enrollments case.
         """
+        factories.EnterpriseCustomerFactory(
+            uuid=FAKE_UUIDS[0],
+            name="test_enterprise"
+        )
+
+        permission = Permission.objects.get(name='Can add Enterprise Customer')
+        self.user.user_permissions.add(permission)
+        mock_get_course_mode.return_value = VERIFIED_SUBSCRIPTION_COURSE_MODE
+
+        self.assertEqual(len(PendingEnrollment.objects.all()), 0)
+        response = self.client.post(
+            settings.TEST_SERVER + ENTERPRISE_CUSTOMER_BULK_ENROLL_LEARNERS_IN_COURSES_ENDPOINT,
+            data=json.dumps(body),
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, expected_code)
+        if expected_response:
+            response_json = response.json()
+            self.assertEqual(expected_response, response_json)
+        self.assertEqual(len(PendingEnrollment.objects.all()), expected_num_pending_licenses)
+
+        if expected_events:
+            mock_track_enroll.assert_has_calls(expected_events[x] for x in range(len(expected_events) - 1))
+        else:
+            mock_track_enroll.assert_not_called()
+
+        # no notifications to be sent unless 'notify' specifically asked for in payload
+        mock_notify_task.assert_not_called()
+
+    @ddt.data(
+        {
+            'body': {
+                'notify': 'true',
+                'licenses_info': [
+                    {
+                        'email': 'abc@test.com',
+                        'course_run_key': 'course-v1:edX+DemoX+Demo_Course',
+                        'license_uuid': '5a88bdcade7c4ecb838f8111b68e18ac'
+                    },
+                    {
+                        'email': 'xyz@test.com',
+                        'course_run_key': 'course-v1:edX+DemoX+Demo_Course',
+                        'license_uuid': '2c58acdade7c4ede838f7111b42e18ac'
+                    },
+                    {
+                        'email': 'abc@test.com',
+                        'course_run_key': 'course-v2:edX+DemoX+Second_Demo_Course',
+                        'license_uuid': '5a88bdcade7c4ecb838f8111b68e18ac'
+                    },
+                    {
+                        'email': 'xyz@test.com',
+                        'course_run_key': 'course-v2:edX+DemoX+Second_Demo_Course',
+                        'license_uuid': '2c58acdade7c4ede838f7111b42e18ac'
+                    },
+                ]
+            },
+            'expected_code': 202,
+            'expected_response': {
+                'successes': [],
+                'pending': [
+                    {'email': 'abc@test.com', 'course_run_key': 'course-v1:edX+DemoX+Demo_Course'},
+                    {'email': 'xyz@test.com', 'course_run_key': 'course-v1:edX+DemoX+Demo_Course'},
+                    {'email': 'abc@test.com', 'course_run_key': 'course-v2:edX+DemoX+Second_Demo_Course'},
+                    {'email': 'xyz@test.com', 'course_run_key': 'course-v2:edX+DemoX+Second_Demo_Course'}
+                ],
+                'failures': []
+            },
+            'expected_num_pending_licenses': 4,
+            'expected_events': [
+                mock.call(PATHWAY_CUSTOMER_ADMIN_ENROLLMENT, 1, 'course-v1:edX+DemoX+Demo_Course'),
+                mock.call(PATHWAY_CUSTOMER_ADMIN_ENROLLMENT, 1, 'course-v2:edX+DemoX+Second_Demo_Course')
+            ],
+        },
+    )
+    @ddt.unpack
+    @mock.patch('enterprise.api.v1.views.get_best_mode_from_course_key')
+    @mock.patch('enterprise.api.v1.views.track_enrollment')
+    @mock.patch("enterprise.models.EnterpriseCustomer.notify_enrolled_learners")
+    # pylint: disable=unused-argument
+    def test_bulk_enrollment_with_notification(
+        self,
+        mock_notify_task,
+        mock_track_enroll,
+        mock_get_course_mode,
+        body,
+        expected_code,
+        expected_response,
+        expected_num_pending_licenses,
+        expected_events,
+    ):
+        """
+        Tests the bulk enrollment endpoint at enroll_learners_in_courses.
+        This test currently does not create any users so is testing the pending
+        enrollments case.
+        """
         enterprise_customer = factories.EnterpriseCustomerFactory(
             uuid=FAKE_UUIDS[0],
             name="test_enterprise"
@@ -3463,47 +3556,41 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
             content_type='application/json',
         )
         self.assertEqual(response.status_code, expected_code)
-        if expected_response:
-            response_json = response.json()
-            self.assertEqual(expected_response, response_json)
+
+        response_json = response.json()
+        self.assertEqual(expected_response, response_json)
         self.assertEqual(len(PendingEnrollment.objects.all()), expected_num_pending_licenses)
 
-        if expected_events:
-            mock_track_enroll.assert_has_calls(expected_events[x] for x in range(len(expected_events) - 1))
-        else:
-            mock_track_enroll.assert_not_called()
+        mock_track_enroll.assert_has_calls(expected_events[x] for x in range(len(expected_events) - 1))
 
         # verify notification sent correctly for each course to applicable learners
-        if 'notify' in body:
-            unique_course_keys = {item['course_run_key'] for item in body['licenses_info']}
-            unique_learners = {item['email'] for item in body['licenses_info']}
-            unique_ent_customer_users = set()
-            for learner in unique_learners:
-                try:
-                    # alternative was to have a factory that uses django_get_or_create
-                    # but did not want to change the existing factory or create a new one
-                    unique_ent_customer_users.add(
-                        PendingEnterpriseCustomerUser.objects.get(user_email=learner)
-                    )
-                except PendingEnterpriseCustomerUser.DoesNotExist:
-                    unique_ent_customer_users.add(PendingEnterpriseCustomerUserFactory(
-                        enterprise_customer=enterprise_customer,
-                        user_email=learner
-                    ))
-            request_user = self.user
-
-            def _make_call(course_run, enrolled_learners):
-                return mock.call(
-                    catalog_api_user=request_user,
-                    course_id=course_run,
-                    users=enrolled_learners,
-                    admin_enrollment=True,
+        unique_course_keys = {item['course_run_key'] for item in body['licenses_info']}
+        unique_learners = {item['email'] for item in body['licenses_info']}
+        unique_ent_customer_users = set()
+        for learner in unique_learners:
+            try:
+                # alternative was to have a factory that uses django_get_or_create
+                # but did not want to change the existing factory or create a new one
+                unique_ent_customer_users.add(
+                    PendingEnterpriseCustomerUser.objects.get(user_email=learner)
                 )
-            mock_calls = [_make_call(course_run, unique_ent_customer_users) for course_run in unique_course_keys]
+            except PendingEnterpriseCustomerUser.DoesNotExist:
+                unique_ent_customer_users.add(PendingEnterpriseCustomerUserFactory(
+                    enterprise_customer=enterprise_customer,
+                    user_email=learner
+                ))
+        request_user = self.user
 
-            mock_notify_task.assert_has_calls(mock_calls)
-        else:
-            mock_notify_task.assert_not_called()
+        def _make_call(course_run, enrolled_learners):
+            return mock.call(
+                catalog_api_user=request_user,
+                course_id=course_run,
+                users=enrolled_learners,
+                admin_enrollment=True,
+            )
+        mock_calls = [_make_call(course_run, unique_ent_customer_users) for course_run in unique_course_keys]
+
+        mock_notify_task.assert_has_calls(mock_calls)
 
     @mock.patch('enterprise.api.v1.views.enroll_licensed_users_in_courses')
     @mock.patch('enterprise.api.v1.views.get_best_mode_from_course_key')

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -3433,8 +3433,8 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
     # pylint: disable=unused-argument
     def test_bulk_enrollment_in_bulk_courses_pending_licenses(
         self,
-        mock_prepare_notification_content,
-        mock_notify_enroll_learners_task,
+        mock_prepare_notification,
+        mock_notify_task,
         mock_track_enroll,
         mock_get_course_mode,
         body,
@@ -3448,13 +3448,13 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
         This test currently does not create any users so is testing the pending
         enrollments case.
         """
-        ent_customer = factories.EnterpriseCustomerFactory(
+        factories.EnterpriseCustomerFactory(
             uuid=FAKE_UUIDS[0],
             name="test_enterprise"
         )
 
         email_items = [{}]
-        mock_prepare_notification_content.return_value = email_items
+        mock_prepare_notification.return_value = email_items
 
         permission = Permission.objects.get(name='Can add Enterprise Customer')
         self.user.user_permissions.add(permission)
@@ -3479,14 +3479,14 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
             mock_track_enroll.assert_not_called()
 
         if 'notify' in body:
-            mock_prepare_notification_content.assert_called_once()
-            mock_notify_enroll_learners_task.assert_called_once_with(
+            mock_prepare_notification.assert_called_once()
+            mock_notify_task.assert_called_once_with(
                 uuid.UUID(FAKE_UUIDS[0]),
                 True,
                 email_items,
             )
         else:
-            mock_prepare_notification_content.assert_not_called()
+            mock_prepare_notification.assert_not_called()
             mock_notify_enroll_learners_task.assert_not_called()
 
     @mock.patch('enterprise.api.v1.views.enroll_licensed_users_in_courses')

--- a/tests/test_enterprise/test_tasks.py
+++ b/tests/test_enterprise/test_tasks.py
@@ -8,7 +8,7 @@ import unittest
 import mock
 from pytest import mark
 
-from enterprise.models import EnterpriseCourseEnrollment, EnterpriseCustomer, EnterpriseEnrollmentSource
+from enterprise.models import EnterpriseCourseEnrollment, EnterpriseEnrollmentSource
 from enterprise.tasks import create_enterprise_enrollment, send_enterprise_email_notification
 from enterprise.utils import serialize_notification_content
 from test_utils.factories import (

--- a/tests/test_enterprise/test_tasks.py
+++ b/tests/test_enterprise/test_tasks.py
@@ -8,7 +8,7 @@ import unittest
 import mock
 from pytest import mark
 
-from enterprise.models import EnterpriseCourseEnrollment, EnterpriseEnrollmentSource
+from enterprise.models import EnterpriseCourseEnrollment, EnterpriseCustomer, EnterpriseEnrollmentSource
 from enterprise.tasks import create_enterprise_enrollment, send_enterprise_email_notification
 from enterprise.utils import serialize_notification_content
 from test_utils.factories import (
@@ -115,7 +115,10 @@ class TestEnterpriseTasks(unittest.TestCase):
         users = [UserFactory(username=f'user{user_id}') for user_id in range_list]
         course_details = {'title': 'course_title', 'start': '2021-09-21T00:01:10'}
         admin_enrollment = True
-        mock_email_conn.return_value = mock.MagicMock()
+
+        mail_conn = mock.MagicMock()
+        mock_email_conn.return_value.__enter__.return_value = mail_conn
+
         email_items = serialize_notification_content(
             enterprise_customer,
             course_details,
@@ -133,7 +136,7 @@ class TestEnterpriseTasks(unittest.TestCase):
             item['enrolled_in'],
             item['dashboard_url'],
             enterprise_customer.uuid,
-            email_connection=mock_email_conn,
+            email_connection=mail_conn,
             admin_enrollment=admin_enrollment,
         ) for item in email_items]
         mock_send_notification.assert_has_calls(calls)

--- a/tests/test_integrated_channels/test_sap_success_factors/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_sap_success_factors/test_exporters/test_content_metadata.py
@@ -10,7 +10,7 @@ import mock
 import responses
 from pytest import mark
 
-from enterprise.api_client.lms import parse_lms_api_datetime
+from enterprise.utils import parse_lms_api_datetime
 from integrated_channels.sap_success_factors.exporters.content_metadata import SapSuccessFactorsContentMetadataExporter
 from test_utils import factories
 from test_utils.fake_enterprise_api import EnterpriseMockMixin

--- a/tests/test_integrated_channels/test_utils.py
+++ b/tests/test_integrated_channels/test_utils.py
@@ -10,7 +10,7 @@ import ddt
 import mock
 from pytest import raises
 
-from enterprise.api_client.lms import parse_lms_api_datetime
+from enterprise.utils import parse_lms_api_datetime
 from integrated_channels import utils
 
 

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -36,6 +36,7 @@ from enterprise.constants import (
     ENTERPRISE_ENROLLMENT_API_ADMIN_ROLE,
     ENTERPRISE_LEARNER_ROLE,
     ENTERPRISE_OPERATOR_ROLE,
+    LMS_API_DATETIME_FORMAT,
 )
 from enterprise.management.commands.assign_enterprise_user_roles import Command as AssignEnterpriseUserRolesCommand
 from enterprise.models import (
@@ -338,7 +339,7 @@ COURSE_KEY = 'edX+DemoX'
 # Mock passing certificate data
 MOCK_PASSING_CERTIFICATE = dict(
     grade='A-',
-    created_date=NOW.strftime(lms_api.LMS_API_DATETIME_FORMAT),
+    created_date=NOW.strftime(LMS_API_DATETIME_FORMAT),
     status='downloadable',
     is_passing=True,
 )
@@ -346,7 +347,7 @@ MOCK_PASSING_CERTIFICATE = dict(
 # Mock failing certificate data
 MOCK_FAILING_CERTIFICATE = dict(
     grade='D',
-    created_date=NOW.strftime(lms_api.LMS_API_DATETIME_FORMAT),
+    created_date=NOW.strftime(LMS_API_DATETIME_FORMAT),
     status='downloadable',
     is_passing=False,
     percent_grade=0.6,

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -8,7 +8,6 @@ import unittest
 from collections import namedtuple
 
 import ddt
-from django.forms.models import model_to_dict
 import mock
 import pytz
 from faker import Factory as FakerFactory
@@ -16,6 +15,7 @@ from pytest import mark, raises
 
 from django.core import mail
 from django.core.exceptions import ValidationError
+from django.forms.models import model_to_dict
 from django.test import override_settings
 
 from enterprise import utils

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -627,7 +627,7 @@ class TestEnterpriseUtils(unittest.TestCase):
         if user is None:
             with raises(TypeError):
                 utils.send_email_notification_message(
-                    model_to_dict(user),
+                    user,
                     enrolled_in,
                     dashboard_url,
                     enterprise_customer.uuid,

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -434,7 +434,7 @@ class TestEnterpriseUtils(unittest.TestCase):
         if user is None:
             with raises(TypeError):
                 utils.send_email_notification_message(
-                    model_to_dict(user),
+                    user,
                     enrolled_in,
                     dashboard_url,
                     enterprise_customer.uuid

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -28,6 +28,7 @@ from enterprise.models import (
 from enterprise.utils import (
     ADMIN_ENROLL_EMAIL_TEMPLATE_TYPE,
     SELF_ENROLL_EMAIL_TEMPLATE_TYPE,
+    create_dict_from_user,
     find_enroll_email_template,
 )
 from integrated_channels.sap_success_factors.models import SAPSuccessFactorsEnterpriseCustomerConfiguration
@@ -433,20 +434,20 @@ class TestEnterpriseUtils(unittest.TestCase):
         if user is None:
             with raises(TypeError):
                 utils.send_email_notification_message(
-                    user,
+                    create_dict_from_user(user),
                     enrolled_in,
                     dashboard_url,
-                    enterprise_customer
+                    enterprise_customer.uuid
                 )
         else:
             conn = mail.get_connection()
             user_cls = user.pop('class')
             user = user_cls(**user)
             utils.send_email_notification_message(
-                user,
+                create_dict_from_user(user),
                 enrolled_in,
                 dashboard_url,
-                enterprise_customer,
+                enterprise_customer.uuid,
                 email_connection=conn,
             )
             assert len(mail.outbox) == 1
@@ -485,10 +486,10 @@ class TestEnterpriseUtils(unittest.TestCase):
         dashboard_url = 'http://lms.example.com'
 
         utils.send_email_notification_message(
-            user,
+            create_dict_from_user(user),
             enrolled_in,
             dashboard_url,
-            enterprise_customer,
+            enterprise_customer.uuid,
             email_connection=conn,
             admin_enrollment=True,
         )
@@ -626,20 +627,20 @@ class TestEnterpriseUtils(unittest.TestCase):
         if user is None:
             with raises(TypeError):
                 utils.send_email_notification_message(
-                    user,
+                    create_dict_from_user(user),
                     enrolled_in,
                     dashboard_url,
-                    enterprise_customer
+                    enterprise_customer.uuid,
                 )
         else:
             conn = mail.get_connection()
             user_cls = user.pop('class')
             user = user_cls(**user)
             utils.send_email_notification_message(
-                user,
+                create_dict_from_user(user),
                 enrolled_in,
                 dashboard_url,
-                enterprise_customer,
+                enterprise_customer.uuid,
                 email_connection=conn,
             )
             assert len(mail.outbox) == 1
@@ -658,10 +659,12 @@ class TestEnterpriseUtils(unittest.TestCase):
         )
     )
     @ddt.unpack
+    @mock.patch('enterprise.utils.get_enterprise_customer')
     def test_send_email_notification_message_with_site_from_email_override(
             self,
             site_config_from_email_address,
-            expected_from_email_address
+            expected_from_email_address,
+            mock_get_ent_customer,
     ):
         """
         Test that we can successfully override a from email address per site.
@@ -686,12 +689,14 @@ class TestEnterpriseUtils(unittest.TestCase):
 
         enterprise_customer = EnterpriseCustomerFactory(site=site)
 
+        mock_get_ent_customer.return_value = enterprise_customer
+
         conn = mail.get_connection()
         utils.send_email_notification_message(
-            user,
+            create_dict_from_user(user),
             enrolled_in,
             dashboard_url,
-            enterprise_customer,
+            enterprise_customer.uuid,
             email_connection=conn,
         )
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -8,6 +8,7 @@ import unittest
 from collections import namedtuple
 
 import ddt
+from django.forms.models import model_to_dict
 import mock
 import pytz
 from faker import Factory as FakerFactory
@@ -28,7 +29,6 @@ from enterprise.models import (
 from enterprise.utils import (
     ADMIN_ENROLL_EMAIL_TEMPLATE_TYPE,
     SELF_ENROLL_EMAIL_TEMPLATE_TYPE,
-    create_dict_from_user,
     find_enroll_email_template,
 )
 from integrated_channels.sap_success_factors.models import SAPSuccessFactorsEnterpriseCustomerConfiguration
@@ -434,7 +434,7 @@ class TestEnterpriseUtils(unittest.TestCase):
         if user is None:
             with raises(TypeError):
                 utils.send_email_notification_message(
-                    create_dict_from_user(user),
+                    model_to_dict(user),
                     enrolled_in,
                     dashboard_url,
                     enterprise_customer.uuid
@@ -444,7 +444,7 @@ class TestEnterpriseUtils(unittest.TestCase):
             user_cls = user.pop('class')
             user = user_cls(**user)
             utils.send_email_notification_message(
-                create_dict_from_user(user),
+                model_to_dict(user),
                 enrolled_in,
                 dashboard_url,
                 enterprise_customer.uuid,
@@ -486,7 +486,7 @@ class TestEnterpriseUtils(unittest.TestCase):
         dashboard_url = 'http://lms.example.com'
 
         utils.send_email_notification_message(
-            create_dict_from_user(user),
+            model_to_dict(user),
             enrolled_in,
             dashboard_url,
             enterprise_customer.uuid,
@@ -627,7 +627,7 @@ class TestEnterpriseUtils(unittest.TestCase):
         if user is None:
             with raises(TypeError):
                 utils.send_email_notification_message(
-                    create_dict_from_user(user),
+                    model_to_dict(user),
                     enrolled_in,
                     dashboard_url,
                     enterprise_customer.uuid,
@@ -637,7 +637,7 @@ class TestEnterpriseUtils(unittest.TestCase):
             user_cls = user.pop('class')
             user = user_cls(**user)
             utils.send_email_notification_message(
-                create_dict_from_user(user),
+                model_to_dict(user),
                 enrolled_in,
                 dashboard_url,
                 enterprise_customer.uuid,
@@ -693,7 +693,7 @@ class TestEnterpriseUtils(unittest.TestCase):
 
         conn = mail.get_connection()
         utils.send_email_notification_message(
-            create_dict_from_user(user),
+            model_to_dict(user),
             enrolled_in,
             dashboard_url,
             enterprise_customer.uuid,


### PR DESCRIPTION
## Included in PR
Summary of changes (updated from what I had since last round of review):
- Added a task to send email notifications in `enterprise/tasks.py`
- Extracted out a method to only serialize the email_items list so that we can use it to call a celery task
- Now calling the celery task from the model's `notify_enrolled_learners` function so every caller of the notify_enrolled_learners function gets this ability, not just bulk enrollment
- Moved a function `parse_lms_api_datetime` to utils. Strictly speaking not needed for this PR but I decided to leave it there 

For bulk enrollment, no. of tasks created = no. of courses. Each task will email all learners for enrollment into that course

ENT-4779

## Testing notes:

* ADDED: Unit test for the new task
* UPDATED: Update tests that call the view to ensure the task is invoked correctly

`Staging`:
Once this (via edx-platform) gets to staging, test plan is to put a pause on edx-platform prod pipeline, run a test with enrollment of these kinds:

- bulk enroll with emails on and off
- regular enroll in a course from courseware page
- learner portal enroll in a course

`Manual`:

Executed bulk enrollment, and verified a task was fired for each course and also an email file was generated per course 

```
ls -al /edx/src/ace_messages/
total 1296
drwxr-xr-x 5 root root    160 Jul 28 03:16 .
drwxr-xr-x 4 root root    128 Jan 14  2021 ..
-rw-r--r-- 1 root root 438845 Jul 28 03:16 20210728-031634-139685836518400.log
-rw-r--r-- 1 root root 438843 Jul 28 03:16 20210728-031636-139685832905728.log
-rw-r--r-- 1 root root 440297 Jul 28 03:16 20210728-031638-139685848429376.log
```

in logs I see 

```
2021-07-29 13:38:53,667 INFO 32082 [enterprise.api.v1.views] [user 17] [ip 172.18.0.16] views.py:315 - Successfully bulk enrolled learners: {<User: ecommerce_worker>, <User: edx>, <User: verified>} into course course-v1:edX+909878+2T2021
2021-07-29 13:38:54,398 INFO 32082 [celery.app.trace] [user 17] [ip 172.18.0.16] trace.py:125 - Task enterprise.tasks.send_enterprise_email_notification[0c160b49-e277-4654-9a8c-da6a3bd78bf8] succeeded in 0.042356400001153816s: None
2021-07-29 13:38:54,399 INFO 32082 [enterprise.api.v1.views] [user 17] [ip 172.18.0.16] views.py:315 - Successfully bulk enrolled learners: {<User: ecommerce_worker>, <User: edx>, <User: verified>} into course course-v1:edX+303707808+2T2021
2021-07-29 13:38:55,056 INFO 32082 [celery.app.trace] [user 17] [ip 172.18.0.16] trace.py:125 - Task enterprise.tasks.send_enterprise_email_notification[a0583741-2b13-4e00-8a66-5685bb492fd5] succeeded in 0.043135300002177246s: None
2021-07-29 13:38:55,057 INFO 32082 [enterprise.api.v1.views] [user 17] [ip 172.18.0.16] views.py:315 - Successfully bulk enrolled learners: {<User: ecommerce_worker>, <User: edx>, <User: verified>} into course course-v1:edX+808404707+2T2021
2021-07-29 13:38:55,740 INFO 32082 [celery.app.trace] [user 17] [ip 172.18.0.16] trace.py:125 - Task enterprise.tasks.send_enterprise_email_notification[4a8eb86b-e88d-4289-a6a0-28ce30d3468a] succeeded in 0.04192120000516297s: None
[29/Jul/2021 13:38:55] "POST /enterprise/api/v1/enterprise-customer/9a5afb8e-63bc-456a-a600-81b60777e5aa/enroll_learners_in_courses/ HTTP/1.1" 201 789
```

Each file represents emails send to all 25 learners I used in testing.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
