### PR TITLE
feat: Added api for fetching choices in EnterpriseCustomerReportingConfiguration

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.29.0]
+---------
+* Added api for fetching field choices from EnterpriseCustomerReportingConfiguration
+
 [3.28.24]
 ---------
 * Integrated channels Canvas: now fills in Start/end dates in description, and uses Course participation type

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.28.24"
+__version__ = "3.29.0"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/enterprise/api/v1/urls.py
+++ b/enterprise/api/v1/urls.py
@@ -57,6 +57,11 @@ urlpatterns = [
         views.TableauAuthView.as_view(),
         name='tableau-token'
     ),
+    url(
+        r'^enterprise_report_types/(?P<enterprise_uuid>[A-Za-z0-9-]+)$',
+        views.EnterpriseCustomerReportTypesView.as_view(),
+        name='enterprise-report-types'
+    ),
 ]
 
 urlpatterns += router.urls

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -61,6 +61,7 @@ from enterprise.utils import (
     NotConnectedToOpenEdX,
     enroll_licensed_users_in_courses,
     get_best_mode_from_course_key,
+    get_enterprise_customer,
     get_request_value,
     track_enrollment,
     validate_email_to_link,
@@ -1249,3 +1250,75 @@ class NotificationReadView(APIView):
                 {'error': str('Notification read request failed')},
                 status=HTTP_500_INTERNAL_SERVER_ERROR
             )
+
+
+class EnterpriseCustomerReportTypesView(APIView):
+    """
+    API for getting the report types associated with an enterprise customer
+    """
+    authentication_classes = [JwtAuthentication, SessionAuthentication]
+    permission_classes = [permissions.IsAuthenticated]
+    http_method_names = ['get']
+
+    @staticmethod
+    def _get_data_types_with_recent_progress_type(data_types):
+        """
+        Get the data types with only the most recent 'progress' type version
+
+        Arguments:
+            data_types (list<str, str>): List of data type tuples.
+
+        Returns:
+            (list<str, str>): List of data type tuples with only the most recent 'progress' type.
+            e.g. [ ... ('progress', 'progress_v3')]
+        """
+        progress_data_types = [data_type for data_type in data_types if data_type[1].startswith('progress')]
+        progress_data_types.sort(key=lambda data_type: data_type[1])
+        data_types_for_frontend = [data_type for data_type in data_types if not data_type[1].startswith('progress')]
+        data_types_for_frontend.append((progress_data_types[-1][1], 'progress'))
+        return data_types_for_frontend
+
+    @staticmethod
+    def _get_data_types_for_non_pearson_customers(data_types):
+        """
+        Get the data types for non-pearson customers
+
+        Arguments:
+            data_types (list<str, str>): List of data type tuples.
+
+        Returns:
+            (list<str, str>): List of data type tuples without the Pearson specific types.
+        """
+        reduced_data_types = []
+        for data_type in data_types:
+            if data_type[1] not in models.EnterpriseCustomerReportingConfiguration.PEARSON_ONLY_REPORTS:
+                reduced_data_types.append(data_type)
+        return reduced_data_types
+
+    @permission_required(
+        'enterprise.can_access_admin_dashboard',
+        fn=lambda request, enterprise_uuid: enterprise_uuid
+    )
+    def get(self, request, enterprise_uuid):
+        """
+        Get the dropdown choices for EnterpriseCustomerReportingConfiguration
+        """
+        enterprise_customer = get_enterprise_customer(enterprise_uuid)
+        if not enterprise_customer:
+            return Response({'detail': 'Could not find the enterprise customer.'}, status=HTTP_404_NOT_FOUND)
+
+        meta = models.EnterpriseCustomerReportingConfiguration._meta
+        choices = {}
+        for field in meta.get_fields():
+            if hasattr(field, 'choices') and field.choices:
+                choices[field.name] = field.choices
+        # filter out deprecated 'progress' type report versions
+        data_types_for_frontend = self._get_data_types_with_recent_progress_type(list(choices.get('data_type', [])))
+        # remove Pearson only reports
+        choices['data_type'] = (
+            self._get_data_types_for_non_pearson_customers(data_types_for_frontend)
+            if 'pearson' not in enterprise_customer.slug
+            else data_types_for_frontend
+        )
+
+        return Response(data=choices, status=HTTP_200_OK)

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -700,7 +700,7 @@ def get_enterprise_customer(uuid):
     EnterpriseCustomer = enterprise_customer_model()
     try:
         return EnterpriseCustomer.objects.get(uuid=uuid)
