### PR TITLE
feat: when no enrollment found, log info and return

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.36.3]
+--------
+feat: Integrated channels, grade send logic only logs instead of raising when enterprise_customer_user record is inactive
+
 [3.36.2]
 --------
 feat: add is_active on enterprise customer invite key

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.36.2"
+__version__ = "3.36.3"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/integrated_channel/exporters/learner_data.py
+++ b/integrated_channels/integrated_channel/exporters/learner_data.py
@@ -177,8 +177,8 @@ class LearnerExporter(ChannelSettingsMixin, Exporter):
             LOGGER.info(generate_formatted_log(
                 self.enterprise_configuration.channel_code(),
                 self.enterprise_configuration.enterprise_customer.uuid,
-                enterprise_enrollment.enterprise_customer_user.user_id,
-                enterprise_enrollment.course_id,
+                lms_user_for_filter,
+                course_run_id,
                 f'Either qualifying enrollments not found for learner, or, '
                 f'enterprise_customer_user record is inactive. Skipping transmit assessment grades.'
             ))

--- a/integrated_channels/integrated_channel/exporters/learner_data.py
+++ b/integrated_channels/integrated_channel/exporters/learner_data.py
@@ -17,7 +17,6 @@ from django.contrib import auth
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 
-from integrated_channels.exceptions import ClientError
 from integrated_channels.integrated_channel.channel_settings import ChannelSettingsMixin
 
 try:

--- a/integrated_channels/integrated_channel/exporters/learner_data.py
+++ b/integrated_channels/integrated_channel/exporters/learner_data.py
@@ -179,8 +179,8 @@ class LearnerExporter(ChannelSettingsMixin, Exporter):
                 self.enterprise_configuration.enterprise_customer.uuid,
                 lms_user_for_filter,
                 course_run_id,
-                f'Either qualifying enrollments not found for learner, or, '
-                f'enterprise_customer_user record is inactive. Skipping transmit assessment grades.'
+                'Either qualifying enrollments not found for learner, or, '
+                'enterprise_customer_user record is inactive. Skipping transmit assessment grades.'
             ))
             return
 


### PR DESCRIPTION
instead of raising clientError, since we don't want this case to be regarded as an error

if another process (such as the one detailed here https://github.com/edx/edx-enterprise/commit/c4121ae321be2b62e73bff87c9d25ec6d8550acd#diff-3c197d9e4526ecff05ae54bc67d7b9d28ccaa5008b8b526eef62bdf2f4b69f7dR54) sets ECU to inactive, we only want to inform and continue.

ENT-5207

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
