### PR TITLE
fix: Convert UUIDField columns to uuid type for MariaDB

### DIFF
--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "6.5.1"
+__version__ = "6.5.2"

--- a/enterprise/migrations/0242_mariadb_uuid_conversion.py
+++ b/enterprise/migrations/0242_mariadb_uuid_conversion.py
@@ -1,0 +1,101 @@
+# Generated migration for MariaDB UUID field conversion (Django 5.2)
+"""
+Migration to convert UUIDField from char(32) to uuid type for MariaDB compatibility.
+
+See: https://www.albertyw.com/note/django-5-mariadb-uuidfield
+"""
+
+from django.db import migrations
+
+
+def apply_mariadb_migration(apps, schema_editor):
+    connection = schema_editor.connection
+    
+    if connection.vendor != 'mysql':
+        return
+    
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT VERSION()")
+        version = cursor.fetchone()[0]
+        if 'mariadb' not in version.lower():
+            return
+    
+    with connection.cursor() as cursor:
+        # EnterpriseCustomer
+        cursor.execute("ALTER TABLE enterprise_enterprisecustomer MODIFY uuid uuid NOT NULL")
+        
+        # PendingEnrollment
+        cursor.execute("ALTER TABLE enterprise_pendingenrollment MODIFY license_uuid uuid NULL")
+        cursor.execute("ALTER TABLE enterprise_historicalpendingenrollment MODIFY license_uuid uuid NULL")
+        
+        # EnterpriseCourseEntitlement
+        cursor.execute("ALTER TABLE enterprise_enterprisecourseentitlement MODIFY uuid uuid NOT NULL")
+        cursor.execute("ALTER TABLE enterprise_historicalenterprisecourseentitlement MODIFY uuid uuid NOT NULL")
+        
+        # Other enterprise models with UUIDs
+        cursor.execute("ALTER TABLE enterprise_learnercreditenterprisecourseenrollment MODIFY transaction_id uuid NOT NULL")
+        cursor.execute("ALTER TABLE enterprise_licensedenterprisecourseenrollment MODIFY license_uuid uuid NOT NULL")
+        cursor.execute("ALTER TABLE enterprise_defaultenterpriseenrollmentintention MODIFY uuid uuid NOT NULL")
+        cursor.execute("ALTER TABLE enterprise_enterprisecatalogquery MODIFY uuid uuid NOT NULL")
+        cursor.execute("ALTER TABLE enterprise_enterprisecustomercatalog MODIFY uuid uuid NOT NULL")
+        cursor.execute("ALTER TABLE enterprise_enterprisecustomerreportingconfiguration MODIFY uuid uuid NOT NULL")
+        cursor.execute("ALTER TABLE enterprise_enterprisecustomerinvitekey MODIFY uuid uuid NOT NULL")
+        cursor.execute("ALTER TABLE enterprise_historicalenterprisecustomerinvitekey MODIFY uuid uuid NOT NULL")
+        cursor.execute("ALTER TABLE enterprise_chatgptresponse MODIFY uuid uuid NOT NULL")
+        cursor.execute("ALTER TABLE enterprise_enterprisecustomerssoconfiguration MODIFY uuid uuid NOT NULL")
+        cursor.execute("ALTER TABLE enterprise_enterprisegroup MODIFY uuid uuid NOT NULL")
+        cursor.execute("ALTER TABLE enterprise_historicalenterprisegroup MODIFY uuid uuid NOT NULL")
+        cursor.execute("ALTER TABLE enterprise_enterprisegroupmembership MODIFY uuid uuid NOT NULL")
+        cursor.execute("ALTER TABLE enterprise_onboardingflow MODIFY uuid uuid NOT NULL")
+        cursor.execute("ALTER TABLE enterprise_enterprisecustomeradmin MODIFY uuid uuid NOT NULL")
+        cursor.execute("ALTER TABLE view_enterprise_customer_support_users MODIFY enterprise_customer_id uuid NOT NULL")
+
+
+def reverse_mariadb_migration(apps, schema_editor):
+    connection = schema_editor.connection
+    
+    if connection.vendor != 'mysql':
+        return
+    
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT VERSION()")
+        version = cursor.fetchone()[0]
+        if 'mariadb' not in version.lower():
+            return
+    
+    with connection.cursor() as cursor:
+        cursor.execute("ALTER TABLE enterprise_enterprisecustomer MODIFY uuid char(32) NOT NULL")
+        cursor.execute("ALTER TABLE enterprise_pendingenrollment MODIFY license_uuid char(32) NULL")
+        cursor.execute("ALTER TABLE enterprise_historicalpendingenrollment MODIFY license_uuid char(32) NULL")
+        cursor.execute("ALTER TABLE enterprise_enterprisecourseentitlement MODIFY uuid char(32) NOT NULL")
+        cursor.execute("ALTER TABLE enterprise_historicalenterprisecourseentitlement MODIFY uuid char(32) NOT NULL")
+        cursor.execute("ALTER TABLE enterprise_learnercreditenterprisecourseenrollment MODIFY transaction_id char(32) NOT NULL")
+        cursor.execute("ALTER TABLE enterprise_licensedenterprisecourseenrollment MODIFY license_uuid char(32) NOT NULL")
+        cursor.execute("ALTER TABLE enterprise_defaultenterpriseenrollmentintention MODIFY uuid char(32) NOT NULL")
+        cursor.execute("ALTER TABLE enterprise_enterprisecatalogquery MODIFY uuid char(32) NOT NULL")
+        cursor.execute("ALTER TABLE enterprise_enterprisecustomercatalog MODIFY uuid char(32) NOT NULL")
+        cursor.execute("ALTER TABLE enterprise_enterprisecustomerreportingconfiguration MODIFY uuid char(32) NOT NULL")
+        cursor.execute("ALTER TABLE enterprise_enterprisecustomerinvitekey MODIFY uuid char(32) NOT NULL")
+        cursor.execute("ALTER TABLE enterprise_historicalenterprisecustomerinvitekey MODIFY uuid char(32) NOT NULL")
+        cursor.execute("ALTER TABLE enterprise_chatgptresponse MODIFY uuid char(32) NOT NULL")
+        cursor.execute("ALTER TABLE enterprise_enterprisecustomerssoconfiguration MODIFY uuid char(32) NOT NULL")
+        cursor.execute("ALTER TABLE enterprise_enterprisegroup MODIFY uuid char(32) NOT NULL")
+        cursor.execute("ALTER TABLE enterprise_historicalenterprisegroup MODIFY uuid char(32) NOT NULL")
+        cursor.execute("ALTER TABLE enterprise_enterprisegroupmembership MODIFY uuid char(32) NOT NULL")
+        cursor.execute("ALTER TABLE enterprise_onboardingflow MODIFY uuid char(32) NOT NULL")
+        cursor.execute("ALTER TABLE enterprise_enterprisecustomeradmin MODIFY uuid char(32) NOT NULL")
+        cursor.execute("ALTER TABLE view_enterprise_customer_support_users MODIFY enterprise_customer_id char(32) NOT NULL")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('enterprise', '0241_alter_defaultenterpriseenrollmentintention_realized_enrollments'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            code=apply_mariadb_migration,
+            reverse_code=reverse_mariadb_migration,
+        ),
+    ]

