### PR TITLE
Only notifying learners when an enrollment is created

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.33.2]
+---------
+fix: no longer notify learners of already existing enrollments
+
 [3.33.1]
 ---------
 fix: Rename model field from key to client_id: Degreed2

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.33.1"
+__version__ = "3.33.2"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -3343,7 +3343,11 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
             'expected_code': 202,
             'expected_response': {
                 'successes': [],
-                'pending': [{'email': 'abc@test.com', 'course_run_key': 'course-v1:edX+DemoX+Demo_Course'}],
+                'pending': [{
+                    'email': 'abc@test.com',
+                    'course_run_key': 'course-v1:edX+DemoX+Demo_Course',
+                    'created': True,
+                }],
                 'failures': []
             },
             'expected_num_pending_licenses': 1,
@@ -3369,8 +3373,8 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
             'expected_response': {
                 'successes': [],
                 'pending': [
-                    {'email': 'abc@test.com', 'course_run_key': 'course-v1:edX+DemoX+Demo_Course'},
-                    {'email': 'xyz@test.com', 'course_run_key': 'course-v1:edX+DemoX+Demo_Course'}
+                    {'email': 'abc@test.com', 'course_run_key': 'course-v1:edX+DemoX+Demo_Course', 'created': True},
+                    {'email': 'xyz@test.com', 'course_run_key': 'course-v1:edX+DemoX+Demo_Course', 'created': True}
                 ],
                 'failures': []
             },
@@ -3409,10 +3413,18 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
             'expected_response': {
                 'successes': [],
                 'pending': [
-                    {'email': 'abc@test.com', 'course_run_key': 'course-v1:edX+DemoX+Demo_Course'},
-                    {'email': 'xyz@test.com', 'course_run_key': 'course-v1:edX+DemoX+Demo_Course'},
-                    {'email': 'abc@test.com', 'course_run_key': 'course-v2:edX+DemoX+Second_Demo_Course'},
-                    {'email': 'xyz@test.com', 'course_run_key': 'course-v2:edX+DemoX+Second_Demo_Course'}
+                    {'email': 'abc@test.com', 'course_run_key': 'course-v1:edX+DemoX+Demo_Course', 'created': True},
+                    {'email': 'xyz@test.com', 'course_run_key': 'course-v1:edX+DemoX+Demo_Course', 'created': True},
+                    {
+                        'email': 'abc@test.com',
+                        'course_run_key': 'course-v2:edX+DemoX+Second_Demo_Course',
+                        'created': True,
+                    },
+                    {
+                        'email': 'xyz@test.com',
+                        'course_run_key': 'course-v2:edX+DemoX+Second_Demo_Course',
+                        'created': True,
+                    }
                 ],
                 'failures': []
             },
@@ -3506,10 +3518,18 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
             'expected_response': {
                 'successes': [],
                 'pending': [
-                    {'email': 'abc@test.com', 'course_run_key': 'course-v1:edX+DemoX+Demo_Course'},
-                    {'email': 'xyz@test.com', 'course_run_key': 'course-v1:edX+DemoX+Demo_Course'},
-                    {'email': 'abc@test.com', 'course_run_key': 'course-v2:edX+DemoX+Second_Demo_Course'},
-                    {'email': 'xyz@test.com', 'course_run_key': 'course-v2:edX+DemoX+Second_Demo_Course'}
+                    {'email': 'abc@test.com', 'course_run_key': 'course-v1:edX+DemoX+Demo_Course', 'created': True},
+                    {'email': 'xyz@test.com', 'course_run_key': 'course-v1:edX+DemoX+Demo_Course', 'created': True},
+                    {
+                        'email': 'abc@test.com',
+                        'course_run_key': 'course-v2:edX+DemoX+Second_Demo_Course',
+                        'created': True
+                    },
+                    {
+                        'email': 'xyz@test.com',
+                        'course_run_key': 'course-v2:edX+DemoX+Second_Demo_Course',
+                        'created': True
+                    }
                 ],
                 'failures': []
             },
@@ -3614,7 +3634,7 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
 
         course = 'course-v1:edX+DemoX+Demo_Course'
         enrollment_response = {
-            'pending': [{'email': 'abc@test.com', 'course_run_key': course, 'user': pending_ecu}],
+            'pending': [{'email': 'abc@test.com', 'course_run_key': course, 'user': pending_ecu, 'created': True}],
             'successes': [],
             'failures': [{'email': 'xyz@test.com', 'course_run_key': course}]
         }

--- a/tests/test_integrated_channels/test_xapi/test_utils.py
+++ b/tests/test_integrated_channels/test_xapi/test_utils.py
@@ -79,7 +79,7 @@ class TestUtils(unittest.TestCase):
             {'status': 500, 'error_messages': None},
         )
 
-        self.x_api_client.lrs.save_statement.assert_called()  # pylint: disable=no-member
+        self.x_api_client.lrs.save_statement.assert_called()  # pylint: disable=no-member, useless-suppression
 
     @mock.patch('integrated_channels.xapi.client.RemoteLRS', mock.MagicMock())
     @mock.patch('enterprise.api_client.discovery.JwtBuilder')
@@ -139,7 +139,7 @@ class TestUtils(unittest.TestCase):
             {'status': 500, 'error_message': None}
         )
 
-        self.x_api_client.lrs.save_statement.assert_called()  # pylint: disable=no-member
+        self.x_api_client.lrs.save_statement.assert_called()  # pylint: disable=no-member, useless-suppression
 
     def test_is_success_response(self):
         """


### PR DESCRIPTION
For both pending and existing users, we need to detect when a bulk enrollment request attempts to create an enrollment that already exists. When we process a bulk enrolment, we should only be email notifying learners who's enrollment is new. 

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
