### PR TITLE
feat: OAuth Auth link for Blackboard Admin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.36.4]
+--------
+feat: OAuth Auth link for Blackboard Admin
+
 [3.36.3]
 --------
 feat: Integrated channels, grade send logic only logs instead of raising when enterprise_customer_user record is inactive

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.36.3"
+__version__ = "3.36.4"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/blackboard/admin/__init__.py
+++ b/integrated_channels/blackboard/admin/__init__.py
@@ -13,6 +13,7 @@ from integrated_channels.blackboard.models import BlackboardEnterpriseCustomerCo
 
 LMS_OAUTH_REDIRECT_URL = urljoin(settings.LMS_ROOT_URL, '/blackboard/oauth-complete')
 
+
 @admin.register(BlackboardEnterpriseCustomerConfiguration)
 class BlackboardEnterpriseCustomerConfigurationAdmin(admin.ModelAdmin):
     """

--- a/integrated_channels/blackboard/admin/__init__.py
+++ b/integrated_channels/blackboard/admin/__init__.py
@@ -49,9 +49,9 @@ class BlackboardEnterpriseCustomerConfigurationAdmin(admin.ModelAdmin):
                 being rendered with this admin form.
         """
         if obj.blackboard_base_url and obj.client_id:
-            return f"{obj.blackboard_base_url}/learn/api/public/v1/oauth2/authorizationcode"\
-            f"?redirect_uri=https://courses.edx.org/blackboard/oauth-complete&"\
-            f"scope=read%20write%20delete%20offline&response_type=code&"\
-            f"client_id={obj.client_id}&state={obj.enterprise_customer.uuid}"
+            return (f"{obj.blackboard_base_url}/learn/api/public/v1/oauth2/authorizationcode"
+                f"?redirect_uri=https://courses.edx.org/blackboard/oauth-complete&"
+                f"scope=read%20write%20delete%20offline&response_type=code&"
+                f"client_id={obj.client_id}&state={obj.enterprise_customer.uuid}")
         else:
             return None

--- a/integrated_channels/blackboard/admin/__init__.py
+++ b/integrated_channels/blackboard/admin/__init__.py
@@ -2,11 +2,16 @@
 Admin integration for configuring Blackboard app to communicate with Blackboard systems.
 """
 
+from six.moves.urllib.parse import urljoin
+
+from django.conf import settings
 from django.contrib import admin
 from django.utils.html import format_html
 
+from enterprise.utils import get_configuration_value
 from integrated_channels.blackboard.models import BlackboardEnterpriseCustomerConfiguration
 
+LMS_OAUTH_REDIRECT_URL = urljoin(settings.LMS_ROOT_URL, '/blackboard/oauth-complete')
 
 @admin.register(BlackboardEnterpriseCustomerConfiguration)
 class BlackboardEnterpriseCustomerConfigurationAdmin(admin.ModelAdmin):
@@ -51,7 +56,7 @@ class BlackboardEnterpriseCustomerConfigurationAdmin(admin.ModelAdmin):
         """
         if obj.blackboard_base_url and obj.client_id:
             return format_html((f'<a href="{obj.blackboard_base_url}/learn/api/public/v1/oauth2/authorizationcode'
-                                f'?redirect_uri=https://courses.edx.org/blackboard/oauth-complete&'
+                                f'?redirect_uri={LMS_OAUTH_REDIRECT_URL}&'
                                 f'scope=read%20write%20delete%20offline&response_type=code&'
                                 f'client_id={obj.client_id}&state={obj.enterprise_customer.uuid}">Authorize Link</a>'))
         else:

--- a/integrated_channels/blackboard/admin/__init__.py
+++ b/integrated_channels/blackboard/admin/__init__.py
@@ -3,6 +3,7 @@ Admin integration for configuring Blackboard app to communicate with Blackboard 
 """
 
 from django.contrib import admin
+from django.utils.html import format_html
 
 from integrated_channels.blackboard.models import BlackboardEnterpriseCustomerConfiguration
 
@@ -49,9 +50,9 @@ class BlackboardEnterpriseCustomerConfigurationAdmin(admin.ModelAdmin):
                 being rendered with this admin form.
         """
         if obj.blackboard_base_url and obj.client_id:
-            return (f"{obj.blackboard_base_url}/learn/api/public/v1/oauth2/authorizationcode"
-                    f"?redirect_uri=https://courses.edx.org/blackboard/oauth-complete&"
-                    f"scope=read%20write%20delete%20offline&response_type=code&"
-                    f"client_id={obj.client_id}&state={obj.enterprise_customer.uuid}")
+            return format_html((f'<a href="{obj.blackboard_base_url}/learn/api/public/v1/oauth2/authorizationcode'
+                                f'?redirect_uri=https://courses.edx.org/blackboard/oauth-complete&'
+                                f'scope=read%20write%20delete%20offline&response_type=code&'
+                                f'client_id={obj.client_id}&state={obj.enterprise_customer.uuid}">Authorize Link</a>'))
         else:
             return None

