### PR TITLE
fix: flex groups reject enrollments from outside the org

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[5.13.6]
+---------
+* fix: flex groups reject enrollments from outside the org
+
 [5.13.5]
 ---------
 * chore: upgrades python requirements

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "5.13.5"
+__version__ = "5.13.6"

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -47,6 +47,8 @@ from enterprise.constants import (
     GROUP_MEMBERSHIP_ACCEPTED_STATUS,
     GROUP_MEMBERSHIP_PENDING_STATUS,
     GROUP_MEMBERSHIP_REMOVED_STATUS,
+    GROUP_TYPE_BUDGET,
+    GROUP_TYPE_FLEX,
     PATHWAY_CUSTOMER_ADMIN_ENROLLMENT,
     SYSTEM_ENTERPRISE_PROVISIONING_ADMIN_ROLE,
 )
@@ -8267,7 +8269,14 @@ class TestEnterpriseGroupViewSet(APITest):
         self.client.login(username=self.user.username, password=TEST_PASSWORD)
 
         self.group_1 = EnterpriseGroupFactory(enterprise_customer=self.enterprise_customer)
-        self.group_2 = EnterpriseGroupFactory(enterprise_customer=self.enterprise_customer)
+        self.group_2 = EnterpriseGroupFactory(
+            enterprise_customer=self.enterprise_customer,
+            group_type=GROUP_TYPE_BUDGET
+        )
+        self.flex_group = EnterpriseGroupFactory(
+            enterprise_customer=self.enterprise_customer,
+            group_type=GROUP_TYPE_FLEX
+        )
         self.set_multiple_enterprise_roles_to_jwt([
             (ENTERPRISE_ADMIN_ROLE, self.enterprise_customer.pk),
             (ENTERPRISE_ADMIN_ROLE, self.group_2.enterprise_customer.pk)
@@ -8303,8 +8312,10 @@ class TestEnterpriseGroupViewSet(APITest):
             'enterprise-group-list',
         )
         response = self.client.get(url)
-        assert response.json().get('count') == 2
+        assert response.json().get('count') == 3
         assert response.json().get('results')[0].get('group_type') == 'flex'
+        assert response.json().get('results')[1].get('group_type') == 'budget'
+        assert response.json().get('results')[2].get('group_type') == 'flex'
         serializer = serializers.EnterpriseGroupSerializer(self.group_1)
         assert serializer.data['accepted_members_count'] == 11
 
@@ -8734,7 +8745,12 @@ class TestEnterpriseGroupViewSet(APITest):
         request_data = {'learner_emails': existing_email}
         response = self.client.post(url, data=request_data)
         assert response.status_code == 201
-        assert response.json() == {'records_processed': 1, 'new_learners': 1, 'existing_learners': 0}
+        assert response.json() == {
+            'records_processed': 1,
+            'new_learners': 1,
+            'existing_learners': 0,
+            'non_org_rejected': 0
+        }
 
     def test_assign_learners_to_group_with_multiple_enterprises(self):
         """
@@ -8843,7 +8859,7 @@ class TestEnterpriseGroupViewSet(APITest):
     @mock.patch('enterprise.tasks.send_group_membership_invitation_notification.delay', return_value=mock.MagicMock())
     def test_successful_assign_learners_to_group(self, mock_send_group_membership_invitation_notification):
         """
-        Test that both existing and new learners assigned to groups properly creates membership records
+        Test that both existing and new learners assigned to groups properly creates membership records for budget group
         """
         url = settings.TEST_SERVER + reverse(
             'enterprise-group-assign-learners',
@@ -8860,7 +8876,12 @@ class TestEnterpriseGroupViewSet(APITest):
         }
         response = self.client.post(url, data=request_data)
         assert response.status_code == 201
-        assert response.data == {'records_processed': 800, 'new_learners': 400, 'existing_learners': 400}
+        assert response.data == {
+            'records_processed': 800,
+            'new_learners': 400,
+            'existing_learners': 400,
+            'non_org_rejected': 0,
+        }
 
         pending_memberships = EnterpriseGroupMembership.objects.filter(
             group=self.group_2,
@@ -8893,6 +8914,44 @@ class TestEnterpriseGroupViewSet(APITest):
                 )],
                 any_order=True,
             )
+
+    def test_add_no_non_member_learners_to_flex_group(self):
+        """
+        Test that existing org members are added and non-org members are not to flex group
+        """
+        url = settings.TEST_SERVER + reverse(
+            'enterprise-group-assign-learners',
+            kwargs={'group_uuid': self.flex_group.uuid},
+        )
+        existing_emails = [UserFactory(email=f"ayylmao{x}@example.com").email for x in range(400)]
+        new_emails = [f"email_{x}@example.com" for x in range(400)]
+        act_by_date = datetime.now(pytz.UTC)
+        catalog_uuid = uuid.uuid4()
+        request_data = {
+            'learner_emails': existing_emails + new_emails,
+            'act_by_date': act_by_date,
+            'catalog_uuid': catalog_uuid,
+        }
+        response = self.client.post(url, data=request_data)
+        assert response.status_code == 201
+        assert response.data == {
+            'records_processed': 400,
+            'new_learners': 0,
+            'existing_learners': 400,
+            'non_org_rejected': 400,
+        }
+
+        pending_memberships = EnterpriseGroupMembership.objects.filter(
+            group=self.flex_group,
+            enterprise_customer_user__isnull=True
+        )
+        existing_memberships = EnterpriseGroupMembership.objects.filter(
+            group=self.flex_group,
+            pending_enterprise_customer_user__isnull=True
+        )
+        assert len(pending_memberships) == 0
+        assert len(existing_memberships) == 400
+        assert existing_memberships.first().status == GROUP_MEMBERSHIP_ACCEPTED_STATUS
 
     def test_specifying_group_members(self):
         """


### PR DESCRIPTION
[Jira Ticket](https://2u-internal.atlassian.net/browse/ENT-10243)

When a learner from outside the enterprise customer org is added to a`Flex` group, they should be rejected.  However, currently a `PendingEnterpriseCustomerUser` is created for each of these outside learners.  We want to keep this behavior for `Budget` groups, but this change removes it for `Flex` groups.

In order to signal this rejection for front end consumption, we are now also returning a `non_org_rejected` count of learners in the `assign_learners` API payload.

## Testing Instructions
- Check out this branch and install in local lms
- In local Admin Portal, create a new Group, populating via csv file that includes at least one learner email from outside the enterprise customer org
- Verify that new group is created without the non-org member present
- Verify that no `PendingEnterpriseCustomerUser` entry is created for the  non-org member

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [x] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [x] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - Trigger the '[Upgrade one Python dependency](https://github.com/openedx/edx-platform/actions/workflows/upgrade-one-python-dependency.yml)' action against master in edx-platform with new version number to generate version bump PR
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
