### PR TITLE
fix: hard delete EnterpriseGroup records instead of soft deleting them (ENT-12073)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[8.7.1] - 2026-07-17
+---------------------
+* fix: hard delete EnterpriseGroup records instead of soft deleting them (ENT-12073)
+
 [8.7.0] - 2026-07-16
 ---------------------
 * feat: add CalculateEnterpriseDiscountedPrice pipeline step

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "8.7.0"
+__version__ = "8.7.1"

--- a/enterprise/admin/__init__.py
+++ b/enterprise/admin/__init__.py
@@ -1263,6 +1263,28 @@ class EnterpriseGroupAdmin(admin.ModelAdmin):
 
     autocomplete_fields = ['enterprise_customer']
 
+    def delete_queryset(self, request, queryset):
+        """
+        Hard delete each selected group individually via the model's overridden
+        ``delete()``. Bulk queryset deletes bypass instance-level overrides and
+        would otherwise soft-delete via ``SoftDeletableQuerySet.delete()``.
+        """
+        for group in queryset:
+            group.delete()
+
+    def save_model(self, request, obj, form, change):
+        """
+        Purge any legacy soft-deleted group with this name/customer before saving,
+        so groups created via the Django admin self-heal the same way the group
+        creation API does, instead of hitting a raw unique-constraint IntegrityError.
+        """
+        if not change:
+            models.EnterpriseGroup.purge_legacy_soft_deleted(
+                name=obj.name,
+                enterprise_customer=obj.enterprise_customer_id,
+            )
+        super().save_model(request, obj, form, change)
+
     def members(self, obj):
         """
         Return the non-deleted members of a group

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -815,7 +815,7 @@ class EnterpriseGroupSerializer(serializers.ModelSerializer):
             'accepted_members_count', 'group_type', 'created')
         validators = [
             UniqueTogetherValidator(
-                queryset=models.EnterpriseGroup.all_objects.all(),
+                queryset=models.EnterpriseGroup.objects.all(),
                 fields=('name', 'enterprise_customer'),
                 message='A group with this name already exists. Please enter a unique name to create a new group.',
             )

--- a/enterprise/api/v1/views/enterprise_group.py
+++ b/enterprise/api/v1/views/enterprise_group.py
@@ -126,6 +126,11 @@ class EnterpriseGroupViewSet(EnterpriseReadWriteModelViewSet):
     def update(self, request, *args, **kwargs):
         """
         PATCH /enterprise/api/v1/enterprise-group/<group uuid>
+
+        If renaming to a name that collides with a legacy soft-deleted group
+        (same enterprise_customer), that legacy row is purged first so the
+        rename doesn't hit the unique_together constraint. See
+        ``EnterpriseGroup.purge_legacy_soft_deleted`` for details.
         """
         if requested_customer := self.request.data.get('enterprise_customer'):
             # Essentially checking ``enterprise.can_access_admin_dashboard`` but for the customer the requester is
@@ -134,6 +139,9 @@ class EnterpriseGroupViewSet(EnterpriseReadWriteModelViewSet):
             explicit_access = rules.has_explicit_access_to_dashboard(self.request.user, requested_customer)
             if not implicit_access and not explicit_access:
                 return Response('Unauthorized', status=401)
+        if name := request.data.get('name'):
+            enterprise_customer = requested_customer or self.get_object().enterprise_customer_id
+            models.EnterpriseGroup.purge_legacy_soft_deleted(name=name, enterprise_customer=enterprise_customer)
         return super().update(request, *args, **kwargs)
 
     @permission_required(
@@ -143,7 +151,23 @@ class EnterpriseGroupViewSet(EnterpriseReadWriteModelViewSet):
     def create(self, request, *args, **kwargs):
         """
         POST /enterprise/api/v1/enterprise-group/
