### PR TITLE
fix: properly weight blackboard grades

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.30.13]
+---------
+fix: properly weight blackboard grades
+
 [3.30.12]
 ---------
 * chore: update course enrollments through lms

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.30.12"
+__version__ = "3.30.13"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/blackboard/client.py
+++ b/integrated_channels/blackboard/client.py
@@ -26,6 +26,7 @@ GRADEBOOK_PATH = '/learn/api/public/v1/courses/{course_id}/gradebook/columns'
 ENROLLMENT_PATH = '/learn/api/public/v1/courses/{course_id}/users'
 COURSE_PATH = '/learn/api/public/v1/courses'
 POST_GRADE_COLUMN_PATH = '/learn/api/public/v2/courses/{course_id}/gradebook/columns'
+PATCH_GRADE_COLUMN_PATH = '/learn/api/public/v2/courses/{course_id}/gradebook/columns/{column_id}'
 POST_GRADE_PATH = '/learn/api/public/v2/courses/{course_id}/gradebook/columns/{column_id}/users/{user_id}'
 COURSE_V3_PATH = '/learn/api/public/v3/courses/{course_id}'
 COURSES_V3_PATH = '/learn/api/public/v3/courses'
@@ -531,6 +532,19 @@ class BlackboardAPIClient(IntegratedChannelApiClient):
             path=POST_GRADE_COLUMN_PATH.format(course_id=course_id),
         )
 
+    def generate_update_grade_column_url(self, course_id, column_id):
+        """
+        Blackboard API url helper method.
+        Path: Update course grade column
+        """
+        return '{base}{path}'.format(
+            base=self.enterprise_configuration.blackboard_base_url,
+            path=PATCH_GRADE_COLUMN_PATH.format(
+                course_id=course_id,
+                column_id=column_id,
+            ),
+        )
+
     def generate_post_users_grade_url(self, course_id, column_id, user_id):
         """
         Blackboard API url helper method.
@@ -659,9 +673,9 @@ class BlackboardAPIClient(IntegratedChannelApiClient):
                 if grade_column.get('externalId') == external_id:
                     grade_column_id = grade_column.get('id')
                     # if includeInCalculations has legacy value, correct it
-                    if grade_column.get('includeInCalculations') != include_in_calculations:
+                    if grade_column.get('includeInCalculations') and grade_column.get('includeInCalculations') != include_in_calculations:
                         calculations_data = {"includeInCalculations": include_in_calculations}
-                        self._patch(self.generate_create_grade_column_url(bb_course_id), calculations_data)
+                        self._patch(self.generate_update_grade_column_url(bb_course_id, grade_column_id), calculations_data)
                     break
             # Blackboard's pagination is returned within the response json if it exists
             # Example:

--- a/integrated_channels/blackboard/client.py
+++ b/integrated_channels/blackboard/client.py
@@ -673,9 +673,15 @@ class BlackboardAPIClient(IntegratedChannelApiClient):
                 if grade_column.get('externalId') == external_id:
                     grade_column_id = grade_column.get('id')
                     # if includeInCalculations has legacy value, correct it
-                    if grade_column.get('includeInCalculations') and grade_column.get('includeInCalculations') != include_in_calculations:
+                    if (
+                        grade_column.get('includeInCalculations') and
+                        grade_column.get('includeInCalculations') != include_in_calculations
+                        ):
                         calculations_data = {"includeInCalculations": include_in_calculations}
-                        self._patch(self.generate_update_grade_column_url(bb_course_id, grade_column_id), calculations_data)
+                        self._patch(
+                            self.generate_update_grade_column_url(bb_course_id, grade_column_id),
+                            calculations_data
+                            )
                     break
             # Blackboard's pagination is returned within the response json if it exists
             # Example:

--- a/integrated_channels/blackboard/client.py
+++ b/integrated_channels/blackboard/client.py
@@ -443,7 +443,8 @@ class BlackboardAPIClient(IntegratedChannelApiClient):
         """
         return str(abs(hash(external_id)))
 
