### PR TITLE
feat: for SAP channel, do not consider grade when diffing audit records ENT-4752

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.33.12]
+---------
+feat: SAPSF integrated no longer considers grade change as a reason to retransmit completions.
+
 [3.33.11]
 ---------
 feat: New management command to backfill end dates on Canvas

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.33.11"
+__version__ = "3.33.12"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/integrated_channel/channel_settings.py
+++ b/integrated_channels/integrated_channel/channel_settings.py
@@ -8,6 +8,10 @@ class ChannelSettingsMixin:
     Mixin for channel settings that apply to all channels.
     Provides common settings for all channels. Each channels is free to override settings at their
     Exporter or Transmitter or Client level, as needed
+
+    Important: If you add a setting here, please add a test to cover this default, as well as
+    any overrides you add on a per channel basis. See this test for an example:
+    tests/test_integrated_channels/test_sap_success_factors/test_transmitters/test_learner_data.py
     """
 
     # a channel should override this to False if they don't want grade changes to

--- a/integrated_channels/integrated_channel/channel_settings.py
+++ b/integrated_channels/integrated_channel/channel_settings.py
@@ -1,3 +1,8 @@
+"""
+Channel level settings (global for all channels).
+"""
+
+
 class ChannelSettingsMixin:
     """
     Mixin for channel settings that apply to all channels.

--- a/integrated_channels/integrated_channel/channel_settings.py
+++ b/integrated_channels/integrated_channel/channel_settings.py
@@ -1,0 +1,10 @@
+class ChannelSettingsMixin:
+    """
+    Mixin for channel settings that apply to all channels.
+    Provides common settings for all channels. Each channels is free to override settings at their
+    Exporter or Transmitter or Client level, as needed
+    """
+
+    # a channel should override this to False if they don't want grade changes to
+    # cause retransmission of completion records
+    INCLUDE_GRADE_FOR_COMPLETION_AUDIT_CHECK = True

--- a/integrated_channels/integrated_channel/transmitters/learner_data.py
+++ b/integrated_channels/integrated_channel/transmitters/learner_data.py
@@ -93,7 +93,7 @@ class LearnerTransmitter(Transmitter, ChannelSettingsMixin):
             except ClientError as client_error:
                 code = client_error.status_code
                 body = client_error.message
