### PR TITLE
chore: drop Python 3.11 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.12']
-        toxenv: [quality, docs, py312-django52, pii_check]
+        toxenv: [quality, docs, django52, pii_check]
     env:
       RUNJSHINT: true
     steps:
@@ -35,14 +35,14 @@ jobs:
         TOXENV: ${{ matrix.toxenv }}
       run: tox
     - name: Run code coverage
-      if: matrix.python-version == '3.12' && matrix.toxenv=='py312-django52' # Only run this once as part of tests
+      if: matrix.python-version == '3.12' && matrix.toxenv == 'django52' # Only run this once as part of tests
       uses: codecov/codecov-action@v5
       with:
         flags: unittests
         fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}
     - name: Run jshint
-      if: matrix.python-version == '3.12' && matrix.toxenv=='py312-django52' # Only run this once as part of tests
+      if: matrix.python-version == '3.12' && matrix.toxenv == 'django52' # Only run this once as part of tests
       run: |
         npm ci
         make jshint

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[7.0.0] - 2026-04-07
+---------------------
+* chore: drop Python 3.11 support
+
 [6.8.6] - 2026-04-07
 ---------------------
 * fix: allow deletion of inactive enterprise admin users (ENT-11714)

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "6.8.6"
+__version__ = "7.0.0"

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -34,7 +34,7 @@ python-discovery==1.2.1
     #   virtualenv
 tomli-w==1.2.0
     # via tox
-tox==4.51.0
+tox==4.52.0
     # via -r requirements/ci.in
 virtualenv==21.2.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -438,7 +438,7 @@ factory-boy==3.3.3
     #   -c requirements/constraints.txt
     #   -r requirements/doc.txt
     #   -r requirements/test.txt
-faker==40.11.1
+faker==40.12.0
     # via
     #   -r requirements/doc.txt
     #   -r requirements/test.txt
@@ -1120,7 +1120,7 @@ tomlkit==0.14.0
     #   -r requirements/test.txt
     #   pylint
     #   snowflake-connector-python
-tox==4.51.0
+tox==4.52.0
     # via -r requirements/dev.in
 tqdm==4.67.3
     # via twine

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -270,7 +270,7 @@ factory-boy==3.3.3
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/doc.in
-faker==40.11.1
+faker==40.12.0
     # via factory-boy
 fastavro==1.12.1
     # via

--- a/requirements/edx-platform-constraints.txt
+++ b/requirements/edx-platform-constraints.txt
@@ -476,7 +476,7 @@ edx-drf-extensions==10.6.0
     #   enterprise-integrated-channels
     #   openedx-authz
     #   openedx-core
-edx-enterprise==6.8.1
+edx-enterprise==6.8.4
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/kernel.in
@@ -569,7 +569,7 @@ enmerkar==0.7.1
     # via enmerkar-underscore
 enmerkar-underscore==2.4.0
     # via -r requirements/edx/kernel.in
-enterprise-integrated-channels==0.1.54
+enterprise-integrated-channels==0.1.55
     # via -r requirements/edx/bundled.in
 event-tracking==3.3.0
     # via
@@ -1292,7 +1292,7 @@ xblock-utils==4.0.0
     # via
     #   edx-sga
     #   xblock-poll
-xblocks-contrib==0.15.1
+xblocks-contrib==0.15.2
     # via -r requirements/edx/bundled.in
 xmlsec==1.3.14
     # via

--- a/requirements/js_test.txt
+++ b/requirements/js_test.txt
@@ -52,7 +52,7 @@ markupsafe==3.0.3
     # via jinja2
 mdurl==0.1.2
     # via markdown-it-py
-more-itertools==10.8.0
+more-itertools==11.0.1
     # via
     #   cheroot
     #   cherrypy

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -257,7 +257,7 @@ factory-boy==3.3.3
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.in
-faker==40.11.1
+faker==40.12.0
     # via factory-boy
 fastavro==1.12.1
     # via


### PR DESCRIPTION
## Summary

- Drop Python 3.11 support: remove from CI test matrix, tox envlist, and package classifiers
- Regenerate pinned requirements using Python 3.12
- Bump version to 7.0.0 — dropping Python support is a breaking change, so this is a major version bump

## Context

Python 3.11 is being dropped across the Open edX ecosystem as part of the move
to standardize on Python 3.12. See the tracking issue for the full list of repos:
https://github.com/openedx/public-engineering/issues/499

## Test plan

- [ ] CI passes with Python 3.12 only