-    def generate_blackboard_gradebook_column_data(self, external_id, grade_column_name, points_possible, include_in_calculations=False):
+    def generate_blackboard_gradebook_column_data(self, external_id, grade_column_name, points_possible,
+                                                  include_in_calculations=False):
         """
         Properly formatted json data to create a new gradebook column in a blackboard course
 
@@ -632,7 +633,8 @@ class BlackboardAPIClient(IntegratedChannelApiClient):
             HTTPStatus.NOT_FOUND.value
         )
 
-    def _get_or_create_integrated_grade_column(self, bb_course_id, grade_column_name, external_id, points_possible=100, include_in_calculations=False):
+    def _get_or_create_integrated_grade_column(self, bb_course_id, grade_column_name, external_id, points_possible=100,
+                                               include_in_calculations=False):
         """
         Helper method to search an edX integrated Blackboard course for the designated edX grade column.
         If the column does not yet exist within the course, create it.
@@ -656,8 +658,11 @@ class BlackboardAPIClient(IntegratedChannelApiClient):
             for grade_column in grade_columns:
                 if grade_column.get('externalId') == external_id:
                     grade_column_id = grade_column.get('id')
+                    # if includeInCalculations has legacy value, correct it
+                    if grade_column.get('includeInCalculations') != include_in_calculations:
+                        calculations_data = {"includeInCalculations": include_in_calculations}
+                        self._patch(self.generate_create_grade_column_url(bb_course_id), calculations_data)
                     break
-
             # Blackboard's pagination is returned within the response json if it exists
             # Example:
             # Response = {

--- a/integrated_channels/blackboard/client.py
+++ b/integrated_channels/blackboard/client.py
@@ -676,7 +676,7 @@ class BlackboardAPIClient(IntegratedChannelApiClient):
                     if (
                         grade_column.get('includeInCalculations') and
                         grade_column.get('includeInCalculations') != include_in_calculations
-                        ):
+                    ):
                         calculations_data = {"includeInCalculations": include_in_calculations}
                         self._patch(
                             self.generate_update_grade_column_url(bb_course_id, grade_column_id),

--- a/integrated_channels/blackboard/client.py
+++ b/integrated_channels/blackboard/client.py
@@ -249,7 +249,8 @@ class BlackboardAPIClient(IntegratedChannelApiClient):
         grade_column_id = self._get_or_create_integrated_grade_column(
             course_id,
             "(edX Integration) Final Grade",
-            "edx_final_grade"
+            "edx_final_grade",
+            include_in_calculations=True,
         )
 
         grade = learner_data.get('grade') * 100
@@ -442,7 +443,7 @@ class BlackboardAPIClient(IntegratedChannelApiClient):
         """
         return str(abs(hash(external_id)))
 
-    def generate_blackboard_gradebook_column_data(self, external_id, grade_column_name, points_possible):
+    def generate_blackboard_gradebook_column_data(self, external_id, grade_column_name, points_possible, include_in_calculations=False):
         """
         Properly formatted json data to create a new gradebook column in a blackboard course
 
@@ -467,6 +468,7 @@ class BlackboardAPIClient(IntegratedChannelApiClient):
                     "type": "None",
                 }
             },
+            "includeInCalculations": include_in_calculations,
         }
 
     def generate_gradebook_url(self, course_id):
@@ -630,7 +632,7 @@ class BlackboardAPIClient(IntegratedChannelApiClient):
             HTTPStatus.NOT_FOUND.value
         )
 
