### PR TITLE
feat: add pluggable override for learner home enterprise customer lookup

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[8.5.0] - 2026-07-10
+---------------------
+* feat: add pluggable override for learner home enterprise customer lookup
+
 [8.4.0] - 2026-07-08
 ---------------------
 * feat: add EnterpriseEnrollmentViewProcessor pipeline step for CourseEnrollmentViewStarted filter (ENT-11570)

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "8.4.0"
+__version__ = "8.5.0"

--- a/enterprise/overrides/learner_home.py
+++ b/enterprise/overrides/learner_home.py
@@ -1,0 +1,35 @@
+"""
+Pluggable override for the learner home enterprise customer lookup.
+"""
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def enterprise_get_enterprise_customer(prev_fn, user, request, is_masquerading):
+    """
+    Return the enterprise customer dict for the given user, or None.
+
+    This function overrides the default ``get_enterprise_customer`` implementation in
+    ``lms/djangoapps/learner_home/views.py`` via the pluggable override mechanism.
+
+    Arguments:
+        prev_fn: the previous (default) implementation — not called because we fully replace it.
+        user: the Django User object.
+        request: the current HTTP request.
+        is_masquerading (bool): True when the request is a staff masquerade.
+
+    Returns:
+        dict or None: enterprise customer data dict, or None if the user is not an
+        enterprise customer user.
+    """
+    # Deferred imports — will be replaced with internal paths in epic 17.
+    from openedx.features.enterprise_support.api import (  # pylint: disable=import-outside-toplevel
+        enterprise_customer_from_session_or_learner_data,
+        get_enterprise_learner_data_from_db,
+    )
+
+    if is_masquerading:
+        learner_data = get_enterprise_learner_data_from_db(user)
+        return learner_data[0]['enterprise_customer'] if learner_data else None
+    return enterprise_customer_from_session_or_learner_data(request)

--- a/enterprise/overrides/learner_home.py
+++ b/enterprise/overrides/learner_home.py
@@ -1,14 +1,8 @@
 """
 Pluggable override for the learner home enterprise customer lookup.
 
-.. note::
-    TODO: Wire this up to OVERRIDE_LEARNER_HOME_GET_ENTERPRISE_CUSTOMER once
-    edx-enterprise is a plugin (ENT-11584), before the plugin becomes optional.
-
-    This override is **not yet wired up** to the
-    ``OVERRIDE_LEARNER_HOME_GET_ENTERPRISE_CUSTOMER`` setting. Registering it requires
-    edx-enterprise to be installable/importable as an openedx plugin, which is not yet
-    the case.
+Wired up to ``OVERRIDE_LEARNER_HOME_GET_ENTERPRISE_CUSTOMER`` in
+``enterprise.settings.common.plugin_settings``.
 """
 import logging
 from typing import TYPE_CHECKING, Optional, TypedDict

--- a/enterprise/overrides/learner_home.py
+++ b/enterprise/overrides/learner_home.py
@@ -11,8 +11,11 @@ Pluggable override for the learner home enterprise customer lookup.
     the case.
 """
 import logging
+from typing import TYPE_CHECKING, Optional, TypedDict
 
-# Will be replaced with an internal path in epic 17.
+from rest_framework.request import Request
+
+# Will be replaced with an internal path in ENT-11576.
 try:
     from openedx.features.enterprise_support.api import (
         enterprise_customer_from_session_or_learner_data,
@@ -22,10 +25,31 @@ except ImportError:
     enterprise_customer_from_session_or_learner_data = None
     get_enterprise_learner_data_from_db = None
 
+if TYPE_CHECKING:
+    from django.contrib.auth.models import User
+
 log = logging.getLogger(__name__)
 
 
-def enterprise_get_enterprise_customer(prev_fn, user, request, is_masquerading):
+class EnterpriseCustomerData(TypedDict):
+    """
+    Required keys for the learner home enterprise dashboard.
+
+    Mirrors ``lms.djangoapps.learner_home.views.EnterpriseCustomerData``
+    """
+    name: str
+    uuid: str
+    slug: str
+    auth_org_id: Optional[str]
+    enable_learner_portal: bool
+
+
+def enterprise_get_enterprise_customer(
+    prev_fn,
+    user: "User",
+    request: Request,
+    is_masquerading: bool,
+) -> Optional[EnterpriseCustomerData]:
     """
     Return the enterprise customer dict for the given user, or None.
 

