### PR TITLE
feat: fetch SAP userid by remote_id_field_name

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[6.5.7] - 2025-11-28
+---------------------
+* feat: fetch SAP user id by remote_id_field_name
+
 [6.5.6] - 2025-11-26
 ---------------------
 * chore: upgrade python requirements

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "6.5.6"
+__version__ = "6.5.7"

--- a/enterprise/api_client/lms.py
+++ b/enterprise/api_client/lms.py
@@ -311,18 +311,19 @@ class ThirdPartyAuthApiClient(UserAPIClient):
     API_BASE_URL = urljoin(f"{settings.LMS_INTERNAL_ROOT_URL}/", "api/third_party_auth/v0/")
 
     @UserAPIClient.refresh_token
-    def get_remote_id(self, identity_provider, username):
+    def get_remote_id(self, identity_provider, username, remote_id_field_name=None):
         """
         Retrieve the remote identifier for the given username.
 
         Args:
         * ``identity_provider`` (str): identifier slug for the third-party authentication service used during SSO.
         * ``username`` (str): The username ID identifying the user for which to retrieve the remote name.
+        * ``remote_id_field_name`` (str) (optional): The field name to use for the remote id lookup.
 
         Returns:
             string or None: the remote name of the given user.  None if not found.
         """
-        return self._get_results(identity_provider, 'username', username, 'remote_id')
+        return self._get_results(identity_provider, 'username', username, 'remote_id', remote_id_field_name)
 
     @UserAPIClient.refresh_token
     def get_username_from_remote_id(self, identity_provider, remote_id):
@@ -338,13 +339,15 @@ class ThirdPartyAuthApiClient(UserAPIClient):
         """
         return self._get_results(identity_provider, 'remote_id', remote_id, 'username')
 
-    def _get_results(self, identity_provider, param_name, param_value, result_field_name):
+    def _get_results(self, identity_provider, param_name, param_value, result_field_name, remote_id_field_name=None):
         """
         Calls the third party auth api endpoint to get the mapping between usernames and remote ids.
         """
         api_url = self.get_api_url(f"providers/{identity_provider}/users")
         try:
             kwargs = {param_name: param_value}
+            if remote_id_field_name:
+                kwargs.update({'remote_id_field_name': remote_id_field_name})
             response = self.client.get(api_url, params=kwargs)
             response.raise_for_status()
             results = response.json().get('results', [])

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -1238,7 +1238,7 @@ class EnterpriseCustomerUser(TimeStampedModel):
         """
         return self.__str__()
 
