### PR TITLE
fix: CSOD workaround bugfix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.33.6]
+---------
+fix: CSOD API session tokens bugfix
+
 [3.33.5]
 ---------
 fix: CSOD API session tokens are now saved to the customer's configuration instead of individual transmission audits

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.33.5"
+__version__ = "3.33.6"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -2344,7 +2344,7 @@ class RouterView(NonAtomicView):
             session_token = request.GET.get('sessionToken')
             if session_token:
                 csod_customer_configuration_model = apps.get_model(
-                    'integrated_channel',
+                    'cornerstone',
                     'CornerstoneEnterpriseCustomerConfiguration'
                 )
                 with transaction.atomic():

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -2339,8 +2339,7 @@ class RouterView(NonAtomicView):
                 )
             kwargs['course_id'] = course_run_id
 
-        # Enrollments through Cornerstone have some params in querystring, need to store those params if exists.
-        if course_key:
+            # Enrollments through Cornerstone have some params in querystring, need to store those params if exists.
             session_token = request.GET.get('sessionToken')
             if session_token:
                 csod_customer_configuration_model = apps.get_model(

--- a/tests/test_enterprise/views/test_router_view.py
+++ b/tests/test_enterprise/views/test_router_view.py
@@ -188,8 +188,33 @@ class TestRouterView(TestCase):
         router_view_mock.redirect = mock.MagicMock(return_value=None)
         kwargs = {
             'enterprise_uuid': str(self.enterprise_customer.uuid),
-            'course_key': 'fake_course_key'
+            'course_key': 'fake_course_key',
         }
+        router_view_mock.get(self.request, **kwargs)
+        router_view_mock.redirect.assert_called_once()
+
+    @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
+    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.RouterView', new_callable=views.RouterView)
+    def test_get_redirects_with_course_key_and_sessionToken(
+            self,
+            router_view_mock,
+            enrollment_api_mock,
+            catalog_api_mock
+    ):
+        """
+        ``get`` performs a redirect with a course key in the request path and
+        exercises the sessionToken/Cornerstone Integrated Channel code path.
+        """
+        enrollment_api_mock.get_enrolled_courses.side_effect = fake_enrollment_api.get_enrolled_courses
+        fake_catalog_api.setup_course_catalog_api_client_mock(catalog_api_mock)
+        router_view_mock.eligible_for_direct_audit_enrollment = mock.MagicMock(return_value=False)
+        router_view_mock.redirect = mock.MagicMock(return_value=None)
+        kwargs = {
+            'enterprise_uuid': str(self.enterprise_customer.uuid),
+            'course_key': 'fake_course_key',
+        }
+        self.request.GET['sessionToken'] = 'fake_token'
         router_view_mock.get(self.request, **kwargs)
         router_view_mock.redirect.assert_called_once()
 


### PR DESCRIPTION
Fix to a name-spacing error introduced by our CSOD workaround. This call uses the [AppConfig.label](https://docs.djangoproject.com/en/3.2/ref/applications/#django.apps.AppConfig.label) which is the last part of the path. This model is defined under `integrated_channels.cornerstone` rather than `integrated_channel`.

This bug is in production and may be affecting enrollments for CSOD learners. I tested this bug and my fix with a local console. I will try to introduce tests to cover these lines of code.

- [ENT-5115](https://openedx.atlassian.net/browse/ENT-5115)

Log lines to look for:

```
LookupError: App 'integrated_channel' doesn't have a 'CornerstoneEnterpriseCustomerConfiguration' model.
```

```
KeyError: 'cornerstoneenterprisecustomerconfiguration'
```