### PR TITLE
feat: fill in now() for completed date for audit: ENT-4918

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.28.12]
+---------
+* Integrated channels automatically fill in current date for audit completions if date not available.
+
 [3.28.11]
 ---------
 * Create "enterprise_learner" role when ``EnterpriseCustomerUser`` records are re-linked.

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.28.11"
+__version__ = "3.28.12"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/integrated_channel/exporters/learner_data.py
+++ b/integrated_channels/integrated_channel/exporters/learner_data.py
@@ -329,7 +329,7 @@ class LearnerExporter(Exporter):
         is_audit_enrollment = enterprise_enrollment.is_audit_enrollment
 
         # The decision to not get incomplete count for non audit enrollments can be questioned
-        # Right now we don't use this number for non audit. But this conditoin can be just removed
+        # Right now we don't use this number for non audit. But this condition can be just removed
         # if we decide we need this for non audit enrollments too
         if not is_audit_enrollment:
             return incomplete_count

--- a/integrated_channels/integrated_channel/exporters/learner_data.py
+++ b/integrated_channels/integrated_channel/exporters/learner_data.py
@@ -269,6 +269,7 @@ class LearnerExporter(Exporter):
         course_details,
         enterprise_enrollment,
         channel_name,
+        incomplete_count=None,
     ):
         '''
         Fetch grades info using either certificate api, or grades api.
@@ -276,6 +277,9 @@ class LearnerExporter(Exporter):
         - For audit enrollments, currently will fetch using grades api,
         - For non audit, it still calls grades api if pacing !=instructor otherwise calls certificate api
         This pacing logic needs cleanup for a more accurate piece of logic since pacing should not be relevant
+
+        Returns: tuple with values:
+            completed_date_from_api, grade_from_api, is_passing_from_api, grade_percent
         '''
         is_audit_enrollment = enterprise_enrollment.is_audit_enrollment
         lms_user_id = enterprise_enrollment.enterprise_customer_user.user_id
@@ -294,7 +298,7 @@ class LearnerExporter(Exporter):
         # For self-paced courses, check the Grades API
         else:
             completed_date_from_api, grade_from_api, is_passing_from_api, grade_percent = \
-                self._collect_grades_data(enterprise_enrollment, course_details, channel_name)
+                self.collect_grades_data(enterprise_enrollment, course_details, channel_name)
             LOGGER.info(generate_formatted_log(
                 channel_name, enterprise_customer_uuid, lms_user_id, course_id,
                 f'_collect_grades_data finished with: CourseMode: {enterprise_enrollment.mode}, '
@@ -303,6 +307,17 @@ class LearnerExporter(Exporter):
                 f' IsPassing: {is_passing_from_api},'
                 f' Audit Mode?: {is_audit_enrollment}'
             ))
+
+        # there is a case for audit enrollment, we are reporting completion based on
+        # content count cmopleted, so we may not get a completed_date_from_api
+        # and the model requires a completed_date field
+        if incomplete_count == 0 and enterprise_enrollment.is_audit_enrollment and completed_date_from_api is None:
+            LOGGER.info(generate_formatted_log(
+                channel_name, enterprise_customer_uuid, lms_user_id, course_id,
+                'Setting completed_date to now() for audit course with all non-gated content done.'
+            ))
+            completed_date_from_api = timezone.now()
+
         return completed_date_from_api, grade_from_api, is_passing_from_api, grade_percent
 
     def get_incomplete_content_count(self, enterprise_enrollment, channel_name):