-    def _get_or_create_integrated_grade_column(self, bb_course_id, grade_column_name, external_id, points_possible=100):
+    def _get_or_create_integrated_grade_column(self, bb_course_id, grade_column_name, external_id, points_possible=100, include_in_calculations=False):
         """
         Helper method to search an edX integrated Blackboard course for the designated edX grade column.
         If the column does not yet exist within the course, create it.
@@ -684,7 +686,7 @@ class BlackboardAPIClient(IntegratedChannelApiClient):
 
         if not grade_column_id:
             grade_column_data = self.generate_blackboard_gradebook_column_data(
-                external_id, grade_column_name, points_possible
+                external_id, grade_column_name, points_possible, include_in_calculations
             )
             response = self._post(self.generate_create_grade_column_url(bb_course_id), grade_column_data)
             parsed_response = response.json()

--- a/integrated_channels/blackboard/client.py
+++ b/integrated_channels/blackboard/client.py
@@ -681,7 +681,7 @@ class BlackboardAPIClient(IntegratedChannelApiClient):
                         self._patch(
                             self.generate_update_grade_column_url(bb_course_id, grade_column_id),
                             calculations_data
-                            )
+                        )
                     break
             # Blackboard's pagination is returned within the response json if it exists
             # Example:

--- a/tests/test_integrated_channels/test_blackboard/test_client.py
+++ b/tests/test_integrated_channels/test_blackboard/test_client.py
@@ -772,16 +772,16 @@ class TestBlackboardApiClient(unittest.TestCase):
         client._create_session()
 
         blackboard_search_response = {
-                'results': [{
-                    'id': self.blackboard_grade_column_id,
-                    'externalId': self.course_id,
-                    'name': self.blackboard_grade_column_name,
-                    'description': "edX learner's grade.",
-                    'created': '2021-07-16T19:46:29.698Z',
-                    'score': {'possible': 100.0},
-                    'availability': {'available': 'Yes'},
-                    'includeInCalculations': True,
-                }],
+            'results': [{
+                'id': self.blackboard_grade_column_id,
+                'externalId': self.course_id,
+                'name': self.blackboard_grade_column_name,
+                'description': "edX learner's grade.",
+                'created': '2021-07-16T19:46:29.698Z',
+                'score': {'possible': 100.0},
+                'availability': {'available': 'Yes'},
+                'includeInCalculations': True,
+            }],
         }
 
         with responses.RequestsMock() as rsps:

--- a/tests/test_integrated_channels/test_blackboard/test_client.py
+++ b/tests/test_integrated_channels/test_blackboard/test_client.py
@@ -763,6 +763,50 @@ class TestBlackboardApiClient(unittest.TestCase):
                 )
                 assert not client.delete_course_from_blackboard.called
 
+    def test_client_assignment_update_on_find(self):
+        """
+        Test that the _get_or_create_integrated_grade_column method properly updates courses
+        with the correct `include_in_calculations` settings as it searches for them
+        """
+        client = self._create_new_mock_client()
+        client._create_session()
+
+        blackboard_search_response = {
+                'results': [{
+                'id': self.blackboard_grade_column_id,
+                'externalId': self.course_id,
+                'name': self.blackboard_grade_column_name,
+                'description': "edX learner's grade.",
+                'created': '2021-07-16T19:46:29.698Z',
+                'score': {'possible': 100.0},
+                'availability': {'available': 'Yes'},
+                'includeInCalculations': True,
+            }],
+        }
+
+        with responses.RequestsMock() as rsps:
+            # Requests mock will iteratively return registered responses on subsequent calls
+            rsps.add(
+                responses.GET,
+                client.generate_gradebook_url(self.blackboard_course_id),
+                json=blackboard_search_response
+            )
+            rsps.add(
+                responses.PATCH,
+                client.generate_update_grade_column_url(self.blackboard_course_id, self.blackboard_grade_column_id),
+                json={"includeInCalculations": False}
+            )
+
+            # find the grade column on the second page of results
+            column_id = client._get_or_create_integrated_grade_column(
+                self.blackboard_course_id,
+                self.blackboard_grade_column_name,
+                self.course_id,
+                include_in_calculations=False
+            )
+
+        assert column_id == self.blackboard_grade_column_id
+
     def test_client_finds_assignment_on_second_results_page(self):
         """
         Test that the _get_or_create_integrated_grade_column method properly traverses over paginated results from

--- a/tests/test_integrated_channels/test_blackboard/test_client.py
+++ b/tests/test_integrated_channels/test_blackboard/test_client.py
@@ -773,15 +773,15 @@ class TestBlackboardApiClient(unittest.TestCase):
 
         blackboard_search_response = {
                 'results': [{
-                'id': self.blackboard_grade_column_id,
-                'externalId': self.course_id,
-                'name': self.blackboard_grade_column_name,
-                'description': "edX learner's grade.",
-                'created': '2021-07-16T19:46:29.698Z',
-                'score': {'possible': 100.0},
-                'availability': {'available': 'Yes'},
-                'includeInCalculations': True,
-            }],
+                    'id': self.blackboard_grade_column_id,
+                    'externalId': self.course_id,
+                    'name': self.blackboard_grade_column_name,
+                    'description': "edX learner's grade.",
+                    'created': '2021-07-16T19:46:29.698Z',
+                    'score': {'possible': 100.0},
+                    'availability': {'available': 'Yes'},
+                    'includeInCalculations': True,
+                }],
         }
 
         with responses.RequestsMock() as rsps:


### PR DESCRIPTION
Similar to Canvas, Blackboard should not include most grade columns in the final grade. Fix up pre-existing settings along the way.

[ENT-4394](https://openedx.atlassian.net/browse/ENT-4394)