### PR TITLE
feat: :goal_net: catch/report status code >=400 for create_course_completion calls

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.28.10]
+---------
+* Integrated channel transmitter completions routine now logs as error, any status codes greater than or equal to 400
+
 [3.28.9]
 ---------
 * Include a ``failure_reason=dsc_denied`` to the DSC failure url when learner denies the DSC terms.

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.28.9"
+__version__ = "3.28.10"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/blackboard/transmitters/learner_data.py
+++ b/integrated_channels/blackboard/transmitters/learner_data.py
@@ -22,17 +22,17 @@ class BlackboardLearnerTransmitter(LearnerTransmitter):
             client=client
         )
 
-    def transmit(self, payload, **kwargs):
+    def transmit(self, exporter, **kwargs):
         """
         Send a completion status call to Blackboard using the client.
 
         Args:
-            payload: The learner completion data payload to send to Blackboard
+            exporter: The learner exporter for Blackboard
         """
         kwargs['app_label'] = 'blackboard'
         kwargs['model_name'] = 'BlackboardLearnerDataTransmissionAudit'
         kwargs['remote_user_id'] = 'blackboard_user_email'
-        super().transmit(payload, **kwargs)
+        super().transmit(exporter, **kwargs)
 
     def single_learner_assessment_grade_transmit(self, exporter, **kwargs):
         """

--- a/integrated_channels/blackboard/transmitters/learner_data.py
+++ b/integrated_channels/blackboard/transmitters/learner_data.py
@@ -22,17 +22,17 @@ class BlackboardLearnerTransmitter(LearnerTransmitter):
             client=client
         )
 
-    def transmit(self, exporter, **kwargs):
+    def transmit(self, payload, **kwargs):
         """
         Send a completion status call to Blackboard using the client.
 
         Args:
-            exporter: The learner exporter for Blackboard
+            payload: The learner completion exporter for Blackboard
         """
         kwargs['app_label'] = 'blackboard'
         kwargs['model_name'] = 'BlackboardLearnerDataTransmissionAudit'
         kwargs['remote_user_id'] = 'blackboard_user_email'
-        super().transmit(exporter, **kwargs)
+        super().transmit(payload, **kwargs)
 
     def single_learner_assessment_grade_transmit(self, exporter, **kwargs):
         """

--- a/integrated_channels/canvas/transmitters/learner_data.py
+++ b/integrated_channels/canvas/transmitters/learner_data.py
@@ -22,17 +22,17 @@ class CanvasLearnerTransmitter(LearnerTransmitter):
             client=client
         )
 
-    def transmit(self, payload, **kwargs):
+    def transmit(self, exporter, **kwargs):
         """
         Send a completion status call to Canvas using the client.
 
         Args:
-            payload: The learner completion data payload to send to Canvas
+            exporter: The learner data exporter for Canvas
         """
         kwargs['app_label'] = 'canvas'
         kwargs['model_name'] = 'CanvasLearnerDataTransmissionAudit'
         kwargs['remote_user_id'] = 'canvas_user_email'
-        super().transmit(payload, **kwargs)
+        super().transmit(exporter, **kwargs)
 
     def single_learner_assessment_grade_transmit(self, exporter, **kwargs):
         """

--- a/integrated_channels/canvas/transmitters/learner_data.py
+++ b/integrated_channels/canvas/transmitters/learner_data.py
@@ -22,17 +22,17 @@ class CanvasLearnerTransmitter(LearnerTransmitter):
             client=client
         )
 
-    def transmit(self, exporter, **kwargs):
+    def transmit(self, payload, **kwargs):
         """
         Send a completion status call to Canvas using the client.
 
         Args:
-            exporter: The learner data exporter for Canvas
+            payload: The learner exporter for Canvas
         """
         kwargs['app_label'] = 'canvas'
         kwargs['model_name'] = 'CanvasLearnerDataTransmissionAudit'
         kwargs['remote_user_id'] = 'canvas_user_email'
-        super().transmit(exporter, **kwargs)
+        super().transmit(payload, **kwargs)
 
     def single_learner_assessment_grade_transmit(self, exporter, **kwargs):
         """

