### PR TITLE
bug: invalid CSOD related course keys are now encoded

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.27.21]
+---------
+* Encode invalid course keys for CSOD customers
+
 [3.27.20]
 ---------
 * Handle content_last_modified not provided by enterprise catalog

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.27.20"
+__version__ = "3.27.21"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/cornerstone/client.py
+++ b/integrated_channels/cornerstone/client.py
@@ -12,6 +12,7 @@ import requests
 from django.apps import apps
 
 from integrated_channels.integrated_channel.client import IntegratedChannelApiClient
+from integrated_channels.utils import convert_invalid_course_ids
 
 LOGGER = logging.getLogger(__name__)
 
@@ -77,6 +78,11 @@ class CornerstoneAPIClient(IntegratedChannelApiClient):
         json_payload = json.loads(payload)
         callback_url = json_payload['data'].pop('callbackUrl')
         session_token = json_payload['data'].pop('sessionToken')
+
+        # When exporting content metadata, we encode course keys that contain invalid chars.
+        course_id = json_payload['data'].get('courseId')
+        json_payload['data']['courseId'] = convert_invalid_course_ids(course_id)
+
         url = '{base_url}{callback_url}{completion_path}?sessionToken={session_token}'.format(
             base_url=self.enterprise_configuration.cornerstone_base_url,
             callback_url=callback_url,

--- a/integrated_channels/cornerstone/exporters/content_metadata.py
+++ b/integrated_channels/cornerstone/exporters/content_metadata.py
@@ -14,6 +14,7 @@ from enterprise.utils import get_closest_course_run, get_language_code
 from integrated_channels.integrated_channel.constants import ISO_8601_DATE_FORMAT
 from integrated_channels.integrated_channel.exporters.content_metadata import ContentMetadataExporter
 from integrated_channels.utils import (
+    convert_invalid_course_ids,
     get_duration_from_estimated_hours,
     get_image_url,
     get_subjects_from_content_metadata,
@@ -52,6 +53,22 @@ class CornerstoneContentMetadataExporter(ContentMetadataExporter):  # pylint: di
         Return the exported and transformed content metadata as a dictionary regardless if there is an update needed.
         """
         return self.export(force_retrieve_all_catalogs=True)
+
+    def transform_courserun_key(self, content_metadata_item):
+        """
+        Return the transformed version of the course run key by converting into a string of valid chars by encoding the
+        key with base 64. Because valid course run keys have already been transmitted as courses, and course keys are
+        used to uniquely identify edx courses, we only want to encode the invalid ones as they would have never been
+        created.
+        """
+        return convert_invalid_course_ids(content_metadata_item.get('key'))
+
+    def transform_course_key(self, content_metadata_item):
+        """
+        Return the transformed version of the course key by converting into a string of valid chars by encoding the key
+        with base 64
+        """
+        return convert_invalid_course_ids(content_metadata_item.get('key'))
 
     def transform_organizations(self, content_metadata_item):
         """

--- a/integrated_channels/utils.py
+++ b/integrated_channels/utils.py
@@ -26,6 +26,18 @@ UNIX_MAX_DATE_STRING = '2038-01-19T03:14:07Z'
 LOGGER = getLogger(__name__)
 
 
+def convert_invalid_course_ids(course_id):
+    """
+    Regex check a course ID to see if it contains any invalid chars. If it does then encode the string, otherwise
+    return the original course ID.
+    """
+    re2 = re.compile(r"[|<>.&%\s\\/\“]+")
+    if re2.search(course_id):
+        # If the course key contains any of the invalid chars, encode the key
+        return encode_course_key_into_base64(course_id)
+    return course_id
+
+
 def encode_course_key_into_base64(edx_course_key):
     """
     Base64 encodes edx course key (string) into a form safe (string) for use with LMS such as Cornerstone


### PR DESCRIPTION
[jira](https://openedx.atlassian.net/browse/ENT-4663)

CSOD customers cannot accept courses that contain keys with invalid chars- thus for any **invalid course key**  we export, encoded it. When exporting learner data, make sure to encode the course ID if it's invalid as well in order to find the right course.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
