### PR TITLE
feat: add CalculateEnterpriseDiscountedPrice pipeline step for course mode checkout

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[8.7.0] - 2026-07-16
+---------------------
+* feat: add CalculateEnterpriseDiscountedPrice pipeline step
+
 [8.6.0] - 2026-07-16
 ---------------------
 * feat: add ``enable_people_management`` flag to EnterpriseCustomer to display the people management page

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "8.6.0"
+__version__ = "8.7.0"

--- a/enterprise/filters/course_modes.py
+++ b/enterprise/filters/course_modes.py
@@ -1,0 +1,53 @@
+"""
+Pipeline steps for the course mode price filter.
+"""
+import logging
+from typing import Any
+
+from crum import get_current_request
+from openedx_filters.filters import PipelineStep
+
+try:
+    from common.djangoapps.course_modes.helpers import get_course_final_price
+except ImportError:
+    get_course_final_price = None
+
+# This import will be replaced with internal paths when enterprise_support is
+# migrated into edx-enterprise.q
+try:
+    from openedx.features.enterprise_support.api import enterprise_customer_for_request
+except ImportError:
+    enterprise_customer_for_request = None
+
+log = logging.getLogger(__name__)
+
+
+class CalculateEnterpriseDiscountedPrice(PipelineStep):
+    """
+    Apply the enterprise-negotiated discount to a course mode's price, if one applies.
+
+    If the current request is associated with an enterprise customer and the course mode
+    has a SKU, this step overrides the price with the result of get_course_final_price.
+    Otherwise the price passes through unchanged.
+    """
+
+    def run_filter(self, user: Any, course_mode_data: Any, price: int) -> dict[str, Any]:  # pylint: disable=arguments-differ
+        """
+        Override price with the enterprise-discounted price, if applicable.
+        """
+        log.info(
+            "Starting CalculateEnterpriseDiscountedPrice pipeline step with user_id=%s, price=%s",
+            user.id if user else None,
+            price
+        )
+        request = get_current_request()
+        if request is None:
+            return {'user': user, 'course_mode_data': course_mode_data, 'price': price}
+
+        enterprise_customer = enterprise_customer_for_request(request)
+
+        discounted_price = price
+        if enterprise_customer and course_mode_data.sku:
+            discounted_price = get_course_final_price(user, course_mode_data.sku, price)
+
+        return {'user': user, 'course_mode_data': course_mode_data, 'price': discounted_price}

--- a/enterprise/settings/common.py
+++ b/enterprise/settings/common.py
@@ -28,6 +28,10 @@ ENTERPRISE_FILTERS_CONFIG: FiltersConfig = {
         "fail_silently": False,
         "pipeline": ["enterprise.filters.courseware.EnterpriseStartDateAccessFailureStep"],
     },
+    "org.openedx.learning.course_mode.price.requested.v1": {
+        "fail_silently": False,
+        "pipeline": ["enterprise.filters.course_modes.CalculateEnterpriseDiscountedPrice"],
+    },
     # NOTE: Pipeline ordering matters here. ActiveEnterpriseCheckStep must run before
     # consent's DataSharingConsentCourseAccessStep to match the original platform behavior
     # (the incorrect-enterprise redirect took priority over the DSC redirect). This ordering

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -673,7 +673,7 @@ openedx-events==11.2.0
     #   -r requirements/doc.txt
     #   -r requirements/test-master.txt
     #   -r requirements/test.txt
-openedx-filters==3.7.0
+openedx-filters==3.8.0
     # via
     #   -r requirements/doc.txt
     #   -r requirements/test-master.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -402,7 +402,7 @@ openedx-atlas==0.7.0
     # via -r requirements/test-master.txt
 openedx-events==11.2.0
     # via -r requirements/test-master.txt
-openedx-filters==3.7.0
+openedx-filters==3.8.0
     # via -r requirements/test-master.txt
 packaging==26.2
     # via

--- a/requirements/edx-platform-constraints.txt
+++ b/requirements/edx-platform-constraints.txt
@@ -858,7 +858,7 @@ openedx-events==11.2.0
     #   openedx-authz
     #   openedx-core
     #   ora2
-openedx-filters==3.7.0
+openedx-filters==3.8.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-enterprise

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -420,7 +420,7 @@ openedx-events==11.2.0
     # via
     #   -c requirements/edx-platform-constraints.txt
     #   -r requirements/base.in
