### PR TITLE
fix: recreate enterprise_learner role when ECU is relinked

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,11 @@ Unreleased
 ----------
 * Nothing
 
+[3.28.11]
+---------
+* Create "enterprise_learner" role when ``EnterpriseCustomerUser`` records are re-linked.
+* When ``EnterpriseCustomerUser`` records get deleted, also delete the "enterprise_admin" role specific to the relevant enterprise customer.
+
 [3.28.10]
 ---------
 * Integrated channel transmitter completions routine now logs as error, any status codes greater than or equal to 400

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.28.10"
+__version__ = "3.28.11"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"


### PR DESCRIPTION
It was observed that we had ~650 `EnterpriseCustomerUser` records (`linked=True`) that had missing "enterprise_learner" system-wide role assignments. In digging through the relevant history tables, I noticed that for many of these cases, the `EnterpriseCustomerUser` record is updated to be unlinked and then later re-linked at a future date.

In the Django signals that create/delete these "enterprise_learner" roles, we handle the case where a learner is unlinked (i.e., delete their "enterprise_learner" role), but do not handle the case where a learner is re-linked. As such, the "enterprise_learner" role is never recreated.

This PR ensures we handle that re-linking case.

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
