### PR TITLE
Canvas integrated channel: add start/end dates to description and use 'Course' participation type ENT-5011

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.28.24]
+---------
+* Integrated channels Canvas: now fills in Start/end dates in description, and uses Course participation type
+
 [3.28.23]
 ---------
 * Fix cornerstone character limit bug with dict database table

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.28.23"
+__version__ = "3.28.24"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/canvas/client.py
+++ b/integrated_channels/canvas/client.py
@@ -91,7 +91,6 @@ class CanvasAPIClient(IntegratedChannelApiClient):
         )
 
         if not located_course:
-            breakpoint()
             # Course does not exist: Create the course
             status_code, response_text = self._post(
                 self.course_create_url,

--- a/integrated_channels/canvas/client.py
+++ b/integrated_channels/canvas/client.py
@@ -78,10 +78,6 @@ class CanvasAPIClient(IntegratedChannelApiClient):
 
         desired_payload = json.loads(serialized_data.decode('utf-8'))
         course_details = desired_payload['course']
-        # this makes the course use a 'participation' type of 'Course' instead of the default 'Term'
-        # which allows us to correctly tell Canvas to honor start/end dates instead of using the
-        # one from the default Term Canvas may end up using for this course
-        desired_payload['course']['restrict_enrollments_to_course_dates'] = True
 
         edx_course_id = course_details['integration_id']
         located_course = CanvasUtil.find_course_by_course_id(
@@ -103,7 +99,7 @@ class CanvasAPIClient(IntegratedChannelApiClient):
             # Course does not exist: Create the course
             status_code, response_text = self._post(
                 self.course_create_url,
-                json.dumps(desired_payload).encode('utf-8'),
+                serialized_data,
             )
             created_course_id = json.loads(response_text)['id']
 
@@ -160,18 +156,12 @@ class CanvasAPIClient(IntegratedChannelApiClient):
             integration_id,
         )
 
-        desired_payload = json.loads(serialized_data.decode('utf-8'))
-        # this makes the course use a 'participation' type of 'Course' instead of the default 'Term'
-        # which allows us to correctly tell Canvas to honor start/end dates instead of using the
-        # one from the default Term Canvas may end up using for this course
-        desired_payload['course']['restrict_enrollments_to_course_dates'] = True
-
         url = CanvasUtil.course_update_endpoint(
             self.enterprise_configuration,
             course_id,
         )
 
-        return self._put(url, json.dumps(desired_payload).encode('utf-8'))
+        return self._put(url, serialized_data)
 
     def delete_content_metadata(self, serialized_data):
         self._create_session()

--- a/integrated_channels/canvas/client.py
+++ b/integrated_channels/canvas/client.py
@@ -81,7 +81,7 @@ class CanvasAPIClient(IntegratedChannelApiClient):
         # this makes the course use a 'participation' type of 'Course' instead of the default 'Term'
         # which allows us to correctly tell Canvas to honor start/end dates instead of using the
         # one from the default Term Canvas may end up using for this course
-        desired_payload['restrict_enrollments_to_course_dates'] = 'true'
+        desired_payload['restrict_enrollments_to_course_dates'] = True
 
         edx_course_id = course_details['integration_id']
         located_course = CanvasUtil.find_course_by_course_id(
@@ -91,6 +91,15 @@ class CanvasAPIClient(IntegratedChannelApiClient):
         )
 
         if not located_course:
+            LOGGER.info(
+                generate_formatted_log(
+                    'canvas',
+                    self.enterprise_configuration.enterprise_customer.uuid,
+                    None,
+                    edx_course_id,
+                    f'Creating new course with payload {desired_payload}',
+                )
+            )
             # Course does not exist: Create the course
             status_code, response_text = self._post(
                 self.course_create_url,

--- a/integrated_channels/canvas/client.py
+++ b/integrated_channels/canvas/client.py
@@ -81,7 +81,7 @@ class CanvasAPIClient(IntegratedChannelApiClient):
         # this makes the course use a 'participation' type of 'Course' instead of the default 'Term'
         # which allows us to correctly tell Canvas to honor start/end dates instead of using the
         # one from the default Term Canvas may end up using for this course
-        desired_payload['restrict_enrollments_to_course_dates'] = True
+        desired_payload['course']['restrict_enrollments_to_course_dates'] = True
 
         edx_course_id = course_details['integration_id']
         located_course = CanvasUtil.find_course_by_course_id(

--- a/integrated_channels/canvas/client.py
+++ b/integrated_channels/canvas/client.py
@@ -81,7 +81,7 @@ class CanvasAPIClient(IntegratedChannelApiClient):
         # this makes the course use a 'participation' type of 'Course' instead of the default 'Term'
         # which allows us to correctly tell Canvas to honor start/end dates instead of using the
         # one from the default Term Canvas may end up using for this course
-        desired_payload['restrict_enrollments_to_course_dates'] = True
+        desired_payload['restrict_enrollments_to_course_dates'] = 'true'
 
         edx_course_id = course_details['integration_id']
         located_course = CanvasUtil.find_course_by_course_id(
@@ -419,6 +419,9 @@ class CanvasAPIClient(IntegratedChannelApiClient):
         Also sets course to 'offer' state by sending 'course[event]=offer',
         which makes the course published in Canvas.
 
+        Also enforces Course (in case we did not create it that way)
+        to use the participation type of 'Course'
+
         Arguments:
           - course_id (Number): Canvas Course id
           - course_details (dict): { 'image_url' } : optional, used if present for course[image_url]
@@ -430,7 +433,7 @@ class CanvasAPIClient(IntegratedChannelApiClient):
             course_id,
         )
         # Providing the param `event` and setting it to `offer` is equivalent to publishing the course.
-        update_payload = {'course': {'event': 'offer'}}
+        update_payload = {'course': {'event': 'offer', 'restrict_enrollments_to_course_dates': 'true'}}
         try:
             # there is no way to do this in a single request during create
             # https://canvas.instructure.com/doc/api/all_resources.html#method.courses.update

--- a/integrated_channels/canvas/client.py
+++ b/integrated_channels/canvas/client.py
@@ -160,12 +160,18 @@ class CanvasAPIClient(IntegratedChannelApiClient):
             integration_id,
         )
 
+        desired_payload = json.loads(serialized_data.decode('utf-8'))
+        # this makes the course use a 'participation' type of 'Course' instead of the default 'Term'
+        # which allows us to correctly tell Canvas to honor start/end dates instead of using the
+        # one from the default Term Canvas may end up using for this course
+        desired_payload['course']['restrict_enrollments_to_course_dates'] = True
+
         url = CanvasUtil.course_update_endpoint(
             self.enterprise_configuration,
             course_id,
         )
 
-        return self._put(url, serialized_data)
+        return self._put(url, json.dumps(desired_payload).encode('utf-8'))
 
     def delete_content_metadata(self, serialized_data):
         self._create_session()

--- a/integrated_channels/canvas/client.py
+++ b/integrated_channels/canvas/client.py
@@ -419,9 +419,6 @@ class CanvasAPIClient(IntegratedChannelApiClient):
         Also sets course to 'offer' state by sending 'course[event]=offer',
         which makes the course published in Canvas.
 
-        Also enforces Course (in case we did not create it that way)
-        to use the participation type of 'Course'
-
         Arguments:
           - course_id (Number): Canvas Course id
           - course_details (dict): { 'image_url' } : optional, used if present for course[image_url]
@@ -433,7 +430,7 @@ class CanvasAPIClient(IntegratedChannelApiClient):
             course_id,
         )
         # Providing the param `event` and setting it to `offer` is equivalent to publishing the course.
-        update_payload = {'course': {'event': 'offer', 'restrict_enrollments_to_course_dates': 'true'}}
+        update_payload = {'course': {'event': 'offer'}}
         try:
             # there is no way to do this in a single request during create
             # https://canvas.instructure.com/doc/api/all_resources.html#method.courses.update

--- a/integrated_channels/canvas/exporters/content_metadata.py
+++ b/integrated_channels/canvas/exporters/content_metadata.py
@@ -12,16 +12,16 @@ LOGGER = getLogger(__name__)
 
 def convert_date_str(date_str):
     '''
-    Returns formatted date string from ISO8601 format (e.g. 2011-01-01T01:00Z)
+    Returns formatted date string from ISO8601 format (e.g. 2011-01-01T01:00:10Z)
     to a human readable suitable for use in Canvas
     Return 'N/A' if input arg is None, or 'N/A'
     If format is not ISO8601, returns original string.
     '''
-    if not date_str:
-        return 'N/A'
+    if not date_str or date_str == 'N/A':
+        return date_str
     try:
-        start_date = datetime.strptime(date_str, '%Y-%m-%dT%H:%M:%SZ') if date_str != 'N/A' else date_str
-        formatted_start_date = start_date.strftime('%a %b %d %Y %H:%M:%S') if start_date != 'N/A' else start_date
+        start_date = datetime.strptime(date_str, '%Y-%m-%dT%H:%M:%SZ')
+        formatted_start_date = start_date.strftime('%a %b %d %Y %H:%M:%S')
     except ValueError:
         return date_str
     return formatted_start_date

--- a/integrated_channels/canvas/exporters/content_metadata.py
+++ b/integrated_channels/canvas/exporters/content_metadata.py
@@ -52,6 +52,10 @@ class CanvasContentMetadataExporter(ContentMetadataExporter):
                 base_description=base_description, short_description=short_description
             )
 
