### PR TITLE
Catalog query deletes logging and bulk query ID updates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.27.12]
+---------
+* Prevent django admin deletions of catalog queries. Added management command to bulk update catalogs of their query IDs
+
 [3.27.11]
 ---------
 * Avoid failure when an email send in the learners loop fails, for notify_enrolled_learners

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.27.11"
+__version__ = "3.27.12"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/admin/__init__.py
+++ b/enterprise/admin/__init__.py
@@ -726,6 +726,9 @@ class EnterpriseCatalogQueryAdmin(admin.ModelAdmin):
         """
         return discovery_query_url(obj.content_filter)
 
+    def has_delete_permission(self, request, obj=None):
+        return False
+
     readonly_fields = ('discovery_query_url', 'uuid')
     discovery_query_url.allow_tags = True
     discovery_query_url.short_description = 'Preview Catalog Courses'

--- a/enterprise/management/commands/bulk_update_catalog_query_id.py
+++ b/enterprise/management/commands/bulk_update_catalog_query_id.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+"""
+Django management command for bulk updating EnterpriseCustomerCatalog record's EnterpriseCatalogQuery's.
+"""
+
+import logging
+
+from django.core.management import BaseCommand
+
+from enterprise.models import EnterpriseCatalogQuery, EnterpriseCustomerCatalog
+
+LOGGER = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    Takes a new and old Enterprise Catalog Query ID, find all most recent records within the historical Enterprise
+    Catalog table where enterprise catalog query ID is the old ID provided and updates the corresponding Enterprise
+    Catalog table entries with the new ID.
+    """
+    help = "Updates specified EnterpriseCatalog's enterprise catalog query ID records with a provided new ID"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            'old_id',
+            action='store',
+            help='Old catalog query ID to be replaced.'
+        )
+        parser.add_argument(
+            'new_id',
+            action='store',
+            help='New catalog query ID to replace the old one.'
+        )
+
+    def handle(self, *args, **options):
+        """
+        Entry point for management command execution.
+        """
+        LOGGER.info("Starting bulk update of EnterpriseCatalog's enterprise catalog query IDs")
+
+        old_id = options['old_id']
+        new_id = options['new_id']
+        uuids_to_change = []
+        if EnterpriseCatalogQuery.objects.filter(id=new_id).first():
+            # pylint: disable=no-member
+            catalogs_to_change = EnterpriseCustomerCatalog.history.filter(enterprise_catalog_query_id=old_id).order_by(
+                '-modified'
+            ).distinct()
+            # pylint: enable=no-member
+            for catalog in catalogs_to_change:
+                if not catalog.next_record and catalog.get_history_type_display() != 'Deleted':
+                    uuids_to_change.append(catalog.uuid)
+
+            EnterpriseCustomerCatalog.objects.filter(uuid__in=uuids_to_change).update(
+                enterprise_catalog_query_id=new_id
+            )
+            LOGGER.info(
+                "Completed bulk update of EnterpriseCatalog's enterprise catalog queries with ID={} to ID={}".format(
+                    old_id,
+                    new_id
+                )
+            )
+        else:
+            LOGGER.exception("Could not find query with ID={}".format(new_id))

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -1855,6 +1855,16 @@ class EnterpriseCatalogQuery(TimeStampedModel):
         """
         return "<EnterpriseCatalogQuery '{title}' >".format(title=self.title)
 
+    def delete(self, *args, **kwargs):
+        """
+        Deletes this ``EnterpriseCatalogQuery``.
+        """
+        super().delete(*args, **kwargs)
+        LOGGER.exception(
+            "Instance {ent_catalog_query} (PK: {PK}) deleted. All associated enterprise customer catalogs are now "
+            "unlinked and will not receive updates.".format(ent_catalog_query=self, PK=self.pk)
+        )
+
 
 @python_2_unicode_compatible
 class EnterpriseCustomerCatalog(TimeStampedModel):

--- a/tests/test_enterprise/management/test_bulk_update_catalog_query_id.py
+++ b/tests/test_enterprise/management/test_bulk_update_catalog_query_id.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for the djagno management command `create_enterprise_course_enrollments`.
+"""
+
+import ddt
+from pytest import mark
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from enterprise.models import EnterpriseCustomerCatalog
+from test_utils.factories import EnterpriseCatalogQueryFactory, EnterpriseCustomerCatalogFactory
+
+EXCEPTION = "DUMMY_TRACE_BACK"
+
+
+@mark.django_db
+@ddt.ddt
+class CreateEnterpriseCourseEnrollmentCommandTests(TestCase):
+    """
+    Test command `bulk_update_catalog_query_id`.
+    """
+    command = 'bulk_update_catalog_query_id'
+
+    def setUp(self):
+        self.enterprise_catalog_query_1 = EnterpriseCatalogQueryFactory()
+        self.enterprise_catalog_query_2 = EnterpriseCatalogQueryFactory()
+        self.enterprise_catalog_query_3 = EnterpriseCatalogQueryFactory()
+        self.enterprise_catalog_1 = EnterpriseCustomerCatalogFactory(
+            enterprise_catalog_query_id=self.enterprise_catalog_query_1.id
+        )
+        self.enterprise_catalog_2 = EnterpriseCustomerCatalogFactory(
+            enterprise_catalog_query_id=self.enterprise_catalog_query_2.id
+        )
+        super().setUp()
+
+    def test_bulk_query_update_only_changes_provided_query(self):
+        """
+        Test that the bulk_update_catalog_query_id command will only update enterprise catalogs who's
+        enterprise_catalog_query_ids match the provided old_id value
+        """
+        call_command(self.command, self.enterprise_catalog_query_1.id, self.enterprise_catalog_query_3.id)
+        assert EnterpriseCustomerCatalog.objects.filter(
+            enterprise_catalog_query_id=self.enterprise_catalog_query_3.id
+        ).first()
+        assert EnterpriseCustomerCatalog.objects.filter(
+            enterprise_catalog_query_id=self.enterprise_catalog_query_2.id
+        ).first()
+        assert not EnterpriseCustomerCatalog.objects.filter(
+            enterprise_catalog_query_id=self.enterprise_catalog_query_1.id
+        ).first()


### PR DESCRIPTION
[jira](https://openedx.atlassian.net/browse/ENT-4783)

background:
deleting catalog query's is currently breaking for a few processes, so we want to log an exception if one get's deleted. Additionally, in order to ever rectify this kind of event in the future, we want to add management command to bulk change enterprise catalog's queries. 

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
