### PR TITLE
bug: localize min datetimes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.28.19]
+---------
+* Localize timezones on catalog modified min (not found) values
+
 [3.27.18]
 ---------
 * Integrated channels util functions needed to base64 urlsafe encode/decode course keys for use with some LMS systems like Cornerstone.

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.27.18"
+__version__ = "3.27.19"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/integrated_channel/exporters/content_metadata.py
+++ b/integrated_channels/integrated_channel/exporters/content_metadata.py
@@ -12,6 +12,8 @@ from collections import OrderedDict
 from datetime import datetime
 from logging import getLogger
 
+import pytz
+
 from django.apps import apps
 from django.utils import dateparse
 
@@ -185,12 +187,12 @@ class ContentMetadataExporter(Exporter):
         content_last_modified = enterprise_catalog_data.get('content_last_modified')
         content_last_modified = dateparse.parse_datetime(
             content_last_modified
-        ) if content_last_modified else datetime.min
+        ) if content_last_modified else datetime.min.replace(tzinfo=pytz.UTC)
 
         catalog_modified = enterprise_catalog_data.get('catalog_modified')
         catalog_modified = dateparse.parse_datetime(
             catalog_modified
-        ) if catalog_modified else datetime.min
+        ) if catalog_modified else datetime.min.replace(tzinfo=pytz.UTC)
         return content_last_modified, catalog_modified
 
     def _get_most_recent_catalog_update_time(self):


### PR DESCRIPTION
```
(Pdb++) content_last_modified
datetime.datetime(1, 1, 1, 0, 0)
(Pdb++) catalog_modified
datetime.datetime(2021, 7, 16, 15, 11, 10, 592956, tzinfo=<UTC>)
(Pdb++) catalog_last_modified = max(content_last_modified, catalog_modified)
*** TypeError: can't compare offset-naive and offset-aware datetimes
```

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
