### PR TITLE
bug: csod content transformer creates nonserializable data

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.30.5]
+--------
+* fix: Integrated channels data transforming generates json serializable fields.
+
 [3.30.4]
 --------
 * fix: Blackboard integrated channel now correctly synchronizes the one-and-only valid refresh_token

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.30.4"
+__version__ = "3.30.5"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/cornerstone/utils.py
+++ b/integrated_channels/cornerstone/utils.py
@@ -65,7 +65,7 @@ def convert_invalid_course_id(course_id):
     # If the encoded or unencoded version of the key are over 50 characters, they will error out
     # in cornerstone, so we convert them to a uuid.
     if len(safe_course_id) > 50:
-        safe_course_id = uuid4()
+        safe_course_id = str(uuid4())
     return safe_course_id
 
 

--- a/test_utils/fake_catalog_api.py
+++ b/test_utils/fake_catalog_api.py
@@ -99,6 +99,9 @@ FAKE_COURSE_RUN = {
 FAKE_COURSE_RUN2 = copy.deepcopy(FAKE_COURSE_RUN)
 FAKE_COURSE_RUN2['key'] = 'course-v1:edX+DemoX+Demo_Course2'
 
+FAKE_INVALID_KEY_COURSE_RUN = copy.deepcopy(FAKE_COURSE_RUN)
+FAKE_INVALID_KEY_COURSE_RUN['key'] = 'course-v1:edX+Thisissuperlong+weneedthistobethelongestitseverbeen<.>'
+
 FAKE_COURSE = {
     'key': 'edX+DemoX',
     'uuid': 'a9e8bb52-0c8d-4579-8496-1a8becb0a79c',
@@ -1328,6 +1331,16 @@ def get_fake_content_metadata():
     content_metadata[FAKE_COURSE_RUN['key']] = copy.deepcopy(FAKE_COURSE_RUN)
     content_metadata[FAKE_COURSE['key']] = copy.deepcopy(FAKE_COURSE)
     content_metadata[FAKE_SEARCH_ALL_PROGRAM_RESULT_1['uuid']] = copy.deepcopy(FAKE_SEARCH_ALL_PROGRAM_RESULT_1)
+    return list(content_metadata.values())
+
+
+def get_fake_content_metadata_with_invalid_key():
+    """
+    Returns a fake response from EnterpriseCatalogApiClient.get_content_metadata with a course key that won't pass
+    CSOD validation
+    """
+    content_metadata = OrderedDict()
+    content_metadata[FAKE_INVALID_KEY_COURSE_RUN['key']] = copy.deepcopy(FAKE_INVALID_KEY_COURSE_RUN)
     return list(content_metadata.values())
 
 


### PR DESCRIPTION
https://openedx.atlassian.net/browse/ENT-5037

CSOD content metadata transformer was adding a UUID to the data payload, in this case the UUID is not json serializable which was throwing an exception when trying to log.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
