### PR TITLE
fix: Update outdated & broken .coveragerc syntax

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,13 +3,15 @@ branch = True
 data_file = .coverage
 source=enterprise
 omit =
-    enterprise/settings*
-    enterprise/conf*
-    enterprise/django_compatibility.py
-    consent/apps.py
-    consent/errors.py
-    *migrations*
-    *admin/__init__.py
-    *static*
-    *templates*
-    *urls.py
+    enterprise/settings/*
+    enterprise/conf/*
+    consent/settings/*
+    consent/conf/*
+    */mocks.py
+    */urls.py
+    */migrations/*
+    */admin.py
+    */static/*
+    */templates/*
+    */tests/*
+    test_*


### PR DESCRIPTION
We've had outdated/broken .coveragerc syntax across all enterprise repos and it's just whack-a-mole to fix them all.