### PR TITLE
feat: register enterprise and consent as openedx LMS plugins

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[6.8.0] - 2026-03-24
+---------------------
+* feat: register enterprise and consent as openedx LMS plugins (ENT-11663)
+
 [6.7.0] - 2026-03-10
 ---------------------
 * feat: Invite admin endpoints with validation  (ENT-11238)

--- a/consent/apps.py
+++ b/consent/apps.py
@@ -11,6 +11,19 @@ from django.apps import AppConfig
 class ConsentConfig(AppConfig):
     """Configuration for edX Enterprise's Consent application."""
 
+    plugin_app = {
+        "settings_config": {
+            "lms.djangoapp": {
+                "common": {
+                    "relative_path": "settings.common",
+                },
+                "production": {
+                    "relative_path": "settings.production",
+                },
+            },
+        },
+    }
+
     name = 'consent'
     verbose_name = "Enterprise Consent"
 

--- a/consent/settings/common.py
+++ b/consent/settings/common.py
@@ -1,0 +1,15 @@
+"""
+Common plugin settings for the consent app.
+"""
+
+
+def plugin_settings(settings):  # pylint: disable=unused-argument
+    """
+    Override platform settings for the consent app.
+
+    This is called by the Open edX plugin system during LMS/CMS startup. Add
+    any Django settings overrides here (e.g. ``settings.FEATURES['...'] = True``).
+
+    Args:
+        settings: The Django settings module being configured.
+    """

--- a/consent/settings/production.py
+++ b/consent/settings/production.py
@@ -1,0 +1,5 @@
+"""
+Production plugin settings for the consent app.
+"""
+
+from consent.settings.common import plugin_settings  # noqa: F401  pylint: disable=unused-import

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "6.7.0"
+__version__ = "6.8.0"

--- a/enterprise/apps.py
+++ b/enterprise/apps.py
@@ -13,6 +13,19 @@ class EnterpriseConfig(AppConfig):
     Configuration for the enterprise Django application.
     """
 
+    plugin_app = {
+        "settings_config": {
+            "lms.djangoapp": {
+                "common": {
+                    "relative_path": "settings.common",
+                },
+                "production": {
+                    "relative_path": "settings.production",
+                },
+            },
+        },
+    }
+
     name = "enterprise"
     valid_image_extensions = [".png", ]
     valid_max_image_size = getattr(settings, 'ENTERPRISE_CUSTOMER_LOGO_IMAGE_SIZE', 512)  # Value in KB's

--- a/enterprise/settings/common.py
+++ b/enterprise/settings/common.py
@@ -1,0 +1,15 @@
+"""
+Common plugin settings for the enterprise app.
+"""
+
+
+def plugin_settings(settings):  # pylint: disable=unused-argument
+    """
+    Override platform settings for the enterprise app.
+
+    This is called by the Open edX plugin system during LMS/CMS startup. Add
+    any Django settings overrides here (e.g. ``settings.FEATURES['...'] = True``).
+
+    Args:
+        settings: The Django settings module being configured.
+    """

--- a/enterprise/settings/production.py
+++ b/enterprise/settings/production.py
@@ -1,0 +1,5 @@
+"""
+Production plugin settings for the enterprise app.
+"""
+
+from enterprise.settings.common import plugin_settings  # noqa: F401  pylint: disable=unused-import

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,12 @@ REQUIREMENTS, DEPENDENCY_LINKS = get_requirements(os.path.join(base_path, 'requi
 setup(
     name="edx-enterprise",
     version=VERSION,
+    entry_points={
+        "lms.djangoapp": [
+            "enterprise = enterprise.apps:EnterpriseConfig",
+            "consent = consent.apps:ConsentConfig",
+        ],
+    },
     description="""Your project description goes here""",
     long_description=f"{README}\n\n{CHANGELOG}",
     author="edX",


### PR DESCRIPTION
Make two django apps (`enterprise` and `consent`) into openedx plugins.  This is a prerequisite for several other tickets which rely on having a plugin_settings() entrypoint to add pluggable overrides to.

ENT-11663

---

Tickets/PRs blocked by this one:

- [ENT-11571](https://2u-internal.atlassian.net/browse/ENT-11571) — Learner Home Enterprise Dashboard                                                                                                                                                                                                                                    
  - [https://github.com/openedx/openedx-platform/pull/38107 ](https://github.com/openedx/openedx-platform/pull/38107)                                                                                                                                                                                                                                                                
  - [https://github.com/openedx/edx-enterprise/pull/2554 ](https://github.com/openedx/edx-enterprise/pull/2554)                                                                                                                                                                                                                                                              
- [ENT-11572](https://2u-internal.atlassian.net/browse/ENT-11572) — Course Home Progress Enterprise Name                                                                                                                                                                                                                                 
  - [https://github.com/openedx/openedx-platform/pull/38108 ](https://github.com/openedx/openedx-platform/pull/38108)
  - [https://github.com/openedx/edx-enterprise/pull/2555 ](https://github.com/openedx/edx-enterprise/pull/2555)
- [ENT-11575](https://2u-internal.atlassian.net/browse/ENT-11575) — Programs API Enterprise Enrollments
  - No PRs created yet

---

Related:
* https://github.com/openedx/openedx-platform/pull/38209