-openedx-filters==3.7.0
+openedx-filters==3.8.0
     # via
     #   -c requirements/edx-platform-constraints.txt
     #   -r requirements/base.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -395,7 +395,7 @@ openedx-atlas==0.7.0
     # via -r requirements/test-master.txt
 openedx-events==11.2.0
     # via -r requirements/test-master.txt
-openedx-filters==3.7.0
+openedx-filters==3.8.0
     # via -r requirements/test-master.txt
 packaging==26.2
     # via

--- a/tests/filters/test_course_modes.py
+++ b/tests/filters/test_course_modes.py
@@ -1,0 +1,101 @@
+"""
+Tests for enterprise.filters.course_modes pipeline step.
+"""
+import unittest
+from unittest.mock import MagicMock, patch
+
+import ddt
+import pytest
+
+from django.test.client import RequestFactory
+
+from enterprise.filters.course_modes import CalculateEnterpriseDiscountedPrice
+from test_utils.factories import UserFactory
+
+
+@ddt.ddt
+class TestCalculateEnterpriseDiscountedPrice(unittest.TestCase):
+    """
+    Tests for CalculateEnterpriseDiscountedPrice pipeline step.
+    """
+
+    def _make_request(self):
+        return RequestFactory().get('/')
+
+    def _make_step(self):
+        return CalculateEnterpriseDiscountedPrice(
+            "org.openedx.learning.course_mode.price.requested.v1",
+            [],
+        )
+
+    @ddt.data(
+        {
+            'description': 'overrides_price_when_enterprise_customer_and_sku_present',
+            'current_request': True,
+            'enterprise_customer': {"uuid": "test-uuid", "name": "Test Enterprise"},
+            'customer_side_effect': None,
+            'sku': 'test-sku',
+            'final_price': 42,
+            'expected_price': 42,
+        },
+        {
+            'description': 'no_enterprise_customer',
+            'current_request': True,
+            'enterprise_customer': None,
+            'customer_side_effect': None,
+            'sku': 'test-sku',
+            'final_price': None,
+            'expected_price': 100,
+        },
+        {
+            'description': 'no_sku',
+            'current_request': True,
+            'enterprise_customer': {"uuid": "test-uuid", "name": "Test Enterprise"},
+            'customer_side_effect': None,
+            'sku': None,
+            'final_price': None,
+            'expected_price': 100,
+        },
+        {
+            'description': 'no_current_request',
+            'current_request': False,
+            'enterprise_customer': None,
+            'customer_side_effect': None,
+            'sku': 'test-sku',
+            'final_price': None,
+            'expected_price': 100,
+        },
+
+    )
+    @ddt.unpack
+    @pytest.mark.django_db
+    @patch('enterprise.filters.course_modes.get_course_final_price')
+    @patch('enterprise.filters.course_modes.enterprise_customer_for_request')
+    @patch('enterprise.filters.course_modes.get_current_request')
+    def test_run_filter_price(
+        self,
+        mock_get_current_request,
+        mock_get_customer,
+        mock_get_final_price,
+        description,  # pylint: disable=W0613
+        current_request,
+        enterprise_customer,
+        customer_side_effect,
+        sku,
+        final_price,
+        expected_price,
+    ):
+        """
+        Verifies the price is overridden with the enterprise discounted price when an
+        enterprise customer and SKU are present, and left unchanged otherwise.
+        """
+        mock_get_current_request.return_value = self._make_request() if current_request else None
+        mock_get_customer.return_value = enterprise_customer
+        mock_get_customer.side_effect = customer_side_effect
+        mock_get_final_price.return_value = final_price
+
+        user = UserFactory()
+        course_mode_data = MagicMock(sku=sku)
+        result = self._make_step().run_filter(user=user, course_mode_data=course_mode_data, price=100.00)
+
+        assert result["price"] == expected_price


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-11573

