### PR TITLE
fix: [SAML Views] Accept an "enterprise_customer_uuid" query param (instead of "enterprise-id")

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,11 @@ Unreleased
 ----------
 * nothing unreleased
 
+[7.0.4] - 2026-04-15
+---------------------
+
+* fix: [SAML Views] Accept an "enterprise_customer_uuid" query param (instead of "enterprise-id")
+
 [7.0.3] - 2026-04-15
 ---------------------
 * feat: add migration for enable_academies default value change (ENT-11220)

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "7.0.3"
+__version__ = "7.0.4"

--- a/enterprise/api/v1/views/saml_provider_config.py
+++ b/enterprise/api/v1/views/saml_provider_config.py
@@ -29,7 +29,7 @@ class SAMLProviderConfigViewSet(PermissionRequiredMixin, viewsets.ModelViewSet):
 
     Usage::
 
-        GET  /auth/saml/v0/provider_config/?enterprise-id=<uuid>
+        GET  /auth/saml/v0/provider_config/?enterprise_customer_uuid=<uuid>
         POST /auth/saml/v0/provider_config/
         PATCH /auth/saml/v0/provider_config/<pk>/
         DELETE /auth/saml/v0/provider_config/<pk>/
@@ -47,7 +47,7 @@ class SAMLProviderConfigViewSet(PermissionRequiredMixin, viewsets.ModelViewSet):
         if an association exists in EnterpriseCustomerIdentityProvider model.
         """
         if self.requested_enterprise_uuid is None:
-            raise ParseError('Required enterprise-id query parameter or enterprise_customer_uuid field is missing')
+            raise ParseError('Required enterprise_customer_uuid query parameter or field is missing')
         enterprise_customer_idps = get_list_or_404(
             EnterpriseCustomerIdentityProvider,
             enterprise_customer__uuid=self.requested_enterprise_uuid
@@ -97,11 +97,11 @@ class SAMLProviderConfigViewSet(PermissionRequiredMixin, viewsets.ModelViewSet):
     def requested_enterprise_uuid(self):
         """The enterprise customer uuid from request params or post body."""
         value = (
-            self.request.query_params.get('enterprise-id') or
+            self.request.query_params.get('enterprise_customer_uuid') or
             self.request.data.get('enterprise_customer_uuid')
         )
         if value is not None and not validate_uuid4_string(value):
-            raise ParseError('Invalid enterprise-id or enterprise_customer_uuid')
+            raise ParseError('Invalid enterprise_customer_uuid')
         return value
 
     def get_permission_object(self):

--- a/enterprise/api/v1/views/saml_provider_data.py
+++ b/enterprise/api/v1/views/saml_provider_data.py
@@ -42,7 +42,7 @@ class SAMLProviderDataViewSet(PermissionRequiredMixin, viewsets.ModelViewSet):
 
     Usage::
 
-        GET  /auth/saml/v0/provider_data/?enterprise-id=<uuid>
+        GET  /auth/saml/v0/provider_data/?enterprise_customer_uuid=<uuid>
         POST /auth/saml/v0/provider_data/
         PATCH /auth/saml/v0/provider_data/<pk>/
         DELETE /auth/saml/v0/provider_data/<pk>/
@@ -64,7 +64,7 @@ class SAMLProviderDataViewSet(PermissionRequiredMixin, viewsets.ModelViewSet):
         then, we fetch enterprisecustomer via samlproviderconfig > enterprisecustomer (via association table).
         """
         if self.requested_enterprise_uuid is None:
