### PR TITLE
feat: Safe encode/decode functions for course key reversible transform for use with LMS (cornerstone mainly)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.27.18]
+---------
+* Integrated channels util functions needed to base64 urlsafe encode/decode course keys for use with some LMS systems like Cornerstone.
+
 [3.27.17]
 ---------
 * Integrated channels now checks and uses catalog modified times to determine if an update is needed before retrieving content metadata.

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.27.17"
+__version__ = "3.27.18"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/utils.py
+++ b/integrated_channels/utils.py
@@ -3,13 +3,13 @@
 Utilities common to different integrated channels.
 """
 
+import base64
 import math
 import re
 from datetime import datetime, timedelta
 from itertools import islice
 from logging import getLogger
 from string import Formatter
-import base64
 
 import requests
 from six.moves import range

--- a/integrated_channels/utils.py
+++ b/integrated_channels/utils.py
@@ -31,7 +31,7 @@ def encode_course_key_into_base64(edx_course_key):
     Base64 encodes edx course key (string) into a form safe (string) for use with LMS such as Cornerstone
     e.g., Cornerstone does not allow some chars
     For Base64, the urlsafe version is used, since it only uses a pretty limited charset, minus the /
-    edX course keys allow these chars `ALLOWED_ID_CHARS = r'[\w\-~.:]'` per: opaque_keys/edx/locator.py
+    edX course keys allow these chars `ALLOWED_ID_CHARS` per: opaque_keys/edx/locator.py
     """
     if edx_course_key is None:
         raise ValueError('Cannot process an undefined edx_course_key')

--- a/integrated_channels/utils.py
+++ b/integrated_channels/utils.py
@@ -26,7 +26,7 @@ UNIX_MAX_DATE_STRING = '2038-01-19T03:14:07Z'
 LOGGER = getLogger(__name__)
 
 
-def encode_course_key_for_lms(edx_course_key):
+def encode_course_key_into_base64(edx_course_key):
     """
     Base64 encodes edx course key (string) into a form safe (string) for use with LMS such as Cornerstone
     e.g., Cornerstone does not allow some chars
@@ -40,7 +40,7 @@ def encode_course_key_for_lms(edx_course_key):
     return base64.urlsafe_b64encode(edx_course_key.encode("utf-8")).decode('utf-8')
 
 
-def decode_course_key_from_lms(lms_course_key):
+def decode_course_key_from_base64(lms_course_key):
     """
     Decodes the base64 urlsafe encoded lms_course_key, into an edX course key (string)
     """

--- a/integrated_channels/utils.py
+++ b/integrated_channels/utils.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta
 from itertools import islice
 from logging import getLogger
 from string import Formatter
+import base64
 
 import requests
 from six.moves import range
@@ -23,6 +24,23 @@ UNIX_MIN_DATE_STRING = '1970-01-01T00:00:00Z'
 UNIX_MAX_DATE_STRING = '2038-01-19T03:14:07Z'
 
 LOGGER = getLogger(__name__)
+
+
+def encode_course_key_for_lms(edx_course_key):
+    """
+    Base64 encodes edx course key (string) into a form safe (string) for use with LMS such as Cornerstone
+    e.g., Cornerstone does not allow some chars
+    For Base64, the urlsafe version is used, since it only uses a pretty limited charset, minus the /
+    edX course keys allow these chars `ALLOWED_ID_CHARS = r'[\w\-~.:]'` per: opaque_keys/edx/locator.py
+    """
+    return base64.urlsafe_b64encode(edx_course_key.encode("utf-8")).decode('utf-8')
+
+
+def decode_course_key_from_lms(lms_course_key):
+    """
+    Decodes the base64 urlsafe encoded lms_course_key, into an edX course key (string)
+    """
+    return base64.urlsafe_b64decode(lms_course_key).decode('utf-8')
 
 
 def parse_datetime_to_epoch(datestamp, magnitude=1.0):

--- a/integrated_channels/utils.py
+++ b/integrated_channels/utils.py
@@ -33,6 +33,10 @@ def encode_course_key_for_lms(edx_course_key):
     For Base64, the urlsafe version is used, since it only uses a pretty limited charset, minus the /
     edX course keys allow these chars `ALLOWED_ID_CHARS = r'[\w\-~.:]'` per: opaque_keys/edx/locator.py
     """
+    if edx_course_key is None:
+        raise ValueError('Cannot process an undefined edx_course_key')
+    if not edx_course_key.replace(' ', ''):
+        raise ValueError('Cannot process a spaces-only edx_course_key')
     return base64.urlsafe_b64encode(edx_course_key.encode("utf-8")).decode('utf-8')
 
 

--- a/tests/test_integrated_channels/test_utils.py
+++ b/tests/test_integrated_channels/test_utils.py
@@ -29,8 +29,8 @@ class TestIntegratedChannelsUtils(unittest.TestCase):
     )
     @ddt.unpack
     def test_encode_course_key_for_lms(self, edx_key, lms_key):
-        assert utils.encode_course_key_for_lms(edx_key) == lms_key
-        assert utils.decode_course_key_from_lms(lms_key) == edx_key
+        assert utils.encode_course_key_into_base64(edx_key) == lms_key
+        assert utils.decode_course_key_from_base64(lms_key) == edx_key
 
     @ddt.data(
         ('2011-01-01T00:00:00Z', '2011-01-01T00:00:00Z', False),

--- a/tests/test_integrated_channels/test_utils.py
+++ b/tests/test_integrated_channels/test_utils.py
@@ -21,6 +21,18 @@ class TestIntegratedChannelsUtils(unittest.TestCase):
     """
 
     @ddt.data(
+        ('course-v1:edX+808404707+2T2021/', 'Y291cnNlLXYxOmVkWCs4MDg0MDQ3MDcrMlQyMDIxLw=='),
+        ('edx+123', 'ZWR4KzEyMw=='),
+        ('UTAustinX/UT.7.01x/3T2014', 'VVRBdXN0aW5YL1VULjcuMDF4LzNUMjAxNA=='),
+        ('WellesleyX/ENG_112x/2014_SOND', 'V2VsbGVzbGV5WC9FTkdfMTEyeC8yMDE0X1NPTkQ=')
+
+    )
+    @ddt.unpack
+    def test_encode_course_key_for_lms(self, edx_key, lms_key):
+        assert utils.encode_course_key_for_lms(edx_key) == lms_key
+        assert utils.decode_course_key_from_lms(lms_key) == edx_key
+
+    @ddt.data(
         ('2011-01-01T00:00:00Z', '2011-01-01T00:00:00Z', False),
         ('2015-01-01T00:00:00Z', '2017-01-01T00:00:00Z', True),
         ('2018-01-01T00:00:00Z', '2020-01-01T00:00:00Z', False),


### PR DESCRIPTION
This PR only addresses part of the requirements to make Cornerstone course pulls safe
- [x] util function to encode/decode reversibly and avoid unsafe chars like `. | \ / < > ” % & and whitespace`


There is an additional set of work, which will be done in a new PR, 
- [ ] uses this util in Cornerstone exporter to convert edx course keys into safe format, when returning data from cornerstone endpoint
- [ ] update tests to use the unsafe course keys to ensure we got coverage
- [ ] address the issue of how we will handle cases where courses were already sent to CSOD so we don't ask CSOD to create dup entries
- [ ] Double check on learner module if we need to take any action (esp if we look up courses on CSOD side, if we don't then it may not be an issue)
 
ENT-4663

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