--- a/integrated_channels/cornerstone/transmitters/learner_data.py
+++ b/integrated_channels/cornerstone/transmitters/learner_data.py
@@ -22,14 +22,14 @@ class CornerstoneLearnerTransmitter(LearnerTransmitter):
             client=client
         )
 
-    def transmit(self, exporter, **kwargs):
+    def transmit(self, payload, **kwargs):
         """
         Send a completion status call to Cornerstone using the client.
 
         Args:
-            exporter: The learner data exporter for Cornerstone
+            payload: The learner exporter for Cornerstone
         """
         kwargs['app_label'] = 'cornerstone'
         kwargs['model_name'] = 'CornerstoneLearnerDataTransmissionAudit'
         kwargs['remote_user_id'] = 'user_guid'
-        super().transmit(exporter, **kwargs)
+        super().transmit(payload, **kwargs)

--- a/integrated_channels/cornerstone/transmitters/learner_data.py
+++ b/integrated_channels/cornerstone/transmitters/learner_data.py
@@ -22,14 +22,14 @@ class CornerstoneLearnerTransmitter(LearnerTransmitter):
             client=client
         )
 
-    def transmit(self, payload, **kwargs):
+    def transmit(self, exporter, **kwargs):
         """
         Send a completion status call to Cornerstone using the client.
 
         Args:
-            payload: The learner completion data payload to send to Cornerstone
+            exporter: The learner data exporter for Cornerstone
         """
         kwargs['app_label'] = 'cornerstone'
         kwargs['model_name'] = 'CornerstoneLearnerDataTransmissionAudit'
         kwargs['remote_user_id'] = 'user_guid'
-        super().transmit(payload, **kwargs)
+        super().transmit(exporter, **kwargs)

--- a/integrated_channels/degreed/transmitters/learner_data.py
+++ b/integrated_channels/degreed/transmitters/learner_data.py
@@ -22,14 +22,14 @@ class DegreedLearnerTransmitter(LearnerTransmitter):
             client=client
         )
 
-    def transmit(self, payload, **kwargs):
+    def transmit(self, exporter, **kwargs):
         """
         Send a completion status call to Degreed using the client.
 
         Args:
-            payload: The learner completion data payload to send to Degreed
+            exporter: The learner data exporter for Degreed
         """
         kwargs['app_label'] = 'degreed'
         kwargs['model_name'] = 'DegreedLearnerDataTransmissionAudit'
         kwargs['remote_user_id'] = 'degreed_user_email'
-        super().transmit(payload, **kwargs)
+        super().transmit(exporter, **kwargs)

--- a/integrated_channels/degreed/transmitters/learner_data.py
+++ b/integrated_channels/degreed/transmitters/learner_data.py
@@ -22,14 +22,14 @@ class DegreedLearnerTransmitter(LearnerTransmitter):
             client=client
         )
 
-    def transmit(self, exporter, **kwargs):
+    def transmit(self, payload, **kwargs):
         """
         Send a completion status call to Degreed using the client.
 
         Args:
-            exporter: The learner data exporter for Degreed
+            payload: The learner exporter for Degreed
         """
         kwargs['app_label'] = 'degreed'
         kwargs['model_name'] = 'DegreedLearnerDataTransmissionAudit'
         kwargs['remote_user_id'] = 'degreed_user_email'
-        super().transmit(exporter, **kwargs)
+        super().transmit(payload, **kwargs)

--- a/integrated_channels/integrated_channel/transmitters/__init__.py
+++ b/integrated_channels/integrated_channel/transmitters/__init__.py
@@ -25,7 +25,7 @@ class Transmitter:
         self.enterprise_configuration = enterprise_configuration
         self.client = client(enterprise_configuration) if client else None
 
-    def transmit(self, payload, **kwargs):
+    def transmit(self, exporter, **kwargs):
         """
         The abstract interface method for sending exported data to an integrated channel through its API client.
         """

--- a/integrated_channels/integrated_channel/transmitters/__init__.py
+++ b/integrated_channels/integrated_channel/transmitters/__init__.py
@@ -25,7 +25,7 @@ class Transmitter:
         self.enterprise_configuration = enterprise_configuration
         self.client = client(enterprise_configuration) if client else None
 
