### PR TITLE
Fix: SAP CourseCompleted Flag - This time using actual payload data

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.27.9]
+--------
+* Fix SAP Course Completion payload format again.
+
 [3.27.8]
 --------
 * Fix SAP Course Completion payload format.

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.27.8"
+__version__ = "3.27.9"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/sap_success_factors/client.py
+++ b/integrated_channels/sap_success_factors/client.py
@@ -148,15 +148,12 @@ class SAPSuccessFactorsAPIClient(IntegratedChannelApiClient):  # pylint: disable
             # TODO:
             #   if/when we decide we should use the generic course completion path
             #   for all customers, we should update the _payload_data method on the
-            #   SapSuccessFactorsLearnerDataTransmissionAudit class instead of doing this json load/dump
-            # Explanation:
-            #  json.loads loads "true" as True and when dumped again will be `true` (without quotes)
-            #  The initial payload explicitly sets the value to "true" *before* the dump, and thus it dumps with quotes.
+            #   SapSuccessFactorsLearnerDataTransmissionAudit class instead of doing this
             payload_to_update = json.loads(payload)
-            payload = json.dumps(payload_to_update)
+            payload_to_update['courseCompleted'] = bool(payload_to_update['courseCompleted'] == 'true')
             return self._call_post_with_session(
                 base_url + self.GENERIC_COURSE_COMPLETION_PATH,
-                payload
+                json.dumps(payload_to_update)
             )
 
         return self._call_post_with_user_override(

--- a/tests/test_integrated_channels/test_sap_success_factors/test_client.py
+++ b/tests/test_integrated_channels/test_sap_success_factors/test_client.py
@@ -340,9 +340,10 @@ class TestSAPSuccessFactorsAPIClient(unittest.TestCase):
         )
 
         expected_response = 200, json.dumps(expected_response_body)
-        transformed_payload = self.completion_payload
-        transformed_payload['courseCompleted'] = True
-        transformed_payload = json.dumps(transformed_payload)
+        # Mimic the transformation behaviour in the client since we expect that to occur when the post is called
+        expected_payload = self.completion_payload.copy()
+        expected_payload['courseCompleted'] = True
+        expected_payload = json.dumps(expected_payload)
 
         payload = json.dumps(self.completion_payload)
 
@@ -350,4 +351,4 @@ class TestSAPSuccessFactorsAPIClient(unittest.TestCase):
         actual_response = sap_client.create_course_completion(self.user_type, payload)
         assert actual_response == expected_response
 
-        sap_client._call_post_with_session.assert_called_with(expected_completion_url, transformed_payload)  # pylint: disable=protected-access
+        sap_client._call_post_with_session.assert_called_with(expected_completion_url, expected_payload)  # pylint: disable=protected-access


### PR DESCRIPTION
With Alex S.' help, we were able to get actual payload data so I could be certain that the test data matched and also go through the SAP transformations step by step.

The last pr didn't work because my test data ended up in a bad state (I didn't realize Python assigns references rather than performing a copy when you try to assign a variable to an existing dictionary) and I mistakenly matched the base code to the test data.

So this one fixes the test data, but also I used actual payload data to verify the functionality outside of the tests to ensure confidence in the code and thus verify the test data was the problem.

The very original problem still needed to be resolved (the endpoint does not support `"true"` as a parameter and it needed to be formatted for JS (`true` without quotes), but with this new code we now actually do that.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
