### PR TITLE
bug: forcing catalog content retrieval on all customer catalogs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.30.6]
+--------
+* maint: Integrated channels detection system of catalog changes needed is now disabled via override.
+
 [3.30.5]
 --------
 * fix: Integrated channels data transforming generates json serializable fields.

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.30.5"
+__version__ = "3.30.6"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/integrated_channel/exporters/content_metadata.py
+++ b/integrated_channels/integrated_channel/exporters/content_metadata.py
@@ -85,6 +85,10 @@ class ContentMetadataExporter(Exporter):
         content_metadata_export = {}
         force_retrieve_all_catalogs = kwargs.get('force_retrieve_all_catalogs', False)
 
+        # DUE TO ERRORS IN DETECTING CATALOG UPDATES ALL CONTENT WILL BE FORCE RETRIEVED FROM THE
+        # CATALOG SERVICE AS OF 10-06-2021. TODO: remove force retrieval
+        force_retrieve_all_catalogs = True
+
         for enterprise_customer_catalog in enterprise_customer_catalogs:
             need_catalog_update = False
             if not force_retrieve_all_catalogs:

--- a/integrated_channels/sap_success_factors/admin/__init__.py
+++ b/integrated_channels/sap_success_factors/admin/__init__.py
@@ -50,6 +50,7 @@ class SAPSuccessFactorsEnterpriseCustomerConfigurationAdmin(admin.ModelAdmin):
         'user_type',
         'has_access_token',
         'prevent_self_submit_grades',
+        'disable_learner_data_transmissions',
         'transmit_total_hours',
         'transmission_chunk_size',
         'additional_locales',

--- a/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_content_metadata.py
@@ -69,43 +69,22 @@ class TestContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):
         """
         ``ContentMetadataExporter``'s ``export`` produces a JSON dump of the course data.
         """
-        mock_ent_catalog_api.return_value.get_content_metadata.return_value = get_fake_content_metadata()
-        mock_ent_catalog_api.return_value.get_enterprise_catalog.return_value = self.fake_catalog
         exporter = ContentMetadataExporter('fake-user', self.config)
         exporter.export()
-        assert mock_ent_catalog_api.called
-        assert mock_ent_catalog_api.return_value.get_enterprise_catalog.call_args[0][0] == \
-            self.config.enterprise_customer.enterprise_customer_catalogs.first().uuid
+        assert not mock_ent_catalog_api.return_value.get_enterprise_catalog.called
+        assert mock_ent_catalog_api.return_value.get_content_metadata.called
         mock_ent_catalog_api.return_value.get_content_metadata.assert_called_with(
             self.config.enterprise_customer,
             [self.config.enterprise_customer.enterprise_customer_catalogs.first()]
         )
 
-        mock_ent_catalog_api.return_value.get_content_metadata.return_value = get_fake_content_metadata()
-        enterprise_catalog_data = {
-            'uuid': str(self.enterprise_customer_catalog.uuid),
-            'title': self.enterprise_customer_catalog.title,
-            'enterprise_customer': str(self.enterprise_customer_catalog.enterprise_customer.uuid),
-            'catalog_query_uuid': str(self.enterprise_customer_catalog.enterprise_catalog_query.uuid),
-            'content_last_modified': str(self.enterprise_customer_catalog.enterprise_catalog_query.modified),
-            'catalog_modified': str(self.enterprise_customer_catalog.modified)
-        }
-        # catalog_modified_date = max(
-        #     enterprise_catalog_data['content_last_modified'], enterprise_catalog_data['catalog_modified']
-        # )
-        mock_ent_catalog_api.return_value.get_enterprise_catalog.return_value = enterprise_catalog_data
         self.config.catalogs_to_transmit = str(self.enterprise_customer_catalog.uuid)
         self.config.save()
         exporter.export()
-        assert mock_ent_catalog_api.return_value.get_enterprise_catalog.call_count == 2
+
         assert mock_ent_catalog_api.return_value.get_content_metadata.call_count == 2
-        # 'catalogs_to_transmit' argument has valid uuid so only that catalog will be transmitted.
-        assert mock_ent_catalog_api.return_value.get_enterprise_catalog.call_args[0][0] == \
-            self.config.customer_catalogs_to_transmit.first().uuid
-        mock_ent_catalog_api.return_value.get_content_metadata.assert_called_with(
-            self.config.enterprise_customer,
-            [self.enterprise_customer_catalog]
-        )
+        assert mock_ent_catalog_api.return_value.get_content_metadata.call_args[0][1][0].uuid == \
+               self.enterprise_customer_catalog.uuid
 
     @mock.patch('integrated_channels.integrated_channel.exporters.content_metadata.EnterpriseCatalogApiClient')
     def test_content_exporter_bad_data_transform_mapping(self, mock_api_client):
