### PR TITLE
fix: incorrectly skipping completion transmissions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.33.10]
+---------
+fix: incorrectly skipping completion transmissions
+
 [3.33.9]
 ---------
 feat: allow filtering enterprise learners by enterprise uuid and enterprise role

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.33.9"
+__version__ = "3.33.10"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/integrated_channel/exporters/learner_data.py
+++ b/integrated_channels/integrated_channel/exporters/learner_data.py
@@ -425,6 +425,14 @@ class LearnerExporter(Exporter):
                 incomplete_count,
             )
 
+            LOGGER.info(generate_formatted_log(
+                channel_name, enterprise_customer_uuid, lms_user_id, course_run_id,
+                f'kwargs completed_date: '
+                f' {completed_date} '
+                f'api completed_date: '
+                f' {completed_date_from_api} '
+            ))
+
             # Apply the Source of Truth for Grades
             records = self.get_learner_data_records(
                 enterprise_enrollment=enterprise_enrollment,

--- a/integrated_channels/integrated_channel/exporters/learner_data.py
+++ b/integrated_channels/integrated_channel/exporters/learner_data.py
@@ -432,7 +432,7 @@ class LearnerExporter(Exporter):
                 grade=grade_from_api,
                 course_completed=is_course_completed(
                     enterprise_enrollment,
-                    completed_date,
+                    completed_date_from_api,
                     is_passing_from_api,
                     incomplete_count,
                 ),


### PR DESCRIPTION
In debugging two customer reported issues we discovered that we've most likely made a typo here - we should always be using completion date from the API (source of truth)n rather than what is passed with `kwags` - which on the signal side is always `now` and on the bulk side is not passed at all (`None`).

Because the `completed_date` is `None` on the bulk side we don't appropriately retransmit learner audit records in every case.

- [ENT-5095](https://openedx.atlassian.net/browse/ENT-5095)

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