-    def get_remote_id(self, idp_id=None):
+    def get_remote_id(self, idp_id=None, remote_id_field_name=None):
         """
         Retrieve the SSO provider's identifier for this user from the LMS Third Party API.
         In absence of idp_id, returns id from default idp
@@ -1246,6 +1246,7 @@ class EnterpriseCustomerUser(TimeStampedModel):
         Arguments:
             idp_id (str) (optional): If provided, idp resolution skipped and specified idp used
                 to locate remote id.
+            remote_id_field_name (str) (optional): The field name to use for the remote id lookup.
 
         Returns None if:
         * the user doesn't exist, or
@@ -1256,7 +1257,7 @@ class EnterpriseCustomerUser(TimeStampedModel):
         if idp_id:
             enterprise_worker = get_enterprise_worker_user()
             client = ThirdPartyAuthApiClient(enterprise_worker)
-            return client.get_remote_id(idp_id, user.username)
+            return client.get_remote_id(idp_id, user.username, remote_id_field_name)
         if user and self.enterprise_customer.has_identity_providers:
             identity_provider = None
             if self.enterprise_customer.has_multiple_idps:
@@ -1267,7 +1268,7 @@ class EnterpriseCustomerUser(TimeStampedModel):
 
             enterprise_worker = get_enterprise_worker_user()
             client = ThirdPartyAuthApiClient(enterprise_worker)
-            return client.get_remote_id(identity_provider, user.username)
+            return client.get_remote_id(identity_provider, user.username, remote_id_field_name)
         return None
 
     def enroll(self, course_run_id, mode, cohort=None, source_slug=None, discount_percentage=0.0, sales_force_id=None):

--- a/integrated_channels/sap_success_factors/exporters/utils.py
+++ b/integrated_channels/sap_success_factors/exporters/utils.py
@@ -28,3 +28,19 @@ def transform_language_code(code):
         return 'English'
 
     return language_family.get(country_code, language_family['_'])
+
+
+def is_sso_enabled_via_tpa_service(enterprise_customer):
+    """
+    Determines if SSO is enabled via a third party auth service (like Auth0) for customer leveraging
+    SAP integration, by checking presence of org_id and active EnterpriseCustomerSsoConfiguration record.
+    """
+    if enterprise_customer.auth_org_id is None:
+        return False
+
+    enterprise_orchestration_config = enterprise_customer.sso_orchestration_records.filter(
+        active=True
+    )
+    if enterprise_orchestration_config.exists() and enterprise_orchestration_config.first().validated_at is not None:
+        return True
+    return False

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -873,7 +873,7 @@ class TestEnterpriseCustomerUser(unittest.TestCase):
         actual_value = enterprise_customer_user.get_remote_id()
         assert actual_value == expected_value
         if remote_id_called:
-            mock_third_party_api.return_value.get_remote_id.assert_called_once_with(provider_id, "hi")
+            mock_third_party_api.return_value.get_remote_id.assert_called_once_with(provider_id, "hi", None)
         else:
             assert mock_third_party_api.return_value.get_remote_id.call_count == 0
 
@@ -898,7 +898,7 @@ class TestEnterpriseCustomerUser(unittest.TestCase):
         mock_third_party_api.return_value.get_remote_id.return_value = 'saml-user-id'
         mock_social_auth_from_idp.return_value = True
         _ = enterprise_customer_user.get_remote_id()
-        mock_third_party_api.return_value.get_remote_id.assert_called_once_with(default_idp, "hello")
+        mock_third_party_api.return_value.get_remote_id.assert_called_once_with(default_idp, "hello", None)
 
     @mock.patch('enterprise.models.ThirdPartyAuthApiClient')
     def test_get_remote_id_specific_idp(self, mock_third_party_api):
@@ -925,7 +925,7 @@ class TestEnterpriseCustomerUser(unittest.TestCase):
         remote_id = enterprise_customer_user.get_remote_id(idp_id=non_default_idp_id)
 
         assert remote_id == 'specified-user-id'
-        mock_third_party_api.return_value.get_remote_id.assert_called_once_with(non_default_idp_id, "hello")
+        mock_third_party_api.return_value.get_remote_id.assert_called_once_with(non_default_idp_id, "hello", None)
 
     @mock.patch('enterprise.utils.segment')
     @mock.patch('enterprise.models.EnrollmentApiClient')


### PR DESCRIPTION
For SAP customers leveraging Auth0 for SSO , the UID value returned in the SAML response represents the Auth0 User ID, not the SAP User ID. However, SAP integrations require the SAP User ID to properly report learner activity and completions. To support this, these changes introduce logic to fetch the SAP User ID from UserSocialAuth records, using the relevant remote user ID attribute (the attribute that Auth0 returns as the SAP User ID).
This attribute name can be provided as a query parameter to the UserMapping API, which will then retrieve the correct ID.

Related work: https://github.com/edx/edx-platform/pull/33 
 
**Note**: These changes are made only to support existing SAP + Auth0 customers.
We cannot alter current learner UIDs because such changes would directly impact authentication and SSO flows. For new SAP customers using Auth0, the recommended approach is to configure the User ID attribute in SAMLProviderConfig to directly pass the SAP User ID attribute returned by Auth0.

**JIRA**:
- https://2u-internal.atlassian.net/browse/ENT-10804
- https://2u-internal.atlassian.net/browse/ENT-11158


