### PR TITLE
fix(integrated_channels): :mute: fix bug causing log noise due to cou…

### DIFF
--- a/integrated_channels/canvas/exporters/content_metadata.py
+++ b/integrated_channels/canvas/exporters/content_metadata.py
@@ -26,6 +26,7 @@ class CanvasContentMetadataExporter(ContentMetadataExporter):
         'course_code': 'key',
         'indexed': 'indexed'
     }
+    SKIP_KEY_IF_NONE = True
 
     LONG_STRING_LIMIT = 2000
 
@@ -78,3 +79,17 @@ class CanvasContentMetadataExporter(ContentMetadataExporter):
         Whether to make the course default to the public index or not.
         """
         return 1
+
+    def transform_start(self, content_metadata_item):
+        """
+        Returns none if no start date is available (the case for courses),
+        and the start date (the case for course run data)
+        """
+        return content_metadata_item.get('start', None)
+
+    def transform_end(self, content_metadata_item):
+        """
+        Returns none if no end date is available (the case for courses),
+         and the end date (the case for course run data)
+        """
+        return content_metadata_item.get('end', None)

--- a/tests/test_integrated_channels/test_canvas/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_canvas/test_exporters/test_content_metadata.py
@@ -69,6 +69,52 @@ class TestCanvasContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):
 
     @ddt.data(
         (
+            {},
+            None
+        ),
+        (
+            {
+                'end': 'test_end_string'
+            },
+            'test_end_string'
+        ),
+    )
+    @responses.activate
+    @ddt.unpack
+    def test_transform_end(self, content_metadata_item, expected_end_value):
+        """
+        ``CanvasContentMetadataExporter``'s ``transform_end`` returns string passed in from
+        Content metadata or None if no 'end' field present on content_metadata_item.
+        """
+        exporter = CanvasContentMetadataExporter('fake-user', self.config)
+        end = exporter.transform_end(content_metadata_item)
+        assert end == expected_end_value
+
+    @ddt.data(
+        (
+            {},
+            None
+        ),
+        (
+            {
+                'start': 'test_start_string'
+            },
+            'test_start_string'
+        ),
+    )
+    @responses.activate
+    @ddt.unpack
+    def test_transform_start(self, content_metadata_item, expected_start_value):
+        """
+        ``CanvasContentMetadataExporter``'s ``transform_start`` returns string passed in from
+        Content metadata or None if no 'start' field present on content_metadata_item.
+        """
+        exporter = CanvasContentMetadataExporter('fake-user', self.config)
+        start = exporter.transform_start(content_metadata_item)
+        assert start == expected_start_value
+
+    @ddt.data(
+        (
             {
                 'enrollment_url': 'http://some/enrollment/url/',
                 'title': 'edX Demonstration Course',


### PR DESCRIPTION
…rse metadata not containing a start or end field.

**Merge checklist:**
- [N/A ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ N/A] `make static` has been run to update webpack bundling if any static content was updated
- [N/A ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [N/A ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ N/A] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ N/A can wait until next normal bump] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [N/A ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [N/A ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
