### PR TITLE
maint: allowing management command to run on inactive configurations

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.30.1]
+--------
+* Allowing management commands to optionally run on inactive Integrated Channel configurations
+
 [3.30.0]
 ---------
 * Switched back to ``jsonfield`` from ``jsonfield2``

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.30.0"
+__version__ = "3.30.1"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/integrated_channel/management/commands/__init__.py
+++ b/integrated_channels/integrated_channel/management/commands/__init__.py
@@ -84,7 +84,8 @@ class IntegratedChannelCommandMixin:
 
         Raises errors when invalid options are encountered.
 
-        See ``add_arguments`` for the accepted options.
+        Note: in order to retrieve in active configurations, the option `prevent_disabled_configurations` must be set to
+        false. For other available configurations, see ``add_arguments`` for all accepted options.
         """
         assessment_level_support = options.get('assessment_level_support', False)
         content_metadata_job_support = options.get('content_metadata_job_support', False)
@@ -94,9 +95,11 @@ class IntegratedChannelCommandMixin:
             content_metadata_job_support=content_metadata_job_support,
         )
         filter_kwargs = {
-            'active': True,
             'enterprise_customer__active': True,
         }
+        if options.get('prevent_disabled_configurations', True):
+            filter_kwargs['active'] = True
+
         enterprise_customer = self.get_enterprise_customer(options.get('enterprise_customer'))
 
         if enterprise_customer:

--- a/integrated_channels/integrated_channel/management/commands/update_content_transmission_catalogs.py
+++ b/integrated_channels/integrated_channel/management/commands/update_content_transmission_catalogs.py
@@ -34,7 +34,7 @@ class Command(IntegratedChannelCommandMixin, BaseCommand):
         Update all past content transmission items to have their respective catalog's uuid.
         """
         username = options['catalog_user']
-
+        options['prevent_disabled_configurations'] = False
         # Before we do a whole bunch of database queries, make sure that the user we were passed exists.
         try:
             User.objects.get(username=username)


### PR DESCRIPTION
`update_content_transmission_catalogs` now runs on all configs under active customers, not just active configs.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