+        description = (f"{description} <br />"
+                       f"<br />Starts: {content_metadata_item.get('start', 'N/A')}"
+                       f"<br />Ends: {content_metadata_item.get('end', 'N/A')}")
+
         return description
 
     def transform_default_view(self, content_metadata_item):  # pylint: disable=unused-argument

--- a/integrated_channels/canvas/exporters/content_metadata.py
+++ b/integrated_channels/canvas/exporters/content_metadata.py
@@ -2,11 +2,29 @@
 Content metadata exporter for Canvas
 """
 
+from datetime import datetime
 from logging import getLogger
 
 from integrated_channels.integrated_channel.exporters.content_metadata import ContentMetadataExporter
 
 LOGGER = getLogger(__name__)
+
+
+def convert_date_str(date_str):
+    '''
+    Returns formatted date string from ISO8601 format (e.g. 2011-01-01T01:00Z)
+    to a human readable suitable for use in Canvas
+    Return 'N/A' if input arg is None, or 'N/A'
+    If format is not ISO8601, returns original string.
+    '''
+    if not date_str:
+        return 'N/A'
+    try:
+        start_date = datetime.strptime(date_str, '%Y-%m-%dT%H:%M:%SZ') if date_str != 'N/A' else date_str
+        formatted_start_date = start_date.strftime('%a %b %d %Y %H:%M:%S') if start_date != 'N/A' else start_date
+    except ValueError:
+        return date_str
+    return formatted_start_date
 
 
 class CanvasContentMetadataExporter(ContentMetadataExporter):
@@ -52,9 +70,11 @@ class CanvasContentMetadataExporter(ContentMetadataExporter):
                 base_description=base_description, short_description=short_description
             )
 
+        formatted_start_date = convert_date_str(content_metadata_item.get('start', 'N/A'))
+        formatted_end_date = convert_date_str(content_metadata_item.get('end', 'N/A'))
         description = (f"{description} <br />"
-                       f"<br />Starts: {content_metadata_item.get('start', 'N/A')}"
-                       f"<br />Ends: {content_metadata_item.get('end', 'N/A')}")
+                       f"<br />Starts: {formatted_start_date}"
+                       f"<br />Ends: {formatted_end_date}")
 
         return description
 

--- a/integrated_channels/canvas/exporters/content_metadata.py
+++ b/integrated_channels/canvas/exporters/content_metadata.py
@@ -42,11 +42,18 @@ class CanvasContentMetadataExporter(ContentMetadataExporter):
         'is_public': 'is_public',
         'self_enrollment': 'self_enrollment',
         'course_code': 'key',
-        'indexed': 'indexed'
+        'indexed': 'indexed',
+        'restrict_enrollments_to_course_dates': 'restrict_enrollments_to_course_dates',
     }
     SKIP_KEY_IF_NONE = True
 
     LONG_STRING_LIMIT = 2000
+
+    def transform_restrict_enrollments_to_course_dates(self, content_metadata_item):  # pylint: disable=unused-argument
+        '''
+        This enforces the course to use the participation type of 'Course' rather than Term
+        '''
+        return True
 
     def transform_description(self, content_metadata_item):
         """

