### PR TITLE
feat: grant enterprise_openedx_operator the manage admins permission [ENT-11806]

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,10 @@ Unreleased
 
 * nothing unreleased
 
+[8.0.4] - 2026-05-05
+---------------------
+* feat: extend manage enterprise customer admins permission to the enterprise_openedx_operator role
+
 [8.0.3] - 2026-04-29
 ---------------------
 * feat: adding the missing consent_required_courses injection

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "8.0.3"
+__version__ = "8.0.4"

--- a/enterprise/rules.py
+++ b/enterprise/rules.py
@@ -18,6 +18,7 @@ from enterprise.constants import (
     ENTERPRISE_DASHBOARD_ADMIN_ROLE,
     ENTERPRISE_ENROLLMENT_API_ADMIN_ROLE,
     ENTERPRISE_FULFILLMENT_OPERATOR_ROLE,
+    ENTERPRISE_OPERATOR_ROLE,
     ENTERPRISE_REPORTING_CONFIG_ADMIN_ROLE,
     ENTERPRISE_SSO_ORCHESTRATOR_OPERATOR_ROLE,
     MANAGE_ENTERPRISE_CUSTOMER_ADMINS_PERMISSION,
@@ -105,6 +106,33 @@ def has_implicit_access_to_enterprise_admin(user, obj):  # pylint: disable=unuse
     for role_data in decoded_jwt.get('roles', []):
         role, _, context = role_data.partition(':')
         if role == ENTERPRISE_ADMIN_ROLE and (context == str(obj) or context == ALL_ACCESS_CONTEXT):
+            return True
+    return False
+
+
+@rules.predicate
+def has_implicit_access_to_enterprise_operator(user, obj):  # pylint: disable=unused-argument
+    """
+    Check if a requesting user has the `ENTERPRISE_OPERATOR_ROLE` system-wide role in their JWT.
+
+    ``ENTERPRISE_OPERATOR_ROLE`` is a system role key in ``SYSTEM_TO_FEATURE_ROLE_MAPPING``,
+    not a feature role value, so we inspect the raw JWT ``roles`` claim directly. By convention
+    operators are all-access; a context of ``ALL_ACCESS_CONTEXT`` (or one matching ``obj``) grants access.
+
+    Params:
+        user: An ``auth.User`` instance.
+        obj: The string version of an ``EnterpriseCustomer.uuid``.
+
+    Returns:
+        boolean: whether the request user has access or not
+    """
+    request = crum.get_current_request()
+    decoded_jwt = get_decoded_jwt(request) or get_decoded_jwt_from_auth(request)
+    if not decoded_jwt:
+        return False
+    for role_data in decoded_jwt.get('roles', []):
+        role, _, context = role_data.partition(':')
+        if role == ENTERPRISE_OPERATOR_ROLE and (context == str(obj) or context == ALL_ACCESS_CONTEXT):
             return True
     return False
 
@@ -322,7 +350,8 @@ rules.add_perm(
 rules.add_perm(
     MANAGE_ENTERPRISE_CUSTOMER_ADMINS_PERMISSION,
     has_implicit_access_to_provisioning_enterprise_customers
-    | has_implicit_access_to_enterprise_admin,
+    | has_implicit_access_to_enterprise_admin
+    | has_implicit_access_to_enterprise_operator,
 )
 
 rules.add_perm(

--- a/tests/test_enterprise/api/test_enterprise_customer_admin.py
+++ b/tests/test_enterprise/api/test_enterprise_customer_admin.py
@@ -737,7 +737,6 @@ class TestDeleteAdminEndpoint(APITest):
     @ddt.data(
         ENTERPRISE_DASHBOARD_ADMIN_ROLE,
         ENTERPRISE_LEARNER_ROLE,
-        ENTERPRISE_OPERATOR_ROLE,
         SYSTEM_ENTERPRISE_CATALOG_ADMIN_ROLE,
     )
     def test_delete_admin_forbidden_roles(self, role):
@@ -1230,7 +1229,6 @@ class TestDeleteAdminEndpoint(APITest):
     @ddt.data(
         ENTERPRISE_DASHBOARD_ADMIN_ROLE,
         ENTERPRISE_LEARNER_ROLE,
-        ENTERPRISE_OPERATOR_ROLE,
         SYSTEM_ENTERPRISE_CATALOG_ADMIN_ROLE,
     )
     def test_delete_pending_admin_forbidden_roles(self, role):
@@ -1419,7 +1417,6 @@ class TestInviteAdminsEndpoint(APITest):
     @ddt.data(
         ENTERPRISE_DASHBOARD_ADMIN_ROLE,
         ENTERPRISE_LEARNER_ROLE,
-        ENTERPRISE_OPERATOR_ROLE,
         SYSTEM_ENTERPRISE_CATALOG_ADMIN_ROLE,
     )
     def test_invite_admins_forbidden_roles(self, role):

--- a/tests/test_enterprise/test_rules.py
+++ b/tests/test_enterprise/test_rules.py
@@ -72,6 +72,7 @@ class TestEnterpriseRBACPermissions(APITest):
     @mock.patch('enterprise.rules.crum.get_current_request')
     @ddt.data(
         ENTERPRISE_ADMIN_ROLE,
+        ENTERPRISE_OPERATOR_ROLE,
         SYSTEM_ENTERPRISE_PROVISIONING_ADMIN_ROLE,
     )
     def test_manage_enterprise_customer_admins_has_implicit_access(self, enterprise_role, get_current_request_mock):
@@ -81,7 +82,7 @@ class TestEnterpriseRBACPermissions(APITest):
     @mock.patch('enterprise.rules.crum.get_current_request')
     @ddt.data(
         ENTERPRISE_DASHBOARD_ADMIN_ROLE,
-        ENTERPRISE_OPERATOR_ROLE,
+        ENTERPRISE_LEARNER_ROLE,
     )
     def test_manage_enterprise_customer_admins_access_denied(self, enterprise_role, get_current_request_mock):
         get_current_request_mock.return_value = self.get_request_with_jwt_cookie(enterprise_role, TEST_UUID)


### PR DESCRIPTION
## Ticket
[ENT-11806](https://2u-internal.atlassian.net/browse/ENT-11806) — `[BE] Expand permissions to "invite admin" functionality to the enterprise_openedx_operator role and enterprise_admin`

## Summary
Extends the `MANAGE_ENTERPRISE_CUSTOMER_ADMINS_PERMISSION` rule to also recognize the `enterprise_openedx_operator` system role. With this change, users holding that role can invite and delete enterprise admins on the endpoints that already require this permission:

- `POST` invite_admins
- `DELETE` delete_admin
- `DELETE` delete_pending_admin
- `pending-enterprise-customer-admin-user` viewset

The `enterprise_admin` role (with `applies_to_all_contexts == true`) was already wired to this permission via the previously merged `has_implicit_access_to_enterprise_admin` predicate, so no change was needed there.

## Implementation notes
`enterprise_openedx_operator` is a **system role** (not a feature role), so the standard `request_user_has_implicit_access_via_jwt` helper — which only matches roles listed in `SYSTEM_TO_FEATURE_ROLE_MAPPING` — does not work for it. The new `has_implicit_access_to_enterprise_operator` predicate inspects the raw JWT `roles` claim directly, the same pattern used for other operator/provisioning predicates in this module. It honors the `ALL_ACCESS_CONTEXT` (`*`) wildcard.

## Files changed (3)
- `enterprise/rules.py` — new predicate; OR'd into the existing MANAGE permission
- `tests/test_enterprise/test_rules.py` — moves `ENTERPRISE_OPERATOR_ROLE` from access-denied to implicit-access ddt block
- `tests/test_enterprise/api/test_enterprise_customer_admin.py` — drops operator from `forbidden_roles` ddt for invite_admins / delete_admin / delete_pending_admin

## Test plan
- [x] `pytest tests/test_enterprise/test_rules.py` — passes
- [x] `pytest tests/test_enterprise/api/test_enterprise_customer_admin.py` — passes (104 tests)
- [x] `isort` + `pycodestyle` + `pylint` clean on modified files
postman test
<img width="1293" height="796" alt="image" src="https://github.com/user-attachments/assets/ee436936-7d09-458c-a1e2-b78fed02bd3c" />
<img width="1312" height="750" alt="image" src="https://github.com/user-attachments/assets/3ffacd66-56a4-4135-aa1a-c58a57f71ecd" />
<img width="1259" height="830" alt="image" src="https://github.com/user-attachments/assets/767a86cc-6214-4615-9c0c-95807a390e5c" />
<img width="1308" height="789" alt="image" src="https://github.com/user-attachments/assets/302704ed-26bc-4a52-a6ab-5262d7373291" />
<img width="1228" height="808" alt="image" src="https://github.com/user-attachments/assets/ada03907-86f2-4e7a-aaf9-33f34e395d5f" />
