### PR TITLE
feat: log response code and message if SAP post fails

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,10 @@ Unreleased
 * Nothing
 
 
+[3.28.3]
+---------
+* Integrated channels: log response code and message if SAP post fails
+
 [3.28.2]
 ---------
 * Add `progress_v3` report type for enterprise reporting.

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.28.2"
+__version__ = "3.28.3"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/tests/test_integrated_channels/test_sap_success_factors/test_client.py
+++ b/tests/test_integrated_channels/test_sap_success_factors/test_client.py
@@ -22,6 +22,7 @@ from integrated_channels.sap_success_factors.models import (
     SAPSuccessFactorsEnterpriseCustomerConfiguration,
     SAPSuccessFactorsGlobalConfiguration,
 )
+from test_utils.factories import EnterpriseCustomerFactory
 
 NOW = datetime.datetime(2017, 1, 2, 3, 4, 5)
 
@@ -76,6 +77,7 @@ class TestSAPSuccessFactorsAPIClient(unittest.TestCase):
             sapsf_user_id=self.user_id,
             secret=self.client_secret
         )
+        self.enterprise_config.enterprise_customer = EnterpriseCustomerFactory()
         self.completion_payload = {
             "userID": "abc123",
             "courseID": "course-v1:ColumbiaX+DS101X+1T2016",


### PR DESCRIPTION
While starting to work on ENT-4784 I realized this log may help us, also this was mentioned as lacking in the ticket, because we had to lookup error in snowflake

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
