### PR TITLE
feat: add migration for enable_academies default value change (ENT-11220)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[7.0.3] - 2026-04-15
+---------------------
+* feat: add migration for enable_academies default value change (ENT-11220)
+
 [7.0.2] - 2026-04-14
 ---------------------
 * feat: enable academies by default for customers (ENT-11220)

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "7.0.2"
+__version__ = "7.0.3"

--- a/enterprise/migrations/0245_alter_enterprisecustomer_enable_academies_and_more.py
+++ b/enterprise/migrations/0245_alter_enterprisecustomer_enable_academies_and_more.py
@@ -1,0 +1,29 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("enterprise", "0244_enable_academies_for_existing_customers"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='enterprisecustomer',
+            name='enable_academies',
+            field=models.BooleanField(
+                default=True,
+                help_text='If checked, the learners will be able to see the academies on the learner portal dashboard.',
+                verbose_name='Display academies screen',
+            ),
+        ),
+        migrations.AlterField(
+            model_name='historicalenterprisecustomer',
+            name='enable_academies',
+            field=models.BooleanField(
+                default=True,
+                help_text='If checked, the learners will be able to see the academies on the learner portal dashboard.',
+                verbose_name='Display academies screen',
+            ),
+        ),
+    ]


### PR DESCRIPTION
## Context

Follow-up to #2594.

PR #2594 changed the `enable_academies` model default from `False` to `True` but did not include the corresponding Django migration that `makemigrations` generates for a `default=` change. This PR adds that missing `AlterField` migration so Django's migration graph stays in sync with the model state.

## What Changed

`enterprise/migrations/0245_alter_enterprisecustomer_enable_academies_and_more.py` — generated by `./manage.py makemigrations enterprise` after the model default was flipped in #2594.

- `AlterField` on `enterprisecustomer.enable_academies` → `default=True`
- `AlterField` on `historicalenterprisecustomer.enable_academies` → `default=True`

No data migration is needed — PR #2594 already handled existing customers with search enabled via `0244_enable_academies_for_existing_customers`.

## Related
- #2594 — original model default change
- https://2u-internal.atlassian.net/browse/ENT-11220

## Test plan
- [ ] Run `./manage.py migrate enterprise` and verify the migration applies cleanly
- [ ] Verify `./manage.py makemigrations enterprise --dry-run` reports "No changes detected" afterwards
- [ ] Verify no test regressions