### PR TITLE
feat: pass idp_id to get_remote_id for degreed

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.28.7]
+---------
+* Degreed integrated channel now uses idp_id explicitly when calling get_remote_id()
+
 [3.28.6]
 ---------
 * SAP integrated channel now uses idp_id explicitly when calling get_remote_id()

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.28.6"
+__version__ = "3.28.7"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/degreed/exporters/learner_data.py
+++ b/integrated_channels/degreed/exporters/learner_data.py
@@ -34,7 +34,9 @@ class DegreedLearnerExporter(LearnerExporter):
         """
         # Degreed expects completion dates of the form 'yyyy-mm-dd'.
         completed_timestamp = completed_date.strftime("%F") if isinstance(completed_date, datetime) else None
-        if enterprise_enrollment.enterprise_customer_user.get_remote_id() is not None:
+        if enterprise_enrollment.enterprise_customer_user.get_remote_id(
+            self.enterprise_configuration.idp_id
+        ) is not None:
             DegreedLearnerDataTransmissionAudit = apps.get_model(
                 'degreed',
                 'DegreedLearnerDataTransmissionAudit'


### PR DESCRIPTION
After a recent change, we can now pass idp_id (the slug of the idp provider) into the get_remote_id() call. If the Integrated channel config does not provide this value it will be passed as None or empty and we get toda's behavior. If we do set it though, we can now resolve the correct remote id based on idp slug.

I am hoping this will fix issues with not being able to send learner data completions for Degreed going forward. It won't fix previously missed completions. we have to find a different way to re-send those.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
