### PR TITLE
Sjasti/ent 11714 allow delete inactive admins

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[6.8.6] - 2026-04-07
+---------------------
+* fix: allow deletion of inactive enterprise admin users (ENT-11714)
+
 [6.8.5] - 2026-03-31
 ---------------------
 * feat: add AccountSettingsEnterpriseReadOnlyFieldsStep pipeline step (ENT-11510)

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "6.8.5"
+__version__ = "6.8.6"

--- a/enterprise/api/v1/views/enterprise_admin_members.py
+++ b/enterprise/api/v1/views/enterprise_admin_members.py
@@ -12,6 +12,7 @@ from django.db.models.functions import Coalesce
 from enterprise import models
 from enterprise.api.v1 import serializers
 from enterprise.api.v1.views.base_views import EnterpriseViewSet
+from enterprise.constants import ENTERPRISE_ADMIN_ROLE
 from enterprise.logging import getEnterpriseLogger
 
 LOGGER = getEnterpriseLogger(__name__)
@@ -66,7 +67,13 @@ class EnterpriseAdminMembersViewSet(
         return (
             models.EnterpriseCustomerAdmin.objects.filter(
                 enterprise_customer_user__enterprise_customer__uuid=enterprise_uuid,
-                enterprise_customer_user__user_fk__is_active=True,
+                enterprise_customer_user__active=True,
+                enterprise_customer_user__user_fk__systemwideenterpriseuserroleassignment__role__name=(
+                    ENTERPRISE_ADMIN_ROLE
+                ),
+                enterprise_customer_user__user_fk__systemwideenterpriseuserroleassignment__enterprise_customer__uuid=(
+                    enterprise_uuid
+                ),
             )
             .annotate(
                 admin_id=F("enterprise_customer_user__id"),

--- a/enterprise/api/v1/views/enterprise_customer_admin.py
+++ b/enterprise/api/v1/views/enterprise_customer_admin.py
@@ -478,17 +478,18 @@ class EnterpriseCustomerAdminViewSet(
 
         deleted_count, _ = role_assignment.delete()
         if deleted_count == 0:
-            return self._error_response(
-                'Admin role assignment not found',
-                status.HTTP_404_NOT_FOUND
+            logger.warning(
+                "No admin role assignment found for user %s in enterprise %s, proceeding with deletion",
+                user.id,
+                enterprise_customer.uuid
             )
-
-        logger.info(
-            "Deleted %d admin role assignment(s) for user %s in enterprise %s",
-            deleted_count,
-            user.id,
-            enterprise_customer.uuid
-        )
+        else:
+            logger.info(
+                "Deleted %d admin role assignment(s) for user %s in enterprise %s",
+                deleted_count,
+                user.id,
+                enterprise_customer.uuid
+            )
 
         # Hard-delete the EnterpriseCustomerAdmin record
         admin_record.delete()

--- a/tests/test_enterprise/api/test_enterprise_admin_members.py
+++ b/tests/test_enterprise/api/test_enterprise_admin_members.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from django.urls import reverse
 
 from enterprise.constants import ENTERPRISE_ADMIN_ROLE
+from enterprise.roles_api import assign_admin_role
 from test_utils import APITest
 from test_utils.factories import (
     EnterpriseCustomerAdminFactory,
@@ -46,6 +47,7 @@ class TestEnterpriseAdminMembersViewSet(APITest):
         self.admin_record = EnterpriseCustomerAdminFactory(
             enterprise_customer_user=self.admin_ecu,
         )
+        assign_admin_role(self.admin_user, self.enterprise_customer)
 
         # Pending admin
         self.pending_admin = PendingEnterpriseCustomerAdminUserFactory(
@@ -128,19 +130,20 @@ class TestEnterpriseAdminMembersViewSet(APITest):
         assert pending_result["invited_date"] is not None
         assert pending_result["joined_date"] is None
 
-    def test_inactive_user_excluded(self):
-        """Admin whose auth_user.is_active=False is not returned."""
+    def test_inactive_user_included(self):
+        """Admin whose auth_user.is_active=False is still returned so they can be deleted."""
         inactive_user = UserFactory(username="inactive_admin", is_active=False)
         inactive_ecu = EnterpriseCustomerUserFactory(
             user_id=inactive_user.id,
             enterprise_customer=self.enterprise_customer,
         )
         EnterpriseCustomerAdminFactory(enterprise_customer_user=inactive_ecu)
+        assign_admin_role(inactive_user, self.enterprise_customer)
 
         response = self.client.get(self.url)
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data["count"] == 2
+        assert response.data["count"] == 3
 
     def test_scoped_to_enterprise(self):
         """Results are scoped to the given enterprise UUID."""
@@ -223,6 +226,7 @@ class TestEnterpriseAdminMembersViewSet(APITest):
             enterprise_customer=self.enterprise_customer,
         )
         EnterpriseCustomerAdminFactory(enterprise_customer_user=alpha_ecu)
+        assign_admin_role(alpha_user, self.enterprise_customer)
 
         response = self.client.get(self.url)
 
@@ -285,6 +289,7 @@ class TestEnterpriseAdminMembersViewSet(APITest):
             enterprise_customer=self.enterprise_customer,
         )
         EnterpriseCustomerAdminFactory(enterprise_customer_user=bob_ecu)
+        assign_admin_role(bob_user, self.enterprise_customer)
 
         response = self.client.get(
             self.url,

--- a/tests/test_enterprise/api/test_enterprise_customer_admin.py
+++ b/tests/test_enterprise/api/test_enterprise_customer_admin.py
@@ -857,7 +857,7 @@ class TestDeleteAdminEndpoint(APITest):
 
     def test_delete_admin_no_role_assignment(self):
         """
-        Test 404 when admin record exists but has no role assignment.
+        Test that deletion succeeds even when admin has no role assignment.
         """
         self.set_jwt_cookie(SYSTEM_ENTERPRISE_PROVISIONING_ADMIN_ROLE, ALL_ACCESS_CONTEXT)
 
@@ -869,8 +869,7 @@ class TestDeleteAdminEndpoint(APITest):
 
         response = self.client.delete(f'{self.delete_url}?role={ACTIVE_ADMIN_ROLE_TYPE}')
 
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-        self.assertIn('Admin role assignment not found', response.data['error'])
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_delete_admin_soft_deleted_ecu_not_processed(self):
         """


### PR DESCRIPTION
Title:                                                                                                                                 
  fix: allow deletion of inactive admin users (ENT-11714)                                                                                
                                                                                                                                         
  Body:                                                                                                                                  
                                                                                                                                         
  ## Summary                                                                                                                             
  - Removed `auth_user.is_active=True` filter from the admin listing query so inactive admin users appear in the admin list              
  - Added `EnterpriseCustomerUser.active=True` filter to ensure only actively linked ECU records are returned                            
  - Added `enterprise_admin` role check via `SystemWideEnterpriseUserRoleAssignment` to verify users have the admin role
  - Changed hard delete to log a warning instead of returning 404 when admin role assignment is missing
                                              
  ## Problem                                                                                                                             
  Admin users whose `auth_user.is_active = False` could not be deleted because:
  1. The listing API filtered on `auth_user.is_active=True`, hiding inactive admins from the list                                        
  2. The delete API returned 404 if the admin role assignment was missing
                                                                                                                                         
  ## Changes                                                

  ### 1. Listing fix: `enterprise/api/v1/views/enterprise_admin_members.py`                                                              
   
  Replaced `auth_user.is_active=True` filter with `ECU.active=True` and admin role verification.                                         
                                                            
  | Filter | Table | Action |                 
  |--------|-------|--------|                                                                                                            
  | `user_fk__is_active=True` | `auth_user` | **Removed** (bug fix) |
  | `active=True` | `EnterpriseCustomerUser` | **Added** |                                                                               
  | `role__name=enterprise_admin` | `SystemWideEnterpriseUserRoleAssignment` | **Added** |
                                                                                                                                         
  ### 2. Delete fix: `enterprise/api/v1/views/enterprise_customer_admin.py`

  Changed `_delete_active_admin()` to log a warning instead of returning 404 when the admin role assignment is not found, allowing       
  deletion to proceed.                    
                                                                                                                                         
  ### 3. Tests                                                                                                                           
   
  - `test_enterprise_admin_members.py`: Added `assign_admin_role()` calls, renamed `test_inactive_user_excluded` →                       
  `test_inactive_user_included` (count 2 → 3)               
  - `test_enterprise_customer_admin.py`: Updated `test_delete_admin_no_role_assignment` to expect HTTP 200 instead of 404
                                                                                                                                         
  ## Test plan                            
  - [x] All 96 tests pass (76 admin + 20 members)                                                                                        
 
                                              