--- a/enterprise/overrides/learner_home.py
+++ b/enterprise/overrides/learner_home.py
@@ -5,9 +5,11 @@ Wired up to ``OVERRIDE_LEARNER_HOME_GET_ENTERPRISE_CUSTOMER`` in
 ``enterprise.settings.common.plugin_settings``.
 """
 import logging
-from typing import TYPE_CHECKING, Optional, TypedDict
+from typing import Optional, TypedDict
 
 from rest_framework.request import Request
+
+from django.contrib.auth.models import AbstractBaseUser
 
 # Will be replaced with an internal path in ENT-11576.
 try:
@@ -18,9 +20,6 @@ try:
 except ImportError:
     enterprise_customer_from_session_or_learner_data = None
     get_enterprise_learner_data_from_db = None
-
-if TYPE_CHECKING:
-    from django.contrib.auth.models import User
 
 log = logging.getLogger(__name__)
 
@@ -39,8 +38,8 @@ class EnterpriseCustomerData(TypedDict):
 
 
 def enterprise_get_enterprise_customer(
-    prev_fn,
-    user: "User",
+    prev_fn,  # pylint: disable=unused-argument
+    user: AbstractBaseUser,
     request: Request,
     is_masquerading: bool,
 ) -> Optional[EnterpriseCustomerData]:

--- a/enterprise/overrides/learner_home.py
+++ b/enterprise/overrides/learner_home.py
@@ -3,6 +3,16 @@ Pluggable override for the learner home enterprise customer lookup.
 """
 import logging
 
+# Will be replaced with an internal path in epic 17.
+try:
+    from openedx.features.enterprise_support.api import (
+        enterprise_customer_from_session_or_learner_data,
+        get_enterprise_learner_data_from_db,
+    )
+except ImportError:
+    enterprise_customer_from_session_or_learner_data = None
+    get_enterprise_learner_data_from_db = None
+
 log = logging.getLogger(__name__)
 
 
@@ -14,7 +24,8 @@ def enterprise_get_enterprise_customer(prev_fn, user, request, is_masquerading):
     ``lms/djangoapps/learner_home/views.py`` via the pluggable override mechanism.
 
     Arguments:
-        prev_fn: the previous (default) implementation — not called because we fully replace it.
+        prev_fn: the previous (default) implementation, called when the enterprise
+            utility is unavailable.
         user: the Django User object.
         request: the current HTTP request.
         is_masquerading (bool): True when the request is a staff masquerade.
@@ -23,11 +34,8 @@ def enterprise_get_enterprise_customer(prev_fn, user, request, is_masquerading):
         dict or None: enterprise customer data dict, or None if the user is not an
         enterprise customer user.
     """
-    # Deferred imports — will be replaced with internal paths in epic 17.
-    from openedx.features.enterprise_support.api import (  # pylint: disable=import-outside-toplevel
-        enterprise_customer_from_session_or_learner_data,
-        get_enterprise_learner_data_from_db,
-    )
+    if enterprise_customer_from_session_or_learner_data is None:
+        return prev_fn(user, request, is_masquerading)
 
     if is_masquerading:
         learner_data = get_enterprise_learner_data_from_db(user)

--- a/enterprise/overrides/learner_home.py
+++ b/enterprise/overrides/learner_home.py
@@ -1,5 +1,14 @@
 """
 Pluggable override for the learner home enterprise customer lookup.