--- a/integrated_channels/blackboard/admin/__init__.py
+++ b/integrated_channels/blackboard/admin/__init__.py
@@ -22,6 +22,7 @@ class BlackboardEnterpriseCustomerConfigurationAdmin(admin.ModelAdmin):
     readonly_fields = (
         "enterprise_customer_name",
         "refresh_token",
+        "oauth_authorization_url",
     )
 
     search_fields = ("enterprise_customer_name",)
@@ -38,3 +39,19 @@ class BlackboardEnterpriseCustomerConfigurationAdmin(admin.ModelAdmin):
                 being rendered with this admin form.
         """
         return obj.enterprise_customer.name
+
+    def oauth_authorization_url(self, obj):
+        """
+        Returns: the oauth authorization url when the blackboard_base_url and client_id are available.
+
+        Args:
+            obj: The instance of BlackboardEnterpriseCustomerConfiguration
+                being rendered with this admin form.
+        """
+        if obj.blackboard_base_url and obj.client_id:
+            return f"{obj.blackboard_base_url}/learn/api/public/v1/oauth2/authorizationcode"\
+            f"?redirect_uri=https://courses.edx.org/blackboard/oauth-complete&"\
+            f"scope=read%20write%20delete%20offline&response_type=code&"\
+            f"client_id={obj.client_id}&state={obj.enterprise_customer.uuid}"
+        else:
+            return None

--- a/integrated_channels/blackboard/admin/__init__.py
+++ b/integrated_channels/blackboard/admin/__init__.py
@@ -50,8 +50,8 @@ class BlackboardEnterpriseCustomerConfigurationAdmin(admin.ModelAdmin):
         """
         if obj.blackboard_base_url and obj.client_id:
             return (f"{obj.blackboard_base_url}/learn/api/public/v1/oauth2/authorizationcode"
-                f"?redirect_uri=https://courses.edx.org/blackboard/oauth-complete&"
-                f"scope=read%20write%20delete%20offline&response_type=code&"
-                f"client_id={obj.client_id}&state={obj.enterprise_customer.uuid}")
+                    f"?redirect_uri=https://courses.edx.org/blackboard/oauth-complete&"
+                    f"scope=read%20write%20delete%20offline&response_type=code&"
+                    f"client_id={obj.client_id}&state={obj.enterprise_customer.uuid}")
         else:
             return None

--- a/tox.ini
+++ b/tox.ini
@@ -75,7 +75,7 @@ deps =
     -r{toxinidir}/requirements/dev.txt
 commands =
     touch tests/__init__.py
-    pylint -j 0 enterprise enterprise_learner_portal consent integrated_channels tests test_utils requirements/check_pins.py --django-settings-module=enterprise.settings.test
+    pylint -j 1 --errors-only enterprise enterprise_learner_portal consent integrated_channels tests test_utils requirements/check_pins.py --django-settings-module=enterprise.settings.test
     rm tests/__init__.py
     pycodestyle enterprise enterprise_learner_portal consent integrated_channels tests test_utils
     isort --skip migrations --check-only --diff tests test_utils enterprise enterprise_learner_portal consent integrated_channels manage.py setup.py

--- a/tox.ini
+++ b/tox.ini
@@ -75,7 +75,7 @@ deps =
     -r{toxinidir}/requirements/dev.txt
 commands =
     touch tests/__init__.py
-    pylint -j 1 --errors-only enterprise enterprise_learner_portal consent integrated_channels tests test_utils requirements/check_pins.py --django-settings-module=enterprise.settings.test
+    pylint -j 0 enterprise enterprise_learner_portal consent integrated_channels tests test_utils requirements/check_pins.py --django-settings-module=enterprise.settings.test
     rm tests/__init__.py
     pycodestyle enterprise enterprise_learner_portal consent integrated_channels tests test_utils
     isort --skip migrations --check-only --diff tests test_utils enterprise enterprise_learner_portal consent integrated_channels manage.py setup.py


### PR DESCRIPTION
# Description

A small win to reduce setup complexity. Generate oauth auth URL in Django Admin once required fields are available.

- [ENT-4389](https://openedx.atlassian.net/browse/ENT-4389)


<img width="752" alt="Screen Shot 2021-12-07 at 3 00 58 PM" src="https://user-images.githubusercontent.com/31442/145097883-fdebef7a-e23c-490a-bcce-62b0cef17467.png">
)
