### PR TITLE
feat: add ai pathways operator waffle flag

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,10 @@ Unreleased
 
 * nothing unreleased
 
+[8.0.2] - 2026-04-27
+---------------------
+* feat: add ai pathways operator waffle flag
+
 [8.0.1] - 2026-04-27
 ---------------------
 * feat: add DashboardContextEnricher pipeline step for student dashboard filter

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "8.0.1"
+__version__ = "8.0.2"

--- a/enterprise/toggles.py
+++ b/enterprise/toggles.py
@@ -116,6 +116,18 @@ INVITE_ADMINS_ENABLED = WaffleFlag(
     ENTERPRISE_LOG_PREFIX,
 )
 
+# .. toggle_name: enterprise.ai_pathways_operator_enabled
+# .. toggle_implementation: WaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Enables specific learners the ability to use the Xpert Platform API in production
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2026-04-28
+AI_PATHWAYS_OPERATOR_ENABLED = WaffleFlag(
+    f'{ENTERPRISE_NAMESPACE}.ai_pathways_operator_enabled',
+    __name__,
+    ENTERPRISE_LOG_PREFIX,
+)
+
 
 def top_down_assignment_real_time_lcm():
     """
@@ -180,6 +192,13 @@ def enterprise_invite_admins_enabled():
     return INVITE_ADMINS_ENABLED.is_enabled()
 
 
+def enterprise_ai_pathways_operator_enabled():
+    """
+    Returns whether the invite admins feature flag is enabled.
+    """
+    return AI_PATHWAYS_OPERATOR_ENABLED.is_enabled()
+
+
 def enterprise_features():
     """
     Returns a dict of enterprise Waffle-based feature flags.
@@ -194,4 +213,5 @@ def enterprise_features():
         'enterprise_admin_onboarding_enabled': enterprise_admin_onboarding_enabled(),
         'enterprise_edit_highlights_enabled': enterprise_edit_highlights_enabled(),
         'enterprise_invite_admins_enabled': enterprise_invite_admins_enabled(),
+        'enterprise_ai_pathways_operator_enabled': enterprise_ai_pathways_operator_enabled(),
     }

--- a/tests/test_enterprise/api/test_filters.py
+++ b/tests/test_enterprise/api/test_filters.py
@@ -309,6 +309,7 @@ class TestEnterpriseLinkedUserFilterBackend(APITest):
                     'enterprise_admin_onboarding_enabled': False,
                     'enterprise_edit_highlights_enabled': False,
                     'enterprise_invite_admins_enabled': False,
+                    'enterprise_ai_pathways_operator_enabled': False,
                 }
             }
             assert response == mock_empty_200_success_response

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -77,6 +77,7 @@ from enterprise.models import (
 from enterprise.roles_api import admin_role
 from enterprise.toggles import (
     ADMIN_PORTAL_LEARNER_PROFILE_VIEW_ENABLED,
+    AI_PATHWAYS_OPERATOR_ENABLED,
     CATALOG_QUERY_SEARCH_FILTERS_ENABLED,
     EDIT_HIGHLIGHTS_ENABLED,
     ENTERPRISE_ADMIN_ONBOARDING,
@@ -2061,62 +2062,62 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
     @ddt.data(
         # Request missing required permissions query param.
         (True, False, [], {}, False, {'detail': 'User is not allowed to access the view.'},
-         False, False, False, False, False, False, False, False, False),
+         False, False, False, False, False, False, False, False, False, False),
         # Staff user that does not have the specified group permission.
         (True, False, [], {'permissions': ['enterprise_enrollment_api_access']},
          False,
          {'detail': 'User is not allowed to access the view.'},
-         False, False, False, False, False, False, False, False, False),
+         False, False, False, False, False, False, False, False, False, False),
         # Staff user that does have the specified group permission.
         (True, False, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access']},
-         True, None, False, False, False, False, False, False, False, False, False),
+         True, None, False, False, False, False, False, False, False, False, False, False),
         # Non staff user that is not linked to the enterprise, nor do they have the group permission.
         (False, False, [], {'permissions': ['enterprise_enrollment_api_access']},
          False,
          {'detail': 'User is not allowed to access the view.'},
-         False, False, False, False, False, False, False, False, False),
+         False, False, False, False, False, False, False, False, False, False),
         # Non staff user that is not linked to the enterprise, but does have the group permission.
         (False, False, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access']},
-         False, None, False, False, False, False, False, False, False, False, False),
+         False, None, False, False, False, False, False, False, False, False, False, False),
         # Non staff user that is linked to the enterprise, but does not have the group permission.
         (False, True, [], {'permissions': ['enterprise_enrollment_api_access']},
          False,
          {'detail': 'User is not allowed to access the view.'},
-         False, False, False, False, False, False, False, False, False),
+         False, False, False, False, False, False, False, False, False, False),
         # Non staff user that is linked to the enterprise and does have the group permission
         (False, True, ['enterprise_enrollment_api_access'], {'permissions': ['enterprise_enrollment_api_access']},
-         True, None, False, False, False, False, False, False, False, False, False),
+         True, None, False, False, False, False, False, False, False, False, False, False),
         # Non staff user that is linked to the enterprise and has group permission and the request has passed
         # multiple groups to check.
         (False, True, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access', 'enterprise_data_api_access']}, True, None,
-         False, False, False, False, False, False, False, False, False),
+         False, False, False, False, False, False, False, False, False, False),
         # Staff user with group permission filtering on non existent enterprise id.
         (True, False, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access'], 'enterprise_id': FAKE_UUIDS[1]}, False,
-         None, False, False, False, False, False, False, False, False, False),
+         None, False, False, False, False, False, False, False, False, False, False),
         # Staff user with group permission filtering on enterprise id successfully.
         (True, False, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access'], 'enterprise_id': FAKE_UUIDS[0]}, True,
-         None, False, False, False, False, False, False, False, False, False),
+         None, False, False, False, False, False, False, False, False, False, False),
         # Staff user with group permission filtering on search param with no results.
         (True, False, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access'], 'search': 'blah'}, False,
-         None, False, False, False, False, False, False, False, False, False),
+         None, False, False, False, False, False, False, False, False, False, False),
         # Staff user with group permission filtering on search param with results.
         (True, False, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access'], 'search': 'test'}, True,
-         None, False, False, False, False, False, False, False, False, False),
+         None, False, False, False, False, False, False, False, False, False, False),
         # Staff user with group permission filtering on slug with results.
         (True, False, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access'], 'slug': TEST_SLUG}, True,
-         None, False, False, False, False, False, False, False, False, False),
+         None, False, False, False, False, False, False, False, False, False, False),
         # Staff user with group permissions filtering on slug with no results.
         (True, False, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access'], 'slug': 'blah'}, False,
-         None, False, False, False, False, False, False, False, False, False),
+         None, False, False, False, False, False, False, False, False, False, False),
         # Staff user with group permission filtering on slug with results, with
         # top down assignment & real-time LCM feature enabled,
         # prequery search results enabled
