### PR TITLE
fix: Django admin a-tag rather than text url

### DIFF
--- a/integrated_channels/canvas/admin/__init__.py
+++ b/integrated_channels/canvas/admin/__init__.py
@@ -24,7 +24,7 @@ class CanvasEnterpriseCustomerConfigurationAdmin(admin.ModelAdmin):
     readonly_fields = (
         "enterprise_customer_name",
         "refresh_token",
-        "oauth_authorization_url",
+        "customer_oauth_authorization_url",
         "uuid",
     )
 


### PR DESCRIPTION
# Desctiption

A quick fix/enhancement, show an 'Authorize' link rather than a plain URL in Django Admin, [similar to how blackboard is setup](https://github.com/edx/edx-enterprise/blob/master/integrated_channels/blackboard/admin/__init__.py#L30).


Before:
![Screen Shot 2021-12-22 at 10 21 11 AM](https://user-images.githubusercontent.com/31442/147115061-8a148163-7cd4-40ca-a6c9-a23162c60082.png)

After:
![Screen Shot 2021-12-22 at 10 21 33 AM](https://user-images.githubusercontent.com/31442/147115109-301d2d2d-40fe-4d52-98be-72c43a4f2a4c.png)


# References

- [ENT-5238](https://openedx.atlassian.net/browse/ENT-5238)

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
