### PR TITLE
feat: add enterprise.use_algolia_index_v2 waffle flag

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[8.3.0] - 2026-06-30
+---------------------
+* feat: add enterprise.use_algolia_index_v2 waffle flag and expose it in the enterprise_features API response
+
 [8.2.0] - 2026-06-22
 ---------------------
 * feat: add DiscountEligibilityStep pipeline step

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "8.2.0"
+__version__ = "8.3.0"

--- a/enterprise/api_client/xpert_ai.py
+++ b/enterprise/api_client/xpert_ai.py
@@ -28,7 +28,7 @@ def chat_completion(prompt, role):
     }
 
     body = {
-        'messages': [{'role': role, 'content': prompt},],
+        'messages': [{'role': role, 'content': prompt}],
         'client_id': settings.ENTERPRISE_ANALYSIS_CLIENT_ID,
         'system_message': settings.ENTERPRISE_ANALYSIS_SYSTEM_PROMPT
     }

--- a/enterprise/toggles.py
+++ b/enterprise/toggles.py
@@ -116,6 +116,18 @@ AI_PATHWAYS_OPERATOR_ENABLED = WaffleFlag(
     ENTERPRISE_LOG_PREFIX,
 )
 
+# .. toggle_name: enterprise.use_algolia_index_v2
+# .. toggle_implementation: WaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Use the v2 Algolia index for enterprise search
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2026-06-30
+USE_ALGOLIA_INDEX_V2 = WaffleFlag(
+    f'{ENTERPRISE_NAMESPACE}.use_algolia_index_v2',
+    __name__,
+    ENTERPRISE_LOG_PREFIX,
+)
+
 
 def top_down_assignment_real_time_lcm():
     """
@@ -180,6 +192,13 @@ def enterprise_ai_pathways_operator_enabled():
     return AI_PATHWAYS_OPERATOR_ENABLED.is_enabled()
 
 
+def use_algolia_index_v2():
+    """
+    Returns whether the v2 Algolia index should be used.
+    """
+    return USE_ALGOLIA_INDEX_V2.is_enabled()
+
+
 def enterprise_features():
     """
     Returns a dict of enterprise Waffle-based feature flags.
@@ -194,4 +213,5 @@ def enterprise_features():
         'enterprise_admin_onboarding_enabled': enterprise_admin_onboarding_enabled(),
         'enterprise_edit_highlights_enabled': enterprise_edit_highlights_enabled(),
         'enterprise_ai_pathways_operator_enabled': enterprise_ai_pathways_operator_enabled(),
+        'use_algolia_index_v2': use_algolia_index_v2(),
     }

--- a/tests/test_enterprise/api/test_filters.py
+++ b/tests/test_enterprise/api/test_filters.py
@@ -309,6 +309,7 @@ class TestEnterpriseLinkedUserFilterBackend(APITest):
                     'enterprise_admin_onboarding_enabled': False,
                     'enterprise_edit_highlights_enabled': False,
                     'enterprise_ai_pathways_operator_enabled': False,
+                    'use_algolia_index_v2': False,
                 }
             }
             assert response == mock_empty_200_success_response

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -85,6 +85,7 @@ from enterprise.toggles import (
     ENTERPRISE_LEARNER_BFF_ENABLED,
     FEATURE_PREQUERY_SEARCH_SUGGESTIONS,
     TOP_DOWN_ASSIGNMENT_REAL_TIME_LCM,
+    USE_ALGOLIA_INDEX_V2,
 )
 from enterprise.utils import (
     NotConnectedToOpenEdX,
@@ -2072,62 +2073,62 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
     @ddt.data(
         # Request missing required permissions query param.
         (True, False, [], {}, False, {'detail': 'User is not allowed to access the view.'},
-         False, False, False, False, False, False, False, False, False),
+         False, False, False, False, False, False, False, False, False, False),
         # Staff user that does not have the specified group permission.
         (True, False, [], {'permissions': ['enterprise_enrollment_api_access']},
          False,
          {'detail': 'User is not allowed to access the view.'},
-         False, False, False, False, False, False, False, False, False),
+         False, False, False, False, False, False, False, False, False, False),
         # Staff user that does have the specified group permission.
         (True, False, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access']},
-         True, None, False, False, False, False, False, False, False, False, False),
+         True, None, False, False, False, False, False, False, False, False, False, False),
         # Non staff user that is not linked to the enterprise, nor do they have the group permission.
         (False, False, [], {'permissions': ['enterprise_enrollment_api_access']},
          False,
          {'detail': 'User is not allowed to access the view.'},
-         False, False, False, False, False, False, False, False, False),
+         False, False, False, False, False, False, False, False, False, False),
         # Non staff user that is not linked to the enterprise, but does have the group permission.
         (False, False, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access']},
-         False, None, False, False, False, False, False, False, False, False, False),
+         False, None, False, False, False, False, False, False, False, False, False, False),
         # Non staff user that is linked to the enterprise, but does not have the group permission.
         (False, True, [], {'permissions': ['enterprise_enrollment_api_access']},
          False,
          {'detail': 'User is not allowed to access the view.'},
-         False, False, False, False, False, False, False, False, False),
+         False, False, False, False, False, False, False, False, False, False),
         # Non staff user that is linked to the enterprise and does have the group permission
         (False, True, ['enterprise_enrollment_api_access'], {'permissions': ['enterprise_enrollment_api_access']},
-         True, None, False, False, False, False, False, False, False, False, False),
+         True, None, False, False, False, False, False, False, False, False, False, False),
         # Non staff user that is linked to the enterprise and has group permission and the request has passed
         # multiple groups to check.
         (False, True, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access', 'enterprise_data_api_access']}, True, None,
-         False, False, False, False, False, False, False, False, False),
+         False, False, False, False, False, False, False, False, False, False),
         # Staff user with group permission filtering on non existent enterprise id.
         (True, False, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access'], 'enterprise_id': FAKE_UUIDS[1]}, False,
-         None, False, False, False, False, False, False, False, False, False),
+         None, False, False, False, False, False, False, False, False, False, False),
         # Staff user with group permission filtering on enterprise id successfully.
         (True, False, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access'], 'enterprise_id': FAKE_UUIDS[0]}, True,
-         None, False, False, False, False, False, False, False, False, False),
+         None, False, False, False, False, False, False, False, False, False, False),
         # Staff user with group permission filtering on search param with no results.
         (True, False, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access'], 'search': 'blah'}, False,
-         None, False, False, False, False, False, False, False, False, False),
+         None, False, False, False, False, False, False, False, False, False, False),
         # Staff user with group permission filtering on search param with results.
         (True, False, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access'], 'search': 'test'}, True,
-         None, False, False, False, False, False, False, False, False, False),
+         None, False, False, False, False, False, False, False, False, False, False),
         # Staff user with group permission filtering on slug with results.
         (True, False, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access'], 'slug': TEST_SLUG}, True,
-         None, False, False, False, False, False, False, False, False, False),
+         None, False, False, False, False, False, False, False, False, False, False),
         # Staff user with group permissions filtering on slug with no results.
         (True, False, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access'], 'slug': 'blah'}, False,
-         None, False, False, False, False, False, False, False, False, False),
+         None, False, False, False, False, False, False, False, False, False, False),
         # Staff user with group permission filtering on slug with results, with
         # top down assignment & real-time LCM feature enabled,
         # prequery search results enabled