--- a/integrated_channels/blackboard/migrations/0025_mariadb_uuid_conversion.py
+++ b/integrated_channels/blackboard/migrations/0025_mariadb_uuid_conversion.py
@@ -1,0 +1,54 @@
+# Generated migration for MariaDB UUID field conversion (Django 5.2)
+"""
+Migration to convert UUIDField from char(32) to uuid type for MariaDB compatibility.
+
+See: https://www.albertyw.com/note/django-5-mariadb-uuidfield
+"""
+
+from django.db import migrations
+
+
+def apply_mariadb_migration(apps, schema_editor):
+    connection = schema_editor.connection
+
+    if connection.vendor != 'mysql':
+        return
+
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT VERSION()")
+        version = cursor.fetchone()[0]
+        if 'mariadb' not in version.lower():
+            return
+
+    with connection.cursor() as cursor:
+        cursor.execute("ALTER TABLE blackboard_blackboardenterprisecustomerconfiguration MODIFY uuid uuid NOT NULL")
+
+
+def reverse_mariadb_migration(apps, schema_editor):
+    connection = schema_editor.connection
+
+    if connection.vendor != 'mysql':
+        return
+
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT VERSION()")
+        version = cursor.fetchone()[0]
+        if 'mariadb' not in version.lower():
+            return
+
+    with connection.cursor() as cursor:
+        cursor.execute("ALTER TABLE blackboard_blackboardenterprisecustomerconfiguration MODIFY uuid char(32) NOT NULL")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('blackboard', '0024_rename_blackboardlearnerdatatransmissionaudit_enterprise_customer_uuid_plugin_configuration_id_black'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            code=apply_mariadb_migration,
+            reverse_code=reverse_mariadb_migration,
+        ),
+    ]