-    def transmit(self, exporter, **kwargs):
+    def transmit(self, payload, **kwargs):
         """
         The abstract interface method for sending exported data to an integrated channel through its API client.
         """

--- a/integrated_channels/integrated_channel/transmitters/learner_data.py
+++ b/integrated_channels/integrated_channel/transmitters/learner_data.py
@@ -165,12 +165,12 @@ class LearnerTransmitter(Transmitter):
 
             learner_data.save()
 
-    def transmit(self, exporter, **kwargs):
+    def transmit(self, payload, **kwargs):
         """
         Send a completion status call to the integrated channel using the client.
 
         Args:
-            exporter: The learner data exporter.
+            payload: The learner data exporter.
             kwargs: Contains integrated channel-specific information for customized transmission variables.
                 - app_label: The app label of the integrated channel for whom to store learner data records for.
                 - model_name: The name of the specific learner data record model to use.
@@ -191,7 +191,7 @@ class LearnerTransmitter(Transmitter):
         # one by course key and one by course run id.
         # If the transmission with the course key succeeds, the next one will get skipped.
         # If it fails, the one with the course run id will be attempted and (presumably) succeed.
-        for learner_data in exporter.export(**kwargs):
+        for learner_data in payload.export(**kwargs):
             serialized_payload = learner_data.serialize(enterprise_configuration=self.enterprise_configuration)
 
             enterprise_enrollment_id = learner_data.enterprise_course_enrollment_id

--- a/integrated_channels/moodle/transmitters/learner_data.py
+++ b/integrated_channels/moodle/transmitters/learner_data.py
@@ -22,14 +22,14 @@ class MoodleLearnerTransmitter(LearnerTransmitter):
             client=client
         )
 
-    def transmit(self, payload, **kwargs):
+    def transmit(self, exporter, **kwargs):
         """
         Send a completion status call to Moodle using the client.
 
         Args:
-            payload: The learner completion data payload to send to Moodle
+            exporter: The learner data exporter for Moodle
         """
         kwargs['app_label'] = 'moodle'
         kwargs['model_name'] = 'MoodleLearnerDataTransmissionAudit'
         kwargs['remote_user_id'] = 'moodle_user_email'
-        super().transmit(payload, **kwargs)
+        super().transmit(exporter, **kwargs)

--- a/integrated_channels/moodle/transmitters/learner_data.py
+++ b/integrated_channels/moodle/transmitters/learner_data.py
@@ -22,14 +22,14 @@ class MoodleLearnerTransmitter(LearnerTransmitter):
             client=client
         )
 
-    def transmit(self, exporter, **kwargs):
+    def transmit(self, payload, **kwargs):
         """
         Send a completion status call to Moodle using the client.
 
         Args:
-            exporter: The learner data exporter for Moodle
+            payload: The learner data exporter for Moodle
         """
         kwargs['app_label'] = 'moodle'
         kwargs['model_name'] = 'MoodleLearnerDataTransmissionAudit'
         kwargs['remote_user_id'] = 'moodle_user_email'
-        super().transmit(exporter, **kwargs)
+        super().transmit(payload, **kwargs)

--- a/integrated_channels/sap_success_factors/transmitters/learner_data.py
+++ b/integrated_channels/sap_success_factors/transmitters/learner_data.py
@@ -29,17 +29,17 @@ class SapSuccessFactorsLearnerTransmitter(LearnerTransmitter):
             client=client
         )
 
-    def transmit(self, exporter, **kwargs):
+    def transmit(self, payload, **kwargs):
         """
         Send a completion status call to SAP SuccessFactors using the client.
 
         Args:
-            exporter: The learner data exporter for SAP SuccessFactors
+            payload: The learner data exporter for SAP SuccessFactors
         """
         kwargs['app_label'] = 'sap_success_factors'
         kwargs['model_name'] = 'SapSuccessFactorsLearnerDataTransmissionAudit'
         kwargs['remote_user_id'] = 'sapsf_user_id'
-        super().transmit(exporter, **kwargs)
+        super().transmit(payload, **kwargs)
 
     def handle_transmission_error(self, learner_data, client_exception, integrated_channel_name,
                                   enterprise_customer_uuid, learner_id, course_id):

--- a/integrated_channels/sap_success_factors/transmitters/learner_data.py
+++ b/integrated_channels/sap_success_factors/transmitters/learner_data.py
@@ -29,17 +29,17 @@ class SapSuccessFactorsLearnerTransmitter(LearnerTransmitter):
             client=client
         )
 
-    def transmit(self, payload, **kwargs):
+    def transmit(self, exporter, **kwargs):
         """
         Send a completion status call to SAP SuccessFactors using the client.
 
         Args:
