### PR TITLE
fix: Add error handling for role assignment backfill management command

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.28.22]
+---------
+* fix: Adding error handling for role assignment backfill management command
+
 [3.28.21]
 ---------
 * bug: The exporter now properly handles instances when enterprise customer catalogs do no need updates.

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.28.21"
+__version__ = "3.28.22"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/enterprise/management/commands/backfill_learner_role_assignments.py
+++ b/enterprise/management/commands/backfill_learner_role_assignments.py
@@ -7,6 +7,7 @@ import logging
 from time import sleep
 
 from django.contrib import auth
+from django.core.exceptions import MultipleObjectsReturned
 from django.core.management.base import BaseCommand
 
 from enterprise.constants import ENTERPRISE_LEARNER_ROLE
@@ -65,11 +66,15 @@ class Command(BaseCommand):
                 user = User.objects.get(id=ecu.user_id)
                 enterprise_customer = ecu.enterprise_customer
 
-                role_assignment, created = SystemWideEnterpriseUserRoleAssignment.objects.get_or_create(
-                    user=user,
-                    role=role,
-                    enterprise_customer=enterprise_customer
-                )
+                try:
+                    role_assignment, created = SystemWideEnterpriseUserRoleAssignment.objects.get_or_create(
+                        user=user,
+                        role=role,
+                        enterprise_customer=enterprise_customer
+                    )
+                except MultipleObjectsReturned:
+                    log.info('Found MultipleObjectsReturned for user %s. Skipping.', user)
+                    continue
 
                 if created:
                     log.info(

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -1876,11 +1876,11 @@ class TestBackfillLearnerRoleAssignmentsCommand(unittest.TestCase):
             )
 
             # Make sure we see the skip message
-            log_capture.check_present(
-                ('enterprise.management.commands.backfill_learner_role_assignments',
+            log_capture.check_present((
+                'enterprise.management.commands.backfill_learner_role_assignments',
                 'INFO',
-                'Found MultipleObjectsReturned for user user-0. Skipping.')
-            )
+                'Found MultipleObjectsReturned for user user-0. Skipping.'
+            ))
 
     def test_user_role_assignments_created(self):
         """

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -1842,6 +1842,46 @@ class TestBackfillLearnerRoleAssignmentsCommand(unittest.TestCase):
 
         self.addCleanup(self.cleanup_test_objects)
 
+    def test_user_role_assignments_multiple_objects(self):
+        """
+        Verify that multiple objects returned error from the
+        create_or_get does not cause an error.
+        """
+
+        user = User.objects.first()
+
+        # Create some duplicate role assignments
+        for i in range(2):
+            factories.SystemWideEnterpriseUserRoleAssignment(
+                user=user,
+                role=roles_api.learner_role(),
+                enterprise_customer=self.alpha_customer,
+            ).save()
+
+        role_assignments = SystemWideEnterpriseUserRoleAssignment.objects.filter(
+            user=user,
+            role=roles_api.learner_role(),
+            enterprise_customer=self.alpha_customer,
+        )
+        assert role_assignments.count() == 2
+
+        # Run the command and check the logs
+        with LogCapture(level=logging.INFO) as log_capture:
+            call_command(
+                'backfill_learner_role_assignments',
+                '--batch-sleep',
+                '0',
+                '--batch-limit',
+                '10',
+            )
+
+            # Make sure we see the skip message
+            log_capture.check_present(
+                ('enterprise.management.commands.backfill_learner_role_assignments',
+                'INFO',
+                'Found MultipleObjectsReturned for user user-0. Skipping.')
+            )
+
     def test_user_role_assignments_created(self):
         """
         Verify that the management command correctly creates User Role Assignments

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -1851,7 +1851,7 @@ class TestBackfillLearnerRoleAssignmentsCommand(unittest.TestCase):
         user = User.objects.first()
 
         # Create some duplicate role assignments
-        for i in range(2):
+        for _ in range(2):
             factories.SystemWideEnterpriseUserRoleAssignment(
                 user=user,
                 role=roles_api.learner_role(),


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
