### PR TITLE
feat: OAuth Auth link for Blackboard Admin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.36.6]
+--------
+feat: Show OAuth Auth link for Blackboard Admin
+
 [3.36.5]
 --------
 fix: add support for an ``enterprise_customer_invite_key`` UUID query parameter to be passed and handled by the ``EnterpriseProxyLoginView``

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.36.5"
+__version__ = "3.36.6"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/api/v1/blackboard/serializers.py
+++ b/integrated_channels/api/v1/blackboard/serializers.py
@@ -7,6 +7,7 @@ from integrated_channels.blackboard.models import BlackboardEnterpriseCustomerCo
 
 
 class BlackboardConfigSerializer(serializers.ModelSerializer):
+    oauth_authorization_url = serializers.ReadOnlyField()
     class Meta:
         model = BlackboardEnterpriseCustomerConfiguration
         fields = '__all__'

--- a/integrated_channels/api/v1/blackboard/serializers.py
+++ b/integrated_channels/api/v1/blackboard/serializers.py
@@ -8,6 +8,7 @@ from integrated_channels.blackboard.models import BlackboardEnterpriseCustomerCo
 
 class BlackboardConfigSerializer(serializers.ModelSerializer):
     oauth_authorization_url = serializers.ReadOnlyField()
+
     class Meta:
         model = BlackboardEnterpriseCustomerConfiguration
         fields = '__all__'

--- a/integrated_channels/blackboard/admin/__init__.py
+++ b/integrated_channels/blackboard/admin/__init__.py
@@ -11,8 +11,6 @@ from django.utils.html import format_html
 from enterprise.utils import get_configuration_value
 from integrated_channels.blackboard.models import BlackboardEnterpriseCustomerConfiguration
 
-LMS_OAUTH_REDIRECT_URL = urljoin(settings.LMS_ROOT_URL, '/blackboard/oauth-complete')
-
 
 @admin.register(BlackboardEnterpriseCustomerConfiguration)
 class BlackboardEnterpriseCustomerConfigurationAdmin(admin.ModelAdmin):
@@ -29,7 +27,7 @@ class BlackboardEnterpriseCustomerConfigurationAdmin(admin.ModelAdmin):
     readonly_fields = (
         "enterprise_customer_name",
         "refresh_token",
-        "oauth_authorization_url",
+        "customer_oauth_authorization_url",
     )
 
     search_fields = ("enterprise_customer_name",)
@@ -47,18 +45,15 @@ class BlackboardEnterpriseCustomerConfigurationAdmin(admin.ModelAdmin):
         """
         return obj.enterprise_customer.name
 
-    def oauth_authorization_url(self, obj):
+    def customer_oauth_authorization_url(self, obj):
         """
-        Returns: the oauth authorization url when the blackboard_base_url and client_id are available.
+        Returns: an html formatted oauth authorization link when the blackboard_base_url and client_id are available.
 
         Args:
             obj: The instance of BlackboardEnterpriseCustomerConfiguration
                 being rendered with this admin form.
         """
-        if obj.blackboard_base_url and obj.client_id:
-            return format_html((f'<a href="{obj.blackboard_base_url}/learn/api/public/v1/oauth2/authorizationcode'
-                                f'?redirect_uri={LMS_OAUTH_REDIRECT_URL}&'
-                                f'scope=read%20write%20delete%20offline&response_type=code&'
-                                f'client_id={obj.client_id}&state={obj.enterprise_customer.uuid}">Authorize Link</a>'))
+        if obj.oauth_authorization_url:
+            return format_html((f'<a href="{obj.oauth_authorization_url}">Authorize Link</a>'))
         else:
             return None

--- a/integrated_channels/blackboard/models.py
+++ b/integrated_channels/blackboard/models.py
@@ -16,7 +16,13 @@ from integrated_channels.blackboard.transmitters.content_metadata import Blackbo
 from integrated_channels.blackboard.transmitters.learner_data import BlackboardLearnerTransmitter
 from integrated_channels.integrated_channel.models import EnterpriseCustomerPluginConfiguration
 
+from six.moves.urllib.parse import urljoin
+
+from django.conf import settings
+from django.contrib import admin
+
 LOGGER = getLogger(__name__)
+LMS_OAUTH_REDIRECT_URL = urljoin(settings.LMS_ROOT_URL, '/blackboard/oauth-complete')
 
 
 class BlackboardEnterpriseCustomerConfiguration(EnterpriseCustomerPluginConfiguration):
@@ -74,6 +80,23 @@ class BlackboardEnterpriseCustomerConfiguration(EnterpriseCustomerPluginConfigur
 
     class Meta:
         app_label = 'blackboard'
+
+    @property
+    def oauth_authorization_url(self):
+        """
+        Returns: the oauth authorization url when the blackboard_base_url and client_id are available.
+
+        Args:
+            obj: The instance of BlackboardEnterpriseCustomerConfiguration
+                being rendered with this admin form.
+        """
+        if self.blackboard_base_url and self.client_id:
+            return (f'{self.blackboard_base_url}/learn/api/public/v1/oauth2/authorizationcode'
+                    f'?redirect_uri={LMS_OAUTH_REDIRECT_URL}&'
+                    f'scope=read%20write%20delete%20offline&response_type=code&'
+                    f'client_id={self.client_id}&state={self.enterprise_customer.uuid}')
+        else:
+            return None
 
     def __str__(self):
         """

--- a/integrated_channels/blackboard/models.py
+++ b/integrated_channels/blackboard/models.py
@@ -7,7 +7,9 @@ import json
 from logging import getLogger
 
 from simple_history.models import HistoricalRecords
+from six.moves.urllib.parse import urljoin
 
+from django.conf import settings
 from django.db import models
 
 from integrated_channels.blackboard.exporters.content_metadata import BlackboardContentMetadataExporter
@@ -15,11 +17,6 @@ from integrated_channels.blackboard.exporters.learner_data import BlackboardLear
 from integrated_channels.blackboard.transmitters.content_metadata import BlackboardContentMetadataTransmitter
 from integrated_channels.blackboard.transmitters.learner_data import BlackboardLearnerTransmitter
 from integrated_channels.integrated_channel.models import EnterpriseCustomerPluginConfiguration
-
-from six.moves.urllib.parse import urljoin
-
-from django.conf import settings
-from django.contrib import admin
 
 LOGGER = getLogger(__name__)
 LMS_OAUTH_REDIRECT_URL = urljoin(settings.LMS_ROOT_URL, '/blackboard/oauth-complete')


### PR DESCRIPTION
A better approach to https://github.com/edx/edx-enterprise/pull/1424 which adds the property to the model and serializer so it can be used beyond just django admin (enables display in the self-service portal)

[ENT-4389](https://openedx.atlassian.net/browse/ENT-4389)

<img width="752" alt="Screen Shot 2021-12-07 at 3 00 58 PM" src="https://user-images.githubusercontent.com/31442/145097883-fdebef7a-e23c-490a-bcce-62b0cef17467.png">
)

![Screen Shot 2021-12-10 at 8 30 34 AM](https://user-images.githubusercontent.com/31442/145581644-6a64695e-c8b9-447c-820a-d243efa7bb76.png)