+
+        If a legacy soft-deleted group with the same name and enterprise_customer
+        exists, it is hard-deleted before the new record is created so it doesn't
+        collide with the unique_together constraint. Active groups with the same
+        name are left untouched and continue to be rejected as duplicates.
+
+        Unlike ``DefaultEnterpriseEnrollmentIntention.clean()``, which blocks
+        creation and points admins to restore a soft-deleted record, these legacy
+        rows only exist due to a past bug (groups used to be soft-deleted) and
+        aren't something a customer would want restored, and group admins have no
+        access to the Django admin to do so. Auto-deleting them here is what makes
+        the original bug report self-heal instead of requiring manual cleanup.
         """
+        models.EnterpriseGroup.purge_legacy_soft_deleted(
+            name=request.data.get('name'),
+            enterprise_customer=request.data.get('enterprise_customer'),
+        )
         return super().create(request, *args, **kwargs)
 
     @action(methods=['patch'], detail=False, permission_classes=[permissions.IsAuthenticated])

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -4773,6 +4773,47 @@ class EnterpriseGroup(TimeStampedModel, SoftDeletableModel):
         unique_together = (("name", "enterprise_customer"),)
         ordering = ['-modified']
 
+    def delete(self, *args, **kwargs):
+        """
+        Hard delete groups instead of the default soft delete, relying on
+        django-simple-history (``self.history``) for the audit trail.
+        """
+        # Always hard delete, even if a caller explicitly passes soft=True.
+        kwargs['soft'] = False
+        super().delete(*args, **kwargs)
+
+    @classmethod
+    def purge_legacy_soft_deleted(cls, name, enterprise_customer):
+        """
+        Hard delete any legacy soft-deleted group with the given name and
+        enterprise_customer, so it doesn't collide with the unique_together
+        constraint when a new group with the same name is created.
+
+        Groups used to be soft-deleted, leaving rows behind that can conflict
+        with this constraint even though they're not visible in the admin or
+        API by default. Used by both the group creation API and the Django
+        admin, since bulk queryset deletes and the admin "Add" form don't go
+        through the model-level hard delete on their own.
+
+        Silently no-ops on a malformed ``enterprise_customer`` (e.g. not a
+        valid UUID), leaving normal field validation to surface that error.
+        """
+        try:
+            existing = cls.all_objects.filter(
+                name=name,
+                enterprise_customer=enterprise_customer,
+                is_removed=True,
+            )
+            deleted_count, _ = existing.delete()
+            if deleted_count:
+                LOGGER.info(
+                    'Hard-deleted %d legacy soft-deleted EnterpriseGroup record(s) with name "%s" '
+                    'for enterprise_customer %s before creating a new one.',
+                    deleted_count, name, enterprise_customer,
+                )
+        except (ValidationError, ValueError):
+            pass
+
     def _get_filtered_ecu_ids(self, user_query):
         """
         Filter a group's enterprise customer user members by their User email.

--- a/tests/test_admin/test_admin.py
+++ b/tests/test_admin/test_admin.py
@@ -6,8 +6,8 @@ from django.db import connection
 from django.test import RequestFactory, TestCase
 from django.test.utils import CaptureQueriesContext
 
-from enterprise.admin import EnterpriseGroupMembershipAdmin
-from enterprise.models import EnterpriseGroupMembership
+from enterprise.admin import EnterpriseGroupAdmin, EnterpriseGroupMembershipAdmin
+from enterprise.models import EnterpriseGroup, EnterpriseGroupMembership
 from integrated_channels.integrated_channel.admin import IntegratedChannelAPIRequestLogAdmin
 from integrated_channels.integrated_channel.models import IntegratedChannelAPIRequestLogs
 from test_utils import factories
@@ -123,3 +123,59 @@ class EnterpriseGroupMembershipAdminTest(TestCase):
         self.assertEqual(len(results), 2)
         # is_removed value should differ between the two results
         self.assertNotEqual(results[0].is_removed, results[1].is_removed)