-                self.handle_transmission_error(
+                self.process_transmission_error(
                     learner_data,
                     client_error,
                     app_label,
@@ -194,7 +194,7 @@ class LearnerTransmitter(Transmitter, ChannelSettingsMixin):
             except ClientError as client_error:
                 code = client_error.status_code
                 body = client_error.message
-                self.handle_transmission_error(
+                self.process_transmission_error(
                     learner_data,
                     client_error,
                     app_label,
@@ -312,7 +312,7 @@ class LearnerTransmitter(Transmitter, ChannelSettingsMixin):
             except ClientError as client_error:
                 code = client_error.status_code
                 body = client_error.message
-                self.handle_transmission_error(
+                self.process_transmission_error(
                     learner_data,
                     client_error,
                     app_label,
@@ -381,9 +381,30 @@ class LearnerTransmitter(Transmitter, ChannelSettingsMixin):
                 payload=learner_data
             )), exc_info=True)
 
-    def handle_transmission_error(self, learner_data, client_exception,
-                                  integrated_channel_name, enterprise_customer_uuid, learner_id, course_id):
-        """Handle the case where the transmission fails."""
+    def handle_transmission_error(self, learner_data, client_exception):
+        """
+        Subclasses who wish to do additional processing of transmission error
+        before logging, can do so in overrides of this method
+        """
+
+    def process_transmission_error(
+        self,
+        learner_data,
+        client_exception,
+        integrated_channel_name,
+        enterprise_customer_uuid,
+        learner_id,
+        course_id,
+    ):
+        """
+        applies any needed processing of transmission error before logging it
+        subclasses should override handle_transmission_error if they want to do additional
+        processing of the error before it's logged
+        """
+        self.handle_transmission_error(
+            learner_data,
+            client_exception,
+        )
         LOGGER.exception(generate_formatted_log(
             integrated_channel_name, enterprise_customer_uuid, learner_id, course_id,
             'Failed to send completion status call for enterprise enrollment {}'

--- a/integrated_channels/integrated_channel/transmitters/learner_data.py
+++ b/integrated_channels/integrated_channel/transmitters/learner_data.py
@@ -93,7 +93,7 @@ class LearnerTransmitter(ChannelSettingsMixin, Transmitter):
             except ClientError as client_error:
                 code = client_error.status_code
                 body = client_error.message
-                self.log_transmission_error(
+                self.handle_transmission_error(
                     learner_data,
                     client_error,
                     app_label,
@@ -194,7 +194,7 @@ class LearnerTransmitter(ChannelSettingsMixin, Transmitter):
             except ClientError as client_error:
                 code = client_error.status_code
                 body = client_error.message
-                self.log_transmission_error(
+                self.handle_transmission_error(
                     learner_data,
                     client_error,
                     app_label,
@@ -312,7 +312,7 @@ class LearnerTransmitter(ChannelSettingsMixin, Transmitter):
             except ClientError as client_error:
                 code = client_error.status_code
                 body = client_error.message
-                self.log_transmission_error(
+                self.handle_transmission_error(
                     learner_data,
                     client_error,
                     app_label,
@@ -381,8 +381,8 @@ class LearnerTransmitter(ChannelSettingsMixin, Transmitter):
                 payload=learner_data
             )), exc_info=True)
 
-    def log_transmission_error(self, learner_data, client_exception,
-                               integrated_channel_name, enterprise_customer_uuid, learner_id, course_id):
+    def handle_transmission_error(self, learner_data, client_exception,
+                                  integrated_channel_name, enterprise_customer_uuid, learner_id, course_id):
         """Handle the case where the transmission fails."""
         LOGGER.exception(generate_formatted_log(
             integrated_channel_name, enterprise_customer_uuid, learner_id, course_id,

--- a/integrated_channels/integrated_channel/transmitters/learner_data.py
+++ b/integrated_channels/integrated_channel/transmitters/learner_data.py
@@ -18,7 +18,7 @@ from integrated_channels.utils import generate_formatted_log, is_already_transmi
 LOGGER = logging.getLogger(__name__)
 
 
-class LearnerTransmitter(ChannelSettingsMixin, Transmitter):
+class LearnerTransmitter(Transmitter, ChannelSettingsMixin):
     """
     A generic learner data transmitter.
 

--- a/integrated_channels/sap_success_factors/client.py
+++ b/integrated_channels/sap_success_factors/client.py
@@ -144,6 +144,7 @@ class SAPSuccessFactorsAPIClient(IntegratedChannelApiClient):  # pylint: disable
             The body of the response from SAP SuccessFactors, if successful
         Raises:
             HTTPError: if we received a failure response code from SAP SuccessFactors
+            ClientError: if we receive an error response code >=400 from SAPSF
         """
         base_url = self.enterprise_configuration.sapsf_base_url
 
@@ -238,6 +239,8 @@ class SAPSuccessFactorsAPIClient(IntegratedChannelApiClient):  # pylint: disable
             sap_user_id (str): The user to use to retrieve an auth token.
             url (str): The url to post to.
             payload (str): The json encoded payload to post.
+
+        Raises: ClientError if error status code >=400 from SAPSF
         """
         SAPSuccessFactorsEnterpriseCustomerConfiguration = apps.get_model(
             'sap_success_factors',

--- a/integrated_channels/sap_success_factors/exporters/learner_data.py
+++ b/integrated_channels/sap_success_factors/exporters/learner_data.py
@@ -25,6 +25,8 @@ class SapSuccessFactorsLearnerExporter(LearnerExporter):
     Class to provide a SAPSF learner data transmission audit prepared for serialization.
     """
 
+    INCLUDE_GRADE_FOR_COMPLETION_AUDIT_CHECK = False
+
     def get_learner_data_records(
             self,
             enterprise_enrollment,

--- a/integrated_channels/sap_success_factors/transmitters/learner_data.py
+++ b/integrated_channels/sap_success_factors/transmitters/learner_data.py
@@ -20,6 +20,8 @@ class SapSuccessFactorsLearnerTransmitter(LearnerTransmitter):
     sent to SuccessFactors.
     """
 
+    INCLUDE_GRADE_FOR_COMPLETION_AUDIT_CHECK = False
+
     def __init__(self, enterprise_configuration, client=SAPSuccessFactorsAPIClient):
         """
         By default, use the ``SAPSuccessFactorsAPIClient`` for learner data transmission to SAPSF.
@@ -61,5 +63,5 @@ class SapSuccessFactorsLearnerTransmitter(LearnerTransmitter):
                     ecu.user_id, ecu.id, ecu.enterprise_customer
                 )
                 return
-        super().handle_transmission_error(learner_data, client_exception,
-                                          integrated_channel_name, enterprise_customer_uuid, learner_id, course_id)
+        super().log_transmission_error(learner_data, client_exception,
+                                       integrated_channel_name, enterprise_customer_uuid, learner_id, course_id)

--- a/integrated_channels/sap_success_factors/transmitters/learner_data.py
+++ b/integrated_channels/sap_success_factors/transmitters/learner_data.py
@@ -63,5 +63,11 @@ class SapSuccessFactorsLearnerTransmitter(LearnerTransmitter):
                     ecu.user_id, ecu.id, ecu.enterprise_customer
                 )
                 return
-        super().log_transmission_error(learner_data, client_exception,
-                                       integrated_channel_name, enterprise_customer_uuid, learner_id, course_id)
+        super().log_transmission_error(
+            learner_data,
+            client_exception,
+            integrated_channel_name,
+            enterprise_customer_uuid,
+            learner_id,
+            course_id,
+        )

--- a/integrated_channels/sap_success_factors/transmitters/learner_data.py
+++ b/integrated_channels/sap_success_factors/transmitters/learner_data.py
@@ -43,8 +43,7 @@ class SapSuccessFactorsLearnerTransmitter(LearnerTransmitter):
         kwargs['remote_user_id'] = 'sapsf_user_id'
         super().transmit(payload, **kwargs)
 
-    def handle_transmission_error(self, learner_data, client_exception, integrated_channel_name,
-                                  enterprise_customer_uuid, learner_id, course_id):
+    def handle_transmission_error(self, learner_data, client_exception):
         """Handle the case where the employee on SAPSF's side is marked as inactive."""
         try:
             sys_msg = six.text_type(client_exception.message)
@@ -63,11 +62,3 @@ class SapSuccessFactorsLearnerTransmitter(LearnerTransmitter):
                     ecu.user_id, ecu.id, ecu.enterprise_customer
                 )
                 return
-        super().log_transmission_error(
-            learner_data,
-            client_exception,
-            integrated_channel_name,
-            enterprise_customer_uuid,
-            learner_id,
-            course_id,
-        )

--- a/integrated_channels/utils.py
+++ b/integrated_channels/utils.py
@@ -215,7 +215,7 @@ def is_already_transmitted(
         latest_transmitted_tx = already_transmitted.latest('id')
         if detect_grade_updated:
             return latest_transmitted_tx and getattr(latest_transmitted_tx, 'grade', None) == grade
-        return latest_transmitted_tx
+        return latest_transmitted_tx is not None
     except transmission.DoesNotExist:
         return False
 

--- a/integrated_channels/utils.py
+++ b/integrated_channels/utils.py
@@ -185,7 +185,13 @@ def get_image_url(content_metadata_item):
     return image_url
 
 
-def is_already_transmitted(transmission, enterprise_enrollment_id, grade, subsection_id=None):
+def is_already_transmitted(
+    transmission,
+    enterprise_enrollment_id,
+    grade,
+    subsection_id=None,
+    detect_grade_updated=True,
+):
     """
     Returns: Boolean indicating if completion date for given enrollment is already sent of not.
 
@@ -195,6 +201,7 @@ def is_already_transmitted(transmission, enterprise_enrollment_id, grade, subsec
         grade: 'Pass' or 'Fail' status
         subsection_id (Optional): The id of the subsection, needed if transmitting assessment level grades as there can
         be multiple per course.
+        detect_grade_updated: default True. if this is False, method does not take into account grade changes
     """
     try:
         already_transmitted = transmission.objects.filter(
@@ -206,7 +213,9 @@ def is_already_transmitted(transmission, enterprise_enrollment_id, grade, subsec
             already_transmitted = already_transmitted.filter(subsection_id=subsection_id)
 
         latest_transmitted_tx = already_transmitted.latest('id')
-        return latest_transmitted_tx and getattr(latest_transmitted_tx, 'grade', None) == grade
+        if detect_grade_updated:
+            return latest_transmitted_tx and getattr(latest_transmitted_tx, 'grade', None) == grade
+        return latest_transmitted_tx
     except transmission.DoesNotExist:
         return False
 

--- a/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_learner_data.py
+++ b/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_learner_data.py
@@ -89,6 +89,12 @@ class TestLearnerExporter(unittest.TestCase):
         assert isinstance(self.exporter, LearnerExporter)
         super().setUp()
 
+    def test_default_channel_settings(self):
+        """
+        If you add any settings to the ChannelSettingsMixin, add a test here for the common default value
+        """
+        assert LearnerExporter('fake-user', self.config).INCLUDE_GRADE_FOR_COMPLETION_AUDIT_CHECK is True
+
     def test_collect_learner_data_no_enrollments(self):
         learner_data = list(self.exporter.export())
         assert not learner_data

--- a/tests/test_integrated_channels/test_integrated_channel/test_transmitters/test_learner_data.py
+++ b/tests/test_integrated_channels/test_integrated_channel/test_transmitters/test_learner_data.py
@@ -108,12 +108,12 @@ class TestLearnerDataTransmitter(unittest.TestCase):
         records.course_completed = True
         records.serialize = Mock(return_value='serialized data')
         exporter.export = MagicMock(return_value=[records])
-        self.learner_transmitter.handle_transmission_error = Mock()
+        self.learner_transmitter.log_transmission_error = Mock()
         self.learner_transmitter.transmit(
             exporter,
             remote_user_id='user_id'
         )
-        self.learner_transmitter.handle_transmission_error.assert_called_once()
+        self.learner_transmitter.log_transmission_error.assert_called_once()
 
     def test_learner_data_transmission_feature_flag(self):
         """

--- a/tests/test_integrated_channels/test_integrated_channel/test_transmitters/test_learner_data.py
+++ b/tests/test_integrated_channels/test_integrated_channel/test_transmitters/test_learner_data.py
@@ -42,6 +42,12 @@ class TestLearnerDataTransmitter(unittest.TestCase):
 
         self.learner_transmitter = LearnerTransmitter(self.enterprise_config)
 
+    def test_default_channel_settings(self):
+        """
+        If you add any settings to the ChannelSettingsMixin, add a test here for the common default value
+        """
+        assert LearnerTransmitter(self.enterprise_config).INCLUDE_GRADE_FOR_COMPLETION_AUDIT_CHECK is True
+
     def test_transmit_single_learner_data_signal_kwargs(self):
         """
         transmit_single_learner_data is called with kwargs as a shared task from OpenEdx,

--- a/tests/test_integrated_channels/test_integrated_channel/test_transmitters/test_learner_data.py
+++ b/tests/test_integrated_channels/test_integrated_channel/test_transmitters/test_learner_data.py
@@ -108,12 +108,12 @@ class TestLearnerDataTransmitter(unittest.TestCase):
         records.course_completed = True
         records.serialize = Mock(return_value='serialized data')
         exporter.export = MagicMock(return_value=[records])
-        self.learner_transmitter.log_transmission_error = Mock()
+        self.learner_transmitter.process_transmission_error = Mock()
         self.learner_transmitter.transmit(
             exporter,
             remote_user_id='user_id'
         )
-        self.learner_transmitter.log_transmission_error.assert_called_once()
+        self.learner_transmitter.process_transmission_error.assert_called_once()
 
     def test_learner_data_transmission_feature_flag(self):
         """

--- a/tests/test_integrated_channels/test_sap_success_factors/test_exporters/test_learner_data.py
+++ b/tests/test_integrated_channels/test_sap_success_factors/test_exporters/test_learner_data.py
@@ -57,3 +57,18 @@ class TestSAPSuccessFactorLearnerDataExporter(unittest.TestCase):
         enterprise_enrollment.enterprise_customer_user.get_remote_id.assert_called_once_with(
             enterprise_configuration.idp_id
         )
+
+    def test_override_of_default_channel_settings(self):
+        """
+        If you override any settings to the ChannelSettingsMixin, add a test here for those
+        """
+        user = UserFactory()
+        enterprise_customer = EnterpriseCustomerFactory()
+        enterprise_configuration = SAPSuccessFactorsEnterpriseCustomerConfigurationFactory(
+            enterprise_customer=enterprise_customer,
+            idp_id='test-id'
+        )
+        assert SapSuccessFactorsLearnerExporter(
+            user,
+            enterprise_configuration
+        ).INCLUDE_GRADE_FOR_COMPLETION_AUDIT_CHECK is False

--- a/tests/test_integrated_channels/test_sap_success_factors/test_transmitters/test_learner_data.py
+++ b/tests/test_integrated_channels/test_sap_success_factors/test_transmitters/test_learner_data.py
@@ -223,3 +223,11 @@ class TestSapSuccessFactorsLearnerDataTransmitter(unittest.TestCase):
         assert payloads[0].error_message == 'error occurred'
         assert payloads[1].status == '200'
         assert payloads[1].error_message == ''
+
+    def test_override_channel_settings(self):
+        """
+        If you add any settings to the ChannelSettingsMixin, add a test here for the common default value
+        """
+        assert learner_data.SapSuccessFactorsLearnerTransmitter(
+            self.enterprise_config
+        ).INCLUDE_GRADE_FOR_COMPLETION_AUDIT_CHECK is False

--- a/tests/test_integrated_channels/test_sap_success_factors/test_transmitters/test_learner_data.py
+++ b/tests/test_integrated_channels/test_sap_success_factors/test_transmitters/test_learner_data.py
@@ -81,6 +81,22 @@ class TestSapSuccessFactorsLearnerDataTransmitter(unittest.TestCase):
         transmitter.transmit(self.exporter())
         self.create_course_completion_mock.assert_not_called()
 
+    def test_avoid_retransmit_on_grade_change(self):
+        """
+        SAPSF does not support retransmsmitting completion, so we don't do that
+        if just a grade changed relative to what is already saved
+        """
+
+        self.payloads[0].save()
+
+        # let's try to send a payload with everything same except the grade
+        payload = self.payloads[0]
+        payload.grade = 'a_bit_different_grade'
+
+        transmitter = learner_data.SapSuccessFactorsLearnerTransmitter(self.enterprise_config)
+        transmitter.transmit(self.exporter([payload]))
+        self.create_course_completion_mock.assert_not_called()
+
     def test_transmit_success(self):
         """
         Learner data transmission is successful and the payload is saved with the appropriate data.

--- a/tests/test_integrated_channels/test_utils.py
+++ b/tests/test_integrated_channels/test_utils.py
@@ -177,7 +177,7 @@ class TestIntegratedChannelsUtils(unittest.TestCase):
 
         transmission.objects.filter.return_value = mock_audit_record
 
-        enterprise_enrollment_id = 'a'
+        enterprise_enrollment_id = 123
 
        # note: detect_grade_updated=True by default
         assert utils.is_already_transmitted(
@@ -215,7 +215,7 @@ class TestIntegratedChannelsUtils(unittest.TestCase):
 
         transmission.objects.filter.return_value = mock_audit_record
 
-        enterprise_enrollment_id = 'a'
+        enterprise_enrollment_id = 1234
 
         assert utils.is_already_transmitted(
             transmission,

--- a/tests/test_integrated_channels/test_utils.py
+++ b/tests/test_integrated_channels/test_utils.py
@@ -6,6 +6,7 @@ Tests for the utilities used by integration channels.
 import unittest
 from collections import namedtuple
 from datetime import timedelta
+from unittest.mock import MagicMock, PropertyMock
 
 import ddt
 import mock
@@ -146,3 +147,80 @@ class TestIntegratedChannelsUtils(unittest.TestCase):
         mock_get_course_run_for_enrollment.return_value = course_run_verify_expired
         enterprise_enrollment = ent_enrollment(is_audit_enrollment=False)
         assert not utils.is_course_completed(enterprise_enrollment, None, False, 0)
+
+    @ddt.data((True, True,), (False, False,))
+    @ddt.unpack
+    def test_is_already_transmitted_with_grade_considered(
+        self,
+        grade_should_match_audit,
+        expected_is_already_transmitted,
+    ):
+        """
+        When detect_grade_updated is True, grade is also matched against passed grade,
+        when comparing audit records
+        """
+        transmission = MagicMock()
+        transmission.objects.filter = MagicMock()
+        mock_audit_record = MagicMock()
+        mock_audit_record.latest = MagicMock()
+        matching_grade = 'A+'
+
+        mock_audit_record_from_audit_logs = MagicMock()
+        grade_match = PropertyMock(return_value=matching_grade)
+        grade_non_matched = PropertyMock(return_value='B+')
+        if grade_should_match_audit:
+            type(mock_audit_record_from_audit_logs).grade = grade_match
+        else:
+            type(mock_audit_record_from_audit_logs).grade = grade_non_matched
+
+        mock_audit_record.latest.return_value = mock_audit_record_from_audit_logs
+
+        transmission.objects.filter.return_value = mock_audit_record
+
+        enterprise_enrollment_id = 'a'
+
+       # note: detect_grade_updated=True by default
+        assert utils.is_already_transmitted(
+            transmission,
+            enterprise_enrollment_id,
+            matching_grade,
+            subsection_id=None,
+        ) is expected_is_already_transmitted
+
+    @ddt.data((True,), (False,))
+    @ddt.unpack
+    def test_is_already_transmitted_grade_not_considered(
+        self,
+        grade_should_match_audit,
+    ):
+        """
+        When detect_grade_updated is False, the grade difference between database record and passed grade
+        should not matter
+        """
+        transmission = MagicMock()
+        transmission.objects.filter = MagicMock()
+        mock_audit_record = MagicMock()
+        mock_audit_record.latest = MagicMock()
+        matching_grade = 'A+'
+
+        mock_audit_record_from_audit_logs = MagicMock()
+        grade_match = PropertyMock(return_value=matching_grade)
+        grade_non_matched = PropertyMock(return_value='B+')
+        if grade_should_match_audit:
+            type(mock_audit_record_from_audit_logs).grade = grade_match
+        else:
+            type(mock_audit_record_from_audit_logs).grade = grade_non_matched
+
+        mock_audit_record.latest.return_value = mock_audit_record_from_audit_logs
+
+        transmission.objects.filter.return_value = mock_audit_record
+
+        enterprise_enrollment_id = 'a'
+
+        assert utils.is_already_transmitted(
+            transmission,
+            enterprise_enrollment_id,
+            matching_grade,
+            subsection_id=None,
+            detect_grade_updated=False,
+        ) is True

--- a/tests/test_integrated_channels/test_utils.py
+++ b/tests/test_integrated_channels/test_utils.py
@@ -179,7 +179,7 @@ class TestIntegratedChannelsUtils(unittest.TestCase):
 
         enterprise_enrollment_id = 123
 
-       # note: detect_grade_updated=True by default
+        # note: detect_grade_updated=True by default
         assert utils.is_already_transmitted(
             transmission,
             enterprise_enrollment_id,


### PR DESCRIPTION
this allows us to avoid retransmitting completion reports for SAP, when grade changes

What this PR does:

- [x] introduces a new `ChannelSettingsMixin` which will house class level properties that represent settings. I added one setting there called `INCLUDE_GRADE_FOR_COMPLETION_AUDIT_CHECK` which is True by default. This keeps today's behavior when sending completions (meaning it also considers grade changes as a reason to retransmit completions)
- [x] Makes the learner_data Exporter and Transmitter classes inherit this mixin as in `class LearnerExporter(ChannelSettingsMixin, Exporter):`
- [x] Disables this flag for SAP Exporter/Transmitter for learner_data which uses this mixin.
- [x] Uses this flag when passing a flag to the util method `is_already_transmitted` which will in turn ignore grade diff when answering the question, if this flag is False

ENT-4752

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