--- a/tests/test_integrated_channels/test_canvas/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_canvas/test_exporters/test_content_metadata.py
@@ -149,6 +149,17 @@ class TestCanvasContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):
                 'enrollment_url': 'http://some/enrollment/url/'
             },
             '<a href=http://some/enrollment/url/>Go to edX course page</a><br /> <br /><br />Starts: N/A<br />Ends: N/A'
+        ),
+        (
+            {
+                'enrollment_url': 'http://some/enrollment/url/',
+                'title': 'edX Demonstration Course',
+                'short_description': 'Some short description.',
+                'start': '2011-01-01T01:00:00Z',
+                'end': '2011-03-01T01:00:00Z'
+            },
+            ('<a href=http://some/enrollment/url/>Go to edX course page</a><br />Some short description. <br />'
+             '<br />Starts: Sat Jan 01 2011 01:00:00<br />Ends: Tue Mar 01 2011 01:00:00')
         )
 
     )

--- a/tests/test_integrated_channels/test_canvas/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_canvas/test_exporters/test_content_metadata.py
@@ -125,7 +125,7 @@ class TestCanvasContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):
                 'full_description': 'Detailed description of edx demo course.',
             },
             '<a href=http://some/enrollment/url/>Go to edX course page</a><br />'
-            'Detailed description of edx demo course.'
+            'Detailed description of edx demo course. <br /><br />Starts: N/A<br />Ends: N/A'
         ),
         (
             {
@@ -133,7 +133,7 @@ class TestCanvasContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):
                 'title': 'edX Demonstration Course',
             },
             '<a href=http://some/enrollment/url/>Go to edX course page</a><br />'
