### PR TITLE
fix: refactor moodle _post to use body params

### DIFF
--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.30.8"
+__version__ = "3.30.9"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/moodle/client.py
+++ b/integrated_channels/moodle/client.py
@@ -6,7 +6,7 @@ Client for connecting to Moodle.
 import json
 import logging
 from http import HTTPStatus
-from urllib.parse import urlencode, urljoin
+from urllib.parse import urljoin
 
 import requests
 

--- a/integrated_channels/moodle/client.py
+++ b/integrated_channels/moodle/client.py
@@ -114,6 +114,9 @@ class MoodleAPIClient(IntegratedChannelApiClient):
         """
         Compile common params and run request's post function
         """
+        headers = {
+            'Content-Type': 'application/x-www-form-urlencoded',
+        }
         params = {
             'wstoken': self.token,
             'moodlewsrestformat': 'json',
@@ -121,18 +124,18 @@ class MoodleAPIClient(IntegratedChannelApiClient):
         params.update(additional_params)
         if method_url:
             response = requests.post(
-                url='{url}&{querystring}'.format(
-                    url=method_url,
-                    querystring=urlencode(params)
-                )
+                url=method_url,
+                data=params,
+                headers=headers
             )
         else:
             response = requests.post(
-                url='{url}{api_path}?{querystring}'.format(
+                url='{url}{api_path}'.format(
                     url=self.enterprise_configuration.moodle_base_url,
-                    api_path=self.MOODLE_API_PATH,
-                    querystring=urlencode(params)
-                )
+                    api_path=self.MOODLE_API_PATH
+                ),
+                data=params,
+                headers=headers
             )
         return response
 


### PR DESCRIPTION
For historical reasons/understandings the Moodle client was sending POST parameters as url params rather than a form-encoded body. This was resulting in HTTP 414 (uri too long) errors for certain course metadata (ie long descriptions). This PR refactors the client's `_post` method to set appropriate headers and pass params as a form-encoded body.

Although the client calls are mocked for testing, I've manually tested these changes with postman and python scripts.

- [ENT-5043](https://openedx.atlassian.net/browse/ENT-5043)