--- a/integrated_channels/canvas/migrations/0041_mariadb_uuid_conversion.py
+++ b/integrated_channels/canvas/migrations/0041_mariadb_uuid_conversion.py
@@ -1,0 +1,54 @@
+# Generated migration for MariaDB UUID field conversion (Django 5.2)
+"""
+Migration to convert UUIDField from char(32) to uuid type for MariaDB compatibility.
+
+See: https://www.albertyw.com/note/django-5-mariadb-uuidfield
+"""
+
+from django.db import migrations
+
+
+def apply_mariadb_migration(apps, schema_editor):
+    connection = schema_editor.connection
+
+    if connection.vendor != 'mysql':
+        return
+
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT VERSION()")
+        version = cursor.fetchone()[0]
+        if 'mariadb' not in version.lower():
+            return
+
+    with connection.cursor() as cursor:
+        cursor.execute("ALTER TABLE canvas_canvasenterprisecustomerconfiguration MODIFY uuid uuid NOT NULL")
+
+
+def reverse_mariadb_migration(apps, schema_editor):
+    connection = schema_editor.connection
+
+    if connection.vendor != 'mysql':
+        return
+
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT VERSION()")
+        version = cursor.fetchone()[0]
+        if 'mariadb' not in version.lower():
+            return
+
+    with connection.cursor() as cursor:
+        cursor.execute("ALTER TABLE canvas_canvasenterprisecustomerconfiguration MODIFY uuid char(32) NOT NULL")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('canvas', '0040_rename_canvaslearnerdatatransmissionaudit_enterprise_customer_uuid_plugin_configuration_id_canvas_cu'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            code=apply_mariadb_migration,
+            reverse_code=reverse_mariadb_migration,
+        ),
+    ]

--- a/integrated_channels/integrated_channel/migrations/0037_mariadb_uuid_conversion.py
+++ b/integrated_channels/integrated_channel/migrations/0037_mariadb_uuid_conversion.py
@@ -1,0 +1,56 @@
+# Generated migration for MariaDB UUID field conversion (Django 5.2)
+"""
+Migration to convert UUIDField from char(32) to uuid type for MariaDB compatibility.
+
+See: https://www.albertyw.com/note/django-5-mariadb-uuidfield
+"""
+
+from django.db import migrations
+
+
+def apply_mariadb_migration(apps, schema_editor):
+    connection = schema_editor.connection
+
+    if connection.vendor != 'mysql':
+        return
+
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT VERSION()")
+        version = cursor.fetchone()[0]
+        if 'mariadb' not in version.lower():
+            return
+
+    with connection.cursor() as cursor:
+        cursor.execute("ALTER TABLE integrated_channel_learnerdatatransmissionaudit MODIFY enterprise_customer_uuid uuid NULL")
+        cursor.execute("ALTER TABLE integrated_channel_contentmetadataitemtransmission MODIFY enterprise_customer_catalog_uuid uuid NOT NULL")
+
+
+def reverse_mariadb_migration(apps, schema_editor):
+    connection = schema_editor.connection
+
+    if connection.vendor != 'mysql':
+        return
+
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT VERSION()")
+        version = cursor.fetchone()[0]
+        if 'mariadb' not in version.lower():
+            return
+
+    with connection.cursor() as cursor:
+        cursor.execute("ALTER TABLE integrated_channel_learnerdatatransmissionaudit MODIFY enterprise_customer_uuid char(32) NULL")
+        cursor.execute("ALTER TABLE integrated_channel_contentmetadataitemtransmission MODIFY enterprise_customer_catalog_uuid char(32) NOT NULL")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('integrated_channel', '0036_rename_contentmetadataitemtransmission_enterprise_customer_integrated_channel_code_plugin_configurat'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            code=apply_mariadb_migration,
+            reverse_code=reverse_mariadb_migration,
+        ),
+    ]


### PR DESCRIPTION
## Description
The behavior of the MariaDB backend has changed for UUIDField from a `CharField(32)` to an actual `uuid` type in Django 5. This migration converts affected columns to prevent data insertion errors.

## Supporting information
https://docs.djangoproject.com/en/5.2/releases/5.0/#migrating-uuidfield

Related PR: https://github.com/openedx/edx-platform/pull/37494