### PR TITLE
feat: add search_default_sort_newest waffle flag (ENT-11384)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[7.0.1] - 2026-06-11
+---------------------
+* feat: add the ``enterprise.search_default_sort_newest`` waffle flag, surfaced via ``enterprise_features``, to gate the Learner Portal "newest courses first" search sort (ENT-11384).
+
 [7.0.0] - 2026-04-07
 ---------------------
 * chore: drop Python 3.11 support

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "7.0.0"
+__version__ = "7.0.1"

--- a/enterprise/toggles.py
+++ b/enterprise/toggles.py
@@ -116,6 +116,18 @@ INVITE_ADMINS_ENABLED = WaffleFlag(
     ENTERPRISE_LOG_PREFIX,
 )
 
+# .. toggle_name: enterprise.search_default_sort_newest
+# .. toggle_implementation: WaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Makes the enterprise Learner Portal search default to a "newest courses first" sort (a sorted Algolia replica). Used as the eligibility gate / kill-switch for the newest-first sort A/B experiment.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2026-06-11
+SEARCH_DEFAULT_SORT_NEWEST = WaffleFlag(
+    f'{ENTERPRISE_NAMESPACE}.search_default_sort_newest',
+    __name__,
+    ENTERPRISE_LOG_PREFIX,
+)
+
 
 def top_down_assignment_real_time_lcm():
     """
@@ -180,6 +192,13 @@ def enterprise_invite_admins_enabled():
     return INVITE_ADMINS_ENABLED.is_enabled()
 
 
+def search_default_sort_newest_enabled():
+    """
+    Returns whether the "newest courses first" default search sort is enabled.
+    """
+    return SEARCH_DEFAULT_SORT_NEWEST.is_enabled()
+
+
 def enterprise_features():
     """
     Returns a dict of enterprise Waffle-based feature flags.
@@ -194,4 +213,5 @@ def enterprise_features():
         'enterprise_admin_onboarding_enabled': enterprise_admin_onboarding_enabled(),
         'enterprise_edit_highlights_enabled': enterprise_edit_highlights_enabled(),
         'enterprise_invite_admins_enabled': enterprise_invite_admins_enabled(),
+        'search_default_sort_newest_enabled': search_default_sort_newest_enabled(),
     }

--- a/tests/test_enterprise/api/test_filters.py
+++ b/tests/test_enterprise/api/test_filters.py
@@ -309,6 +309,7 @@ class TestEnterpriseLinkedUserFilterBackend(APITest):
                     'enterprise_admin_onboarding_enabled': False,
                     'enterprise_edit_highlights_enabled': False,
                     'enterprise_invite_admins_enabled': False,
+                    'search_default_sort_newest_enabled': False,
                 }
             }
             assert response == mock_empty_200_success_response

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -2332,6 +2332,7 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
                     'enterprise_admin_onboarding_enabled': enterprise_admin_onboarding_enabled,
                     'enterprise_edit_highlights_enabled': enterprise_edit_highlights_enabled,
                     'enterprise_invite_admins_enabled': enterprise_invite_admins_enabled,
+                    'search_default_sort_newest_enabled': False,
                 }
             }
             assert response in (expected_error, mock_empty_200_success_response)


### PR DESCRIPTION
## What
Adds the `enterprise.search_default_sort_newest` waffle flag, surfaced via `enterprise_features`, to gate the Learner Portal "newest courses first" search sort. This is the **eligibility gate / kill-switch** for the Optimizely A/B experiment.

- `SEARCH_DEFAULT_SORT_NEWEST` WaffleFlag + `search_default_sort_newest_enabled()` helper + entry in `enterprise_features()` (`enterprise/toggles.py`).
- Updated the two exact-match `enterprise_features` test fixtures (`test_views.py`, `test_filters.py`).
- Version bump 7.0.0 → 7.0.1 + CHANGELOG entry.

## Testing
The two affected tests pass in an isolated venv (pinned Django 5.2.12): `TestEnterpriseCustomerViewSet::test_enterprise_customer_with_access_to` (15 passed) and `TestEnterpriseLinkedUserFilterBackend::test_filter` (4 passed).

## Related (rollout order)
1. enterprise-catalog recency replica → https://github.com/edx/enterprise-catalog/pull/118
2. **this PR** (waffle flag)
3. frontend-app-learner-portal-enterprise index swap + Optimizely experiment

ENT-11384.

🤖 Generated with [Claude Code](https://claude.com/claude-code)