@@ -2125,9 +2126,10 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
         # admin portal learner profile view enabled
         # enterprise admin onboarding enabled
         # invite admins enabled
+        # ai pathways enabled
         (True, False, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access'], 'slug': TEST_SLUG}, True,
-         None, True, True, True, True, True, True, True, True, True),
+         None, True, True, True, True, True, True, True, True, True, True),
     )
     @ddt.unpack
     @mock.patch('enterprise.utils.get_logo_url')
@@ -2148,6 +2150,7 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
             enterprise_admin_onboarding_enabled,
             enterprise_edit_highlights_enabled,
             enterprise_invite_admins_enabled,
+            enterprise_ai_pathways_operator_enabled,
             mock_get_logo_url,
     ):
         """
@@ -2257,6 +2260,13 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
             response = client.get(
                 f"{settings.TEST_SERVER}{ENTERPRISE_CUSTOMER_WITH_ACCESS_TO_ENDPOINT}?{urlencode(query_params, True)}"
             )
+        with override_waffle_flag(
+            AI_PATHWAYS_OPERATOR_ENABLED,
+            active=enterprise_ai_pathways_operator_enabled
+        ):
+            response = client.get(
+                f"{settings.TEST_SERVER}{ENTERPRISE_CUSTOMER_WITH_ACCESS_TO_ENDPOINT}?{urlencode(query_params, True)}"
+            )
         response = self.load_json(response.content)
         if has_access_to_enterprise:
             assert response['results'][0] == {
@@ -2332,6 +2342,7 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
                     'enterprise_admin_onboarding_enabled': enterprise_admin_onboarding_enabled,
                     'enterprise_edit_highlights_enabled': enterprise_edit_highlights_enabled,
                     'enterprise_invite_admins_enabled': enterprise_invite_admins_enabled,
+                    'enterprise_ai_pathways_operator_enabled': enterprise_ai_pathways_operator_enabled,
                 }
             }
             assert response in (expected_error, mock_empty_200_success_response)


### PR DESCRIPTION
This pull request introduces a new Waffle flag to control access to the Xpert Platform API for specific learners and integrates it into the enterprise feature toggles. The main changes are the addition of the flag definition, a corresponding helper function, and its inclusion in the enterprise features dictionary.

New feature flag for Xpert Platform API:

* Added a new Waffle flag `enterprise.ai_pathways_operator_enabled` to enable or disable access to the Xpert Platform API for specific learners.
* Created the helper function `enterprise_ai_pathways_operator_enabled()` to check the status of the new feature flag.
* Included the new flag in the output of the `enterprise_features()` dictionary, making it available wherever enterprise feature toggles are consumed.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - Trigger the '[Upgrade one Python dependency](https://github.com/openedx/edx-platform/actions/workflows/upgrade-one-python-dependency.yml)' action against master in edx-platform with new version number to generate version bump PR
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
