### PR TITLE
fix: allowing records to be cross catalogs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.33.7]
+---------
+fix: allow for records to be saved for integrated channels' content across catalogs
+
 [3.33.6]
 ---------
 fix: CSOD API session tokens bugfix

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.33.6"
+__version__ = "3.33.7"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/tests/test_integrated_channels/test_integrated_channel/test_transmitters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_integrated_channel/test_transmitters/test_content_metadata.py
@@ -26,16 +26,19 @@ class TestContentMetadataTransmitter(unittest.TestCase):
 
     def setUp(self):
         super().setUp()
-        enterprise_customer = factories.EnterpriseCustomerFactory(name='Starfleet Academy')
+        self.enterprise_customer = factories.EnterpriseCustomerFactory(name='Starfleet Academy')
         # We need some non-abstract configuration for these things to work,
         # so it's okay for it to be any arbitrary channel. We randomly choose SAPSF.
         self.enterprise_config = factories.SAPSuccessFactorsEnterpriseCustomerConfigurationFactory(
-            enterprise_customer=enterprise_customer,
+            enterprise_customer=self.enterprise_customer,
             key="client_id",
             sapsf_base_url="http://test.successfactors.com/",
             sapsf_company_id="company_id",
             sapsf_user_id="user_id",
             secret="client_secret",
+        )
+        self.enterprise_catalog = factories.EnterpriseCustomerCatalogFactory(
+            enterprise_customer=self.enterprise_customer
         )
         self.global_config = factories.SAPSuccessFactorsGlobalConfigurationFactory()
 
@@ -70,7 +73,6 @@ class TestContentMetadataTransmitter(unittest.TestCase):
             content_id_2: channel_metadata,
         }
         update_payload = {}
-        delete_payload = {}
         delete_payload = {}
         content_updated_mapping = {
             content_id: {'catalog_uuid': uuid.uuid4(), 'modified': datetime.now()},
@@ -287,3 +289,70 @@ class TestContentMetadataTransmitter(unittest.TestCase):
             content_id=content_id,
             channel_metadata=channel_metadata
         ).first().deleted_at
+
+    @mark.django_db
+    @ddt.ddt
+    def test_transmitting_create_content_with_previously_deleted_record(self):
+        """
+        Test that records associated with content that was transmitted under a different catalog will be converted to
+        the new catalog
+        """
+        content_id = 'course:DemoX'
+        channel_metadata = {'update': True}
+        past_transmission = ContentMetadataItemTransmission(
+            enterprise_customer=self.enterprise_config.enterprise_customer,
+            integrated_channel_code=self.enterprise_config.channel_code(),
+            content_id=content_id,
+            channel_metadata=channel_metadata,
+            enterprise_customer_catalog_uuid=self.enterprise_catalog.uuid,
+            deleted_at=datetime.now()
+        )
+        past_transmission.save()
+        create_payload = {content_id: channel_metadata}
+        update_payload = {}
+        delete_payload = {}
+        content_updated_mapping = {
+            content_id: {'catalog_uuid': self.enterprise_catalog.uuid, 'modified': datetime.now()},
+        }
+        self.create_content_metadata_mock.return_value = (200, '{"success":"true"}')
+        transmitter = ContentMetadataTransmitter(self.enterprise_config)
+        assert past_transmission.deleted_at
+        transmitter.transmit(create_payload, update_payload, delete_payload, content_updated_mapping)
+        past_transmission.refresh_from_db()
+        assert not past_transmission.deleted_at
+
+    @mark.django_db
+    @ddt.ddt
+    def test_transmitting_same_content_over_different_catalogs(self):
+        """
+        Test that records associated with content that was transmitted under a different catalog will be converted to
+        the new catalog
+        """
+        content_id = 'course:DemoX'
+        channel_metadata = {'update': True}
+        past_transmission = ContentMetadataItemTransmission(
+            enterprise_customer=self.enterprise_config.enterprise_customer,
+            integrated_channel_code=self.enterprise_config.channel_code(),
+            content_id=content_id,
+            channel_metadata=channel_metadata,
+            enterprise_customer_catalog_uuid=self.enterprise_catalog.uuid
+        )
+        past_transmission.save()
+
+        new_catalog_uuid = uuid.uuid4()
+
+        create_payload = {content_id: channel_metadata}
+        update_payload = {}
+        delete_payload = {}
+        content_updated_mapping = {
+            content_id: {'catalog_uuid': new_catalog_uuid, 'modified': datetime.now()},
+        }
+        self.create_content_metadata_mock.return_value = (200, '{"success":"true"}')
+        transmitter = ContentMetadataTransmitter(self.enterprise_config)
+        transmitter.transmit(create_payload, update_payload, delete_payload, content_updated_mapping)
+        assert not ContentMetadataItemTransmission.objects.filter(
+            enterprise_customer_catalog_uuid=self.enterprise_catalog.uuid
+        ).first()
+        assert ContentMetadataItemTransmission.objects.filter(
+            enterprise_customer_catalog_uuid=new_catalog_uuid
+        ).first()


### PR DESCRIPTION
[Jira](https://openedx.atlassian.net/browse/ENT-5097)

A create request may be made for a piece of content that already exists for a customer under a different catalog. Therefore we need to check if a content record exists under another catalog before we attempt to create one. 

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