-    except EnterpriseCustomer.DoesNotExist:
+    except (EnterpriseCustomer.DoesNotExist, ValidationError):
         return None
 
 

--- a/test_utils/enterprise_report_choices.py
+++ b/test_utils/enterprise_report_choices.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+"""
+Enterprise Django application tests constants.
+"""
+
+LIMITED_REPORT_TYPES = {
+    'data_type': [
+        ['catalog', 'catalog'],
+        ['engagement', 'engagement'],
+        ['progress_v3', 'progress']
+    ],
+    'day_of_week': [
+        [0, 'Monday'],
+        [1, 'Tuesday'],
+        [2, 'Wednesday'],
+        [3, 'Thursday'],
+        [4, 'Friday'],
+        [5, 'Saturday'],
+        [6, 'Sunday']
+    ],
+    'delivery_method': [
+        ['email', 'email'], ['sftp', 'sftp']
+    ],
+    'frequency': [
+        ['daily', 'daily'],
+        ['monthly', 'monthly'],
+        ['weekly', 'weekly']
+    ],
+    'report_type': [
+        ['csv', 'csv'], ['json', 'json']
+    ]
+}
+
+FULL_REPORT_TYPES = {
+    'data_type': [
+        ['catalog', 'catalog'],
+        ['engagement', 'engagement'],
+        ['grade', 'grade'],
+        ['completion', 'completion'],
+        ['course_structure', 'course_structure'],
+        ['progress_v3', 'progress']
+    ],
+    'day_of_week': [
+        [0, 'Monday'],
+        [1, 'Tuesday'],
+        [2, 'Wednesday'],
+        [3, 'Thursday'],
+        [4, 'Friday'],
+        [5, 'Saturday'],
+        [6, 'Sunday']
+    ],
+    'delivery_method': [
+        ['email', 'email'], ['sftp', 'sftp']
+    ],
+    'frequency': [
+        ['daily', 'daily'],
+        ['monthly', 'monthly'],
+        ['weekly', 'weekly']
+    ],
+    'report_type': [
+        ['csv', 'csv'], ['json', 'json']
+    ]
+}

--- a/tests/test_integrated_channels/test_xapi/test_utils.py
+++ b/tests/test_integrated_channels/test_xapi/test_utils.py
@@ -79,7 +79,7 @@ class TestUtils(unittest.TestCase):
             {'status': 500, 'error_messages': None},
         )
 
-        self.x_api_client.lrs.save_statement.assert_called()  # pylint: disable=no-member
+        self.x_api_client.lrs.save_statement.assert_called()
 
     @mock.patch('integrated_channels.xapi.client.RemoteLRS', mock.MagicMock())
     @mock.patch('enterprise.api_client.discovery.JwtBuilder')
@@ -139,7 +139,7 @@ class TestUtils(unittest.TestCase):
             {'status': 500, 'error_message': None}
         )
 
-        self.x_api_client.lrs.save_statement.assert_called()  # pylint: disable=no-member
+        self.x_api_client.lrs.save_statement.assert_called()
 
     def test_is_success_response(self):
         """


### PR DESCRIPTION
**Description**: This PR adds an api to fetch the dropdown options from EnterpriseCustomerReportingConfiguration.
**Sample Request Response**:
**(label, value) tuple**
![image](https://user-images.githubusercontent.com/34648393/135875127-0e7dbb9e-362f-44b7-b5fa-306184705c8d.png)

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
