### PR TITLE
maint: making params options so things work

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.27.16]
+---------
+* Making bulk catalog query ID update params optional
+
 [3.27.15]
 ---------
 * Added title field in ``AdminNotification`` table.

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.27.15"
+__version__ = "3.27.16"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/enterprise/management/commands/bulk_update_catalog_query_id.py
+++ b/enterprise/management/commands/bulk_update_catalog_query_id.py
@@ -27,13 +27,15 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
-            'old_id',
-            action='store',
+            '-o', '--old_id',
+            metavar='OLD_ID',
+            dest='old_id',
             help='Old catalog query ID to be replaced.'
         )
         parser.add_argument(
-            'new_id',
-            action='store',
+            '-n', '--new_id',
+            metavar='NEW_ID',
+            dest='new_id',
             help='New catalog query ID to replace the old one.'
         )
         parser.add_argument(
@@ -62,12 +64,16 @@ class Command(BaseCommand):
         Entry point for management command execution.
         """
         LOGGER.info("Starting bulk update of EnterpriseCatalog's enterprise catalog query IDs")
-
         if options['args_from_database']:
             options = self.get_args_from_database()
 
-        old_id = options['old_id']
-        new_id = options['new_id']
+        old_id = options.get('old_id')
+        new_id = options.get('new_id')
+        if not old_id:
+            raise CommandError('You must specify an old query ID')
+        if not new_id:
+            raise CommandError('You must specify a new query ID')
+
         uuids_to_change = []
         if EnterpriseCatalogQuery.objects.filter(id=new_id).first():
             # pylint: disable=no-member

--- a/tests/test_enterprise/management/test_bulk_update_catalog_query_id.py
+++ b/tests/test_enterprise/management/test_bulk_update_catalog_query_id.py
@@ -40,7 +40,7 @@ class CreateEnterpriseCourseEnrollmentCommandTests(TestCase):
         Test that the bulk_update_catalog_query_id command will only update enterprise catalogs who's
         enterprise_catalog_query_ids match the provided old_id value
         """
-        call_command(self.command, self.enterprise_catalog_query_1.id, self.enterprise_catalog_query_3.id)
+        call_command(self.command, old_id=self.enterprise_catalog_query_1.id, new_id=self.enterprise_catalog_query_3.id)
         assert EnterpriseCustomerCatalog.objects.filter(
             enterprise_catalog_query_id=self.enterprise_catalog_query_3.id
         ).first()


### PR DESCRIPTION
args from database require the params be optional :(

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