-            'edX Demonstration Course'
+            'edX Demonstration Course <br /><br />Starts: N/A<br />Ends: N/A'
         ),
         (
             {
@@ -142,13 +142,13 @@ class TestCanvasContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):
                 'short_description': 'Some short description.',
             },
             '<a href=http://some/enrollment/url/>Go to edX course page</a><br />'
-            'Some short description.'
+            'Some short description. <br /><br />Starts: N/A<br />Ends: N/A'
         ),
         (
             {
                 'enrollment_url': 'http://some/enrollment/url/'
             },
-            '<a href=http://some/enrollment/url/>Go to edX course page</a><br />'
+            '<a href=http://some/enrollment/url/>Go to edX course page</a><br /> <br /><br />Starts: N/A<br />Ends: N/A'
         )
 
     )

--- a/tests/test_integrated_channels/test_canvas/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_canvas/test_exporters/test_content_metadata.py
@@ -208,3 +208,12 @@ class TestCanvasContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):
         content_metadata_item = GENERIC_CONTENT_METADATA_ITEM
         exporter = CanvasContentMetadataExporter('fake-user', self.config)
         assert exporter.transform_indexed(content_metadata_item) == 1
+
+    @responses.activate
+    def test_transform_restrict_enrollments_to_course_dates(self):
+        """
+        `CanvasContentMetadataExporter``'s ''transform_restrict_enrollments_to_course_dates` returns True as a value
+        """
+        content_metadata_item = GENERIC_CONTENT_METADATA_ITEM
+        exporter = CanvasContentMetadataExporter('fake-user', self.config)
+        assert exporter.transform_restrict_enrollments_to_course_dates(content_metadata_item) is True


### PR DESCRIPTION
Description updated with dates:

Course looks like this after create, on syllabus page
https://edx.instructure.com/courses/6554

```
participation type fix
Jump to Today 
Go to edX course page (Links to an external site.)
lk



Starts: Fri Oct 01 2021 16:00:00
Ends: Thu Oct 28 2021 16:00:00
```

Course participation type

<img width="846" alt="Screen Shot 2021-10-01 at 3 38 21 PM" src="https://user-images.githubusercontent.com/528166/135677204-9aaf30f4-e061-4c80-a1b4-43e729f1426e.png">

Also added the enforcement of course participation type to the update_content_metadata, so we get 'free' backfills when updates run

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