-            raise ParseError('Required enterprise-id query parameter or enterprise_customer_uuid field is missing')
+            raise ParseError('Required enterprise_customer_uuid query parameter or field is missing')
         enterprise_customer_idp = get_object_or_404(
             EnterpriseCustomerIdentityProvider,
             enterprise_customer__uuid=self.requested_enterprise_uuid
@@ -86,11 +86,11 @@ class SAMLProviderDataViewSet(PermissionRequiredMixin, viewsets.ModelViewSet):
     def requested_enterprise_uuid(self):
         """The enterprise customer uuid from request params or post body."""
         value = (
-            self.request.query_params.get('enterprise-id') or
+            self.request.query_params.get('enterprise_customer_uuid') or
             self.request.data.get('enterprise_customer_uuid')
         )
         if value is not None and not validate_uuid4_string(value):
-            raise ParseError('Invalid enterprise-id or enterprise_customer_uuid')
+            raise ParseError('Invalid enterprise_customer_uuid')
         return value
 
     def get_permission_object(self):

--- a/tests/test_enterprise/api/test_saml_provider_config.py
+++ b/tests/test_enterprise/api/test_saml_provider_config.py
@@ -48,7 +48,7 @@ class TestSAMLProviderConfigViewSet(APITest):
         mock_config.provider_id = idp.provider_id
         mock_saml_provider_config.objects.current_set.return_value.filter.return_value = MockSet(mock_config)
 
-        url = f'{PROVIDER_CONFIG_LIST_URL}?enterprise-id={self.enterprise_uuid}'
+        url = f'{PROVIDER_CONFIG_LIST_URL}?enterprise_customer_uuid={self.enterprise_uuid}'
         self.client.get(settings.TEST_SERVER + url)
 
         mock_saml_provider_config.objects.current_set.return_value.filter.assert_called_once_with(
@@ -66,7 +66,7 @@ class TestSAMLProviderConfigViewSet(APITest):
     def test_get_queryset_returns_404_when_no_idp(self, _mock_saml_provider_config, _mock_serializer_cls):
         nonexistent_uuid = str(uuid.uuid4())
         self.set_jwt_cookie(ENTERPRISE_ADMIN_ROLE, nonexistent_uuid)
-        url = f'{PROVIDER_CONFIG_LIST_URL}?enterprise-id={nonexistent_uuid}'
+        url = f'{PROVIDER_CONFIG_LIST_URL}?enterprise_customer_uuid={nonexistent_uuid}'
         response = self.client.get(settings.TEST_SERVER + url)
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
@@ -74,7 +74,7 @@ class TestSAMLProviderConfigViewSet(APITest):
     @patch('enterprise.api.v1.views.saml_provider_config.SAMLProviderConfig')
     def test_get_queryset_raises_parse_error_when_uuid_invalid(self, _mock_saml_provider_config, _mock_serializer_cls):
         self.set_jwt_cookie(ENTERPRISE_ADMIN_ROLE, ALL_ACCESS_CONTEXT)
-        url = f'{PROVIDER_CONFIG_LIST_URL}?enterprise-id=not-a-uuid'
+        url = f'{PROVIDER_CONFIG_LIST_URL}?enterprise_customer_uuid=not-a-uuid'
         response = self.client.get(settings.TEST_SERVER + url)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
@@ -93,7 +93,7 @@ class TestSAMLProviderConfigViewSet(APITest):
 
         detail_url = reverse('enterprise-saml-provider-config-detail', kwargs={'pk': 42})
         response = self.client.delete(
-            settings.TEST_SERVER + f'{detail_url}?enterprise-id=not-a-uuid'
+            settings.TEST_SERVER + f'{detail_url}?enterprise_customer_uuid=not-a-uuid'
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
@@ -181,7 +181,7 @@ class TestSAMLProviderConfigViewSet(APITest):
 
         detail_url = reverse('enterprise-saml-provider-config-detail', kwargs={'pk': 42})
         response = self.client.delete(
-            settings.TEST_SERVER + f'{detail_url}?enterprise-id={self.enterprise_uuid}'
+            settings.TEST_SERVER + f'{detail_url}?enterprise_customer_uuid={self.enterprise_uuid}'
         )
 
         assert response.status_code == status.HTTP_200_OK
@@ -210,6 +210,6 @@ class TestSAMLProviderConfigViewSet(APITest):
 
         detail_url = reverse('enterprise-saml-provider-config-detail', kwargs={'pk': 42})
         response = self.client.delete(
-            settings.TEST_SERVER + f'{detail_url}?enterprise-id={nonexistent_uuid}'
+            settings.TEST_SERVER + f'{detail_url}?enterprise_customer_uuid={nonexistent_uuid}'
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/tests/test_enterprise/api/test_saml_provider_data.py
+++ b/tests/test_enterprise/api/test_saml_provider_data.py
@@ -50,7 +50,7 @@ class TestSAMLProviderDataViewSet(APITest):
         mock_saml_provider_config.objects.current_set.return_value.get.return_value = mock_saml_provider
         mock_saml_provider_data.objects.filter.return_value = MockSet()
 
-        url = f'{PROVIDER_DATA_LIST_URL}?enterprise-id={self.enterprise_uuid}'
+        url = f'{PROVIDER_DATA_LIST_URL}?enterprise_customer_uuid={self.enterprise_uuid}'
         self.client.get(settings.TEST_SERVER + url)
 
         mock_saml_provider_config.objects.current_set.return_value.get.assert_called_once_with(slug='testslug')
@@ -81,7 +81,7 @@ class TestSAMLProviderDataViewSet(APITest):
         mock_saml_provider_data.objects.filter.return_value = MockSet(mock_data_obj)
 
         detail_url = reverse('enterprise-saml-provider-data-detail', kwargs={'pk': 5})
-        url = f'{detail_url}?enterprise-id={self.enterprise_uuid}'
+        url = f'{detail_url}?enterprise_customer_uuid={self.enterprise_uuid}'
         self.client.get(settings.TEST_SERVER + url)
 
         mock_saml_provider_data.objects.filter.assert_called_once_with(id='5', entity_id='http://test-entity')
@@ -103,7 +103,7 @@ class TestSAMLProviderDataViewSet(APITest):
     ):
         nonexistent_uuid = str(uuid.uuid4())
         self.set_jwt_cookie(ENTERPRISE_ADMIN_ROLE, nonexistent_uuid)
-        url = f'{PROVIDER_DATA_LIST_URL}?enterprise-id={nonexistent_uuid}'
+        url = f'{PROVIDER_DATA_LIST_URL}?enterprise_customer_uuid={nonexistent_uuid}'
         response = self.client.get(settings.TEST_SERVER + url)
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
@@ -123,7 +123,7 @@ class TestSAMLProviderDataViewSet(APITest):
             mock_saml_provider_config.DoesNotExist
         )
 
-        url = f'{PROVIDER_DATA_LIST_URL}?enterprise-id={self.enterprise_uuid}'
+        url = f'{PROVIDER_DATA_LIST_URL}?enterprise_customer_uuid={self.enterprise_uuid}'
         response = self.client.get(settings.TEST_SERVER + url)
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
@@ -134,7 +134,7 @@ class TestSAMLProviderDataViewSet(APITest):
         self, _mock_saml_provider_config, _mock_saml_provider_data, _mock_serializer_cls,
     ):
         self.set_jwt_cookie(ENTERPRISE_ADMIN_ROLE, ALL_ACCESS_CONTEXT)
-        url = f'{PROVIDER_DATA_LIST_URL}?enterprise-id=not-a-uuid'
+        url = f'{PROVIDER_DATA_LIST_URL}?enterprise_customer_uuid=not-a-uuid'
         response = self.client.get(settings.TEST_SERVER + url)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 


### PR DESCRIPTION
SAML views should accept "enterprise_customer_uuid", not "enterprise-id".

There was a typo in the original docstring which claimed the correct param name was "enterprise-id" which was over-indexed by Claude Code as a source of truth, causing it to recommend a behavior change when migrating the views.  I should have caught this, but I also saw the docstring myself and over-indexed on it.

The original docstring typo: https://github.com/openedx/openedx-platform/blob/01dc3c84/common/djangoapps/third_party_auth/samlproviderconfig/views.py#L33

The original code which I SHOULD have interpreted as source of truth: https://github.com/openedx/openedx-platform/blob/01dc3c84/common/djangoapps/third_party_auth/samlproviderconfig/views.py#L94

ENT-11567