+
+.. note::
+    TODO: Wire this up to OVERRIDE_LEARNER_HOME_GET_ENTERPRISE_CUSTOMER once
+    edx-enterprise is a plugin (ENT-11584), before the plugin becomes optional.
+
+    This override is **not yet wired up** to the
+    ``OVERRIDE_LEARNER_HOME_GET_ENTERPRISE_CUSTOMER`` setting. Registering it requires
+    edx-enterprise to be installable/importable as an openedx plugin, which is not yet
+    the case.
 """
 import logging
 

--- a/enterprise/overrides/learner_home.py
+++ b/enterprise/overrides/learner_home.py
@@ -57,8 +57,8 @@ def enterprise_get_enterprise_customer(
     ``lms/djangoapps/learner_home/views.py`` via the pluggable override mechanism.
 
     Arguments:
-        prev_fn: the previous (default) implementation, called when the enterprise
-            utility is unavailable.
+        prev_fn: the previous (default) implementation. Unused; retained for
+            pluggable-override signature compatibility.
         user: the Django User object.
         request: the current HTTP request.
         is_masquerading (bool): True when the request is a staff masquerade.
@@ -67,9 +67,6 @@ def enterprise_get_enterprise_customer(
         dict or None: enterprise customer data dict, or None if the user is not an
         enterprise customer user.
     """
-    if enterprise_customer_from_session_or_learner_data is None:
-        return prev_fn(user, request, is_masquerading)
-
     if is_masquerading:
         learner_data = get_enterprise_learner_data_from_db(user)
         return learner_data[0]['enterprise_customer'] if learner_data else None

--- a/enterprise/settings/common.py
+++ b/enterprise/settings/common.py
@@ -87,6 +87,10 @@ def plugin_settings(settings):
         'enterprise.overrides.course_home_progress.enterprise_obfuscated_username'
     )
 
+    settings.OVERRIDE_LEARNER_HOME_GET_ENTERPRISE_CUSTOMER = (
+        'enterprise.overrides.learner_home.enterprise_get_enterprise_customer'
+    )
+
     pipeline = getattr(settings, 'SOCIAL_AUTH_PIPELINE', None)
     if pipeline is not None:
         email_step = 'enterprise.tpa_pipeline.enterprise_associate_by_email'

