### PR TITLE
fix: Added fix_dsc_records management command to fix DSC records with spaces.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.32.0]
+---------
+feat: Added management command to fix DSC records having spaces instead of +.
+
 [3.31.1]
 ---------
 fix: pip-tools upgrade

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.31.1"
+__version__ = "3.32.0"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/enterprise/management/commands/fix_dsc_records.py
+++ b/enterprise/management/commands/fix_dsc_records.py
@@ -1,0 +1,68 @@
+"""
+Django management command to Fix DSC records having spaces in there course Id.
+"""
+import logging
+
+from edx_django_utils.db import chunked_queryset
+
+from django.core.management import BaseCommand
+
+from consent.models import DataSharingConsent
+
+LOGGER = logging.getLogger(__name__)
+MESSAGE_FORMAT = 'DSC enterprise: {}, username: {}, course_id: {}'
+
+
+class Command(BaseCommand):
+    """
+    Django management command to Fix DSC records having spaces in there course Id.
+
+    This Command fixes the DSC records what were saved due to bug in our system and DSC records were saved with spaces.
+
+    Example usage:
+    ./manage.py lms fix_dsc_records
+    ./manage.py lms fix_dsc_records --no-commit
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--no-commit',
+            action='store_true',
+            dest='no_commit',
+            default=False,
+            help='Dry Run, print log messages without committing anything.',
+        )
+
+    def handle(self, *args, **options):
+        should_commit = not options['no_commit']
+
+        LOGGER.info('[Fix DSC Records]  Process started.')
+
+        results = {
+            'Fixed Record Count': 0,
+            'Deleted Record Count': 0,
+            'Fixed Records': [],
+            'Deleted Records': [],
+        }
+        dsc_records = DataSharingConsent.objects.filter(course_id__contains=' ')
+        LOGGER.info('[Fix DSC Records]  {} records to be fixed'.format(dsc_records.count()))
+        for chunked_dsc_records in chunked_queryset(dsc_records):
+            for dsc in chunked_dsc_records:
+                fixed_dsc_course_id = dsc.course_id.replace(' ', '+')
+                existing_fixed_record = DataSharingConsent.objects.filter(
+                    enterprise_customer=dsc.enterprise_customer, username=dsc.username, course_id=fixed_dsc_course_id
+                )
+                message = MESSAGE_FORMAT.format(dsc.enterprise_customer, dsc.username, dsc.course_id)
+                if existing_fixed_record.exists():
+                    if should_commit:
+                        dsc.delete()
+                    results['Deleted Records'].append(message)
+                    results['Deleted Record Count'] += 1
+                else:
+                    if should_commit:
+                        dsc.course_id = fixed_dsc_course_id
+                        dsc.save()
+                    results['Fixed Records'].append(message)
+                    results['Fixed Record Count'] += 1
+
+        LOGGER.info('[Fix DSC Records] Execution completed.\nResults: {}'.format(results))

--- a/tests/test_enterprise/management/test_fix_dsc_records.py
+++ b/tests/test_enterprise/management/test_fix_dsc_records.py
@@ -1,0 +1,99 @@
+"""
+Tests for the django management command `email_drip_for_missing_dsc_records`.
+"""
+
+from pytest import mark
+from testfixtures import LogCapture
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from consent.models import DataSharingConsent
+from enterprise.management.commands.fix_dsc_records import MESSAGE_FORMAT
+from test_utils.factories import DataSharingConsentFactory, EnterpriseCustomerFactory
+
+LOGGER_NAME = 'enterprise.management.commands.fix_dsc_records'
+
+
+@mark.django_db
+class FixDSCRecordsCommandTests(TestCase):
+    """
+    Test command `fix_dsc_records`.
+    """
+    command = 'fix_dsc_records'
+
+    def setUp(self):
+        super().setUp()
+        self.enterprise_customer = EnterpriseCustomerFactory()
+        self.username = 'edx'
+        self.course_101_correct = 'course-v1:edX+E2E-101+course'
+        self.course_101_incorrect = 'course-v1:edX E2E-101 course'
+        self.course_200_correct = 'course-v1:edX+E2E-200+course'
+        self.course_300_incorrect = 'course-v1:edX E2E-300 course'
+        self.course_300_correct = 'course-v1:edX+E2E-300+course'
+        course_ids = [
+            self.course_101_correct, self.course_101_incorrect, self.course_200_correct, self.course_300_incorrect
+        ]
+        for course_id in course_ids:
+            DataSharingConsentFactory(
+                enterprise_customer=self.enterprise_customer,
+                username=self.username,
+                course_id=course_id
+            )
+        fixed = MESSAGE_FORMAT.format(self.enterprise_customer, self.username, self.course_300_incorrect)
+        deleted = MESSAGE_FORMAT.format(self.enterprise_customer, self.username, self.course_101_incorrect)
+        self.expect_log_message = "[Fix DSC Records] Execution completed.\nResults: " \
+                                  "{'Fixed Record Count': 1, " \
+                                  "'Deleted Record Count': 1, " \
+                                  "'Fixed Records': ['%s'], " \
+                                  "'Deleted Records': ['%s']}" % (fixed, deleted)
+
+    def assert_valid_state(self):
+        """
+        Validate that data is in valid state.
+        """
+        dsc_records = DataSharingConsent.objects.all()
+        self.assertEqual(dsc_records.count(), 3)
+        self.assertTrue(dsc_records.filter(course_id=self.course_101_correct).exists())
+        self.assertTrue(dsc_records.filter(course_id=self.course_200_correct).exists())
+        self.assertTrue(dsc_records.filter(course_id=self.course_300_correct).exists())
+        self.assertFalse(dsc_records.filter(course_id=self.course_101_incorrect).exists())
+        self.assertFalse(dsc_records.filter(course_id=self.course_300_incorrect).exists())
+
+    def assert_invalid_state(self):
+        """
+        Validate that data is in invalid state.
+        """
+        dsc_records = DataSharingConsent.objects.all()
+        self.assertEqual(dsc_records.count(), 4)
+        self.assertTrue(dsc_records.filter(course_id=self.course_101_correct).exists())
+        self.assertTrue(dsc_records.filter(course_id=self.course_101_incorrect).exists())
+        self.assertTrue(dsc_records.filter(course_id=self.course_200_correct).exists())
+        self.assertTrue(dsc_records.filter(course_id=self.course_300_incorrect).exists())
+        self.assertFalse(dsc_records.filter(course_id=self.course_300_correct).exists())
+
+    def test_fix_dsc_records(self):
+        """
+        Test fix DSC records.
+        """
+        with LogCapture(LOGGER_NAME) as log:
+            self.assert_invalid_state()
+            call_command(self.command)
+            self.assert_valid_state()
+            self.assertIn(
+                self.expect_log_message,
+                log.records[-1].message,
+            )
+
+    def test_fix_dsc_records_with_no_commit(self):
+        """
+        Test with --no-commit param.
+        """
+        with LogCapture(LOGGER_NAME) as log:
+            self.assert_invalid_state()
+            call_command(self.command, '--no-commit')
+            self.assert_invalid_state()
+            self.assertIn(
+                self.expect_log_message,
+                log.records[-1].message,
+            )

--- a/tests/test_integrated_channels/test_xapi/test_utils.py
+++ b/tests/test_integrated_channels/test_xapi/test_utils.py
@@ -79,7 +79,7 @@ class TestUtils(unittest.TestCase):
             {'status': 500, 'error_messages': None},
         )
 
-        self.x_api_client.lrs.save_statement.assert_called()
+        self.x_api_client.lrs.save_statement.assert_called()  # pylint: disable=no-member
 
     @mock.patch('integrated_channels.xapi.client.RemoteLRS', mock.MagicMock())
     @mock.patch('enterprise.api_client.discovery.JwtBuilder')
@@ -139,7 +139,7 @@ class TestUtils(unittest.TestCase):
             {'status': 500, 'error_message': None}
         )
 
-        self.x_api_client.lrs.save_statement.assert_called()
+        self.x_api_client.lrs.save_statement.assert_called()  # pylint: disable=no-member
 
     def test_is_success_response(self):
         """


### PR DESCRIPTION
https://openedx.atlassian.net/browse/ENT-4908

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
