### PR TITLE
bug: 404s on integrated channel metadata deletions should not error

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.27.22]
+---------
+* Prevent failures on integrated channels delete requests when courses are not found.
+
 [3.27.21]
 ---------
 * Encode invalid course keys for CSOD customers

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.27.21"
+__version__ = "3.27.22"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"  # pylint: disable=invalid-name

--- a/integrated_channels/blackboard/client.py
+++ b/integrated_channels/blackboard/client.py
@@ -147,7 +147,9 @@ class BlackboardAPIClient(IntegratedChannelApiClient):
         BlackboardAPIClient._validate_channel_metadata(channel_metadata_item)
         external_id = channel_metadata_item.get('externalId')
         course_id = self._resolve_blackboard_course_id(external_id)
-        BlackboardAPIClient._validate_course_id(course_id, external_id)
+
+        if not course_id:
+            return HTTPStatus.OK.value, 'Course:{} already removed.'.format(external_id)
 
         LOGGER.info("Deleting course with courseId: %s", course_id)
         update_url = self.generate_course_update_url(course_id)

--- a/tests/test_integrated_channels/test_blackboard/test_client.py
+++ b/tests/test_integrated_channels/test_blackboard/test_client.py
@@ -481,6 +481,25 @@ class TestBlackboardApiClient(unittest.TestCase):
         )
         assert client._resolve_blackboard_course_id.called  # pylint: disable=protected-access
 
+    def test_delete_no_course_found(self):
+        client = self._create_new_mock_client()
+        serialized_data = json.dumps({
+            'externalId': 'a-course-id'
+        }).encode('utf-8')
+
+        client._create_session()  # pylint: disable=protected-access
+        client._delete = unittest.mock.MagicMock(name='_delete')  # pylint: disable=protected-access
+        client._resolve_blackboard_course_id = unittest.mock.MagicMock(  # pylint: disable=protected-access
+            name='_resolve_blackboard_course_id',
+            return_value=None
+        )
+
+        status_code, status_text = client.delete_content_metadata(serialized_data)
+        assert client._resolve_blackboard_course_id.called  # pylint: disable=protected-access
+        assert not client._delete.called  # pylint: disable=protected-access
+        assert status_code == 200
+        assert status_text == 'Course:a-course-id already removed.'
+
     def test_delete_content_metadata(self):
         client = self._create_new_mock_client()
         serialized_data = json.dumps({


### PR DESCRIPTION
[jira](https://openedx.atlassian.net/browse/ENT-4082)

When the integrated channels sends a delete request to external LMS' and receive a 404 meaning the course is not found, it shouldn't be treated as a failure, but instead a success. 

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
