### PR TITLE
fix: add failure_reason to failure url when dsc is denied

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.28.9]
+---------
+* Include a ``failure_reason=dsc_denied`` to the DSC failure url when learner denies the DSC terms.
+
 [3.28.8]
 ---------
 * SAP integrated channel django form gets missing idp id field

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.28.8"
+__version__ = "3.28.9"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -178,6 +178,10 @@ VERIFIED_MODE_UNAVAILABLE = FailedEnrollmentReason(
     enrollment_client_error='The [verified] course mode is expired or otherwise unavailable',
     failure_reason_message='verified_mode_unavailable',
 )
+DSC_DENIED = FailedEnrollmentReason(
+    enrollment_client_error='Data Sharing Consent terms must be accepted in order to enroll',
+    failure_reason_message='dsc_denied',
+)
 
 
 def verify_edx_resources():
@@ -931,8 +935,15 @@ class GrantDataSharingPermissions(View):
                 course_id, program_uuid, license_uuid,
                 success_url, failure_url, consent_record=consent_record,
             )
+        if consent_provided:
+            return redirect(success_url)
 
-        return redirect(success_url if consent_provided else failure_url)
+        return redirect(
+            add_reason_to_failure_url(
+                failure_url,
+                DSC_DENIED.failure_reason_message,
+            )
+        )
 
 
 class EnterpriseLoginView(FormView):

--- a/tests/test_enterprise/views/test_grant_data_sharing_permissions.py
+++ b/tests/test_enterprise/views/test_grant_data_sharing_permissions.py
@@ -622,21 +622,21 @@ class TestGrantDataSharingPermissions(MessagesMixin, TestCase):
     @mock.patch('enterprise.views.reverse')
     @ddt.data(
         (True, True, '/successful_enrollment', 'course-v1:edX+DemoX+Demo_Course', str(uuid.uuid4())),
-        (True, False, '/failure_url', 'course-v1:edX+DemoX+Demo_Course', str(uuid.uuid4())),
+        (True, False, '/failure_url?failure_reason=dsc_denied', 'course-v1:edX+DemoX+Demo_Course', str(uuid.uuid4())),
         (False, True, '/successful_enrollment', 'course-v1:edX+DemoX+Demo_Course', str(uuid.uuid4())),
-        (False, False, '/failure_url', 'course-v1:edX+DemoX+Demo_Course', str(uuid.uuid4())),
+        (False, False, '/failure_url?failure_reason=dsc_denied', 'course-v1:edX+DemoX+Demo_Course', str(uuid.uuid4())),
         (True, True, '/successful_enrollment', 'edX+DemoX', str(uuid.uuid4())),
-        (True, False, '/failure_url', 'edX+DemoX', str(uuid.uuid4())),
+        (True, False, '/failure_url?failure_reason=dsc_denied', 'edX+DemoX', str(uuid.uuid4())),
         (False, True, '/successful_enrollment', 'edX+DemoX', str(uuid.uuid4())),
-        (False, False, '/failure_url', 'edX+DemoX', str(uuid.uuid4())),
+        (False, False, '/failure_url?failure_reason=dsc_denied', 'edX+DemoX', str(uuid.uuid4())),
         (True, True, '/successful_enrollment', 'course-v1:edX+DemoX+Demo_Course', ''),
-        (True, False, '/failure_url', 'course-v1:edX+DemoX+Demo_Course', ''),
+        (True, False, '/failure_url?failure_reason=dsc_denied', 'course-v1:edX+DemoX+Demo_Course', ''),
         (False, True, '/successful_enrollment', 'course-v1:edX+DemoX+Demo_Course', ''),
-        (False, False, '/failure_url', 'course-v1:edX+DemoX+Demo_Course', ''),
+        (False, False, '/failure_url?failure_reason=dsc_denied', 'course-v1:edX+DemoX+Demo_Course', ''),
         (True, True, '/successful_enrollment', 'edX+DemoX', ''),
-        (True, False, '/failure_url', 'edX+DemoX', ''),
+        (True, False, '/failure_url?failure_reason=dsc_denied', 'edX+DemoX', ''),
         (False, True, '/successful_enrollment', 'edX+DemoX', ''),
-        (False, False, '/failure_url', 'edX+DemoX', ''),
+        (False, False, '/failure_url?failure_reason=dsc_denied', 'edX+DemoX', ''),
     )
     @ddt.unpack
     def test_post_course_specific_consent(
@@ -1157,7 +1157,8 @@ class TestProgramDataSharingPermissions(TestCase):
         response = self.client.post(self.url, params, follow=False)
         # No need to update the consent record if consent not provided
         assert consent_record.save.called is False
-        self.assertRedirects(response, 'https://facebook.com/', fetch_redirect_response=False)
+        expected_failure_url = 'https://facebook.com/?failure_reason=dsc_denied'
+        self.assertRedirects(response, expected_failure_url, fetch_redirect_response=False)
 
     def test_post_program_consent_deferred(self):
         consent_record = self.get_data_sharing_consent.return_value


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