--- a/tests/test_enterprise/test_overrides_learner_home.py
+++ b/tests/test_enterprise/test_overrides_learner_home.py
@@ -1,0 +1,76 @@
+"""
+Tests for enterprise.overrides.learner_home pluggable override.
+"""
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+
+ENTERPRISE_SUPPORT_API_PATH = 'openedx.features.enterprise_support.api'
+
+
+class TestEnterpriseGetEnterpriseCustomer(TestCase):
+    """
+    Tests for enterprise_get_enterprise_customer override function.
+    """
+
+    def _call(self, user=None, request=None, is_masquerading=False):
+        """Import and call the override function."""
+        # pylint: disable=import-outside-toplevel
+        from enterprise.overrides.learner_home import enterprise_get_enterprise_customer
+        prev_fn = MagicMock()
+        return enterprise_get_enterprise_customer(prev_fn, user, request, is_masquerading)
+
+    def test_non_masquerading_delegates_to_session_api(self):
+        """
+        When is_masquerading is False, should call
+        enterprise_customer_from_session_or_learner_data(request) and return its result.
+        """
+        request = MagicMock()
+        user = MagicMock()
+        expected = {'uuid': 'test-uuid'}
+        mock_api = MagicMock()
+        mock_api.enterprise_customer_from_session_or_learner_data.return_value = expected
+        mock_api.get_enterprise_learner_data_from_db.return_value = []
+
+        with patch.dict('sys.modules', {ENTERPRISE_SUPPORT_API_PATH: mock_api}):
+            result = self._call(user=user, request=request, is_masquerading=False)
+
+        mock_api.enterprise_customer_from_session_or_learner_data.assert_called_once_with(request)
+        mock_api.get_enterprise_learner_data_from_db.assert_not_called()
+        self.assertEqual(result, expected)
+
+    def test_masquerading_returns_enterprise_customer_from_db(self):
+        """
+        When is_masquerading is True and learner data exists, should return the
+        enterprise_customer from the first learner data entry.
+        """
+        user = MagicMock()
+        request = MagicMock()
+        enterprise_customer = {'uuid': 'ec-uuid', 'name': 'Test Enterprise'}
+        mock_api = MagicMock()
+        mock_api.get_enterprise_learner_data_from_db.return_value = [
+            {'enterprise_customer': enterprise_customer}
+        ]
+
+        with patch.dict('sys.modules', {ENTERPRISE_SUPPORT_API_PATH: mock_api}):
+            result = self._call(user=user, request=request, is_masquerading=True)
+
+        mock_api.get_enterprise_learner_data_from_db.assert_called_once_with(user)
+        mock_api.enterprise_customer_from_session_or_learner_data.assert_not_called()
+        self.assertEqual(result, enterprise_customer)
+
+    def test_masquerading_returns_none_when_no_learner_data(self):
+        """
+        When is_masquerading is True but no learner data exists, should return None.
+        """
+        user = MagicMock()
+        request = MagicMock()
+        mock_api = MagicMock()
+        mock_api.get_enterprise_learner_data_from_db.return_value = []
+
+        with patch.dict('sys.modules', {ENTERPRISE_SUPPORT_API_PATH: mock_api}):
+            result = self._call(user=user, request=request, is_masquerading=True)
+
+        mock_api.get_enterprise_learner_data_from_db.assert_called_once_with(user)
+        mock_api.enterprise_customer_from_session_or_learner_data.assert_not_called()
+        self.assertIsNone(result)

--- a/tests/test_enterprise/test_overrides_learner_home.py
+++ b/tests/test_enterprise/test_overrides_learner_home.py
@@ -4,7 +4,6 @@ Tests for enterprise.overrides.learner_home pluggable override.
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
-
 ENTERPRISE_SUPPORT_API_PATH = 'openedx.features.enterprise_support.api'
 
 

--- a/tests/test_enterprise/test_overrides_learner_home.py
+++ b/tests/test_enterprise/test_overrides_learner_home.py
@@ -12,13 +12,6 @@ class TestEnterpriseGetEnterpriseCustomer(TestCase):
     Tests for enterprise_get_enterprise_customer override function.
     """
 
-    def _call(self, user=None, request=None, is_masquerading=False):
-        """Import and call the override function."""
-        # pylint: disable=import-outside-toplevel
-        from enterprise.overrides.learner_home import enterprise_get_enterprise_customer
-        prev_fn = MagicMock()
-        return enterprise_get_enterprise_customer(prev_fn, user, request, is_masquerading)
-
     def test_non_masquerading_delegates_to_session_api(self):
         """
         When is_masquerading is False, should call
@@ -32,7 +25,9 @@ class TestEnterpriseGetEnterpriseCustomer(TestCase):
         mock_api.get_enterprise_learner_data_from_db.return_value = []
 
         with patch.dict('sys.modules', {ENTERPRISE_SUPPORT_API_PATH: mock_api}):
-            result = self._call(user=user, request=request, is_masquerading=False)
+            from enterprise.overrides.learner_home import \
+                enterprise_get_enterprise_customer  # pylint: disable=import-outside-toplevel
+            result = enterprise_get_enterprise_customer(MagicMock(), user, request, is_masquerading=False)
 
         mock_api.enterprise_customer_from_session_or_learner_data.assert_called_once_with(request)
         mock_api.get_enterprise_learner_data_from_db.assert_not_called()
@@ -52,7 +47,9 @@ class TestEnterpriseGetEnterpriseCustomer(TestCase):
         ]
 
         with patch.dict('sys.modules', {ENTERPRISE_SUPPORT_API_PATH: mock_api}):