@@ -312,6 +327,10 @@ class LearnerExporter(Exporter):
         '''
         incomplete_count = None
         is_audit_enrollment = enterprise_enrollment.is_audit_enrollment
+
+        # The decision to not get incomplete count for non audit enrollments can be questioned
+        # Right now we don't use this number for non audit. But this conditoin can be just removed
+        # if we decide we need this for non audit enrollments too
         if not is_audit_enrollment:
             return incomplete_count
         lms_user_id = enterprise_enrollment.enterprise_customer_user.user_id
@@ -371,23 +390,15 @@ class LearnerExporter(Exporter):
             enterprise_customer_uuid = enterprise_enrollment.enterprise_customer_user.enterprise_customer.uuid
             course_id = enterprise_enrollment.course_id
 
-            course_details = None
-            try:
-                course_details = get_course_details(course_id)
-            except (InvalidKeyError, CourseOverview.DoesNotExist):
-                LOGGER.error(generate_formatted_log(
-                    channel_name, enterprise_customer_uuid, lms_user_id, course_id,
-                    'get_course_details failed for EnterpriseCourseEnrollment {enterprise_enrollment_pk}'.format(
-                        enterprise_enrollment_pk=enterprise_enrollment.pk
-                    )), exc_info=True)
+            course_details, error_message = LearnerExporterUtility.get_course_details_by_id(course_id)
 
             if course_details is None:
                 # Course not found, so we have nothing to report.
                 LOGGER.error(generate_formatted_log(
                     channel_name, enterprise_customer_uuid, lms_user_id, course_id,
-                    'get_course_details returned None for EnterpriseCourseEnrollment {enterprise_enrollment_pk}'.format(
-                        enterprise_enrollment_pk=enterprise_enrollment.pk
-                    )))
+                    f'get_course_details returned None for EnterpriseCourseEnrollment {enterprise_enrollment.pk}'
+                    f', error_message: {error_message}'
+                ))
                 continue
 
             # For audit courses, check if 100% completed
@@ -398,6 +409,7 @@ class LearnerExporter(Exporter):
                 course_details,
                 enterprise_enrollment,
                 channel_name,
+                incomplete_count,
             )
 
             # Apply the Source of Truth for Grades
@@ -655,7 +667,7 @@ class LearnerExporter(Exporter):
 
         return assessment_grades
 
-    def _collect_grades_data(self, enterprise_enrollment, course_details, channel_name):
+    def collect_grades_data(self, enterprise_enrollment, course_details, channel_name):
         """
         Collect the learner completion data from the Grades API.
 
@@ -721,7 +733,7 @@ class LearnerExporter(Exporter):
 class LearnerExporterUtility:
     """ Utility class namespace for accessing Django objects in a common way. """
 
-    @ staticmethod
+    @staticmethod
     def lms_user_id_for_ent_course_enrollment_id(enterprise_course_enrollment_id):
         """ Returns the ID of the LMS User for the EnterpriseCourseEnrollment id passed in
         or None if EnterpriseCourseEnrollment not found """
@@ -730,3 +742,14 @@ class LearnerExporterUtility:
                 id=enterprise_course_enrollment_id).enterprise_customer_user.user_id
         except EnterpriseCourseEnrollment.DoesNotExist:
             return None
+
+    @staticmethod
+    def get_course_details_by_id(course_id):
+        course_details = None
+        error_message = None
+        try:
+            course_details = get_course_details(course_id)
+        except (InvalidKeyError, CourseOverview.DoesNotExist):
+            error_message = f'get_course_details failed for course_id {course_id}'
+
+        return course_details, error_message

--- a/integrated_channels/integrated_channel/exporters/learner_data.py
+++ b/integrated_channels/integrated_channel/exporters/learner_data.py
@@ -745,6 +745,9 @@ class LearnerExporterUtility:
 
     @staticmethod
     def get_course_details_by_id(course_id):
+        '''
+        Convenience method to fetch course details or None (if not found)
+        '''
         course_details = None
         error_message = None
         try:

--- a/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_learner_data.py
+++ b/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_learner_data.py
@@ -20,6 +20,9 @@ from test_utils.integrated_channels_utils import mock_course_overview, mock_sing
 
 
 def create_ent_enrollment_mock(is_audit=True):
+    '''
+    creates a magicmock instance for enterprise enrollment
+    '''
     enterprise_enrollment = MagicMock()
     enterprise_enrollment.enterprise_customer_user = MagicMock()
     enterprise_enrollment.enterprise_customer_user.user_id = 1

--- a/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_learner_data.py
+++ b/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_learner_data.py
@@ -8,6 +8,7 @@ import unittest
 import ddt
 import mock
 from freezegun import freeze_time
+from mock.mock import MagicMock
 from pytest import mark
 
 from django.utils import timezone
@@ -16,6 +17,16 @@ from integrated_channels.integrated_channel.exporters.learner_data import Learne
 from integrated_channels.integrated_channel.models import LearnerDataTransmissionAudit
 from test_utils import factories
 from test_utils.integrated_channels_utils import mock_course_overview, mock_single_learner_grade
+
+
+def create_ent_enrollment_mock(is_audit=True):
+    enterprise_enrollment = MagicMock()
+    enterprise_enrollment.enterprise_customer_user = MagicMock()
+    enterprise_enrollment.enterprise_customer_user.user_id = 1
+    enterprise_enrollment.enterprise_customer_user.enterprise_customer = MagicMock()
+    enterprise_enrollment.enterprise_customer_user.enterprise_customer.uuid = 'abc'
+    enterprise_enrollment.is_audit_enrollment = MagicMock(return_value=is_audit)
+    return enterprise_enrollment
 
 
 @mark.django_db
@@ -736,3 +747,46 @@ class TestLearnerExporter(unittest.TestCase):
         assert len(unique_enrollments) == 2
         assert self.course_id in unique_enrollments
         assert self.course_id_2 in unique_enrollments
+
+    def test_grades_summary_for_completed_audit_has_autofilled_date(self):
+        '''
+        We will insert a current date time stamp for audit enrollment,
+        if it's completed, and if the grades api returns no completion date
+        '''
+        exporter = LearnerExporter('fake-user', self.config)
+        course_details = mock_course_overview()
+        enterprise_enrollment = create_ent_enrollment_mock()
+        incomplete_count = 0
+
+        exporter.collect_grades_data = MagicMock(return_value=(None, None, None, None, ))
+        completed_date_from_api, _, _, _ = exporter.get_grades_summary(
+            course_details,
+            enterprise_enrollment,
+            'test-channel',
+            incomplete_count
+        )
+        # if we autofill the date, then this shouldn't be None since collect_grades_data is set to
+        # return a None value for completed_date
+        assert completed_date_from_api is not None
+        exporter.collect_grades_data.assert_called_once()
+
+    def test_grades_summary_for_incompleted_audit_honors_existing_date(self):
+        '''
+        If there is a completed_date from the api called by collect_grades_data
+        still honor it rather than override using now, just as a safety measure
+        '''
+        exporter = LearnerExporter('fake-user', self.config)
+        course_details = mock_course_overview()
+        enterprise_enrollment = create_ent_enrollment_mock()
+        incomplete_count = 0
+
+        a_date = timezone.now()
+        exporter.collect_grades_data = MagicMock(return_value=(a_date, None, None, None, ))
+        completed_date_from_api, _, _, _ = exporter.get_grades_summary(
+            course_details,
+            enterprise_enrollment,
+            'test-channel',
+            incomplete_count
+        )
+        assert completed_date_from_api is a_date
+        exporter.collect_grades_data.assert_called_once()


### PR DESCRIPTION
if audit course completed, and no date from api, then fill in with now() for completed audit courses
this is needed since we get None completed_date for audit courses in some cases when we decide to call it completed based on incomplete_count == 0

JIRA: https://openedx.atlassian.net/browse/ENT-4918

if for some rason a date does come back from api it still honors it
if audit complete is not completed (based on incomplete_count), it still avoid filling in
if track isn't even audit, it avoid filling date in

so only sets date to now() when audit + completed + date_not_coming_from_api

ENT-4918

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
