### PR TITLE
feat: implement hard delete for enterprise customer admin (ENT-11650)

### DIFF
--- a/enterprise/api/utils.py
+++ b/enterprise/api/utils.py
@@ -14,7 +14,6 @@ from django.utils.translation import gettext as _
 from enterprise.constants import (
     BRAZE_ADMIN_INVITE_CAMPAIGN_SETTING,
     BRAZE_LEARNER_INVITE_CAMPAIGN_SETTING,
-    ENTERPRISE_ADMIN_ROLE,
     ENTERPRISE_CATALOG_ADMIN_ROLE,
     ENTERPRISE_DASHBOARD_ADMIN_ROLE,
     ENTERPRISE_REPORTING_CONFIG_ADMIN_ROLE,
@@ -31,7 +30,6 @@ from enterprise.models import (
     EnterpriseFeatureUserRoleAssignment,
     EnterpriseGroup,
     PendingEnterpriseCustomerAdminUser,
-    SystemWideEnterpriseUserRoleAssignment,
 )
 from enterprise.tasks import send_enterprise_admin_invite_email
 
@@ -45,13 +43,12 @@ def get_existing_admin_emails(enterprise_customer: EnterpriseCustomer) -> Set[st
     Only includes admins who have:
     1. An EnterpriseCustomerAdmin record
     2. An active EnterpriseCustomerUser (active=True)
-    3. An active admin role assignment in SystemWideEnterpriseUserRoleAssignment
 
     Args:
         enterprise_customer: The enterprise customer instance.
 
     Returns:
-        Set of lowercased email addresses of active admins with valid role assignments.
+        Set of lowercased email addresses of active admins.
 
     Raises:
         DatabaseError: If database query fails.
@@ -62,20 +59,12 @@ def get_existing_admin_emails(enterprise_customer: EnterpriseCustomer) -> Set[st
         True
     """
     try:
-        # Get user IDs with active admin role assignments
-        users_with_admin_role = set(
-            SystemWideEnterpriseUserRoleAssignment.objects.filter(
-                enterprise_customer=enterprise_customer,
-                role__name=ENTERPRISE_ADMIN_ROLE,
-            ).values_list('user_id', flat=True)
-        )
-
-        # Return emails of admins who have active ECU AND active role assignment
+        # Return emails of admins who have active ECU
+        # Roles are not considered in customer admin lookup
         return set(
             EnterpriseCustomerAdmin.objects.filter(
                 enterprise_customer_user__enterprise_customer=enterprise_customer,
-                enterprise_customer_user__active=True,
-                enterprise_customer_user__user_id__in=users_with_admin_role,
+                enterprise_customer_user__active=True
             )
             .annotate(email_l=Lower(F("enterprise_customer_user__user_fk__email")))
             .values_list("email_l", flat=True)

--- a/enterprise/api/v1/views/enterprise_customer_admin.py
+++ b/enterprise/api/v1/views/enterprise_customer_admin.py
@@ -490,6 +490,14 @@ class EnterpriseCustomerAdminViewSet(
             enterprise_customer.uuid
         )
 
+        # Hard-delete the EnterpriseCustomerAdmin record
+        admin_record.delete()
+        logger.info(
+            "Hard deleted EnterpriseCustomerAdmin for EnterpriseCustomerUser id=%s in enterprise %s",
+            enterprise_customer_user.id,
+            enterprise_customer.uuid
+        )
+
         # Check if user has other roles for this enterprise
         # No locking needed - we're only checking existence, and ECU is already locked
         has_other_roles_in_enterprise = models.SystemWideEnterpriseUserRoleAssignment.objects.filter(

--- a/tests/test_enterprise/api/test_enterprise_customer_admin.py
+++ b/tests/test_enterprise/api/test_enterprise_customer_admin.py
@@ -436,13 +436,10 @@ class TestDeleteAdminEndpoint(APITest):
         self.assertIn('user_deactivated', response.data)
         self.assertTrue(response.data['user_deactivated'])
 
-        # EnterpriseCustomerAdmin record still exists (soft delete via ECU deactivation).
-        self.assertTrue(
+        # EnterpriseCustomerAdmin record is hard deleted.
+        self.assertFalse(
             EnterpriseCustomerAdmin.objects.filter(pk=self.admin.pk).exists()
         )
-        # ECA record still exists in DB
-        admin = EnterpriseCustomerAdmin.objects.get(pk=self.admin.pk)
-        self.assertIsNotNone(admin)
 
         # ECU is deactivated
         self.enterprise_customer_user.refresh_from_db()
@@ -539,8 +536,8 @@ class TestDeleteAdminEndpoint(APITest):
         self.target_user.refresh_from_db()
         self.assertEqual(self.target_user.is_active, initial_user_is_active)
 
-        # Admin model record still exists (not hard deleted).
-        self.assertTrue(
+        # Admin model record is hard deleted.
+        self.assertFalse(
             EnterpriseCustomerAdmin.objects.filter(pk=self.admin.pk).exists()
         )
 


### PR DESCRIPTION
## Summary

This PR updates the existing Delete Admin behavior to support hard delete, aligned with ENT-11264.

Also removes role-based filtering from admin email lookup, as roles are not considered in customer admin.

## Changes

### `enterprise/api/utils.py`
- Removed role-based filtering from `get_existing_admin_emails()` — no longer queries `SystemWideEnterpriseUserRoleAssignment` to check admin role before returning emails
- Roles are not considered in customer admin lookup (admins added via Django portal without role assignment are now correctly identified)
- Removed unused `ENTERPRISE_ADMIN_ROLE` and `SystemWideEnterpriseUserRoleAssignment` imports
- Updated docstring to reflect the change

### `enterprise/api/v1/views/enterprise_customer_admin.py`
- Added `admin_record.delete()` — hard-deletes the `EnterpriseCustomerAdmin` record after removing the admin role assignment
- Added logger statement for hard delete operation
- Removed unused `unused-argument` pylint suppression on `delete_admin`
- Deletion order: Role first → Admin record second (as per ENT-11264 guidance)

### `tests/test_enterprise/api/test_enterprise_customer_admin.py`
- Updated `test_soft_delete_success`: changed assertion from ECA record exists → ECA record is hard deleted
- Updated `test_user_with_other_roles_ecu_stays_active`: changed assertion from ECA record exists → ECA record is hard deleted

## Test plan
- [x] All 76 admin endpoint tests passing
- [x] `test_soft_delete_success` — verifies ECA is hard deleted + ECU deactivated + auth_user deactivated
- [x] `test_user_with_other_roles_ecu_stays_active` — verifies ECA hard deleted but ECU stays active
- [x] Pylint clean on changed files