### PR TITLE
fix: Fix Start my course URL for admin enrollment email

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.27.13]
+---------
+* Revert 'Start my course' links in bulk enrollment emails to courseware based links instead of learner portal.
+
 [3.27.12]
 ---------
 * Prevent django admin deletions of catalog queries. Added management command to bulk update catalogs of their query IDs

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.27.12"
+__version__ = "3.27.13"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -520,7 +520,7 @@ def serialize_notification_content(
     if admin_enrollment:
         dashboard_url = get_learner_portal_url(enterprise_customer)
 
-    # add tap_hint if there is only one IdP attached with enterprise_customer
+    # add tpa_hint if there is only one IdP attached with enterprise_customer
     if enterprise_customer.has_single_idp:
         params = {'tpa_hint': enterprise_customer.identity_providers.first().provider_id}
     elif enterprise_customer.has_multiple_idps and enterprise_customer.default_provider_idp:


### PR DESCRIPTION
Should be proper learner portal course link, also add tests for both admin_enroll and self_enroll cases

### OPEN QUESTION!!
What about when learner portal is off for enterprise?  Should this url be made different in that case?

ANSWERED: we want the prior behavior of sending users direct to register or login, with next url being the courseware page url

JIRA: ENT-4789

### Testing Notes

After fixing ENT-4789

#### Existing learner:

Took me to this page when I click on Start my Course link (from devstack email file)
http://localhost:18000/login?next=/courses/course-v1%3AedX%2B808404707%2B2T2021/course%3F

which redirected me to
http://localhost:18000/courses/course-v1:edX+808404707+2T2021/course/


#### Pending learner:

Invited non edx learner (abc@mouse.com) to subscription
Then directly enrolled them using bulk enrollment into a course
Email link was this:
http://localhost:18000/register?next=/courses/course-v1%3AedX%2B909878%2B2T2021/course%3F

When visited it prompted me to register new account
I registered as abc@mouse.com as expected

Note: they have not activated the license yet.


#### Using manage learners to invite a new learner not yet in edX
I got an email with the activation link which works


**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