@@ -2136,9 +2137,10 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
         # admin portal learner profile view enabled
         # enterprise admin onboarding enabled
         # ai pathways enabled
+        # use_algolia_index_v2 enabled
         (True, False, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access'], 'slug': TEST_SLUG}, True,
-         None, True, True, True, True, True, True, True, True, True),
+         None, True, True, True, True, True, True, True, True, True, True),
     )
     @ddt.unpack
     @mock.patch('enterprise.utils.get_logo_url')
@@ -2159,6 +2161,7 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
             enterprise_admin_onboarding_enabled,
             enterprise_edit_highlights_enabled,
             enterprise_ai_pathways_operator_enabled,
+            use_algolia_index_v2_enabled,
             mock_get_logo_url,
     ):
         """
@@ -2268,6 +2271,13 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
             response = client.get(
                 f"{settings.TEST_SERVER}{ENTERPRISE_CUSTOMER_WITH_ACCESS_TO_ENDPOINT}?{urlencode(query_params, True)}"
             )
+        with override_waffle_flag(
+            USE_ALGOLIA_INDEX_V2,
+            active=use_algolia_index_v2_enabled
+        ):
+            response = client.get(
+                f"{settings.TEST_SERVER}{ENTERPRISE_CUSTOMER_WITH_ACCESS_TO_ENDPOINT}?{urlencode(query_params, True)}"
+            )
         response = self.load_json(response.content)
         if has_access_to_enterprise:
             assert response['results'][0] == {
@@ -2344,6 +2354,7 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
                     'enterprise_admin_onboarding_enabled': enterprise_admin_onboarding_enabled,
                     'enterprise_edit_highlights_enabled': enterprise_edit_highlights_enabled,
                     'enterprise_ai_pathways_operator_enabled': enterprise_ai_pathways_operator_enabled,
+                    'use_algolia_index_v2': use_algolia_index_v2_enabled,
                 }
             }
             assert response in (expected_error, mock_empty_200_success_response)

--- a/tests/test_enterprise/test_toggles.py
+++ b/tests/test_enterprise/test_toggles.py
@@ -1,0 +1,19 @@
+"""
+Tests for enterprise/toggles.py.
+"""
+import ddt
+from edx_toggles.toggles.testutils import override_waffle_flag
+
+from django.test import TestCase
+
+from enterprise.toggles import USE_ALGOLIA_INDEX_V2, enterprise_features
+
+
+@ddt.ddt
+class TestEnterpriseFeatures(TestCase):
+    """Tests for enterprise_features()."""
+
+    @ddt.data(True, False)
+    def test_use_algolia_index_v2(self, active):
+        with override_waffle_flag(USE_ALGOLIA_INDEX_V2, active=active):
+            assert enterprise_features()['use_algolia_index_v2'] is active


### PR DESCRIPTION
## Summary

- Adds `USE_ALGOLIA_INDEX_V2` WaffleFlag (`enterprise.use_algolia_index_v2`, default `False`) to `enterprise/toggles.py`
- Exposes it as `use_algolia_index_v2` in the `enterprise_features()` response dict
- Adds `tests/test_enterprise/test_toggles.py` with a `@ddt.data(True, False)` test covering both flag states

## Manual Testing screenshots
<img width="1251" height="769" alt="image" src="https://github.com/user-attachments/assets/7a47f7c1-f204-46f8-8cb8-7e366750ee06" />
<img width="960" height="675" alt="image" src="https://github.com/user-attachments/assets/1fb003f8-e15e-479b-9fb7-ab54a85aaaec" />
