### PR TITLE
feat: inject a failure reason into the failure_url query params when …

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,11 @@ Unreleased
 * Nothing
 
 
+[3.28.1]
+---------
+* Inject a failure reason into the ``failure_url`` query params when a verified course mode
+  is not available for DSC-based enrollment.
+
 [3.28.0]
 ---------
 * Added support for Django 3.0, 3.1 and 3.2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,7 +21,7 @@ Unreleased
 [3.28.1]
 ---------
 * Inject a failure reason into the ``failure_url`` query params when a verified course mode
-  is not available for DSC-based enrollment.
+  is not available for DSC-based enrollments.
 
 [3.28.0]
 ---------

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.28.0"
+__version__ = "3.28.1"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/test_utils/__init__.py
+++ b/test_utils/__init__.py
@@ -203,7 +203,7 @@ def update_search_with_enterprise_context(search_result, add_utm_info):
     return search_result
 
 
-def fake_render(request, template, context):  # pylint: disable=unused-argument
+def fake_render(request, template, context, **kwargs):  # pylint: disable=unused-argument
     """
     Switch the request to use a template that does not depend on edx-platform.
     The choice of the template here is arbitrary, as long as it renders successfully for tests.

--- a/tests/test_enterprise/views/test_grant_data_sharing_permissions.py
+++ b/tests/test_enterprise/views/test_grant_data_sharing_permissions.py
@@ -3,11 +3,13 @@
 Tests for the ``GrantDataSharingPermissions`` view of the Enterprise app.
 """
 
+import json
 import uuid
 
 import ddt
 import mock
 from dateutil.parser import parse
+from edx_rest_api_client.exceptions import HttpClientError
 from pytest import mark
 
 from django.conf import settings
@@ -17,6 +19,7 @@ from django.test import Client, TestCase
 from django.urls import reverse
 
 from enterprise.models import EnterpriseCourseEnrollment, LicensedEnterpriseCourseEnrollment
+from enterprise.views import FAILED_ENROLLMENT_REASON_QUERY_PARAM, VERIFIED_MODE_UNAVAILABLE, add_reason_to_failure_url
 from integrated_channels.exceptions import ClientError
 from test_utils import fake_render
 from test_utils.factories import (
@@ -42,6 +45,9 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
         self.user.set_password("QWERTY")
         self.user.save()
         self.client = Client()
+
+        LicensedEnterpriseCourseEnrollment.objects.all().delete()
+        EnterpriseCourseEnrollment.objects.all().delete()
         super().setUp()
 
     url = reverse('grant_data_sharing_permissions')
@@ -884,6 +890,107 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
         assert resp.status_code == 404
         dsc.refresh_from_db()
         assert dsc.granted is False
+
+    def test_add_reason_to_failure_url(self):
+        base_failure_url = 'https://example.com/?enrollment_failed=true'
+        failure_reason = 'something weird happened'
+
+        actual_url = add_reason_to_failure_url(base_failure_url, failure_reason)
+        expected_url = (
+            'https://example.com/?enrollment_failed=true&'
+            '{reason_param}=something+weird+happened'.format(
+                reason_param=FAILED_ENROLLMENT_REASON_QUERY_PARAM,
+            )
+        )
+        self.assertEqual(actual_url, expected_url)
+
+    @mock.patch('enterprise.views.reverse', return_value='/dashboard')
+    @mock.patch('enterprise.views.render', side_effect=fake_render)
+    @mock.patch('enterprise.views.get_best_mode_from_course_key')
+    @mock.patch('enterprise.models.EnterpriseCatalogApiClient')
+    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
+    @ddt.data(True, False)
+    def test_get_dsc_verified_mode_unavailable(
+        self,
+        is_post,
+        mock_course_catalog_api_client,
+        mock_enrollment_api_client,
+        mock_enterprise_catalog_client,
+        mock_get_course_mode,
+        *args,
+    ):
+        self._login()
+        course_id = 'course-v1:edX+DemoX+Demo_Course'
+        license_uuid = str(uuid.uuid4())
+
+        enterprise_customer = EnterpriseCustomerFactory(
+            name='Starfleet Academy',
+            enable_data_sharing_consent=True,
+            enforce_data_sharing_consent='at_enrollment',
+        )
+        EnterpriseCustomerCatalogFactory(
+            enterprise_customer=enterprise_customer,
+            content_filter={'key': [course_id]},
+        )
+        ecu = EnterpriseCustomerUserFactory(
+            user_id=self.user.id,
+            enterprise_customer=enterprise_customer
+        )
+        DataSharingConsentFactory(
+            username=self.user.username,
+            course_id=course_id,
+            enterprise_customer=enterprise_customer,
+            granted=not is_post,
+        )
+
+        mock_course_catalog_api_client.return_value.program_exists.return_value = True
+        mock_course_catalog_api_client.return_value.get_course_id.return_value = course_id
+
+        enterprise_catalog_client = mock_enterprise_catalog_client.return_value
+        enterprise_catalog_client.enterprise_contains_content_items.return_value = True
+
+        course_mode = 'verified'
+        mock_get_course_mode.return_value = course_mode
+
+        mock_get_enrollment = mock_enrollment_api_client.return_value.get_course_enrollment
+        mock_get_enrollment.return_value = None
+
+        mock_enroll_user = mock_enrollment_api_client.return_value.enroll_user_in_course
+        client_error_content = json.dumps(
+            {'message': VERIFIED_MODE_UNAVAILABLE.enrollment_client_error}
+        ).encode()
+        mock_enroll_user.side_effect = HttpClientError(content=client_error_content)
+
+        params = {
+            'enterprise_customer_uuid': str(enterprise_customer.uuid),
+            'course_id': course_id,
+            'next': 'https://success.url',
+            'redirect_url': 'https://success.url',
+            'failure_url': 'https://failure.url',
+            'license_uuid': license_uuid,
+            'data_sharing_consent': True,
+        }
+        if is_post:
+            response = self.client.post(self.url, data=params)
+        else:
+            response = self.client.get(self.url, data=params)
+
+        assert response.status_code == 302
+        self.assertRedirects(
+            response,
+            'https://failure.url?failure_reason={}'.format(VERIFIED_MODE_UNAVAILABLE.failure_reason_message),
+            fetch_redirect_response=False,
+        )
+
+        assert EnterpriseCourseEnrollment.objects.filter(
+            enterprise_customer_user=ecu,
+            course_id=course_id,
+        ).exists() is False
+
+        assert LicensedEnterpriseCourseEnrollment.objects.filter(
+            license_uuid=license_uuid,
+        ).exists() is False
 
 
 @mark.django_db

--- a/tests/test_integrated_channels/test_canvas/test_utils.py
+++ b/tests/test_integrated_channels/test_canvas/test_utils.py
@@ -61,7 +61,7 @@ class TestCanvasUtils(unittest.TestCase):
             return_value=success_response
         )
         root_account = CanvasUtil.find_root_canvas_account(self.enterprise_config, mock_session)
