### PR TITLE
ENT-4763 degreed learner data audit in Django admin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.28.7]
+---------
+* Degreed integrated channel now uses idp_id explicitly when calling get_remote_id()
+
 [3.28.6]
 ---------
 * SAP integrated channel now uses idp_id explicitly when calling get_remote_id()

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.28.6"
+__version__ = "3.28.7"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/degreed/admin/__init__.py
+++ b/integrated_channels/degreed/admin/__init__.py
@@ -7,7 +7,11 @@ from config_models.admin import ConfigurationModelAdmin
 
 from django.contrib import admin
 
-from integrated_channels.degreed.models import DegreedEnterpriseCustomerConfiguration, DegreedGlobalConfiguration
+from integrated_channels.degreed.models import (
+    DegreedEnterpriseCustomerConfiguration,
+    DegreedGlobalConfiguration,
+    DegreedLearnerDataTransmissionAudit,
+)
 
 
 @admin.register(DegreedGlobalConfiguration)
@@ -63,3 +67,30 @@ class DegreedEnterpriseCustomerConfigurationAdmin(admin.ModelAdmin):
                 being rendered with this admin form.
         """
         return obj.enterprise_customer.name
+
+
+@admin.register(DegreedLearnerDataTransmissionAudit)
+class DegreedLearnerDataTransmissionAuditAdmin(admin.ModelAdmin):
+    """
+    Django admin model for DegreedLearnerDataTransmissionAudit.
+    """
+    class Meta:
+        model = DegreedLearnerDataTransmissionAudit
+
+    list_display = (
+        'enterprise_course_enrollment_id',
+        'course_id',
+        'course_completed',
+        'completed_timestamp',
+        'status',
+        'created'
+    )
+
+    readonly_fields = (
+        'enterprise_course_enrollment_id',
+        'course_id',
+        'course_completed',
+        'completed_timestamp',
+        'status',
+        'created',
+    )

--- a/integrated_channels/degreed/exporters/learner_data.py
+++ b/integrated_channels/degreed/exporters/learner_data.py
@@ -34,7 +34,9 @@ class DegreedLearnerExporter(LearnerExporter):
         """
         # Degreed expects completion dates of the form 'yyyy-mm-dd'.
         completed_timestamp = completed_date.strftime("%F") if isinstance(completed_date, datetime) else None
-        if enterprise_enrollment.enterprise_customer_user.get_remote_id() is not None:
+        if enterprise_enrollment.enterprise_customer_user.get_remote_id(
+            self.enterprise_configuration.idp_id
+        ) is not None:
             DegreedLearnerDataTransmissionAudit = apps.get_model(
                 'degreed',
                 'DegreedLearnerDataTransmissionAudit'


### PR DESCRIPTION
__Why?__
So that we can remove specific records only for cases when this is unavoidable and we need a re-transmit

We are brainstorming ways to better do this rather than delete the record, such as updating a field on the record


**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
