### PR TITLE
feat: Follow up to ENT-4779 PR to handle in loop exceptions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.27.11]
+---------
+* Avoid failure when an email send in the learners loop fails, for notify_enrolled_learners
+
 [3.27.10]
 ---------
 * Use celery tasks for emails sent using EnterpriseCustomer's notify_enrolled_learners method

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.27.10"
+__version__ = "3.27.11"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/tasks.py
+++ b/enterprise/tasks.py
@@ -40,14 +40,23 @@ def send_enterprise_email_notification(
     """
     with mail.get_connection() as email_conn:
         for item in email_items:
-            send_email_notification_message(
-                item['user'],
-                item['enrolled_in'],
-                item['dashboard_url'],
-                enterprise_customer_uuid,
-                email_connection=email_conn,
-                admin_enrollment=admin_enrollment,
-            )
+            course_name = item['enrolled_in']['name']
+            try:
+                send_email_notification_message(
+                    item['user'],
+                    item['enrolled_in'],
+                    item['dashboard_url'],
+                    enterprise_customer_uuid,
+                    email_connection=email_conn,
+                    admin_enrollment=admin_enrollment,
+                )
+            except Exception as exc:  # pylint: disable=broad-except
+                LOGGER.exception(
+                    f"Failed notifying user: "
+                    f"enterprise_customer_uuid: {enterprise_customer_uuid}"
+                    f"of enterprise enrollment in course {course_name}",
+                    exc_info=exc,
+                )
 
 
 @shared_task

--- a/enterprise/tasks.py
+++ b/enterprise/tasks.py
@@ -41,6 +41,10 @@ def send_enterprise_email_notification(
     with mail.get_connection() as email_conn:
         for item in email_items:
             course_name = item['enrolled_in']['name']
+            if 'username' in item['user']:
+                username = item['user']['username']
+            else:
+                username = 'no_username_found'
             try:
                 send_email_notification_message(
                     item['user'],
@@ -52,9 +56,10 @@ def send_enterprise_email_notification(
                 )
             except Exception as exc:  # pylint: disable=broad-except
                 LOGGER.exception(
-                    f"Failed notifying user: "
-                    f"enterprise_customer_uuid: {enterprise_customer_uuid}"
-                    f"of enterprise enrollment in course {course_name}",
+                    "Failed notifying user: {}"
+                    "enterprise_customer_uuid: {}"
+                    "of enterprise enrollment in course {}"
+                    .format(username, enterprise_customer_uuid, course_name),
                     exc_info=exc,
                 )
 


### PR DESCRIPTION
follow up to https://github.com/edx/edx-enterprise/pull/1312 per Brian's feedback

If one email send fails for any reason, avoid failure and log exception, includes a test

ENT-4779

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