-        assert root_account['id'] == 1
+        assert root_account['id'] == 1  # pylint: disable=unsubscriptable-object
 
     def test_find_root_canvas_account_not_found(self):
         success_response = unittest.mock.Mock(spec=Response)

--- a/tests/test_integrated_channels/test_xapi/test_utils.py
+++ b/tests/test_integrated_channels/test_xapi/test_utils.py
@@ -79,7 +79,7 @@ class TestUtils(unittest.TestCase):
             {'status': 500, 'error_messages': None},
         )
 
-        self.x_api_client.lrs.save_statement.assert_called()
+        self.x_api_client.lrs.save_statement.assert_called()  # pylint: disable=no-member
 
     @mock.patch('integrated_channels.xapi.client.RemoteLRS', mock.MagicMock())
     @mock.patch('enterprise.api_client.discovery.JwtBuilder')
@@ -139,7 +139,7 @@ class TestUtils(unittest.TestCase):
             {'status': 500, 'error_message': None}
         )
 
-        self.x_api_client.lrs.save_statement.assert_called()
+        self.x_api_client.lrs.save_statement.assert_called()  # pylint: disable=no-member
 
     def test_is_success_response(self):
         """


### PR DESCRIPTION
…a verified course mode is not available for DSC-based enrollment. ENT-4564

https://openedx.atlassian.net/browse/ENT-4564

**Please merge the related learner-portal change after this is deployed.**
https://github.com/edx/frontend-app-learner-portal-enterprise/pull/295

How to test:
* Checkout the above learner-portal PR and run it.
* Go to the course modes page for your course and set the verified deadline for some time in the past: http://localhost:18000/admin/course_modes/coursemode/
* Go to the learner portal, go directly to your course page i.e. http://localhost:8734/pied-piper/course/edX+DemoX and click enroll - make sure you're not already enrolled.  If you are, delete your data:
```
SELECT id from enterprise_enterprisecourseenrollment where course_id = 'course-v1:edX+DemoX+Demo_Course' and user_id = YOUR_USERS_ID;
DELETE FROM enterprise_licensedenterprisecourseenrollment where enterprise_course_enrollment_id = ID_YOU_JUST_FOUND;
DELETE FROM enterprise_enterprisecourseenrollment where id = ID_YOU_JUST_FOUND;
DELETE FROM consent_datasharingconsent WHERE course_id = 'course-v1:edX+DemoX+Demo_Course' and username = 'YOUR_USERNAME';
```
* Fill out DSC form.
* After submitting, you should be directed back to the learner portal course page with a message saying that the verified deadline has expired.

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [x] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