@@ -124,32 +103,33 @@ class TestContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):
             )
             assert expected_message in log_capture.records[0].getMessage()
 
-    @mock.patch('integrated_channels.integrated_channel.exporters.content_metadata.EnterpriseCatalogApiClient')
-    def test_export_fetches_content_only_when_update_needed(self, mock_ent_catalog_api):
-        """
-        Test that when a ContentMetadataItemTransmission exists with a `catalog_last_changed` field that comes after the
-        last modified time of content's associated catalog, we don't fetch the catalog's metadata.
-        """
-        # Generate a past transmission item that will indicate no updated needed
-        past_content_transmission = factories.ContentMetadataItemTransmissionFactory(
-            enterprise_customer=self.config.enterprise_customer,
-            integrated_channel_code=self.config.channel_code(),
-            content_last_changed='2021-07-16T15:11:10.521611Z',
-            enterprise_customer_catalog_uuid=self.enterprise_customer_catalog.uuid
-        )
-        mock_ent_catalog_api.return_value.get_content_metadata.return_value = get_fake_content_metadata()
-        mock_ent_catalog_api.return_value.get_enterprise_catalog.return_value = self.fake_catalog
-        exporter = ContentMetadataExporter('fake-user', self.config)
-        payload = exporter.export()
-
-        # Even though no metadata was fetched, in order to report a `No updates needed` to the transmitter, the exporter
-        # will still return a payload. However, this payload will contain exactly what's kept in the content item audit
-        # record.
-        assert len(payload) == 1
-        for transmission in payload.values():
-            assert transmission.content_id == past_content_transmission.content_id
-            assert transmission.channel_metadata == past_content_transmission.channel_metadata
-
-        # We should make a call for the enterprise catalog, but no call for the metadata because no update needed
-        assert mock_ent_catalog_api.return_value.get_content_metadata.call_count == 0
-        assert mock_ent_catalog_api.return_value.get_enterprise_catalog.call_count == 1
+    #  NOTE: Catalog needs updating requests are forced overwritten to True as of 10-06-2021
+    # @mock.patch('integrated_channels.integrated_channel.exporters.content_metadata.EnterpriseCatalogApiClient')
+    # def test_export_fetches_content_only_when_update_needed(self, mock_ent_catalog_api):
+    #     """
+    #     Test that when a ContentMetadataItemTransmission exists with a `catalog_last_changed` field that comes after
+    #     the last modified time of content's associated catalog, we don't fetch the catalog's metadata.
+    #     """
+    #     # Generate a past transmission item that will indicate no updated needed
+    #     past_content_transmission = factories.ContentMetadataItemTransmissionFactory(
+    #         enterprise_customer=self.config.enterprise_customer,
+    #         integrated_channel_code=self.config.channel_code(),
+    #         content_last_changed='2021-07-16T15:11:10.521611Z',
+    #         enterprise_customer_catalog_uuid=self.enterprise_customer_catalog.uuid
+    #     )
+    #     mock_ent_catalog_api.return_value.get_content_metadata.return_value = get_fake_content_metadata()
+    #     mock_ent_catalog_api.return_value.get_enterprise_catalog.return_value = self.fake_catalog
+    #     exporter = ContentMetadataExporter('fake-user', self.config)
+    #     payload = exporter.export()
+    #
+    #     # Even though no metadata was fetched, in order to report a `No updates needed` to the transmitter, the
+    #     # exporter will still return a payload. However, this payload will contain exactly what's kept in the content
+    #     # item audit record.
+    #     assert len(payload) == 1
+    #     for transmission in payload.values():
+    #         assert transmission.content_id == past_content_transmission.content_id
+    #         assert transmission.channel_metadata == past_content_transmission.channel_metadata
+    #
+    #     # We should make a call for the enterprise catalog, but no call for the metadata because no update needed
+    #     assert mock_ent_catalog_api.return_value.get_content_metadata.call_count == 0
+    #     assert mock_ent_catalog_api.return_value.get_enterprise_catalog.call_count == 1


### PR DESCRIPTION
Chunking is posing a fundamental problem for the integrated channels efficiency improvements for querying the catalog service. In order to address customers with live configurations, this PR enforces an override to the check if catalogs need updating and instead just has the transmission fetch catalog data on every iteration.

Unit tests updated to reflect the forced behavior.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