openedx-filters [#338](https://github.com/openedx/openedx-filters/pull/338) — CourseModePriceRequested filter definition
edx-enterprise [#2556](https://github.com/openedx/edx-enterprise/pull/2556) — CalculateEnterpriseDiscountedPrice pipeline step
edx-platform [#365](https://github.com/edx/edx-platform/pull/365) — view wired to invoke the filter

Prerequisites: local devstack running with all three branches installed ([Runbook](https://2u-internal.atlassian.net/wiki/spaces/SOL/pages/3710353504/Enterprise+Plugin+Ticket+Runbook)); an enterprise customer, an enterprise learner, and a course with a verified mode that has a non-empty SKU and a future expiration date.

### E2E Testing Instructions: 
Note: replace any enterprise customer uuids, users, or course keys with your own applicable local data. 

In lms/envs/devstack.py, confirm/add, then restart after to capture changes:
```
AUTOMATIC_AUTH_FOR_TESTING = True
RESTRICT_AUTOMATIC_AUTH = False
```

**Test 1: Check if pipeline correctly hooked up, and then check against control user with no enterprise link**
Write the test file in lms-shell
```
cat > /tmp/test1.py << 'EOF'
from django.test import Client

client = Client()
response = client.get(
    '/auto_auth',
    {'username': 'e2e_control_user', 'password': 'testpass123'},
    follow=True,
)
print("auto_auth status:", response.status_code)

course_id = "course-v1:edX+DemoX+Demo_Course"
response = client.get(f"/course_modes/choose/{course_id}/", follow=True)
print("choose status:", response.status_code)
content = response.content.decode()
print("contains '149':", "149" in content)
EOF
```
Then execute the file in the bash script `exec(open('/tmp/test1.py').read())`

_Expected: choose status: 200, contains '149': True._

**Test 2: Check against enterprise-linked user with SKU present on course**
```
cat > /tmp/test2.py << 'EOF'
from django.test import Client

client = Client()
client.get('/auto_auth', {'username': 'e2e_enterprise_user', 'password': 'testpass123'}, follow=True)

enterprise_uuid = "8400978a-7eb5-43a8-8a02-aa6063e842e2"
course_id = "course-v1:edX+DemoX+Demo_Course"

# The 'new_enterprise_login=yes' param bypasses RouterView's force_fresh_session
# check, which otherwise logs out any session not flagged as freshly SSO'd
r1 = client.get(
    f"/enterprise/{enterprise_uuid}/course/{course_id}/enroll/",
    {"new_enterprise_login": "yes"},
    follow=True,
)
print("landing hit status:", r1.status_code)

r2 = client.get(f"/course_modes/choose/{course_id}/", follow=True)
print("choose status:", r2.status_code)
content = r2.content.decode()
print("contains '149':", "149" in content)
EOF
```

_Expected: no /logout in the log, choose status: 200, log line [e-commerce calculate endpoint] The discounted price for sku [8CF08E5]... is [149.0] confirming the ecommerce call happened and returned the (undiscounted) price._

**Test 3: Check against enterprise-linked user, verified mode with no SKU**

Create a no-SKU verified mode on a second course — inside make lms-shell, at >>>:
```
from common.djangoapps.course_modes.models import CourseMode

CourseMode.objects.create(
    course_id="course-v1:edX+E202+3T2025",
    mode_slug="verified",
    mode_display_name="Verified Certificate",
    min_price=100,
    currency="usd",
    sku="",
)
```
```
cat > /tmp/test3.py << 'EOF'
from django.test import Client

client = Client()
client.get('/auto_auth', {'username': 'e2e_enterprise_user', 'password': 'testpass123'}, follow=True)

enterprise_uuid = "8400978a-7eb5-43a8-8a02-aa6063e842e2"
course_id = "course-v1:edX+E202+3T2025"

# This course isn't seeded in the discovery service, so the landing page 500s
# on a pre-existing edx-enterprise bug (discovery.py:251) — but the enterprise
# customer is written to session before that crash, so we catch it and proceed
try:
    r1 = client.get(
        f"/enterprise/{enterprise_uuid}/course/{course_id}/enroll/",
        {"new_enterprise_login": "yes"},
        follow=True,
    )
    print("landing hit status:", r1.status_code)
except Exception as e:
    print("landing hit raised (expected, discovery API 404):", type(e).__name__)

r2 = client.get(f"/course_modes/choose/{course_id}/", follow=True)
print("choose status:", r2.status_code)
content = r2.content.decode()
print("contains '100':", "100" in content)
EOF
```

_Expected: choose status: 200, contains '100': True, and — the key check — no [e-commerce calculate endpoint] log line, confirming the SKU guard blocked the ecommerce call entirely._