+
+
+class EnterpriseGroupAdminTest(TestCase):
+    """
+    Test the admin functionality for the EnterpriseGroup model.
+    """
+
+    def setUp(self):
+        """
+        Set up the test environment by creating a test admin instance and sample data.
+        """
+        self.site = AdminSite()
+        self.admin = EnterpriseGroupAdmin(EnterpriseGroup, self.site)
+
+    def test_delete_queryset_hard_deletes(self):
+        """
+        Test that the admin's bulk "Delete selected" action hard deletes groups,
+        instead of soft deleting them via the default bulk queryset delete.
+        """
+        group_1 = factories.EnterpriseGroupFactory()
+        group_2 = factories.EnterpriseGroupFactory()
+        queryset = EnterpriseGroup.objects.filter(uuid__in=[group_1.uuid, group_2.uuid])
+
+        self.admin.delete_queryset(RequestFactory().get("/"), queryset)
+
+        self.assertEqual(EnterpriseGroup.all_objects.filter(uuid__in=[group_1.uuid, group_2.uuid]).count(), 0)
+
+    def test_save_model_purges_legacy_soft_deleted_group_on_create(self):
+        """
+        Test that saving a new group via the admin purges any legacy soft-deleted
+        group with the same name/customer, so it doesn't hit a raw IntegrityError.
+        """
+        legacy_group = factories.EnterpriseGroupFactory(name='foobar')
+        legacy_group.is_removed = True
+        legacy_group.save()
+
+        new_group = EnterpriseGroup(name='foobar', enterprise_customer=legacy_group.enterprise_customer)
+        self.admin.save_model(RequestFactory().get("/"), new_group, form=None, change=False)
+
+        self.assertEqual(EnterpriseGroup.all_objects.filter(name='foobar', is_removed=True).count(), 0)
+        self.assertEqual(EnterpriseGroup.objects.filter(name='foobar', uuid=new_group.uuid).count(), 1)
+
+    def test_save_model_does_not_purge_on_change(self):
+        """
+        Test that editing an existing group via the admin does not run the legacy
+        soft-deleted group purge, since that's only relevant on creation.
+        """
+        legacy_group = factories.EnterpriseGroupFactory(name='foobar')
+        legacy_group.is_removed = True
+        legacy_group.save()
+
+        existing_group = factories.EnterpriseGroupFactory(name='existing-group')
+        existing_group.name = 'renamed-group'
+        self.admin.save_model(RequestFactory().get("/"), existing_group, form=None, change=True)
+
+        self.assertEqual(EnterpriseGroup.all_objects.filter(name='foobar', is_removed=True).count(), 1)

--- a/tests/test_enterprise/api/test_serializers.py
+++ b/tests/test_enterprise/api/test_serializers.py
@@ -223,8 +223,8 @@ class TestEnterpriseGroupSerializer(APITest):
         assert not serializer.is_valid()
         assert serializer.errors.get('non_field_errors') == [self.duplicate_name_error]
 
