### PR TITLE
feat: Log better on key error during extract_integration_id

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.28.14]
+---------
+* logging improvement when calling integrated channels extract_integration_id
+
 [3.28.13]
 ---------
 * fixes the way moodle queries for courses ENT-4806

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.28.13"
+__version__ = "3.28.14"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/canvas/client.py
+++ b/integrated_channels/canvas/client.py
@@ -502,11 +502,18 @@ class CanvasAPIClient(IntegratedChannelApiClient):
         """
         if not data:
             raise ClientError("No data to transmit.", HTTPStatus.NOT_FOUND.value)
+        decoded_payload = data.decode("utf-8")
+        decoded_json = json.loads(decoded_payload)
         try:
-            integration_id = json.loads(
-                data.decode("utf-8")
-            )['course']['integration_id']
+            integration_id = decoded_json['course']['integration_id']
         except KeyError as error:
+            LOGGER.error(generate_formatted_log(
+                'canvas',
+                self.enterprise_configuration.enterprise_customer.uuid,
+                None,
+                None,
+                f'KeyError processing decoded json. decoded payload was: {decoded_payload}'
+            ))
             raise ClientError(
                 "Could not transmit data, no integration ID present.", HTTPStatus.NOT_FOUND.value
             ) from error

--- a/integrated_channels/canvas/client.py
+++ b/integrated_channels/canvas/client.py
@@ -502,24 +502,27 @@ class CanvasAPIClient(IntegratedChannelApiClient):
         """
         if not data:
             raise ClientError("No data to transmit.", HTTPStatus.NOT_FOUND.value)
-        decoded_payload = data.decode("utf-8")
-        decoded_json = json.loads(decoded_payload)
+
+        try:
+            decoded_payload = data.decode("utf-8")
+            decoded_json = json.loads(decoded_payload)
+        except AttributeError as error:
+            raise ClientError(
+                f"Unable to decode data. Type of data was {type(data)}", HTTPStatus.BAD_REQUEST.value
+            ) from error
+
         try:
             integration_id = decoded_json['course']['integration_id']
         except KeyError as error:
-            LOGGER.error(generate_formatted_log(
+            LOGGER.exception(generate_formatted_log(
                 'canvas',
                 self.enterprise_configuration.enterprise_customer.uuid,
                 None,
                 None,
                 f'KeyError processing decoded json. decoded payload was: {decoded_payload}'
-            ))
+            ), exc_info=error)
             raise ClientError(
                 "Could not transmit data, no integration ID present.", HTTPStatus.NOT_FOUND.value
-            ) from error
-        except AttributeError as error:
-            raise ClientError(
-                "Unable to decode data.", HTTPStatus.BAD_REQUEST.value
             ) from error
 
         return integration_id

--- a/integrated_channels/utils.py
+++ b/integrated_channels/utils.py
@@ -289,7 +289,7 @@ def generate_formatted_log(
     return '[integrated_channel:{channel_name}]'\
         '[integrated_channel_enterprise_customer_uuid:{enterprise_customer_uuid}]' \
         '[integrated_channel_lms_user:{lms_user_id}]'\
-        '[integrated_channel_course_key:{course_or_course_run_key}]{message}'.format(
+        '[integrated_channel_course_key:{course_or_course_run_key}] {message}'.format(
             enterprise_customer_uuid=enterprise_customer_uuid,
             channel_name=channel_name,
             message=message,

--- a/tests/test_integrated_channels/test_canvas/test_client.py
+++ b/tests/test_integrated_channels/test_canvas/test_client.py
@@ -1008,7 +1008,7 @@ class TestCanvasApiClient(unittest.TestCase):
                 transmitter_method = getattr(canvas_api_client, request_type)
                 transmitter_method(poorly_formatted_data)
 
-        assert client_error.value.message == 'Unable to decode data.'
+        assert client_error.value.message == "Unable to decode data. Type of data was <class 'str'>"
 
     def update_fails_with_poorly_constructed_data(self, request_type):
         """


### PR DESCRIPTION
Adds some logging of the decoded payload and contextual info for failure. We are getting key errors during delete_content_metadata.

Once we find out more from logging, we may be able to actually fix the issue or determine what causes it in the first place

ENT-4953

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
