### PR TITLE
fix: also register enterprise and consent as CMS plugins

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[6.8.1] - 2026-03-25
+---------------------
+* fix: also register enterprise and consent as CMS plugins (ENT-11663)
+
 [6.8.0] - 2026-03-24
 ---------------------
 * feat: register enterprise and consent as openedx LMS plugins (ENT-11663)

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "6.8.0"
+__version__ = "6.8.1"

--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,10 @@ setup(
             "enterprise = enterprise.apps:EnterpriseConfig",
             "consent = consent.apps:ConsentConfig",
         ],
+        "cms.djangoapp": [
+            "enterprise = enterprise.apps:EnterpriseConfig",
+            "consent = consent.apps:ConsentConfig",
+        ],
     },
     description="""Your project description goes here""",
     long_description=f"{README}\n\n{CHANGELOG}",


### PR DESCRIPTION
Somehow I missed testing CMS unit tests on openedx-platform, and as a result the CI failed due to platform code which imports `enterprise.models` without having the `enterprise` app installed on CMS.  It's weird because CMS doesn't actually use anything from enterprise, but makes sense because CMS and LMS share the same source code.

I thought I could maybe get away with NOT installing enterprise & consent within the CMS, but alas this is not yet possible.  FWIW, the situation currently is that we DO install enterprise & support within the CMS, so this maintains that status quo.

ENT-11663

---

Fixes tests in:
- https://github.com/openedx/openedx-platform/pull/38209
- https://github.com/edx/edx-platform/pull/196
