### PR TITLE
fix: fixes datetime attribute error

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[5.12.10]
+---------
+* fix: fixes datetime attribute error
+
 [5.12.9]
 --------
 * fix: sync ecu table user_fk changes with django

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "5.12.9"
+__version__ = "5.12.10"

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -523,7 +523,7 @@ class EnterpriseCourseEnrollmentAdminViewSerializer(serializers.ModelSerializer)
         passing certificate.
 
         Arguments:
-            course_details : the details for the exececutive education course run
+            course_details : the details for the executive education course run
             certificate_info: A dict containing the following key:
                 ``is_passing``: whether the  user has a passing certificate in the course run
 
@@ -542,8 +542,8 @@ class EnterpriseCourseEnrollmentAdminViewSerializer(serializers.ModelSerializer)
         start_date = course_details.start_date
         end_date = course_details.end_date
 
-        has_started = datetime.now(pytz.utc) > start_date if start_date is not None else True
-        has_ended = datetime.now(pytz.utc) > end_date if end_date is not None else False
+        has_started = datetime.datetime.now(pytz.utc) > start_date if start_date is not None else True
+        has_ended = datetime.datetime.now(pytz.utc) > end_date if end_date is not None else False
 
         if has_ended or is_certificate_passing:
             return CourseRunProgressStatuses.COMPLETED


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-10387

Fixes the `datetime` attribute error in `_get_exec_ed_course_run_status`.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [x] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [x] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [x] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - Trigger the '[Upgrade one Python dependency](https://github.com/openedx/edx-platform/actions/workflows/upgrade-one-python-dependency.yml)' action against master in edx-platform with new version number to generate version bump PR
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