-            payload: The learner completion data payload to send to SAP SuccessFactors
+            exporter: The learner data exporter for SAP SuccessFactors
         """
         kwargs['app_label'] = 'sap_success_factors'
         kwargs['model_name'] = 'SapSuccessFactorsLearnerDataTransmissionAudit'
         kwargs['remote_user_id'] = 'sapsf_user_id'
-        super().transmit(payload, **kwargs)
+        super().transmit(exporter, **kwargs)
 
     def handle_transmission_error(self, learner_data, client_exception, integrated_channel_name,
                                   enterprise_customer_uuid, learner_id, course_id):

--- a/tests/test_integrated_channels/test_integrated_channel/test_transmitters/test_learner_data.py
+++ b/tests/test_integrated_channels/test_integrated_channel/test_transmitters/test_learner_data.py
@@ -2,15 +2,15 @@
 Tests for the base learner data transmitter.
 """
 
-from mock.mock import MagicMock
-from integrated_channels.exceptions import ClientError
 import unittest
 from unittest.mock import Mock
 
 import ddt
 import mock
+from mock.mock import MagicMock
 from pytest import mark
 
+from integrated_channels.exceptions import ClientError
 from integrated_channels.integrated_channel.exporters.learner_data import LearnerExporter
 from integrated_channels.integrated_channel.tasks import transmit_single_learner_data
 from integrated_channels.integrated_channel.transmitters.learner_data import LearnerTransmitter

--- a/tests/test_integrated_channels/test_integrated_channel/test_transmitters/test_learner_data.py
+++ b/tests/test_integrated_channels/test_integrated_channel/test_transmitters/test_learner_data.py
@@ -2,6 +2,8 @@
 Tests for the base learner data transmitter.
 """
 
+from mock.mock import MagicMock
+from integrated_channels.exceptions import ClientError
 import unittest
 from unittest.mock import Mock
 
@@ -21,6 +23,7 @@ class TestLearnerDataTransmitter(unittest.TestCase):
     """
     Tests for the class ``LearnerDataTransmitter``.
     """
+
     def setUp(self):
         super().setUp()
 
@@ -86,3 +89,22 @@ class TestLearnerDataTransmitter(unittest.TestCase):
         assert learner_data_transmission_audit_mock.save.called
         assert learner_data_transmission_audit_mock.error_message == ''
         assert learner_data_transmission_audit_mock.status == '200'
+
+    @mock.patch('integrated_channels.integrated_channel.transmitters.'
+                'learner_data.LearnerExporterUtility.lms_user_id_for_ent_course_enrollment_id')
+    @mock.patch('integrated_channels.integrated_channel.transmitters.learner_data.is_already_transmitted')
+    def test_raises_client_error_on_status_code(self, is_already_tx, mock_lms_id):
+        mock_lms_id.return_value = 'abc'
+        is_already_tx.return_value = False
+        self.learner_transmitter.client.create_course_completion = Mock(return_value=(401, 'fail'))
+        exporter = MagicMock()
+        records = MagicMock()
+        records.course_completed = True
+        records.serialize = Mock(return_value='serialized data')
+        exporter.export = MagicMock(return_value=[records])
+        self.learner_transmitter.handle_transmission_error = Mock()
+        self.learner_transmitter.transmit(
+            exporter,
+            remote_user_id='user_id'
+        )
+        self.learner_transmitter.handle_transmission_error.assert_called_once()


### PR DESCRIPTION
Applies to all channels and we get free logging from base class

Also renamed `payload` to `exporter` in transmit() method docstrings

ENT-4929

there is a except block that catches and handles logging for ClientError around the completion call, so I took advantage of that:
```
except ClientError as client_error:
```
does not fix any existing issue, this is logging-only that makes up for missing logs in some cases when we don't necessarily catch and re-raise/log >=400 cases

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