-            result = self._call(user=user, request=request, is_masquerading=True)
+            from enterprise.overrides.learner_home import \
+                enterprise_get_enterprise_customer  # pylint: disable=import-outside-toplevel
+            result = enterprise_get_enterprise_customer(MagicMock(), user, request, is_masquerading=True)
 
         mock_api.get_enterprise_learner_data_from_db.assert_called_once_with(user)
         mock_api.enterprise_customer_from_session_or_learner_data.assert_not_called()
@@ -68,7 +65,9 @@ class TestEnterpriseGetEnterpriseCustomer(TestCase):
         mock_api.get_enterprise_learner_data_from_db.return_value = []
 
         with patch.dict('sys.modules', {ENTERPRISE_SUPPORT_API_PATH: mock_api}):
-            result = self._call(user=user, request=request, is_masquerading=True)
+            from enterprise.overrides.learner_home import \
+                enterprise_get_enterprise_customer  # pylint: disable=import-outside-toplevel
+            result = enterprise_get_enterprise_customer(MagicMock(), user, request, is_masquerading=True)
 
         mock_api.get_enterprise_learner_data_from_db.assert_called_once_with(user)
         mock_api.enterprise_customer_from_session_or_learner_data.assert_not_called()

--- a/tests/test_enterprise/test_overrides_learner_home.py
+++ b/tests/test_enterprise/test_overrides_learner_home.py
@@ -4,7 +4,7 @@ Tests for enterprise.overrides.learner_home pluggable override.
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
-ENTERPRISE_SUPPORT_API_PATH = 'openedx.features.enterprise_support.api'
+from enterprise.overrides.learner_home import enterprise_get_enterprise_customer
 
 
 class TestEnterpriseGetEnterpriseCustomer(TestCase):
@@ -12,7 +12,13 @@ class TestEnterpriseGetEnterpriseCustomer(TestCase):
     Tests for enterprise_get_enterprise_customer override function.
     """
 
-    def test_non_masquerading_delegates_to_session_api(self):
+    @patch('enterprise.overrides.learner_home.enterprise_customer_from_session_or_learner_data')
+    @patch('enterprise.overrides.learner_home.get_enterprise_learner_data_from_db')
+    def test_non_masquerading_delegates_to_session_api(
+        self,
+        mock_get_enterprise_learner_data_from_db,
+        mock_enterprise_customer_from_session_or_learner_data,
+    ):
         """
         When is_masquerading is False, should call
         enterprise_customer_from_session_or_learner_data(request) and return its result.
@@ -20,20 +26,22 @@ class TestEnterpriseGetEnterpriseCustomer(TestCase):
         request = MagicMock()
         user = MagicMock()
         expected = {'uuid': 'test-uuid'}
-        mock_api = MagicMock()
-        mock_api.enterprise_customer_from_session_or_learner_data.return_value = expected
-        mock_api.get_enterprise_learner_data_from_db.return_value = []
+        mock_enterprise_customer_from_session_or_learner_data.return_value = expected
+        mock_get_enterprise_learner_data_from_db.return_value = []
 
-        with patch.dict('sys.modules', {ENTERPRISE_SUPPORT_API_PATH: mock_api}):
-            from enterprise.overrides.learner_home import \
-                enterprise_get_enterprise_customer  # pylint: disable=import-outside-toplevel
-            result = enterprise_get_enterprise_customer(MagicMock(), user, request, is_masquerading=False)
+        result = enterprise_get_enterprise_customer(MagicMock(), user, request, is_masquerading=False)
 
-        mock_api.enterprise_customer_from_session_or_learner_data.assert_called_once_with(request)
-        mock_api.get_enterprise_learner_data_from_db.assert_not_called()
+        mock_enterprise_customer_from_session_or_learner_data.assert_called_once_with(request)
+        mock_get_enterprise_learner_data_from_db.assert_not_called()
         self.assertEqual(result, expected)
 
