### PR TITLE
fix:  enterprise invite key support for proxy login

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.36.5]
+--------
+fix: add support for an ``enterprise_customer_invite_key`` UUID query parameter to be passed and handled by the ``EnterpriseProxyLoginView``
+
 [3.36.4]
 --------
 feat: OAuth Auth link for Blackboard Admin

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.36.4"
+__version__ = "3.36.5"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -703,6 +703,13 @@ def licensed_enterprise_course_enrollment_model():
     return apps.get_model('enterprise', 'LicensedEnterpriseCourseEnrollment')
 
 
+def enterprise_customer_invite_key_model():
+    """
+    Returns the ``EnterpriseCustomerInviteKey`` class.
+    """
+    return apps.get_model('enterprise', 'EnterpriseCustomerInviteKey')
+
+
 def get_enterprise_customer(uuid):
     """
     Get the ``EnterpriseCustomer`` instance associated with ``uuid``.
@@ -890,6 +897,23 @@ def get_enterprise_customer_by_slug_or_404(slug):
         enterprise_customer_model(),
         slug=slug,
     )
+
+def get_enterprise_customer_by_invite_key_or_404(invite_key_uuid):
+    """
+    Given an EnterpriseCustomerInviteKey UUID, return the corresponding EnterpriseCustomer or raise a 404.
+
+    Arguments:
+        invite_key_uuid (str): The UUID identifying an EnterpriseCustomerInviteKey.
+
+    Returns:
+        (EnterpriseCustomer): The EnterpriseCustomer given the EnterpriseCustomerInviteKey UUID.
+    """
+    print('get_enterprise_customer_by_invite_key_or_404!!!', invite_key_uuid)
+    customer_invite_key = get_object_or_404(
+        enterprise_customer_invite_key_model(),
+        uuid=invite_key_uuid,
+    )
+    return customer_invite_key.enterprise_customer
 
 
 def clean_html_for_template_rendering(text):

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -909,7 +909,6 @@ def get_enterprise_customer_by_invite_key_or_404(invite_key_uuid):
     Returns:
         (EnterpriseCustomer): The EnterpriseCustomer given the EnterpriseCustomerInviteKey UUID.
     """
-    print('get_enterprise_customer_by_invite_key_or_404!!!', invite_key_uuid)
     customer_invite_key = get_object_or_404(
         enterprise_customer_invite_key_model(),
         uuid=invite_key_uuid,

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -898,6 +898,7 @@ def get_enterprise_customer_by_slug_or_404(slug):
         slug=slug,
     )
 
+
 def get_enterprise_customer_by_invite_key_or_404(invite_key_uuid):
     """
     Given an EnterpriseCustomerInviteKey UUID, return the corresponding EnterpriseCustomer or raise a 404.

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -25,7 +25,7 @@ from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import ImproperlyConfigured, PermissionDenied
 from django.db import IntegrityError, transaction
-from django.http import Http404, HttpResponse, JsonResponse
+from django.http import Http404, JsonResponse
 from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.utils.decorators import method_decorator
@@ -1012,10 +1012,7 @@ class EnterpriseProxyLoginView(View):
         enterprise_slug = query_params.get('enterprise_slug')
         enterprise_invite_key = query_params.get('enterprise_customer_invite_key')
         if not enterprise_slug and not enterprise_invite_key:
-            return HttpResponse(
-                'Either an enterprise_slug or enterprise_customer_invite_key must be provided',
-                status=400,
-            )
+            raise Http404
 
         if enterprise_slug:
             enterprise_customer = get_enterprise_customer_by_slug_or_404(enterprise_slug)
@@ -1030,7 +1027,7 @@ class EnterpriseProxyLoginView(View):
             # Default redirect is to the Learner Portal for the given Enterprise
             learner_portal_base_url = get_configuration_value(
                 'ENTERPRISE_LEARNER_PORTAL_BASE_URL',
-                settings.ENTERPRISE_LEARNER_PORTAL_BASE_URL
+                settings.ENTERPRISE_LEARNER_PORTAL_BASE_URL,
             )
             query_dict['next'] = f"{learner_portal_base_url}/{enterprise_slug}"
 

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -1016,7 +1016,7 @@ class EnterpriseProxyLoginView(View):
 
         if enterprise_slug:
             enterprise_customer = get_enterprise_customer_by_slug_or_404(enterprise_slug)
-        elif enterprise_invite_key:
+        else:
             enterprise_customer = get_enterprise_customer_by_invite_key_or_404(enterprise_invite_key)
 
         # Add the next param to the redirect's query parameters

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -70,8 +70,8 @@ from enterprise.utils import (
     get_configuration_value,
     get_create_ent_enrollment,
     get_current_course_run,
-    get_enterprise_customer_by_slug_or_404,
     get_enterprise_customer_by_invite_key_or_404,
+    get_enterprise_customer_by_slug_or_404,
     get_enterprise_customer_or_404,
     get_enterprise_customer_user,
     get_platform_logo_url,
@@ -1029,7 +1029,7 @@ class EnterpriseProxyLoginView(View):
                 'ENTERPRISE_LEARNER_PORTAL_BASE_URL',
                 settings.ENTERPRISE_LEARNER_PORTAL_BASE_URL,
             )
-            query_dict['next'] = f"{learner_portal_base_url}/{enterprise_slug}"
+            query_dict['next'] = f"{learner_portal_base_url}/{enterprise_customer.slug}"
 
         tpa_hint_param = query_params.get('tpa_hint')
         tpa_hint = enterprise_customer.get_tpa_hint(tpa_hint_param)

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -48,7 +48,7 @@ from enterprise.models import (
     PendingEnrollment,
     PendingEnterpriseCustomerUser,
 )
-from enterprise.utils import NotConnectedToOpenEdX
+from enterprise.utils import NotConnectedToOpenEdX, localized_utcnow
 from enterprise_learner_portal.utils import CourseRunProgressStatuses
 from test_utils import (
     FAKE_UUIDS,
@@ -4926,11 +4926,11 @@ class TestEnterpriseCustomerInviteKeyViewSet(BaseTestEnterpriseAPIViews):
         self.enterprise_customer_3 = factories.EnterpriseCustomerFactory()
         self.enterprise_customer_3_invite_key = factories.EnterpriseCustomerInviteKeyFactory(
             enterprise_customer=self.enterprise_customer_3,
-            expiration_date=datetime.utcnow() + timedelta(days=365)
+            expiration_date=localized_utcnow() + timedelta(days=365),
         )
         self.invalid_enterprise_customer_3_invite_key = factories.EnterpriseCustomerInviteKeyFactory(
             enterprise_customer=self.enterprise_customer_3,
-            expiration_date=datetime.utcnow() - timedelta(days=365)
+            expiration_date=localized_utcnow() - timedelta(days=365),
         )
 
     def tearDown(self):


### PR DESCRIPTION
# Description

* Adds support for `enterprise_customer_invite_key` query parameter on EnterpriseProxyLoginView such that when a UI redirects learners through the EnterpriseProxyLoginView by passing an invite key UUID, the proxy login view can find the enterprise customer associated with the invite key and shows its logo during logistration.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
