### PR TITLE
feat: exporter now only requests metadata for courses that need updating

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.33.4]
+---------
+feat: integrated channels only requests content metadata for courses that need updating
+
 [3.33.3]
 ---------
 feat: Change Bulk Enrollment Assignment Logic for Pending learners

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.33.3"
+__version__ = "3.33.4"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -913,6 +913,20 @@ def get_cache_key(**kwargs):
     return get_django_cache_key(**kwargs)
 
 
+def chunk_content_keys(content_filter, chunk_size):
+    """
+    Chunk a list of content keys according to a provided chunk size
+    """
+    chunks = []
+    index = 0
+    while index < len(content_filter):
+        content_filter_chunk = content_filter[index:index + chunk_size]
+        index += chunk_size
+        chunks += [content_filter_chunk]
+
+    return chunks
+
+
 def traverse_pagination(response, endpoint):
     """
     Traverse a paginated API response.

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -913,20 +913,6 @@ def get_cache_key(**kwargs):
     return get_django_cache_key(**kwargs)
 
 
-def chunk_content_keys(content_filter, chunk_size):
-    """
-    Chunk a list of content keys according to a provided chunk size
-    """
-    chunks = []
-    index = 0
-    while index < len(content_filter):
-        content_filter_chunk = content_filter[index:index + chunk_size]
-        index += chunk_size
-        chunks += [content_filter_chunk]
-
-    return chunks
-
-
 def traverse_pagination(response, endpoint):
     """
     Traverse a paginated API response.

--- a/integrated_channels/integrated_channel/exporters/content_metadata.py
+++ b/integrated_channels/integrated_channel/exporters/content_metadata.py
@@ -214,8 +214,8 @@ class ContentMetadataExporter(Exporter):
             # We only need to fetch content metadata if there are items to update or create
             if items_to_create or items_to_update:
                 items_create_keys = [key.get('content_key') for key in items_to_create]
-                items_update_key = list(items_to_update.keys())
-                content_keys_filter = items_create_keys + items_update_key
+                items_update_keys = list(items_to_update.keys())
+                content_keys_filter = items_create_keys + items_update_keys
                 content_metadata_items = self.enterprise_catalog_api.get_content_metadata(
                     self.enterprise_customer,
                     [enterprise_customer_catalog],
@@ -234,7 +234,7 @@ class ContentMetadataExporter(Exporter):
                     transformed_item = self._transform_item(item)
                     if key in items_create_keys:
                         create_payload[key] = transformed_item
-                    elif key in items_update_key:
+                    elif key in items_update_keys:
                         existing_record = items_to_update.get(key)
                         existing_record.channel_metadata = transformed_item
                         existing_record.content_last_changed = item.get('content_last_modified')

--- a/tests/test_integrated_channels/test_xapi/test_utils.py
+++ b/tests/test_integrated_channels/test_xapi/test_utils.py
@@ -79,6 +79,8 @@ class TestUtils(unittest.TestCase):
             {'status': 500, 'error_messages': None},
         )
 
+        # Pylint has no way of knowing that the returned value here is a mock, so it assumes it cannot have the
+        # assert_called attr
         self.x_api_client.lrs.save_statement.assert_called()  # pylint: disable=no-member, useless-suppression
 
     @mock.patch('integrated_channels.xapi.client.RemoteLRS', mock.MagicMock())
@@ -139,6 +141,8 @@ class TestUtils(unittest.TestCase):
             {'status': 500, 'error_message': None}
         )
 
+        # Pylint has no way of knowing that the returned value here is a mock, so it assumes it cannot have the
+        # assert_called attr
         self.x_api_client.lrs.save_statement.assert_called()  # pylint: disable=no-member, useless-suppression
 
     def test_is_success_response(self):


### PR DESCRIPTION
fast follow to https://github.com/edx/edx-enterprise/pull/1384

To be merged after https://github.com/edx/enterprise-catalog/pull/341 goes live

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
