### PR TITLE
chore: don't expire courses that have been modified after given date

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.30.9]
+---------
+* chore: Don't expire courses that have been modified after given date
+
 [3.30.8]
 ---------
 * feat: Added a boolean in EnterpriseCustomer to specify whether labor market data should be available in learner portal

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.30.8"
+__version__ = "3.30.9"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1568,11 +1568,11 @@ class TestEnterpriseUtils(unittest.TestCase):
                         weeks_to_complete=4,
                         availability='Current',
                     ),
-                    fake_catalog_api.create_course_run_dict(end="2021-10-14T13:11:03Z")
+                    fake_catalog_api.create_course_run_dict()
                 ],
             },
             [],
-            fake_catalog_api.create_course_run_dict(end="2021-10-14T13:11:03Z"),
+            fake_catalog_api.create_course_run_dict(),
         ),
         (   # It will return the active run
             {


### PR DESCRIPTION
The bulk_licensed_enrollments_expiration endpoint currently takes in license uuids and expires all course enrollments for these licenses. This could be run against licenses that have expired in the past and we want to make sure that we don't modify any enrollments that have been modified past the license expiration date. In the future we will implement better error handling so we wouldn't need something like this, but for now this will allow us to fix past course enrollments that were not properly revoked.

- Add optional arg to indicate a date after which the enrollments shouldn't be modified
- Check if licensed enrollment has is_revoked = True (this flag was not set correctly in the past) or if the course enrollment has been modified past given date

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [x] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
