### PR TITLE
fix: remove consent_required_courses and associated code

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,10 @@ Unreleased
 
 * nothing unreleased
 
+[8.0.3] - 2026-04-29
+---------------------
+* feat: adding the missing consent_required_courses injection
+
 [8.0.2] - 2026-04-27
 ---------------------
 * feat: add ai pathways operator waffle flag

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "8.0.2"
+__version__ = "8.0.3"

--- a/enterprise/filters/dashboard.py
+++ b/enterprise/filters/dashboard.py
@@ -23,8 +23,7 @@ class DashboardContextEnricher(PipelineStep):
     """
     Enrich the student dashboard context with enterprise-specific data.
 
-    Injects: enterprise_message, consent_required_courses, is_enterprise_user, and
-    enterprise learner portal context keys.
+    Injects: enterprise_message, is_enterprise_user, and enterprise learner portal context keys.
     """
 
     def run_filter(self, context: dict[str, Any], template_name: str) -> dict[str, Any]:  # pylint: disable=arguments-differ
@@ -33,7 +32,7 @@ class DashboardContextEnricher(PipelineStep):
         """
         request = context.get('request')
         user = context.get('user')
-        course_enrollments = context.get('course_enrollment_pairs', [])
+        course_enrollments = context.get('course_enrollments', [])
 
         if user is None:
             return {'context': context, 'template_name': template_name}

--- a/tests/filters/test_dashboard.py
+++ b/tests/filters/test_dashboard.py
@@ -51,7 +51,7 @@ class TestDashboardContextEnricher(TestCase):
         context = {
             'request': request,
             'user': user,
-            'course_enrollment_pairs': enrollments,
+            'course_enrollments': enrollments,
         }
         template_name = 'student/dashboard.html'
 
@@ -113,11 +113,11 @@ class TestDashboardContextEnricher(TestCase):
         return_value={'enterprise_portal_url': 'https://portal.example.com'},
     )
     @patch(_CONSENT_PATH, return_value='')
-    def test_uses_empty_list_when_course_enrollment_pairs_missing(
+    def test_uses_empty_list_when_course_enrollments_missing(
         self, mock_consent, _mock_portal, _mock_is_enterprise
     ):
         """
-        When course_enrollment_pairs is not in context, an empty list is passed to
+        When course_enrollments is not in context, an empty list is passed to
         get_dashboard_consent_notification.
         """
         request = self._make_request()
@@ -125,7 +125,7 @@ class TestDashboardContextEnricher(TestCase):
         context = {
             'request': request,
             'user': user,
-            # no 'course_enrollment_pairs' key
+            # no 'course_enrollments' key
         }
         template_name = 'student/dashboard.html'
 


### PR DESCRIPTION
Remove all references to conset_required_courses for cleanup

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - Trigger the '[Upgrade one Python dependency](https://github.com/openedx/edx-platform/actions/workflows/upgrade-one-python-dependency.yml)' action against master in edx-platform with new version number to generate version bump PR
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