-    def test_masquerading_returns_enterprise_customer_from_db(self):
+    @patch('enterprise.overrides.learner_home.enterprise_customer_from_session_or_learner_data')
+    @patch('enterprise.overrides.learner_home.get_enterprise_learner_data_from_db')
+    def test_masquerading_returns_enterprise_customer_from_db(
+        self,
+        mock_get_enterprise_learner_data_from_db,
+        mock_enterprise_customer_from_session_or_learner_data,
+    ):
         """
         When is_masquerading is True and learner data exists, should return the
         enterprise_customer from the first learner data entry.
@@ -41,34 +49,32 @@ class TestEnterpriseGetEnterpriseCustomer(TestCase):
         user = MagicMock()
         request = MagicMock()
         enterprise_customer = {'uuid': 'ec-uuid', 'name': 'Test Enterprise'}
-        mock_api = MagicMock()
-        mock_api.get_enterprise_learner_data_from_db.return_value = [
+        mock_get_enterprise_learner_data_from_db.return_value = [
             {'enterprise_customer': enterprise_customer}
         ]
 
-        with patch.dict('sys.modules', {ENTERPRISE_SUPPORT_API_PATH: mock_api}):
-            from enterprise.overrides.learner_home import \
-                enterprise_get_enterprise_customer  # pylint: disable=import-outside-toplevel
-            result = enterprise_get_enterprise_customer(MagicMock(), user, request, is_masquerading=True)
+        result = enterprise_get_enterprise_customer(MagicMock(), user, request, is_masquerading=True)
 
-        mock_api.get_enterprise_learner_data_from_db.assert_called_once_with(user)
-        mock_api.enterprise_customer_from_session_or_learner_data.assert_not_called()
+        mock_get_enterprise_learner_data_from_db.assert_called_once_with(user)
+        mock_enterprise_customer_from_session_or_learner_data.assert_not_called()
         self.assertEqual(result, enterprise_customer)
 
-    def test_masquerading_returns_none_when_no_learner_data(self):
+    @patch('enterprise.overrides.learner_home.enterprise_customer_from_session_or_learner_data')
+    @patch('enterprise.overrides.learner_home.get_enterprise_learner_data_from_db')
+    def test_masquerading_returns_none_when_no_learner_data(
+        self,
+        mock_get_enterprise_learner_data_from_db,
+        mock_enterprise_customer_from_session_or_learner_data,
+    ):
         """
         When is_masquerading is True but no learner data exists, should return None.
         """
         user = MagicMock()
         request = MagicMock()
-        mock_api = MagicMock()
-        mock_api.get_enterprise_learner_data_from_db.return_value = []
+        mock_get_enterprise_learner_data_from_db.return_value = []
 
-        with patch.dict('sys.modules', {ENTERPRISE_SUPPORT_API_PATH: mock_api}):
-            from enterprise.overrides.learner_home import \
-                enterprise_get_enterprise_customer  # pylint: disable=import-outside-toplevel
-            result = enterprise_get_enterprise_customer(MagicMock(), user, request, is_masquerading=True)
+        result = enterprise_get_enterprise_customer(MagicMock(), user, request, is_masquerading=True)
 
-        mock_api.get_enterprise_learner_data_from_db.assert_called_once_with(user)
-        mock_api.enterprise_customer_from_session_or_learner_data.assert_not_called()
+        mock_get_enterprise_learner_data_from_db.assert_called_once_with(user)
+        mock_enterprise_customer_from_session_or_learner_data.assert_not_called()
         self.assertIsNone(result)


### PR DESCRIPTION
[ENT-11571](https://2u-internal.atlassian.net/browse/ENT-11571)

Migrates functionality from openedx-platform to look up a user's enterprise status and populate 
`enterpriseDashboard` in `/api/learner_home/init/` endpoint.

---

Related:
* https://github.com/edx/edx-platform/pull/383
* https://github.com/openedx/edx-enterprise/pull/2554
* https://github.com/openedx/openedx-platform/pull/38107