-    def test_deleted_duplicate_group_name_returns_custom_error_message(self):
-        """Ensure soft-deleted duplicate group names are also blocked with the same validation message."""
+    def test_deleted_duplicate_group_name_is_allowed(self):
+        """Groups are hard deleted, so a deleted group's name no longer blocks creating a new one."""
         group = factories.EnterpriseGroupFactory(
             enterprise_customer=self.enterprise_customer,
             name=self.group_name,
@@ -232,8 +232,7 @@ class TestEnterpriseGroupSerializer(APITest):
         group.delete()
 
         serializer = self._serialize_group()
-        assert not serializer.is_valid()
-        assert serializer.errors.get('non_field_errors') == [self.duplicate_name_error]
+        assert serializer.is_valid()
 
 
 @mark.django_db

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -8755,14 +8755,13 @@ class TestEnterpriseGroupViewSet(APITest):
         response = self.client.get(url + random_enterprise_query_param)
         assert not response.json().get('results')
 
+        # groups are hard deleted, so the deleted group and its cascaded membership no longer exist
         new_group.delete()
-        new_membership.delete()
         enterprise_unfiltered_response = self.client.get(url)
         assert len(enterprise_unfiltered_response.json().get('results')) == 0
         enterprise_query_param = "?include_deleted=true"
         enterprise_filtered_response = self.client.get(url + enterprise_query_param)
-        assert len(enterprise_filtered_response.json().get('results')) == 1
-        assert learner_filtered_response.json().get('results')[0].get('uuid') == str(new_group.uuid)
+        assert len(enterprise_filtered_response.json().get('results')) == 0
 
     def test_successful_post_group(self):
         """
@@ -8784,6 +8783,66 @@ class TestEnterpriseGroupViewSet(APITest):
         response = self.client.post(url, data=request_data)
         assert response.json().get('name') == 'foobar'
         assert len(EnterpriseGroup.objects.filter(name='foobar')) == 1
+
+    def test_post_group_cleans_up_legacy_soft_deleted_group(self):
+        """
+        Test that creating a group purges any legacy soft-deleted group of the same
+        name/customer, so it doesn't collide with the unique_together constraint.
+        """
+        url = settings.TEST_SERVER + reverse('enterprise-group-list')
+        new_customer = EnterpriseCustomerFactory()
+        legacy_group = EnterpriseGroupFactory(enterprise_customer=new_customer, name='foobar')
+        legacy_group.is_removed = True
+        legacy_group.save()
+        assert EnterpriseGroup.all_objects.filter(name='foobar', is_removed=True).count() == 1
+
+        request_data = {
+            'enterprise_customer': str(new_customer.uuid),
+            'name': 'foobar',
+        }
+        self.set_jwt_cookie(ENTERPRISE_ADMIN_ROLE, new_customer.pk)
+        response = self.client.post(url, data=request_data)
+        assert response.status_code == 201
+        assert EnterpriseGroup.all_objects.filter(name='foobar', is_removed=True).count() == 0
+        assert EnterpriseGroup.objects.filter(name='foobar', uuid=response.json().get('uuid')).count() == 1
+
+    def test_post_group_malformed_enterprise_customer_returns_400(self):
+        """
+        Test that a malformed enterprise_customer value returns a 400 validation error
+        rather than an unhandled 500 from the legacy soft-deleted group cleanup lookup.
+        """
+        url = settings.TEST_SERVER + reverse('enterprise-group-list')
+        request_data = {
+            'enterprise_customer': 'not-a-uuid',
+            'name': 'foobar',
+        }
+        self.set_jwt_cookie(ENTERPRISE_ADMIN_ROLE, 'not-a-uuid')
+        response = self.client.post(url, data=request_data)
+        assert response.status_code == 400
+
+    def test_post_group_cleanup_runs_even_if_create_later_fails(self):
+        """
+        Test that the legacy soft-deleted group cleanup happens even if the create
+        request ultimately fails validation for an unrelated reason (e.g. a missing
+        required field), since the cleanup runs before the serializer validates.
+        """
+        url = settings.TEST_SERVER + reverse('enterprise-group-list')
+        new_customer = EnterpriseCustomerFactory()
+        legacy_group = EnterpriseGroupFactory(enterprise_customer=new_customer, name='foobar')
+        legacy_group.is_removed = True
+        legacy_group.save()
+        assert EnterpriseGroup.all_objects.filter(name='foobar', is_removed=True).count() == 1
+
+        request_data = {
+            'enterprise_customer': str(new_customer.uuid),
+            'name': 'foobar',
+            'group_type': 'not-a-valid-group-type',
+        }
+        self.set_jwt_cookie(ENTERPRISE_ADMIN_ROLE, new_customer.pk)
+        response = self.client.post(url, data=request_data)
+        assert response.status_code == 400
+        assert EnterpriseGroup.all_objects.filter(name='foobar', is_removed=True).count() == 0
+        assert EnterpriseGroup.objects.filter(name='foobar').count() == 0
 
     def test_duplicate_group_name_returns_custom_error(self):
         """
@@ -8868,6 +8927,25 @@ class TestEnterpriseGroupViewSet(APITest):
         response = self.client.patch(url, data=request_data)
         assert response.json().get('name') == str(new_name)
 
+    def test_update_group_name_cleans_up_legacy_soft_deleted_group(self):
+        """
+        Test that renaming a group to a name that collides with a legacy
+        soft-deleted group purges that legacy row instead of hitting a raw
+        IntegrityError from the unique_together constraint.
+        """
+        legacy_group = EnterpriseGroupFactory(enterprise_customer=self.enterprise_customer, name='legacy-name')
+        legacy_group.is_removed = True
+        legacy_group.save()
+
+        url = settings.TEST_SERVER + reverse(
+            'enterprise-group-detail',
+            kwargs={'pk': self.group_1.uuid},
+        )
+        response = self.client.patch(url, data={'name': 'legacy-name'})
+        assert response.status_code == 200
+        assert response.json().get('name') == 'legacy-name'
+        assert EnterpriseGroup.all_objects.filter(name='legacy-name', is_removed=True).count() == 0
+
     def test_successful_delete_group(self):
         """
         Test deleting a group record
@@ -8880,9 +8958,9 @@ class TestEnterpriseGroupViewSet(APITest):
         )
         response = self.client.delete(url)
         assert response.status_code == 204
+        # groups are hard deleted (history is retained via django-simple-history)
         assert EnterpriseGroup.available_objects.filter(uuid=group_to_delete_uuid).count() == 0
-        assert EnterpriseGroup.all_objects.filter(uuid=group_to_delete_uuid).count() == 1
-        # if a group gets soft deleted, we still cascade and actually delete the memberships
+        assert EnterpriseGroup.all_objects.filter(uuid=group_to_delete_uuid).count() == 0
         assert EnterpriseGroupMembership.available_objects.filter(group=group_to_delete_uuid).count() == 0
         assert EnterpriseGroupMembership.all_objects.filter(group=group_to_delete_uuid).count() == 0
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2867,17 +2867,29 @@ class TestEnterpriseGroup(unittest.TestCase):
         with raises(Exception):
             factories.EnterpriseGroupFactory(name="foobar", enterprise_customer=group_1.enterprise_customer)
 
-    def test_enterprise_group_soft_delete(self):
+    def test_enterprise_group_hard_delete(self):
         """
-        Test ``EnterpriseGroup`` soft deletion property.
+        Test ``EnterpriseGroup`` deletion is a hard delete, not a soft delete.
         """
         group = factories.EnterpriseGroupFactory()
 
         assert EnterpriseGroup.all_objects.count() == 1
         assert EnterpriseGroup.available_objects.count() == 1
         group.delete()
-        assert EnterpriseGroup.all_objects.count() == 1
+        assert EnterpriseGroup.all_objects.count() == 0
         assert EnterpriseGroup.available_objects.count() == 0
+
+    def test_enterprise_group_hard_delete_preserves_history(self):
+        """
+        Test that hard deleting an ``EnterpriseGroup`` still records the deletion
+        in its django-simple-history audit trail.
+        """
+        group = factories.EnterpriseGroupFactory()
+        group_uuid = group.uuid
+        group.delete()
+
+        history_records = EnterpriseGroup.history.filter(uuid=group_uuid).order_by('history_date')
+        assert history_records.last().history_type == '-'
 
 
 @mark.django_db


### PR DESCRIPTION




Ticket : ENT-12073

 Summary
- Groups are now hard deleted instead of soft deleted, relying on the existing django-simple-history records for the audit trail.
- Soft-deleted groups previously remained in the database and collided with the unique_together constraint on (name, enterprise_customer), blocking customers from reusing a deleted group's name even though the group wasn't visible in the admin (ENT-12073).


 Test plan
-  Full test suite passes (2849 passed, 12 skipped)
- Quality checks pass (pylint, isort, jshint)


https://github.com/user-attachments/assets/a2216993-fab0-4c58-8c5e-07a1715b85de


