### PR TITLE
feat: Change Bulk Enrollment Assignment Logic for Pending learners

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.33.3]
+---------
+feat: Change Bulk Enrollment Assignment Logic for Pending learners
+
 [3.33.2]
 ---------
 fix: no longer notify learners of already existing enrollments

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.33.2"
+__version__ = "3.33.3"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -313,7 +313,8 @@ class EnterpriseCustomerViewSet(EnterpriseReadWriteModelViewSet):
         activation_links = {}
         for result_kind in ['successes', 'pending']:
             for result in results[result_kind]:
-                activation_links[result['email']] if result.get('activation_link') is not None
+                if result.get('activation_link') is not None:
+                    activation_links[result['email']] = result.get('activation_link')
 
         for course_run in course_runs_modes:
             pending_users = {

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -308,7 +308,6 @@ class EnterpriseCustomerViewSet(EnterpriseReadWriteModelViewSet):
 
         results = enroll_licensed_users_in_courses(enterprise_customer, licenses_info, discount)
 
-
         # collect the returned activation links for licenses which need activation
         activation_links = {}
         for result_kind in ['successes', 'pending']:

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -308,6 +308,13 @@ class EnterpriseCustomerViewSet(EnterpriseReadWriteModelViewSet):
 
         results = enroll_licensed_users_in_courses(enterprise_customer, licenses_info, discount)
 
+
+        # collect the returned activation links for licenses which need activation
+        activation_links = {}
+        for result_kind in ['successes', 'pending']:
+            for result in results[result_kind]:
+                activation_links[result['email']] if result.get('activation_link') is not None
+
         for course_run in course_runs_modes:
             pending_users = {
                 result.pop('user') for result in results['pending']
@@ -329,6 +336,7 @@ class EnterpriseCustomerViewSet(EnterpriseReadWriteModelViewSet):
                         course_id=course_run,
                         users=pending_users | existing_users,
                         admin_enrollment=True,
+                        activation_links=activation_links,
                     )
 
         # Remove the user object from the results for any already existing enrollment cases (ie created = False) as

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -674,7 +674,7 @@ class EnterpriseCustomer(TimeStampedModel):
         else:
             PendingEnrollment.objects.filter(user=pending_ecu, course_id__in=course_ids).delete()
 
-    def notify_enrolled_learners(self, catalog_api_user, course_id, users, admin_enrollment=False):
+    def notify_enrolled_learners(self, catalog_api_user, course_id, users, admin_enrollment=False, activation_links=None):
         """
         Notify learners about a course in which they've been enrolled.
 
@@ -698,6 +698,7 @@ class EnterpriseCustomer(TimeStampedModel):
             course_id,
             users,
             admin_enrollment,
+            activation_links,
         )
         send_enterprise_email_notification.delay(self.uuid, admin_enrollment, email_items)
 

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -674,7 +674,8 @@ class EnterpriseCustomer(TimeStampedModel):
         else:
             PendingEnrollment.objects.filter(user=pending_ecu, course_id__in=course_ids).delete()
 
-    def notify_enrolled_learners(self, catalog_api_user, course_id, users, admin_enrollment=False, activation_links=None):
+    def notify_enrolled_learners(self, catalog_api_user, course_id, users, admin_enrollment=False,
+                                 activation_links=None):
         """
         Notify learners about a course in which they've been enrolled.
 

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -685,6 +685,7 @@ class EnterpriseCustomer(TimeStampedModel):
             users: An iterable of the users (or pending users) who were enrolled
             admin_enrollment: Default False. Set to true if using bulk enrollment, for example.
                 When true, we use the admin enrollment template instead.
+            activation_links (dict): a dictionary map of unactivated license user emails to license activation links
         """
         course_details = CourseCatalogApiClient(catalog_api_user, self.site).get_course_run(course_id)
         if not course_details:

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -546,10 +546,17 @@ def serialize_notification_content(
 
     email_items = []
     for user in users:
+        user_dict = model_to_dict(user, fields=['first_name', 'username', 'user_email', 'email'])
+        if 'email' in user_dict:
+            user_email = user_dict['email']
+        elif 'user_email' in user_dict:
+            user_email = user_dict['user_email']
+        else:
+            raise TypeError(_('`user` must have one of either `email` or `user_email`.'))
         login_or_register = 'register' if is_pending_user(user) else 'login'
         # if we have an activation link for a license, use that rather than the course URL
-        if activation_links is not None and activation_links.get(user.email) is not None:
-            destination_url = activation_links.get(user.email)
+        if activation_links is not None and activation_links.get(user_email) is not None:
+            destination_url = activation_links.get(user_email)
         else:
             destination_url = '{site}/{login_or_register}?next={course_path}'.format(
                 site=lms_root_url,
@@ -557,7 +564,7 @@ def serialize_notification_content(
                 course_path=course_path
             )
         email_items.append({
-            "user": model_to_dict(user, fields=['first_name', 'username', 'user_email', 'email']),
+            "user": user_dict,
             "enrolled_in": {
                 'name': course_name,
                 'url': destination_url,

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -495,6 +495,7 @@ def serialize_notification_content(
        (usually obtained via CourseCatalogApiClient)
     * course_id (str)
     * users (list): list of users to enroll (each user should be a User or PendingEnterpriseCustomerUser)
+    * activation_links (dict): a dictionary map of unactivated license user emails to license activation links
 
     Returns: A list of dictionary objects that are of the form:
       {

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -1811,9 +1811,13 @@ def enroll_licensed_users_in_courses(enterprise_customer, licensed_users_info, d
                     enterprise_customer, user, course_mode, course_run_key, enrollment_source, license_uuid
                 )
                 if succeeded:
-                    results['successes'].append(
-                        {'user': user, 'email': user_email, 'course_run_key': course_run_key, 'created': created, 'activation_link': activation_link}
-                    )
+                    results['successes'].append({
+                        'user': user,
+                        'email': user_email,
+                        'course_run_key': course_run_key,
+                        'created': created,
+                        'activation_link': activation_link,
+                    })
                 else:
                     results['failures'].append({'email': user_email, 'course_run_key': course_run_key})
             else:

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -3374,12 +3374,14 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
             'expected_response': {
                 'successes': [],
                 'pending': [
-                    {   'email': 'abc@test.com',
+                    {
+                        'email': 'abc@test.com',
                         'course_run_key': 'course-v1:edX+DemoX+Demo_Course',
                         'created': True,
                         'activation_link': None,
                     },
-                    {   'email': 'xyz@test.com',
+                    {
+                        'email': 'xyz@test.com',
                         'course_run_key': 'course-v1:edX+DemoX+Demo_Course',
                         'created': True,
                         'activation_link': None,
@@ -3422,12 +3424,14 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
             'expected_response': {
                 'successes': [],
                 'pending': [
-                    {   'email': 'abc@test.com',
+                    {
+                        'email': 'abc@test.com',
                         'course_run_key': 'course-v1:edX+DemoX+Demo_Course',
                         'created': True,
                         'activation_link': None,
                     },
-                    {   'email': 'xyz@test.com',
+                    {
+                        'email': 'xyz@test.com',
                         'course_run_key': 'course-v1:edX+DemoX+Demo_Course',
                         'created': True,
                         'activation_link': None,

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -3347,6 +3347,7 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
                     'email': 'abc@test.com',
                     'course_run_key': 'course-v1:edX+DemoX+Demo_Course',
                     'created': True,
+                    'activation_link': None,
                 }],
                 'failures': []
             },
@@ -3373,8 +3374,16 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
             'expected_response': {
                 'successes': [],
                 'pending': [
-                    {'email': 'abc@test.com', 'course_run_key': 'course-v1:edX+DemoX+Demo_Course', 'created': True},
-                    {'email': 'xyz@test.com', 'course_run_key': 'course-v1:edX+DemoX+Demo_Course', 'created': True}
+                    {   'email': 'abc@test.com',
+                        'course_run_key': 'course-v1:edX+DemoX+Demo_Course',
+                        'created': True,
+                        'activation_link': None,
+                    },
+                    {   'email': 'xyz@test.com',
+                        'course_run_key': 'course-v1:edX+DemoX+Demo_Course',
+                        'created': True,
+                        'activation_link': None,
+                    }
                 ],
                 'failures': []
             },
@@ -3413,17 +3422,27 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
             'expected_response': {
                 'successes': [],
                 'pending': [
-                    {'email': 'abc@test.com', 'course_run_key': 'course-v1:edX+DemoX+Demo_Course', 'created': True},
-                    {'email': 'xyz@test.com', 'course_run_key': 'course-v1:edX+DemoX+Demo_Course', 'created': True},
+                    {   'email': 'abc@test.com',
+                        'course_run_key': 'course-v1:edX+DemoX+Demo_Course',
+                        'created': True,
+                        'activation_link': None,
+                    },
+                    {   'email': 'xyz@test.com',
+                        'course_run_key': 'course-v1:edX+DemoX+Demo_Course',
+                        'created': True,
+                        'activation_link': None,
+                    },
                     {
                         'email': 'abc@test.com',
                         'course_run_key': 'course-v2:edX+DemoX+Second_Demo_Course',
                         'created': True,
+                        'activation_link': None,
                     },
                     {
                         'email': 'xyz@test.com',
                         'course_run_key': 'course-v2:edX+DemoX+Second_Demo_Course',
                         'created': True,
+                        'activation_link': None,
                     }
                 ],
                 'failures': []
@@ -3518,17 +3537,29 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
             'expected_response': {
                 'successes': [],
                 'pending': [
-                    {'email': 'abc@test.com', 'course_run_key': 'course-v1:edX+DemoX+Demo_Course', 'created': True},
-                    {'email': 'xyz@test.com', 'course_run_key': 'course-v1:edX+DemoX+Demo_Course', 'created': True},
+                    {
+                        'email': 'abc@test.com',
+                        'course_run_key': 'course-v1:edX+DemoX+Demo_Course',
+                        'created': True,
+                        'activation_link': None,
+                    },
+                    {
+                        'email': 'xyz@test.com',
+                        'course_run_key': 'course-v1:edX+DemoX+Demo_Course',
+                        'created': True,
+                        'activation_link': None,
+                    },
                     {
                         'email': 'abc@test.com',
                         'course_run_key': 'course-v2:edX+DemoX+Second_Demo_Course',
-                        'created': True
+                        'created': True,
+                        'activation_link': None,
                     },
                     {
                         'email': 'xyz@test.com',
                         'course_run_key': 'course-v2:edX+DemoX+Second_Demo_Course',
-                        'created': True
+                        'created': True,
+                        'activation_link': None,
                     }
                 ],
                 'failures': []
@@ -3608,6 +3639,7 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
                 course_id=course_run,
                 users=enrolled_learners,
                 admin_enrollment=True,
+                activation_links={},
             )
         mock_calls = [_make_call(course_run, unique_ent_customer_users) for course_run in unique_course_keys]
 

--- a/tests/test_enterprise/test_utils.py
+++ b/tests/test_enterprise/test_utils.py
@@ -307,7 +307,7 @@ class TestUtils(unittest.TestCase):
             elif 'user_email' in user_dict:
                 user_email = user_dict['user_email']
             else:
-                raise TypeError(_('`user` must have one of either `email` or `user_email`.'))
+                raise TypeError(('`user` must have one of either `email` or `user_email`.'))
             course_path = '/courses/{course_id}/course'.format(course_id=course_id)
             course_path = urlquote("{}?{}".format(course_path, urlencode([])))
             login_or_register = 'register' if is_pending_user(user) else 'login'

--- a/tests/test_enterprise/test_utils.py
+++ b/tests/test_enterprise/test_utils.py
@@ -183,7 +183,8 @@ class TestUtils(unittest.TestCase):
                     'email': self.user.email,
                     'course_run_key': 'course-key-v1',
                     'user': self.user,
-                    'created': True
+                    'created': True,
+                    'activation_link': None,
                 }],
                 'failures': [{'email': failure_user.email, 'course_run_key': 'course-key-v1'}]
             },
@@ -224,7 +225,8 @@ class TestUtils(unittest.TestCase):
                     'email': self.user.email,
                     'course_run_key': 'course-key-v1',
                     'user': self.user,
-                    'created': True
+                    'created': True,
+                    'activation_link': None,
                 }],
                 'failures': []
             },

--- a/tests/test_enterprise/test_utils.py
+++ b/tests/test_enterprise/test_utils.py
@@ -265,11 +265,13 @@ class TestUtils(unittest.TestCase):
         )
         user = factories.UserFactory()
         pending_user = factories.PendingEnterpriseCustomerUserFactory()
-        users = [user, pending_user]
+        needs_activation_user = factories.UserFactory()
+        users = [user, pending_user, needs_activation_user]
+        activation_links = {needs_activation_user.email: 'http://activation.test.learner.portal'}
 
         course_id = 'course-v1:edx+123+T2021'
         course_details = {'title': 'a_course', 'start': '2021-01-01T00:10:10', 'course': 'edx+123'}
-        return ent_customer, users, course_id, course_details
+        return ent_customer, users, course_id, course_details, activation_links
 
     @ddt.unpack
     @ddt.data(
@@ -287,7 +289,7 @@ class TestUtils(unittest.TestCase):
     ):
         mock_get_config_value_for_site.return_value = LMS_BASE_URL
         mock_get_learner_portal_url.return_value = "http://test.learner.portal"
-        ent_customer, users, course_id, course_details = self.setup_notification_test_data()
+        ent_customer, users, course_id, course_details, activation_links = self.setup_notification_test_data()
 
         email_items = serialize_notification_content(
             ent_customer,
@@ -295,19 +297,30 @@ class TestUtils(unittest.TestCase):
             course_id,
             users,
             admin_enrollment=admin_enrollment,
+            activation_links=activation_links,
         )
 
-        def expected_email_item(user):
+        def expected_email_item(user, activation_links):
+            user_dict = model_to_dict(user, fields=['first_name', 'username', 'user_email', 'email'])
+            if 'email' in user_dict:
+                user_email = user_dict['email']
+            elif 'user_email' in user_dict:
+                user_email = user_dict['user_email']
+            else:
+                raise TypeError(_('`user` must have one of either `email` or `user_email`.'))
             course_path = '/courses/{course_id}/course'.format(course_id=course_id)
             course_path = urlquote("{}?{}".format(course_path, urlencode([])))
             login_or_register = 'register' if is_pending_user(user) else 'login'
-            enrolled_url = '{site}/{login_or_register}?next={course_path}'.format(
-                site=LMS_BASE_URL,
-                login_or_register=login_or_register,
-                course_path=course_path
-            )
+            if activation_links is not None and activation_links.get(user_email) is not None:
+                enrolled_url = activation_links.get(user_email)
+            else:
+                enrolled_url = '{site}/{login_or_register}?next={course_path}'.format(
+                    site=LMS_BASE_URL,
+                    login_or_register=login_or_register,
+                    course_path=course_path
+                )
             return {
-                "user": model_to_dict(user, fields=['first_name', 'username', 'user_email', 'email']),
+                "user": user_dict,
                 "enrolled_in": {
                     'name': course_details.get('title'),
                     'url': enrolled_url,
@@ -319,5 +332,5 @@ class TestUtils(unittest.TestCase):
                 "admin_enrollment": admin_enrollment,
             }
 
-        expected_email_items = [expected_email_item(user) for user in users]
+        expected_email_items = [expected_email_item(user, activation_links) for user in users]
         assert email_items == expected_email_items


### PR DESCRIPTION
Change the enrollment notification emails to learners who have yet to activate their enterprise license to push them back into the activation flow rather than directly to the course.

We will click-test in staging/prod and review the sent emails as a final check.

- [ENT-5030](https://openedx.atlassian.net/browse/ENT-5030)
- - https://github.com/edx/license-manager/pull/320